### PR TITLE
Add alternative code paths depending on parameters

### DIFF
--- a/sdk/mediaservices/ci.yml
+++ b/sdk/mediaservices/ci.yml
@@ -4,7 +4,7 @@ trigger:
   branches:
     include:
       - master
-    - main
+      - main
       - hotfix/*
       - release/*
   paths:
@@ -15,7 +15,7 @@ pr:
   branches:
     include:
       - master
-    - main
+      - main
       - feature/*
       - hotfix/*
       - release/*


### PR DESCRIPTION
Add alternative code paths depending on parameters which allows for coming changes to common tools.
This change is solely intended to prevent breaking the build while making changes to common across various repos.

Sample Release Build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=756200&view=results