### PR TITLE
Rename Repo to Repository and minor changes / Import samples project

### DIFF
--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/Azure.Iot.ModelsRepository.sln
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/Azure.Iot.ModelsRepository.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Iot.ModelsRepository.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{1FC8A3EA-3C0D-4DDF-B710-A7091F2CEBB1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModelsRepositoryClientSamples", "samples\ModelsRepositoryClientSamples\ModelsRepositoryClientSamples.csproj", "{51E4AB9E-46F3-450C-B52A-C4C6378E8BA3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{1FC8A3EA-3C0D-4DDF-B710-A7091F2CEBB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1FC8A3EA-3C0D-4DDF-B710-A7091F2CEBB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1FC8A3EA-3C0D-4DDF-B710-A7091F2CEBB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51E4AB9E-46F3-450C-B52A-C4C6378E8BA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51E4AB9E-46F3-450C-B52A-C4C6378E8BA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51E4AB9E-46F3-450C-B52A-C4C6378E8BA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51E4AB9E-46F3-450C-B52A-C4C6378E8BA3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelsRepositoryClientSamples.csproj
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelsRepositoryClientSamples.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1;net5.0</TargetFramework>
+    <RootNamespace>Azure.Iot.ModelsRepository.Samples</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\readme.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Azure.Iot.ModelsRepository.csproj" />
+  </ItemGroup>
+</Project>

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
@@ -14,7 +14,10 @@ namespace Azure.Iot.ModelsRepository.Samples
     {
         public static async Task Main(string[] args)
         {
-            using AzureEventSourceListener listener = AzureEventSourceListener.CreateTraceLogger(EventLevel.Verbose);
+            // Forward all the events written to the console output with a specific format.
+            using AzureEventSourceListener listener = new AzureEventSourceListener(
+                (e, message) => Console.WriteLine("[{0:HH:mm:ss:fff}][{1}] {2}", DateTimeOffset.Now, e.Level, message),
+                level: EventLevel.Verbose);
 
             await ResolveExistingAsync();
             await TryResolveButNotFoundAsync();

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
@@ -16,24 +16,24 @@ namespace Azure.Iot.ModelsRepository.Samples
         {
             using AzureEventSourceListener listener = AzureEventSourceListener.CreateTraceLogger(EventLevel.Verbose);
 
-            await ResolveExisting();
-            await TryResolveButNotFound();
+            await ResolveExistingAsync();
+            await TryResolveButNotFoundAsync();
         }
 
-        private static async Task ResolveExisting()
+        private static async Task ResolveExistingAsync()
         {
-            string dtmi = "dtmi:com:example:TemperatureController;1";
-            ModelsRepositoryClient client = new ModelsRepositoryClient();
+            var dtmi = "dtmi:com:example:TemperatureController;1";
+            var client = new ModelsRepositoryClient();
 
             IDictionary<string, string> models = await client.ResolveAsync(dtmi).ConfigureAwait(false);
 
             Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
         }
 
-        private static async Task TryResolveButNotFound()
+        private static async Task TryResolveButNotFoundAsync()
         {
-            string dtmi = "dtmi:com:example:NotFound;1";
-            ModelsRepositoryClient client = new ModelsRepositoryClient();
+            var dtmi = "dtmi:com:example:NotFound;1";
+            var client = new ModelsRepositoryClient();
 
             try
             {

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
@@ -23,8 +23,9 @@ namespace Azure.Iot.ModelsRepository.Samples
         private static async Task ResolveExisting()
         {
             string dtmi = "dtmi:com:example:TemperatureController;1";
-            ModelsRepositoryClient rc = new ModelsRepositoryClient();
-            IDictionary<string, string> models = await rc.ResolveAsync(dtmi);
+            ModelsRepositoryClient client = new ModelsRepositoryClient();
+
+            IDictionary<string, string> models = await client.ResolveAsync(dtmi);
 
             Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
         }
@@ -32,11 +33,11 @@ namespace Azure.Iot.ModelsRepository.Samples
         private static async Task TryResolveButNotFound()
         {
             string dtmi = "dtmi:com:example:NotFound;1";
-            ModelsRepositoryClient rc = new ModelsRepositoryClient();
+            ModelsRepositoryClient client = new ModelsRepositoryClient();
 
             try
             {
-                IDictionary<string, string> models = await rc.ResolveAsync(dtmi);
+                IDictionary<string, string> models = await client.ResolveAsync(dtmi);
                 Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
             }
             catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Azure.Iot.ModelsRepository.Samples
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            using AzureEventSourceListener listener = AzureEventSourceListener.CreateTraceLogger(EventLevel.Verbose);
+
+            await ResolveExisting();
+            await TryResolveButNotFound();
+        }
+
+        private static async Task ResolveExisting()
+        {
+            string dtmi = "dtmi:com:example:TemperatureController;1";
+            ModelsRepositoryClient rc = new ModelsRepositoryClient();
+            IDictionary<string, string> models = await rc.ResolveAsync(dtmi);
+
+            Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
+        }
+
+        private static async Task TryResolveButNotFound()
+        {
+            string dtmi = "dtmi:com:example:NotFound;1";
+            ModelsRepositoryClient rc = new ModelsRepositoryClient();
+
+            try
+            {
+                IDictionary<string, string> models = await rc.ResolveAsync(dtmi);
+                Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
+            }
+            catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
+            {
+                Console.WriteLine($"{dtmi} was not found in the default public models repository: {ex.Message}");
+            }
+        }
+    }
+}

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
@@ -25,7 +25,7 @@ namespace Azure.Iot.ModelsRepository.Samples
             string dtmi = "dtmi:com:example:TemperatureController;1";
             ModelsRepositoryClient client = new ModelsRepositoryClient();
 
-            IDictionary<string, string> models = await client.ResolveAsync(dtmi);
+            IDictionary<string, string> models = await client.ResolveAsync(dtmi).ConfigureAwait(false);
 
             Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
         }
@@ -37,7 +37,7 @@ namespace Azure.Iot.ModelsRepository.Samples
 
             try
             {
-                IDictionary<string, string> models = await client.ResolveAsync(dtmi);
+                IDictionary<string, string> models = await client.ResolveAsync(dtmi).ConfigureAwait(false);
                 Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
             }
             catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/LocalModelFetcher.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/LocalModelFetcher.cs
@@ -21,7 +21,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
         private readonly bool _tryExpanded;
         private readonly ClientDiagnostics _clientDiagnostics;
 
-        public LocalModelFetcher(ClientDiagnostics clientDiagnostics, ModelsRepoClientOptions clientOptions)
+        public LocalModelFetcher(ClientDiagnostics clientDiagnostics, ModelsRepositoryClientOptions clientOptions)
         {
             _clientDiagnostics = clientDiagnostics;
             _tryExpanded = clientOptions.DependencyResolution == DependencyResolutionOption.TryFromExpanded;
@@ -54,7 +54,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
                     cancellationToken.ThrowIfCancellationRequested();
 
                     string tryContentPath = work.Dequeue();
-                    ModelsRepoEventSource.Instance.FetchingModelContent(tryContentPath);
+                    ModelsRepositoryEventSource.Instance.FetchingModelContent(tryContentPath);
 
                     if (File.Exists(tryContentPath))
                     {
@@ -65,7 +65,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
                         };
                     }
 
-                    ModelsRepoEventSource.Instance.ErrorFetchingModelContent(tryContentPath);
+                    ModelsRepositoryEventSource.Instance.ErrorFetchingModelContent(tryContentPath);
                     fnfError = string.Format(CultureInfo.CurrentCulture, ServiceStrings.ErrorFetchingModelContent, tryContentPath);
                 }
 

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/RemoteModelFetcher.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/RemoteModelFetcher.cs
@@ -23,7 +23,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
         private readonly ClientDiagnostics _clientDiagnostics;
         private readonly bool _tryExpanded;
 
-        public RemoteModelFetcher(ClientDiagnostics clientDiagnostics, ModelsRepoClientOptions clientOptions)
+        public RemoteModelFetcher(ClientDiagnostics clientDiagnostics, ModelsRepositoryClientOptions clientOptions)
         {
             _pipeline = CreatePipeline(clientOptions);
             _tryExpanded = clientOptions.DependencyResolution == DependencyResolutionOption.TryFromExpanded;
@@ -45,7 +45,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
                     cancellationToken.ThrowIfCancellationRequested();
 
                     string tryContentPath = work.Dequeue();
-                    ModelsRepoEventSource.Instance.FetchingModelContent(tryContentPath);
+                    ModelsRepositoryEventSource.Instance.FetchingModelContent(tryContentPath);
 
                     try
                     {
@@ -88,7 +88,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
                     cancellationToken.ThrowIfCancellationRequested();
 
                     string tryContentPath = work.Dequeue();
-                    ModelsRepoEventSource.Instance.FetchingModelContent(tryContentPath);
+                    ModelsRepositoryEventSource.Instance.FetchingModelContent(tryContentPath);
 
                     try
                     {
@@ -219,7 +219,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
             return root.GetRawText();
         }
 
-        private static HttpPipeline CreatePipeline(ModelsRepoClientOptions options)
+        private static HttpPipeline CreatePipeline(ModelsRepositoryClientOptions options)
         {
             return HttpPipelineBuilder.Build(options);
         }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/RemoteModelFetcher.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/RemoteModelFetcher.cs
@@ -105,30 +105,35 @@ namespace Azure.Iot.ModelsRepository.Fetchers
                     catch (RequestFailedException ex)
                     {
                         requestFailedExceptionThrown = ex;
-                        remoteFetchError =
-                            $"{string.Format(CultureInfo.CurrentCulture, ServiceStrings.GenericResolverError, dtmi)} " +
-                            string.Format(CultureInfo.CurrentCulture, StandardStrings.ErrorFetchingModelContent, tryContentPath);
                     }
                     catch (Exception ex)
                     {
                         genericExceptionThrown = ex;
+                    }
+
+                    if (genericExceptionThrown != null || requestFailedExceptionThrown != null)
+                    {
                         remoteFetchError =
                             $"{string.Format(CultureInfo.CurrentCulture, ServiceStrings.GenericResolverError, dtmi)} " +
                             string.Format(CultureInfo.CurrentCulture, StandardStrings.ErrorFetchingModelContent, tryContentPath);
                     }
                 }
 
-                if (requestFailedExceptionThrown == null)
-                {
-                    throw new RequestFailedException((int)HttpStatusCode.BadRequest, remoteFetchError, null, genericExceptionThrown);
-                }
-                else
+                if (requestFailedExceptionThrown != null)
                 {
                     throw new RequestFailedException(
                         requestFailedExceptionThrown.Status,
                         remoteFetchError,
                         requestFailedExceptionThrown.ErrorCode,
                         requestFailedExceptionThrown);
+                }
+                else
+                {
+                    throw new RequestFailedException(
+                        (int)HttpStatusCode.BadRequest,
+                        remoteFetchError,
+                        null,
+                        genericExceptionThrown);
                 }
             }
             catch (Exception ex)

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClient.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClient.cs
@@ -6,84 +6,56 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
 using Azure.Core.Pipeline;
 
 namespace Azure.Iot.ModelsRepository
 {
     /// <summary>
-    /// The ModelsRepoClient class supports operations against DTDL model repositories following the
+    /// The ModelsRepositoryClient class supports operations against DTDL model repositories following the
     /// conventions of the Azure IoT Plug and Play Models repository.
     /// </summary>
-    public class ModelsRepoClient
+    public class ModelsRepositoryClient
     {
         private readonly RepositoryHandler _repositoryHandler;
         private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly ModelsRepositoryClientOptions _clientOptions;
 
         /// <summary>
-        /// Initializes the ModelsRepoClient with default client options while pointing to
+        /// Initializes the ModelsRepositoryClient with default client options while pointing to
         /// the Azure IoT Plug and Play Models repository https://devicemodels.azure.com for resolution.
         /// </summary>
-        public ModelsRepoClient() : this(new Uri(DefaultModelsRepository), new ModelsRepoClientOptions()) { }
+        public ModelsRepositoryClient() : this(DefaultModelsRepository, new ModelsRepositoryClientOptions()) { }
 
         /// <summary>
-        /// Initializes the ModelsRepoClient with default client options while pointing to
-        /// a custom <paramref name="repositoryUri"/> for resolution.
-        /// </summary>
-        /// <param name="repositoryUri">
-        /// The model repository Uri value. This can be a remote endpoint or local directory.
-        /// </param>
-        public ModelsRepoClient(Uri repositoryUri) : this(repositoryUri, new ModelsRepoClientOptions()) { }
-
-        /// <summary>
-        /// Initializes the ModelsRepoClient with custom client <paramref name="options"/> while pointing to
+        /// Initializes the ModelsRepositoryClient with custom client <paramref name="options"/> while pointing to
         /// the Azure IoT Plug and Play Model repository https://devicemodels.azure.com for resolution.
         /// </summary>
         /// <param name="options">
-        /// ModelsRepoClientOptions to configure resolution and client behavior.
+        /// ModelsRepositoryClientOptions to configure resolution and client behavior.
         /// </param>
-        public ModelsRepoClient(ModelsRepoClientOptions options) : this(new Uri(DefaultModelsRepository), options) { }
+        public ModelsRepositoryClient(ModelsRepositoryClientOptions options) : this(DefaultModelsRepository, options) { }
 
         /// <summary>
-        /// Initializes the ModelsRepoClient with default client options while pointing to
-        /// a custom <paramref name="repositoryUriStr"/> for resolution.
-        /// </summary>
-        /// <param name="repositoryUriStr">
-        /// The model repository Uri in string format. This can be a remote endpoint or local directory.
-        /// </param>
-        public ModelsRepoClient(string repositoryUriStr) : this(repositoryUriStr, new ModelsRepoClientOptions()) { }
-
-        /// <summary>
-        /// Initializes the ModelsRepoClient with custom client <paramref name="options"/> while pointing to
-        /// a custom <paramref name="repositoryUriStr"/> for resolution.
-        /// </summary>
-        /// <param name="repositoryUriStr">
-        /// The model repository Uri in string format. This can be a remote endpoint or local directory.
-        /// </param>
-        /// <param name="options">
-        /// ModelsRepoClientOptions to configure resolution and client behavior.
-        /// </param>
-        public ModelsRepoClient(string repositoryUriStr, ModelsRepoClientOptions options)
-            : this(new Uri(repositoryUriStr), options) { }
-
-        /// <summary>
-        /// Initializes the ModelsRepoClient with custom client <paramref name="options"/> while pointing to
+        /// Initializes the ModelsRepositoryClient with custom client <paramref name="options"/> while pointing to
         /// a custom <paramref name="repositoryUri"/> for resolution.
         /// </summary>
         /// <param name="repositoryUri">
         /// The model repository Uri. This can be a remote endpoint or local directory.
         /// </param>
         /// <param name="options">
-        /// ModelsRepoClientOptions to configure resolution and client behavior.
+        /// ModelsRepositoryClientOptions to configure resolution and client behavior.
         /// </param>
-        public ModelsRepoClient(Uri repositoryUri, ModelsRepoClientOptions options)
+        public ModelsRepositoryClient(Uri repositoryUri, ModelsRepositoryClientOptions options = default)
         {
-            Argument.AssertNotNull(options, nameof(options));
+            if (options == null)
+            {
+                options = new ModelsRepositoryClientOptions();
+            }
 
-            ClientOptions = options;
             RepositoryUri = repositoryUri;
+            _clientOptions = options;
             _clientDiagnostics = new ClientDiagnostics(options);
-            _repositoryHandler = new RepositoryHandler(RepositoryUri, _clientDiagnostics, ClientOptions);
+            _repositoryHandler = new RepositoryHandler(RepositoryUri, _clientDiagnostics, _clientOptions);
         }
 
         /// <summary>
@@ -102,7 +74,7 @@ namespace Azure.Iot.ModelsRepository
             Justification = "<Pending>")]
         public virtual async Task<IDictionary<string, string>> ResolveAsync(string dtmi, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepoClient)}.{nameof(Resolve)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepositoryClient)}.{nameof(Resolve)}");
             scope.Start();
             try
             {
@@ -131,7 +103,7 @@ namespace Azure.Iot.ModelsRepository
             Justification = "<Pending>")]
         public virtual IDictionary<string, string> Resolve(string dtmi, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepoClient)}.{nameof(Resolve)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepositoryClient)}.{nameof(Resolve)}");
             scope.Start();
 
             try
@@ -158,7 +130,7 @@ namespace Azure.Iot.ModelsRepository
         [SuppressMessage("Usage", "AZC0015:Unexpected client method return type.", Justification = "<Pending>")]
         public virtual async Task<IDictionary<string, string>> ResolveAsync(IEnumerable<string> dtmis, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepoClient)}.{nameof(Resolve)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepositoryClient)}.{nameof(Resolve)}");
             scope.Start();
 
             try
@@ -185,7 +157,7 @@ namespace Azure.Iot.ModelsRepository
         [SuppressMessage("Usage", "AZC0015:Unexpected client method return type.", Justification = "<Pending>")]
         public virtual IDictionary<string, string> Resolve(IEnumerable<string> dtmis, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepoClient)}.{nameof(Resolve)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepositoryClient)}.{nameof(Resolve)}");
             scope.Start();
 
             try
@@ -205,18 +177,13 @@ namespace Azure.Iot.ModelsRepository
         public static bool IsValidDtmi(string dtmi) => DtmiConventions.IsDtmi(dtmi);
 
         /// <summary>
-        /// Gets the Uri associated with the ModelsRepoClient instance.
+        /// Gets the Uri associated with the ModelsRepositoryClient instance.
         /// </summary>
         public Uri RepositoryUri { get; }
 
         /// <summary>
-        /// Gets the ModelsRepoClientOptions associated with the ModelsRepoClient instance.
-        /// </summary>
-        public ModelsRepoClientOptions ClientOptions { get; }
-
-        /// <summary>
         /// The global Azure IoT Models Repository endpoint used by default.
         /// </summary>
-        public static string DefaultModelsRepository => ModelRepositoryConstants.DefaultModelsRepository;
+        public static Uri DefaultModelsRepository => new Uri(ModelRepositoryConstants.DefaultModelsRepository);
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClientOptions.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClientOptions.cs
@@ -9,7 +9,7 @@ namespace Azure.Iot.ModelsRepository
     /// <summary>
     /// Options that allow configuration of requests sent to the ModelRepositoryService.
     /// </summary>
-    public class ModelsRepoClientOptions : ClientOptions
+    public class ModelsRepositoryClientOptions : ClientOptions
     {
         internal const ServiceVersion LatestVersion = ServiceVersion.V2021_02_11;
 
@@ -33,14 +33,14 @@ namespace Azure.Iot.ModelsRepository
         public ServiceVersion Version { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ModelsRepoClientOptions"/> class.
+        /// Initializes a new instance of the <see cref="ModelsRepositoryClientOptions"/> class.
         /// </summary>
         /// <param name="version">
         /// The <see cref="ServiceVersion"/> of the service API used when
         /// making requests.
         /// </param>
         /// <param name="resolutionOption">The dependency processing options.</param>
-        public ModelsRepoClientOptions(
+        public ModelsRepositoryClientOptions(
             ServiceVersion version = LatestVersion,
             DependencyResolutionOption resolutionOption = DependencyResolutionOption.Enabled)
         {

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryEventSource.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryEventSource.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.Tracing;
 namespace Azure.Iot.ModelsRepository
 {
     [EventSource(Name = EventSourceName)]
-    internal sealed class ModelsRepoEventSource : EventSource
+    internal sealed class ModelsRepositoryEventSource : EventSource
     {
         private const string EventSourceName = ModelRepositoryConstants.ModelRepositoryEventSourceName;
 
@@ -26,9 +26,9 @@ namespace Azure.Iot.ModelsRepository
         private const int ErrorFetchingModelContentEventId = 4004;
         private const int IncorrectDtmiCasingEventId = 4006;
 
-        public static ModelsRepoEventSource Instance { get; } = new ModelsRepoEventSource();
+        public static ModelsRepositoryEventSource Instance { get; } = new ModelsRepositoryEventSource();
 
-        private ModelsRepoEventSource()
+        private ModelsRepositoryEventSource()
             : base(EventSourceName,
                   EventSourceSettings.Default,
                   AzureEventSourceListener.TraitName,

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/RepositoryHandler.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/RepositoryHandler.cs
@@ -18,9 +18,9 @@ namespace Azure.Iot.ModelsRepository
         private readonly Guid _clientId;
         private readonly ClientDiagnostics _clientDiagnostics;
         private readonly Uri _repositoryUri;
-        private readonly ModelsRepoClientOptions _clientOptions;
+        private readonly ModelsRepositoryClientOptions _clientOptions;
 
-        public RepositoryHandler(Uri repositoryUri, ClientDiagnostics clientDiagnostics, ModelsRepoClientOptions options)
+        public RepositoryHandler(Uri repositoryUri, ClientDiagnostics clientDiagnostics, ModelsRepositoryClientOptions options)
         {
             Argument.AssertNotNull(options, nameof(options));
 
@@ -33,7 +33,7 @@ namespace Azure.Iot.ModelsRepository
 
             _repositoryUri = repositoryUri;
 
-            ModelsRepoEventSource.Instance.InitFetcher(_clientId, repositoryUri.Scheme);
+            ModelsRepositoryEventSource.Instance.InitFetcher(_clientId, repositoryUri.Scheme);
         }
 
         public async Task<IDictionary<string, string>> ProcessAsync(string dtmi, CancellationToken cancellationToken)
@@ -68,11 +68,11 @@ namespace Azure.Iot.ModelsRepository
                 string targetDtmi = toProcessModels.Dequeue();
                 if (processedModels.ContainsKey(targetDtmi))
                 {
-                    ModelsRepoEventSource.Instance.SkippingPreprocessedDtmi(targetDtmi);
+                    ModelsRepositoryEventSource.Instance.SkippingPreprocessedDtmi(targetDtmi);
                     continue;
                 }
 
-                ModelsRepoEventSource.Instance.ProcessingDtmi(targetDtmi);
+                ModelsRepositoryEventSource.Instance.ProcessingDtmi(targetDtmi);
 
                 FetchResult result = async
                     ? await FetchAsync(targetDtmi, cancellationToken).ConfigureAwait(false)
@@ -101,7 +101,7 @@ namespace Azure.Iot.ModelsRepository
 
                     if (dependencies.Count > 0)
                     {
-                        ModelsRepoEventSource.Instance.DiscoveredDependencies(string.Join("\", \"", dependencies));
+                        ModelsRepositoryEventSource.Instance.DiscoveredDependencies(string.Join("\", \"", dependencies));
                     }
 
                     foreach (string dep in dependencies)
@@ -113,7 +113,7 @@ namespace Azure.Iot.ModelsRepository
                 string parsedDtmi = metadata.Id;
                 if (!parsedDtmi.Equals(targetDtmi, StringComparison.Ordinal))
                 {
-                    ModelsRepoEventSource.Instance.IncorrectDtmiCasing(targetDtmi, parsedDtmi);
+                    ModelsRepositoryEventSource.Instance.IncorrectDtmiCasing(targetDtmi, parsedDtmi);
                     string formatErrorMsg =
                         $"{string.Format(CultureInfo.CurrentCulture, ServiceStrings.GenericResolverError, targetDtmi)} " +
                         string.Format(CultureInfo.CurrentCulture, ServiceStrings.IncorrectDtmiCasing, targetDtmi, parsedDtmi);
@@ -144,7 +144,7 @@ namespace Azure.Iot.ModelsRepository
             {
                 if (!DtmiConventions.IsDtmi(dtmi))
                 {
-                    ModelsRepoEventSource.Instance.InvalidDtmiInput(dtmi);
+                    ModelsRepositoryEventSource.Instance.InvalidDtmiInput(dtmi);
 
                     string invalidArgMsg =
                         $"{string.Format(CultureInfo.CurrentCulture, ServiceStrings.GenericResolverError, dtmi)} " +

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ClientTests.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ClientTests.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Azure.Iot.ModelsRepository.Tests
 {
-    public class ClientTests : ModelsRepoTestBase
+    public class ClientTests : ModelsRepositoryTestBase
     {
         [Test]
         public void CtorOverloads()
@@ -16,29 +16,26 @@ namespace Azure.Iot.ModelsRepository.Tests
             string remoteUriStr = "https://dtmi.com";
             Uri remoteUri = new Uri(remoteUriStr);
 
-            ModelsRepoClientOptions options = new ModelsRepoClientOptions();
+            ModelsRepositoryClientOptions options = new ModelsRepositoryClientOptions();
 
-            Assert.AreEqual(new Uri(ModelsRepoClient.DefaultModelsRepository), new ModelsRepoClient().RepositoryUri);
-            Assert.AreEqual($"{ModelsRepoClient.DefaultModelsRepository}/", new ModelsRepoClient().RepositoryUri.AbsoluteUri);
-            Assert.AreEqual(new Uri(ModelsRepoClient.DefaultModelsRepository), new ModelsRepoClient(options).RepositoryUri);
+            Assert.AreEqual(ModelsRepositoryClient.DefaultModelsRepository, new ModelsRepositoryClient().RepositoryUri);
+            Assert.AreEqual(ModelsRepositoryClient.DefaultModelsRepository, new ModelsRepositoryClient().RepositoryUri);
+            Assert.AreEqual(ModelsRepositoryClient.DefaultModelsRepository, new ModelsRepositoryClient(options).RepositoryUri);
 
-            Assert.AreEqual(remoteUri, new ModelsRepoClient(remoteUri).RepositoryUri);
-            Assert.AreEqual(remoteUri, new ModelsRepoClient(remoteUri, options).RepositoryUri);
-
-            Assert.AreEqual(remoteUri, new ModelsRepoClient(remoteUriStr).RepositoryUri);
-            Assert.AreEqual(remoteUri, new ModelsRepoClient(remoteUriStr, options).RepositoryUri);
+            Assert.AreEqual(remoteUri, new ModelsRepositoryClient(remoteUri).RepositoryUri);
+            Assert.AreEqual(remoteUri, new ModelsRepositoryClient(remoteUri, options).RepositoryUri);
 
             string localUriStr = TestLocalModelRepository;
             Uri localUri = new Uri(localUriStr);
 
-            Assert.AreEqual(localUri, new ModelsRepoClient(localUri).RepositoryUri);
+            Assert.AreEqual(localUri, new ModelsRepositoryClient(localUri).RepositoryUri);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 localUriStr = localUriStr.Replace("\\", "/");
             }
 
-            Assert.AreEqual(localUriStr, new ModelsRepoClient(localUri).RepositoryUri.AbsolutePath);
+            Assert.AreEqual(localUriStr, new ModelsRepositoryClient(localUri).RepositoryUri.AbsolutePath);
         }
 
         [TestCase("dtmi:com:example:Thermostat;1", true)]
@@ -50,35 +47,13 @@ namespace Azure.Iot.ModelsRepository.Tests
         [TestCase(null, false)]
         public void ClientIsValidDtmi(string dtmi, bool expected)
         {
-            Assert.AreEqual(expected, ModelsRepoClient.IsValidDtmi(dtmi));
-        }
-
-        [Test]
-        public void ClientOptions()
-        {
-            DependencyResolutionOption defaultResolutionOption = DependencyResolutionOption.Enabled;
-
-            ModelsRepoClientOptions customOptions =
-                new ModelsRepoClientOptions(resolutionOption: DependencyResolutionOption.TryFromExpanded);
-
-            int maxRetries = 10;
-            customOptions.Retry.MaxRetries = maxRetries;
-
-            string repositoryUriString = "https://localhost/myregistry/";
-            Uri repositoryUri = new Uri(repositoryUriString);
-
-            ModelsRepoClient defaultClient = new ModelsRepoClient(repositoryUri);
-            Assert.AreEqual(defaultResolutionOption, defaultClient.ClientOptions.DependencyResolution);
-
-            ModelsRepoClient customClient = new ModelsRepoClient(repositoryUriString, customOptions);
-            Assert.AreEqual(DependencyResolutionOption.TryFromExpanded, customClient.ClientOptions.DependencyResolution);
-            Assert.AreEqual(maxRetries, customClient.ClientOptions.Retry.MaxRetries);
+            Assert.AreEqual(expected, ModelsRepositoryClient.IsValidDtmi(dtmi));
         }
 
         [Test]
         public void EvaluateEventSourceKPIs()
         {
-            Type eventSourceType = typeof(ModelsRepoEventSource);
+            Type eventSourceType = typeof(ModelsRepositoryEventSource);
 
             Assert.NotNull(eventSourceType);
             Assert.AreEqual(ModelRepositoryConstants.ModelRepositoryEventSourceName, EventSource.GetName(eventSourceType));

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/DtmiConversionTests.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/DtmiConversionTests.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Azure.Iot.ModelsRepository.Tests
 {
-    public class DtmiConversionTests : ModelsRepoTestBase
+    public class DtmiConversionTests : ModelsRepositoryTestBase
     {
         [TestCase("dtmi:com:Example:Model;1", "dtmi/com/example/model-1.json")]
         [TestCase("dtmi:com:example:Model;1", "dtmi/com/example/model-1.json")]

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ModelQueryTests.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ModelQueryTests.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace Azure.Iot.ModelsRepository.Tests
 {
-    public class ModelQueryTests : ModelsRepoTestBase
+    public class ModelQueryTests : ModelsRepositoryTestBase
     {
         private readonly string _modelTemplate = @"{{
             {0}

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ModelsRepositoryRecordedTestBase.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ModelsRepositoryRecordedTestBase.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 
 namespace Azure.Iot.ModelsRepository.Tests
 {
-    public class ModelsRepoRecordedTestBase : RecordedTestBase<ModelsRepoTestEnvironment>
+    public class ModelsRepositoryRecordedTestBase : RecordedTestBase<ModelsRepositoryTestEnvironment>
     {
         protected const string TestModeEnvVariable = "AZURE_TEST_MODE";
 
@@ -16,7 +16,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             typeof(RecordedTestMode),
             Environment.GetEnvironmentVariable(TestModeEnvVariable));
 
-        public ModelsRepoRecordedTestBase(bool isAsync) : base(isAsync, TestMode)
+        public ModelsRepositoryRecordedTestBase(bool isAsync) : base(isAsync, TestMode)
         {
         }
 
@@ -26,22 +26,22 @@ namespace Azure.Iot.ModelsRepository.Tests
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         }
 
-        protected ModelsRepoClient GetClient(ModelsRepoTestBase.ClientType clientType, ModelsRepoClientOptions options = null)
+        protected ModelsRepositoryClient GetClient(ModelsRepositoryTestBase.ClientType clientType, ModelsRepositoryClientOptions options = default)
         {
             if (options == null)
             {
-                options = new ModelsRepoClientOptions();
+                options = new ModelsRepositoryClientOptions();
             }
 
             return
-                clientType == ModelsRepoTestBase.ClientType.Local
+                clientType == ModelsRepositoryTestBase.ClientType.Local
                 ? InstrumentClient(
-                    new ModelsRepoClient(
-                        new Uri(ModelsRepoTestBase.TestLocalModelRepository),
+                    new ModelsRepositoryClient(
+                        new Uri(ModelsRepositoryTestBase.TestLocalModelRepository),
                         InstrumentClientOptions(options)))
                 : InstrumentClient(
-                    new ModelsRepoClient(
-                        new Uri(ModelsRepoTestBase.TestRemoteModelRepository),
+                    new ModelsRepositoryClient(
+                        new Uri(ModelsRepositoryTestBase.TestRemoteModelRepository),
                         InstrumentClientOptions(options)));
         }
     }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ModelsRepositoryTestBase.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ModelsRepositoryTestBase.cs
@@ -11,9 +11,9 @@ namespace Azure.Iot.ModelsRepository.Tests
     /// <summary>
     /// This class will initialize all the settings and create and instance of the ModelsRepoClient.
     /// </summary>
-    public abstract class ModelsRepoTestBase
+    public abstract class ModelsRepositoryTestBase
     {
-        public ModelsRepoTestBase()
+        public ModelsRepositoryTestBase()
         {
         }
 

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ModelsRepositoryTestEnvironment.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ModelsRepositoryTestEnvironment.cs
@@ -5,7 +5,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.Iot.ModelsRepository.Tests
 {
-    public class ModelsRepoTestEnvironment : TestEnvironment
+    public class ModelsRepositoryTestEnvironment : TestEnvironment
     {
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ResolveIntegrationTests.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ResolveIntegrationTests.cs
@@ -9,19 +9,19 @@ using System.Threading.Tasks;
 
 namespace Azure.Iot.ModelsRepository.Tests
 {
-    public class ResolveIntegrationTests : ModelsRepoRecordedTestBase
+    public class ResolveIntegrationTests : ModelsRepositoryRecordedTestBase
     {
         public ResolveIntegrationTests(bool isAsync) : base(isAsync)
         {
         }
 
-        [TestCase(ModelsRepoTestBase.ClientType.Local)]
-        [TestCase(ModelsRepoTestBase.ClientType.Remote)]
-        public void ResolveWithWrongCasingThrowsException(ModelsRepoTestBase.ClientType clientType)
+        [TestCase(ModelsRepositoryTestBase.ClientType.Local)]
+        [TestCase(ModelsRepositoryTestBase.ClientType.Remote)]
+        public void ResolveWithWrongCasingThrowsException(ModelsRepositoryTestBase.ClientType clientType)
         {
             const string dtmi = "dtmi:com:example:thermostat;1";
 
-            ModelsRepoClient client = GetClient(clientType);
+            ModelsRepositoryClient client = GetClient(clientType);
             string expectedExMsg =
                 string.Format(ServiceStrings.GenericResolverError, "dtmi:com:example:thermostat;1") +
                 " " +
@@ -36,19 +36,19 @@ namespace Azure.Iot.ModelsRepository.Tests
         [TestCase("com:example:Thermostat;1")]
         public void ResolveInvalidDtmiFormatThrowsException(string dtmi)
         {
-            ModelsRepoClient client = GetClient(ModelsRepoTestBase.ClientType.Local);
+            ModelsRepositoryClient client = GetClient(ModelsRepositoryTestBase.ClientType.Local);
             string expectedExMsg = $"{string.Format(ServiceStrings.GenericResolverError, dtmi)} {string.Format(ServiceStrings.InvalidDtmiFormat, dtmi)}";
             RequestFailedException re = Assert.ThrowsAsync<RequestFailedException>(async () => await client.ResolveAsync(dtmi));
             Assert.AreEqual(re.Message, expectedExMsg);
         }
 
-        [TestCase(ModelsRepoTestBase.ClientType.Local)]
-        [TestCase(ModelsRepoTestBase.ClientType.Remote)]
-        public void ResolveNoneExistentDtmiFileThrowsException(ModelsRepoTestBase.ClientType clientType)
+        [TestCase(ModelsRepositoryTestBase.ClientType.Local)]
+        [TestCase(ModelsRepositoryTestBase.ClientType.Remote)]
+        public void ResolveNoneExistentDtmiFileThrowsException(ModelsRepositoryTestBase.ClientType clientType)
         {
             const string dtmi = "dtmi:com:example:thermojax;999";
 
-            ModelsRepoClient client = GetClient(clientType);
+            ModelsRepositoryClient client = GetClient(clientType);
             RequestFailedException re = Assert.ThrowsAsync<RequestFailedException>(async () => await client.ResolveAsync(dtmi));
             Assert.True(re.Message.StartsWith($"Unable to resolve \"{dtmi}\""));
         }
@@ -58,48 +58,48 @@ namespace Azure.Iot.ModelsRepository.Tests
             const string dtmi = "dtmi:com:example:invalidmodel;1";
             const string invalidDep = "dtmi:azure:fakeDeviceManagement:FakeDeviceInformation;2";
 
-            ModelsRepoClient client = GetClient(ModelsRepoTestBase.ClientType.Local);
+            ModelsRepositoryClient client = GetClient(ModelsRepositoryTestBase.ClientType.Local);
             RequestFailedException resolverException = Assert.ThrowsAsync<RequestFailedException>(async () => await client.ResolveAsync(dtmi));
             Assert.True(resolverException.Message.StartsWith($"Unable to resolve \"{invalidDep}\""));
         }
 
-        [TestCase(ModelsRepoTestBase.ClientType.Local)]
-        [TestCase(ModelsRepoTestBase.ClientType.Remote)]
-        public async Task ResolveSingleModelNoDeps(ModelsRepoTestBase.ClientType clientType)
+        [TestCase(ModelsRepositoryTestBase.ClientType.Local)]
+        [TestCase(ModelsRepositoryTestBase.ClientType.Remote)]
+        public async Task ResolveSingleModelNoDeps(ModelsRepositoryTestBase.ClientType clientType)
         {
             const string dtmi = "dtmi:com:example:Thermostat;1";
 
-            ModelsRepoClient client = GetClient(clientType);
+            ModelsRepositoryClient client = GetClient(clientType);
             IDictionary<string, string> result = await client.ResolveAsync(dtmi);
             Assert.True(result.Keys.Count == 1);
             Assert.True(result.ContainsKey(dtmi));
-            Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[dtmi]) == dtmi);
+            Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[dtmi]) == dtmi);
         }
 
-        [TestCase(ModelsRepoTestBase.ClientType.Local)]
-        [TestCase(ModelsRepoTestBase.ClientType.Remote)]
-        public async Task ResolveMultipleModelsNoDeps(ModelsRepoTestBase.ClientType clientType)
+        [TestCase(ModelsRepositoryTestBase.ClientType.Local)]
+        [TestCase(ModelsRepositoryTestBase.ClientType.Remote)]
+        public async Task ResolveMultipleModelsNoDeps(ModelsRepositoryTestBase.ClientType clientType)
         {
             const string dtmi1 = "dtmi:com:example:Thermostat;1";
             const string dtmi2 = "dtmi:azure:DeviceManagement:DeviceInformation;1";
 
-            ModelsRepoClient client = GetClient(clientType);
+            ModelsRepositoryClient client = GetClient(clientType);
             IDictionary<string, string> result = await client.ResolveAsync(new string[] { dtmi1, dtmi2 });
             Assert.True(result.Keys.Count == 2);
             Assert.True(result.ContainsKey(dtmi1));
             Assert.True(result.ContainsKey(dtmi2));
-            Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[dtmi1]) == dtmi1);
-            Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[dtmi2]) == dtmi2);
+            Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[dtmi1]) == dtmi1);
+            Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[dtmi2]) == dtmi2);
         }
 
-        [TestCase(ModelsRepoTestBase.ClientType.Local)]
-        [TestCase(ModelsRepoTestBase.ClientType.Remote)]
-        public async Task ResolveSingleModelWithDeps(ModelsRepoTestBase.ClientType clientType)
+        [TestCase(ModelsRepositoryTestBase.ClientType.Local)]
+        [TestCase(ModelsRepositoryTestBase.ClientType.Remote)]
+        public async Task ResolveSingleModelWithDeps(ModelsRepositoryTestBase.ClientType clientType)
         {
             const string dtmi = "dtmi:com:example:TemperatureController;1";
             const string expectedDeps = "dtmi:com:example:Thermostat;1,dtmi:azure:DeviceManagement:DeviceInformation;1";
 
-            ModelsRepoClient client = GetClient(clientType);
+            ModelsRepositoryClient client = GetClient(clientType);
             IDictionary<string, string> result = await client.ResolveAsync(dtmi);
             var expectedDtmis = $"{dtmi},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
@@ -107,7 +107,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             foreach (var id in expectedDtmis)
             {
                 Assert.True(result.ContainsKey(id));
-                Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[id]) == id);
+                Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[id]) == id);
             }
 
             // TODO: Evaluate using Azure.Core.TestFramework in future iteration.
@@ -138,7 +138,7 @@ namespace Azure.Iot.ModelsRepository.Tests
                   "dtmi:azure:DeviceManagement:DeviceInformation;2," +
                   "dtmi:com:example:Camera;3";
 
-            ModelsRepoClient client = GetClient(ModelsRepoTestBase.ClientType.Local);
+            ModelsRepositoryClient client = GetClient(ModelsRepositoryTestBase.ClientType.Local);
             IDictionary<string, string> result = await client.ResolveAsync(new[] { dtmi1, dtmi2 });
             var expectedDtmis = $"{dtmi1},{dtmi2},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
@@ -146,7 +146,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             foreach (var id in expectedDtmis)
             {
                 Assert.True(result.ContainsKey(id));
-                Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[id]) == id);
+                Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[id]) == id);
             }
         }
 
@@ -155,7 +155,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             const string dtmi1 = "dtmi:com:example:TemperatureController;1";
             const string dtmi2 = "dtmi:com:example:ConferenceRoom;1";
             const string expectedDeps = "dtmi:com:example:Thermostat;1,dtmi:azure:DeviceManagement:DeviceInformation;1,dtmi:com:example:Room;1";
-            ModelsRepoClient client = GetClient(ModelsRepoTestBase.ClientType.Local);
+            ModelsRepositoryClient client = GetClient(ModelsRepositoryTestBase.ClientType.Local);
             IDictionary<string, string> result = await client.ResolveAsync(new[] { dtmi1, dtmi2 });
             var expectedDtmis = $"{dtmi1},{dtmi2},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
@@ -163,7 +163,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             foreach (var id in expectedDtmis)
             {
                 Assert.True(result.ContainsKey(id));
-                Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[id]) == id);
+                Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[id]) == id);
             }
         }
 
@@ -176,7 +176,7 @@ namespace Azure.Iot.ModelsRepository.Tests
                   "dtmi:com:example:Room;1," +
                   "dtmi:com:example:Freezer;1";
 
-            ModelsRepoClient client = GetClient(ModelsRepoTestBase.ClientType.Local);
+            ModelsRepositoryClient client = GetClient(ModelsRepositoryTestBase.ClientType.Local);
             IDictionary<string, string> result = await client.ResolveAsync(new[] { dtmi1, dtmi2 });
             var expectedDtmis = $"{dtmi1},{dtmi2},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
@@ -184,19 +184,19 @@ namespace Azure.Iot.ModelsRepository.Tests
             foreach (var id in expectedDtmis)
             {
                 Assert.True(result.ContainsKey(id));
-                Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[id]) == id);
+                Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[id]) == id);
             }
         }
 
         public async Task ResolveSingleModelWithDepsFromExtendsInline()
         {
             const string dtmi = "dtmi:com:example:base;1";
-            ModelsRepoClient client = GetClient(ModelsRepoTestBase.ClientType.Local);
+            ModelsRepositoryClient client = GetClient(ModelsRepositoryTestBase.ClientType.Local);
             IDictionary<string, string> result = await client.ResolveAsync(dtmi);
 
             Assert.True(result.Keys.Count == 1);
             Assert.True(result.ContainsKey(dtmi));
-            Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[dtmi]) == dtmi);
+            Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[dtmi]) == dtmi);
         }
 
         public async Task ResolveSingleModelWithDepsFromExtendsInlineVariant()
@@ -205,7 +205,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             const string expected = "dtmi:com:example:Freezer;1," +
                   "dtmi:com:example:Thermostat;1";
 
-            ModelsRepoClient client = GetClient(ModelsRepoTestBase.ClientType.Local);
+            ModelsRepositoryClient client = GetClient(ModelsRepositoryTestBase.ClientType.Local);
             IDictionary<string, string> result = await client.ResolveAsync(dtmi);
             var expectedDtmis = $"{dtmi},{expected}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
@@ -213,7 +213,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             foreach (var id in expectedDtmis)
             {
                 Assert.True(result.ContainsKey(id));
-                Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[id]) == id);
+                Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[id]) == id);
             }
         }
 
@@ -222,39 +222,39 @@ namespace Azure.Iot.ModelsRepository.Tests
             const string dtmiDupe1 = "dtmi:azure:DeviceManagement:DeviceInformation;1";
             const string dtmiDupe2 = "dtmi:azure:DeviceManagement:DeviceInformation;1";
 
-            ModelsRepoClient client = GetClient(ModelsRepoTestBase.ClientType.Local);
+            ModelsRepositoryClient client = GetClient(ModelsRepositoryTestBase.ClientType.Local);
             IDictionary<string, string> result = await client.ResolveAsync(new[] { dtmiDupe1, dtmiDupe2 });
             Assert.True(result.Keys.Count == 1);
-            Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[dtmiDupe1]) == dtmiDupe1);
+            Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[dtmiDupe1]) == dtmiDupe1);
         }
 
-        [TestCase(ModelsRepoTestBase.ClientType.Local)]
-        [TestCase(ModelsRepoTestBase.ClientType.Remote)]
-        public async Task ResolveSingleModelWithDepsDisableDependencyResolution(ModelsRepoTestBase.ClientType clientType)
+        [TestCase(ModelsRepositoryTestBase.ClientType.Local)]
+        [TestCase(ModelsRepositoryTestBase.ClientType.Remote)]
+        public async Task ResolveSingleModelWithDepsDisableDependencyResolution(ModelsRepositoryTestBase.ClientType clientType)
         {
             const string dtmi = "dtmi:com:example:Thermostat;1";
 
-            ModelsRepoClientOptions options = new ModelsRepoClientOptions(resolutionOption: DependencyResolutionOption.Disabled);
-            ModelsRepoClient client = GetClient(clientType, options);
+            ModelsRepositoryClientOptions options = new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.Disabled);
+            ModelsRepositoryClient client = GetClient(clientType, options);
 
             IDictionary<string, string> result = await client.ResolveAsync(dtmi);
 
             Assert.True(result.Keys.Count == 1);
             Assert.True(result.ContainsKey(dtmi));
-            Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[dtmi]) == dtmi);
+            Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[dtmi]) == dtmi);
         }
 
-        [TestCase(ModelsRepoTestBase.ClientType.Local)]
-        [TestCase(ModelsRepoTestBase.ClientType.Remote)]
-        public async Task ResolveSingleModelTryFromExpanded(ModelsRepoTestBase.ClientType clientType)
+        [TestCase(ModelsRepositoryTestBase.ClientType.Local)]
+        [TestCase(ModelsRepositoryTestBase.ClientType.Remote)]
+        public async Task ResolveSingleModelTryFromExpanded(ModelsRepositoryTestBase.ClientType clientType)
         {
             const string dtmi = "dtmi:com:example:TemperatureController;1";
             const string expectedDeps = "dtmi:com:example:Thermostat;1,dtmi:azure:DeviceManagement:DeviceInformation;1";
 
             var expectedDtmis = $"{dtmi},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
-            ModelsRepoClientOptions options = new ModelsRepoClientOptions(resolutionOption: DependencyResolutionOption.TryFromExpanded);
-            ModelsRepoClient client = GetClient(clientType, options);
+            ModelsRepositoryClientOptions options = new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.TryFromExpanded);
+            ModelsRepositoryClient client = GetClient(clientType, options);
 
             IDictionary<string, string> result = await client.ResolveAsync(dtmi);
 
@@ -262,7 +262,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             foreach (var id in expectedDtmis)
             {
                 Assert.True(result.ContainsKey(id));
-                Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[id]) == id);
+                Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[id]) == id);
             }
 
             // TODO: Evaluate using Azure.Core.TestFramework in future iteration.
@@ -290,8 +290,8 @@ namespace Azure.Iot.ModelsRepository.Tests
             string[] nonExpandedDtmis = dtmisNonExpanded.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
             string[] totalDtmis = expandedDtmis.Concat(nonExpandedDtmis).ToArray();
 
-            ModelsRepoClientOptions options = new ModelsRepoClientOptions(resolutionOption: DependencyResolutionOption.TryFromExpanded);
-            ModelsRepoClient client = GetClient(ModelsRepoTestBase.ClientType.Local, options);
+            ModelsRepositoryClientOptions options = new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.TryFromExpanded);
+            ModelsRepositoryClient client = GetClient(ModelsRepositoryTestBase.ClientType.Local, options);
 
             // Multi-resolve dtmi:com:example:TemperatureController;1 + dtmi:com:example:ColdStorage;1
             IDictionary<string, string> result = await client.ResolveAsync(new[] { expandedDtmis[0], nonExpandedDtmis[0] });
@@ -300,7 +300,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             foreach (string id in totalDtmis)
             {
                 Assert.True(result.ContainsKey(id));
-                Assert.True(ModelsRepoTestBase.ParseRootDtmiFromJson(result[id]) == id);
+                Assert.True(ModelsRepositoryTestBase.ParseRootDtmiFromJson(result[id]) == id);
             }
 
             // TODO: Evaluate using Azure.Core.TestFramework in future iteration.


### PR DESCRIPTION
In this PR :
- Rename `ModelsRepoClient` to `ModelsRepositoryClient` (along with all related file and class names like options and test base classes that borrowed the name of the client)
- Remove getter and auto property for `ClientOptions` as per Krzysztof's comment
- Bring over Samples project and clean out the parser related pieces
- Rework Exception handling in `RemoteModelFetcher` to include status code and other exception fields from the originally thrown exception.

One outstanding question is regarding the `LocalModelFetcher` exception handling. When `LocalModelFetcher` throws a `RequestFailedException` there is no outgoing HTTP call and as a result there is no status code attached to the `RequestFailedException` which in my opinion is the correct behavior as there is no HTTP stack involved. on the other hand, the consumer might be relying on the status code. we have to have a brief discussion about that.