### PR TITLE
[storage] Replaced operationName value from Default to the respective operation

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -2363,7 +2363,7 @@ namespace Azure.Storage.Blobs.Specialized
                     conditions: options?.OpenConditions,
                     accessTier: default,
                     progressHandler: default,
-                    operationName: default,
+                    operationName: $"{nameof(BlockBlobClient)}.{nameof(OpenWrite)}",
                     async: async,
                     cancellationToken: cancellationToken)
                     .ConfigureAwait(false);

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -4415,7 +4415,7 @@ namespace Azure.Storage.Files.Shares
                 options?.Snapshot,
                 previousSnapshot: default,
                 options?.Conditions,
-                operationName: default,
+                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",
                 async: false,
                 cancellationToken)
                 .EnsureCompleted();
@@ -4450,7 +4450,7 @@ namespace Azure.Storage.Files.Shares
                 options?.Snapshot,
                 previousSnapshot: default,
                 options?.Conditions,
-                operationName: default,
+                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",,
                 async: true,
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -4492,7 +4492,7 @@ namespace Azure.Storage.Files.Shares
                 snapshot: default,
                 previousSnapshot: default,
                 conditions,
-                operationName: default,
+                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",
                 async: false,
                 cancellationToken)
                 .EnsureCompleted();
@@ -4531,7 +4531,7 @@ namespace Azure.Storage.Files.Shares
                 snapshot: default,
                 previousSnapshot: default,
                 conditions: default,
-                operationName: default,
+                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",
                 async: false,
                 cancellationToken)
                 .EnsureCompleted();
@@ -4573,7 +4573,7 @@ namespace Azure.Storage.Files.Shares
                 snapshot: default,
                 previousSnapshot: default,
                 conditions,
-                operationName: default,
+                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",
                 async: true,
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -4612,7 +4612,7 @@ namespace Azure.Storage.Files.Shares
                 snapshot: default,
                 previousSnapshot: default,
                 conditions: default,
-                operationName: default,
+                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",
                 async: true,
                 cancellationToken)
                 .ConfigureAwait(false);

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -4415,7 +4415,7 @@ namespace Azure.Storage.Files.Shares
                 options?.Snapshot,
                 previousSnapshot: default,
                 options?.Conditions,
-                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",
+                operationName: default,
                 async: false,
                 cancellationToken)
                 .EnsureCompleted();
@@ -4450,7 +4450,7 @@ namespace Azure.Storage.Files.Shares
                 options?.Snapshot,
                 previousSnapshot: default,
                 options?.Conditions,
-                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",,
+                operationName: default,
                 async: true,
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -4492,7 +4492,7 @@ namespace Azure.Storage.Files.Shares
                 snapshot: default,
                 previousSnapshot: default,
                 conditions,
-                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",
+                operationName: default,
                 async: false,
                 cancellationToken)
                 .EnsureCompleted();
@@ -4531,7 +4531,7 @@ namespace Azure.Storage.Files.Shares
                 snapshot: default,
                 previousSnapshot: default,
                 conditions: default,
-                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",
+                operationName: default,
                 async: false,
                 cancellationToken)
                 .EnsureCompleted();
@@ -4573,7 +4573,7 @@ namespace Azure.Storage.Files.Shares
                 snapshot: default,
                 previousSnapshot: default,
                 conditions,
-                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",
+                operationName: default,
                 async: true,
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -4612,7 +4612,7 @@ namespace Azure.Storage.Files.Shares
                 snapshot: default,
                 previousSnapshot: default,
                 conditions: default,
-                operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}",
+                operationName: default,
                 async: true,
                 cancellationToken)
                 .ConfigureAwait(false);


### PR DESCRIPTION
# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
