### PR TITLE
[Messaging Clients] Retry Authorization Failures

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/BasicRetryPolicy.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/BasicRetryPolicy.cs
@@ -155,6 +155,7 @@ namespace Azure.Messaging.EventHubs.Core
 
                 case TimeoutException _:
                 case SocketException _:
+                case UnauthorizedAccessException _:
                     return true;
 
                 default:

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/BasicRetryPolicy.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/BasicRetryPolicy.cs
@@ -116,7 +116,8 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         private static bool ShouldRetryException(Exception exception)
         {
-            // There's there's an ambient transaction - should not retry
+            // There's an ambient transaction - should not retry
+
             if (Transaction.Current != null)
             {
                 return false;
@@ -141,6 +142,7 @@ namespace Azure.Messaging.ServiceBus.Core
 
                 case TimeoutException _:
                 case SocketException _:
+                case UnauthorizedAccessException _:
                     return true;
 
                 default:


### PR DESCRIPTION
# Summary

The focus of these changes is to mark the `UnauthorizedAccessException` type as retriable, which had previously been treated as a terminal condition.  Because the messaging services do not differentiate between authentication and authorization, callers cannot reason about whether an `Unauthorized` return from a service operation indicates that the call will never succeed or may trigger a credential renewal that may succeed.

Treating `UnauthorizedAccessException` as terminal also opens a race condition when a credential has expired due to a transient failure acquiring un updated token.  In this case, if the service has force-closed the AMQP link before the client attempts an operation, it is likely to succeed because the act of opening a new link will also acquire a new token.  However, if the link has not yet been force-closed, the client operation will use the expired credential and encounter an authorization failure.  Retrying will allow a consistent experience, as a new credential would be requested when retrying.

This scenario also impacts `TokenCredential` use when the underlying credential has been revoked and a new one issued.  The client will not be aware of the update and will continue to use the revoked credential until the expiration has passed, resulting in an `UnauthorizedAccessException`.  Retrying will allow a new credential to be requested when reestablishing the AMQP link.

# Last Upstream Rebase

Thursday, February 25, 3:00pm (EST)