### PR TITLE
(ADT: Docs): Fix asterisks in generated docs

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Azure.DigitalTwins.Core.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Azure.DigitalTwins.Core.csproj
@@ -5,8 +5,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
-    <NoWarn>$(NoWarn);CA1812</NoWarn>
   </PropertyGroup>
 
   <!-- Nuget properties -->

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceDigitalTwinOptions.cs
@@ -13,9 +13,9 @@ namespace Azure.DigitalTwins.Core
         /// <summary>
         /// If-None-Match header that makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource.
         /// For more information about this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC</see>.
-        /// Acceptable values are null or "*".
+        /// Acceptable values are null or <see langword="*" />.
         /// If IfNonMatch option is null the service will replace the existing entity with the new entity.
-        /// If IfNonMatch option is "*" the service will reject the request if the entity already exists.
+        /// If IfNonMatch option is <see langword="*" /> the service will reject the request if the entity already exists.
         /// </summary>
         [CodeGenMember("IfNoneMatch")]
         public string IfNoneMatch { get; set; }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceDigitalTwinOptions.cs
@@ -13,9 +13,9 @@ namespace Azure.DigitalTwins.Core
         /// <summary>
         /// If-None-Match header that makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource.
         /// For more information about this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC</see>.
-        /// Acceptable values are null or <see langword="*" />.
+        /// Acceptable values are null or <c>"*"</c>.
         /// If IfNonMatch option is null the service will replace the existing entity with the new entity.
-        /// If IfNonMatch option is <see langword="*" /> the service will reject the request if the entity already exists.
+        /// If IfNonMatch option is <c>"*"</c> the service will reject the request if the entity already exists.
         /// </summary>
         [CodeGenMember("IfNoneMatch")]
         public string IfNoneMatch { get; set; }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceRelationshipOptions.cs
@@ -13,9 +13,9 @@ namespace Azure.DigitalTwins.Core
         /// <summary>
         /// If-Non-Match header that makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource.
         /// For more information about this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC</see>.
-        /// Acceptable values are null or <see langword="*" />.
+        /// Acceptable values are null or <c>"*"</c>.
         /// If IfNonMatch option is null the service will replace the existing entity with the new entity.
-        /// If IfNonMatch option is <see langword="*" /> the service will reject the request if the entity already exists.
+        /// If IfNonMatch option is <c>"*"</c> the service will reject the request if the entity already exists.
         /// </summary>
         [CodeGenMember("IfNoneMatch")]
         public string IfNoneMatch { get; set; }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceRelationshipOptions.cs
@@ -13,9 +13,9 @@ namespace Azure.DigitalTwins.Core
         /// <summary>
         /// If-Non-Match header that makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource.
         /// For more information about this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC</see>.
-        /// Acceptable values are null or "*".
+        /// Acceptable values are null or <see langword="*" />.
         /// If IfNonMatch option is null the service will replace the existing entity with the new entity.
-        /// If IfNonMatch option is "*" the service will reject the request if the entity already exists.
+        /// If IfNonMatch option is <see langword="*" /> the service will reject the request if the entity already exists.
         /// </summary>
         [CodeGenMember("IfNoneMatch")]
         public string IfNoneMatch { get; set; }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -226,7 +226,7 @@ namespace Azure.DigitalTwins.Core
 
         /// <summary>
         /// Creates a digital twin asynchronously. If the provided digital twin Id is already in use, then this will attempt to replace the existing digital twin
-        /// with the provided digital twin.
+        /// with the provided digital twin..
         /// </summary>
         /// <param name="digitalTwinId">The Id of the digital twin.</param>
         /// <param name="digitalTwin">The application/json digital twin to create.</param>
@@ -235,9 +235,9 @@ namespace Azure.DigitalTwins.Core
         /// recipient cache or origin server either not having any current
         /// representation of the target resource.  For more information about
         /// this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC 7232</see>.
-        /// Acceptable values are null or <see langword="*" />.  If ifNonMatch option is null
+        /// Acceptable values are null or <c>"*"</c>.  If ifNonMatch option is null
         /// the service will replace the existing entity with the new entity.
-        /// If ifNoneMatch option is <see langword="*" /> (or <see cref="ETag.All"/>) the
+        /// If ifNoneMatch option is <c>"*"</c> (or <see cref="ETag.All"/>) the
         /// service will reject the request if the entity already exists.
         /// An optional ETag to only make the request if the value does not
         /// match on the service.
@@ -321,9 +321,9 @@ namespace Azure.DigitalTwins.Core
         /// recipient cache or origin server either not having any current
         /// representation of the target resource.  For more information about
         /// this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC 7232</see>.
-        /// Acceptable values are null or <see langword="*" />.  If ifNonMatch option is null
+        /// Acceptable values are null or <c>"*"</c>.  If ifNonMatch option is null
         /// the service will replace the existing entity with the new entity.
-        /// If ifNoneMatch option is <see langword="*" /> (or <see cref="ETag.All"/>) the
+        /// If ifNoneMatch option is <c>"*"</c> (or <see cref="ETag.All"/>) the
         /// service will reject the request if the entity already exists.
         /// An optional ETag to only make the request if the value does not
         /// match on the service.
@@ -1261,9 +1261,9 @@ namespace Azure.DigitalTwins.Core
         /// recipient cache or origin server either not having any current
         /// representation of the target resource.  For more information about
         /// this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC 7232</see>.
-        /// Acceptable values are null or <see langword="*" />.  If ifNonMatch option is null
+        /// Acceptable values are null or <c>"*"</c>.  If ifNonMatch option is null
         /// the service will replace the existing entity with the new entity.
-        /// If ifNoneMatch option is <see langword="*" /> (or <see cref="ETag.All"/>) the
+        /// If ifNoneMatch option is <c>"*"</c> (or <see cref="ETag.All"/>) the
         /// service will reject the request if the entity already exists.
         /// An optional ETag to only make the request if the value does not
         /// match on the service.
@@ -1354,9 +1354,9 @@ namespace Azure.DigitalTwins.Core
         /// recipient cache or origin server either not having any current
         /// representation of the target resource.  For more information about
         /// this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC 7232</see>.
-        /// Acceptable values are null or <see langword="*" />.  If ifNonMatch option is null
+        /// Acceptable values are null or <c>"*"</c>.  If ifNonMatch option is null
         /// the service will replace the existing entity with the new entity.
-        /// If ifNoneMatch option is <see langword="*" /> (or <see cref="ETag.All"/>) the
+        /// If ifNoneMatch option is <c>"*"</c> (or <see cref="ETag.All"/>) the
         /// service will reject the request if the entity already exists.
         /// An optional ETag to only make the request if the value does not
         /// match on the service.

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -235,9 +235,9 @@ namespace Azure.DigitalTwins.Core
         /// recipient cache or origin server either not having any current
         /// representation of the target resource.  For more information about
         /// this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC 7232</see>.
-        /// Acceptable values are null or "*".  If ifNonMatch option is null
+        /// Acceptable values are null or <see langword="*" />.  If ifNonMatch option is null
         /// the service will replace the existing entity with the new entity.
-        /// If ifNoneMatch option is "*" (or <see cref="ETag.All"/>) the
+        /// If ifNoneMatch option is <see langword="*" /> (or <see cref="ETag.All"/>) the
         /// service will reject the request if the entity already exists.
         /// An optional ETag to only make the request if the value does not
         /// match on the service.
@@ -321,9 +321,9 @@ namespace Azure.DigitalTwins.Core
         /// recipient cache or origin server either not having any current
         /// representation of the target resource.  For more information about
         /// this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC 7232</see>.
-        /// Acceptable values are null or "*".  If ifNonMatch option is null
+        /// Acceptable values are null or <see langword="*" />.  If ifNonMatch option is null
         /// the service will replace the existing entity with the new entity.
-        /// If ifNoneMatch option is "*" (or <see cref="ETag.All"/>) the
+        /// If ifNoneMatch option is <see langword="*" /> (or <see cref="ETag.All"/>) the
         /// service will reject the request if the entity already exists.
         /// An optional ETag to only make the request if the value does not
         /// match on the service.
@@ -1261,9 +1261,9 @@ namespace Azure.DigitalTwins.Core
         /// recipient cache or origin server either not having any current
         /// representation of the target resource.  For more information about
         /// this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC 7232</see>.
-        /// Acceptable values are null or "*".  If ifNonMatch option is null
+        /// Acceptable values are null or <see langword="*" />.  If ifNonMatch option is null
         /// the service will replace the existing entity with the new entity.
-        /// If ifNoneMatch option is "*" (or <see cref="ETag.All"/>) the
+        /// If ifNoneMatch option is <see langword="*" /> (or <see cref="ETag.All"/>) the
         /// service will reject the request if the entity already exists.
         /// An optional ETag to only make the request if the value does not
         /// match on the service.
@@ -1354,9 +1354,9 @@ namespace Azure.DigitalTwins.Core
         /// recipient cache or origin server either not having any current
         /// representation of the target resource.  For more information about
         /// this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC 7232</see>.
-        /// Acceptable values are null or "*".  If ifNonMatch option is null
+        /// Acceptable values are null or <see langword="*" />.  If ifNonMatch option is null
         /// the service will replace the existing entity with the new entity.
-        /// If ifNoneMatch option is "*" (or <see cref="ETag.All"/>) the
+        /// If ifNoneMatch option is <see langword="*" /> (or <see cref="ETag.All"/>) the
         /// service will reject the request if the entity already exists.
         /// An optional ETag to only make the request if the value does not
         /// match on the service.


### PR DESCRIPTION
I just noticed that our documentation is a bit malformed. and asterisks are showing as empty strings.
https://docs.microsoft.com/en-us/dotnet/api/azure.digitaltwins.core.digitaltwinsclient.createorreplacedigitaltwinasync?view=azure-dotnet

Based on the recommendation from the docs team, we have 3 different options:

- Use `<see langword="*" />` tag
- Use `<c>"*"</c>` tag 
- Escape the character `"\*"` 

I chose the first option as it looks more inline with how we already reference types in our docs, but open to any suggestions and preferences. 