### PR TITLE
Incremental improvements for non-released ModelsRepository client.

### DIFF
--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelResolutionSamples.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelResolutionSamples.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Azure.Iot.ModelsRepository.Samples
+{
+    internal class ModelResolutionSamples
+    {
+        private static string ClientSamplesDirectoryPath => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        private static string ClientSamplesLocalModelsRepository => Path.Combine(ClientSamplesDirectoryPath, "SampleModelsRepo");
+
+        public static void ClientInitialization()
+        {
+            // When no Uri is provided for instantiation. The global Azure IoT Models Repository endpoint is used
+            // and the dependency model resolution option is set to TryFromExpanded.
+            var globalRepoClient = new ModelsRepositoryClient();
+            Console.WriteLine($"Initialized client pointing to global endpoint: {globalRepoClient.RepositoryUri}");
+
+            // This form shows specifing a custom Uri for the models repository with default client options.
+            // The default client options will enable model dependency resolution.
+            var remoteRepoEndpoint = "https://contoso.com/models";
+            var remoteRepoClient = new ModelsRepositoryClient(new Uri(remoteRepoEndpoint));
+            Console.WriteLine($"Initialized client pointing to custom endpoint: {remoteRepoClient.RepositoryUri}");
+
+            // The client will also work with a local filesystem Uri. This example shows initalization
+            // with a local Uri and disabling model dependency resolution.
+            var localRepoPath = ClientSamplesLocalModelsRepository;
+            var localRepoClient = new ModelsRepositoryClient(
+                new Uri(localRepoPath),
+                new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.Disabled));
+            Console.WriteLine($"Initialized client pointing to local path: {localRepoClient.RepositoryUri}");
+        }
+
+        public static async Task ResolveExistingModelsFromEndpointAsync()
+        {
+            var dtmi = "dtmi:com:example:TemperatureController;1";
+
+            // Global endpoint client
+            var client = new ModelsRepositoryClient();
+
+            // The output of ResolveAsync() will include at least the definition for the target dtmi.
+            // If the dependency model resolution option is not disabled, then models in which the
+            // target dtmi depends on will also be included in the returned IDictionary<string, string>.
+            IDictionary<string, string> models = await client.ResolveAsync(dtmi).ConfigureAwait(false);
+
+            // In this case the above dtmi has 2 model dependencies.
+            // dtmi:com:example:Thermostat;1 and dtmi:azure:DeviceManagement:DeviceInformation;1
+            Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
+        }
+
+        public static async Task ResolveExistingModelsFromLocalAsync()
+        {
+            var dtmi = "dtmi:com:example:TemperatureController;1";
+
+            // Local sample repository client
+            var client = new ModelsRepositoryClient(new Uri(ClientSamplesLocalModelsRepository));
+
+            // The output of ResolveAsync() will include at least the definition for the target dtmi.
+            // If the dependency model resolution option is not disabled, then models in which the
+            // target dtmi depends on will also be included in the returned IDictionary<string, string>.
+            IDictionary<string, string> models = await client.ResolveAsync(dtmi).ConfigureAwait(false);
+
+            // In this case the above dtmi has 2 model dependencies.
+            // dtmi:com:example:Thermostat;1 and dtmi:azure:DeviceManagement:DeviceInformation;1
+            Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
+        }
+
+        public static async Task TryResolveFromEndpointButNotFoundAsync()
+        {
+            var dtmi = "dtmi:com:example:NotFound;1";
+            var client = new ModelsRepositoryClient();
+
+            try
+            {
+                IDictionary<string, string> models = await client.ResolveAsync(dtmi).ConfigureAwait(false);
+                Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
+            }
+            catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
+            {
+                Console.WriteLine($"{dtmi} was not found in the default public models repository: {ex.Message}");
+            }
+        }
+
+        public static async Task TryResolveFromLocalButNotFoundAsync()
+        {
+            var dtmi = "dtmi:com:example:NotFound;1";
+            var client = new ModelsRepositoryClient(new Uri(ClientSamplesLocalModelsRepository));
+
+            try
+            {
+                IDictionary<string, string> models = await client.ResolveAsync(dtmi).ConfigureAwait(false);
+                Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
+            }
+            catch (RequestFailedException ex) when (ex.InnerException is FileNotFoundException)
+            {
+                Console.WriteLine($"{dtmi} was not found in the default public models repository: {ex.Message}");
+            }
+        }
+
+        public static async Task TryResolveWithInvalidDtmi()
+        {
+            var invalidDtmi = "dtmi:com:example:InvalidDtmi";
+
+            // Model resolution will fail with invalid dtmis
+            var client = new ModelsRepositoryClient();
+            try
+            {
+                await client.ResolveAsync(invalidDtmi);
+            }
+            catch (ArgumentException ex)
+            {
+                // Invalid DTMI format "dtmi:com:example:InvalidDtmi".
+                Console.WriteLine(ex);
+            }
+        }
+    }
+}

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelResolutionSamples.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelResolutionSamples.cs
@@ -19,25 +19,23 @@ namespace Azure.Iot.ModelsRepository.Samples
         {
             // When no Uri is provided for instantiation. The global Azure IoT Models Repository endpoint is used
             // and the dependency model resolution option is set to TryFromExpanded.
-            var globalRepoClient = new ModelsRepositoryClient();
-            Console.WriteLine($"Initialized client pointing to global endpoint: {globalRepoClient.RepositoryUri}");
+            var client = new ModelsRepositoryClient();
+            Console.WriteLine($"Initialized client pointing to global endpoint: {client.RepositoryUri}");
 
             // This form shows specifing a custom Uri for the models repository with default client options.
             // The default client options will enable model dependency resolution.
-            var remoteRepoEndpoint = "https://contoso.com/models";
-            var remoteRepoClient = new ModelsRepositoryClient(new Uri(remoteRepoEndpoint));
-            Console.WriteLine($"Initialized client pointing to custom endpoint: {remoteRepoClient.RepositoryUri}");
+            const string remoteRepoEndpoint = "https://contoso.com/models";
+            client = new ModelsRepositoryClient(new Uri(remoteRepoEndpoint));
+            Console.WriteLine($"Initialized client pointing to custom endpoint: {client.RepositoryUri}");
 
             // The client will also work with a local filesystem Uri. This example shows initalization
             // with a local Uri and disabling model dependency resolution.
-            var localRepoPath = ClientSamplesLocalModelsRepository;
-            var localRepoClient = new ModelsRepositoryClient(
-                new Uri(localRepoPath),
+            client = new ModelsRepositoryClient(new Uri(ClientSamplesLocalModelsRepository),
                 new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.Disabled));
-            Console.WriteLine($"Initialized client pointing to local path: {localRepoClient.RepositoryUri}");
+            Console.WriteLine($"Initialized client pointing to local path: {client.RepositoryUri}");
         }
 
-        public static async Task ResolveExistingModelsFromEndpointAsync()
+        public static async Task ResolveExistingModelsFromGlobalRepoAsync()
         {
             var dtmi = "dtmi:com:example:TemperatureController;1";
 
@@ -54,7 +52,7 @@ namespace Azure.Iot.ModelsRepository.Samples
             Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
         }
 
-        public static async Task ResolveExistingModelsFromLocalAsync()
+        public static async Task ResolveExistingModelsFromLocalRepoAsync()
         {
             var dtmi = "dtmi:com:example:TemperatureController;1";
 
@@ -71,7 +69,7 @@ namespace Azure.Iot.ModelsRepository.Samples
             Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
         }
 
-        public static async Task TryResolveFromEndpointButNotFoundAsync()
+        public static async Task TryResolveFromGlobalRepoButNotFoundAsync()
         {
             var dtmi = "dtmi:com:example:NotFound;1";
             var client = new ModelsRepositoryClient();
@@ -87,7 +85,7 @@ namespace Azure.Iot.ModelsRepository.Samples
             }
         }
 
-        public static async Task TryResolveFromLocalButNotFoundAsync()
+        public static async Task TryResolveFromLocalRepoButNotFoundAsync()
         {
             var dtmi = "dtmi:com:example:NotFound;1";
             var client = new ModelsRepositoryClient(new Uri(ClientSamplesLocalModelsRepository));

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelsRepositoryClientExtensions.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelsRepositoryClientExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.DigitalTwins.Parser;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Azure.Iot.ModelsRepository.Samples
+{
+    internal static class ModelsRepositoryClientExtensions
+    {
+        /// <summary>
+        /// The ParserDtmiResolver extension illustrates the simplicity of
+        /// integrating the ModelsRepositoryClient with the Digital Twins Parser.
+        /// See ParserIntegrationSamples.cs for example usage.
+        /// </summary>
+        public static async Task<IEnumerable<string>> ParserDtmiResolver(this ModelsRepositoryClient client, IReadOnlyCollection<Dtmi> dtmis)
+        {
+            IEnumerable<string> dtmiStrings = dtmis.Select(s => s.AbsoluteUri);
+            IDictionary<string, string> result = await client.ResolveAsync(dtmiStrings);
+            return result.Values.ToList();
+        }
+    }
+}

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelsRepositoryClientSamples.csproj
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelsRepositoryClientSamples.csproj
@@ -10,6 +10,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.5" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Azure.Iot.ModelsRepository.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="SampleModelsRepo\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ParserIntegrationSamples.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ParserIntegrationSamples.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.DigitalTwins.Parser;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace Azure.Iot.ModelsRepository.Samples
+{
+    internal class ParserIntegrationSamples
+    {
+        public static async Task ResolveAndParseAsync()
+        {
+            var dtmi = "dtmi:com:example:TemperatureController;1";
+            var client = new ModelsRepositoryClient();
+            IDictionary<string, string> models = await client.ResolveAsync(dtmi).ConfigureAwait(false);
+            var parser = new ModelParser();
+            IReadOnlyDictionary<Dtmi, DTEntityInfo> parseResult = await parser.ParseAsync(models.Values.ToArray());
+            Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces with {parseResult.Count} entities.");
+        }
+
+        public static async Task ParseAndResolveAsync()
+        {
+            var dtmi = "dtmi:com:example:TemperatureController;1";
+            var client = new ModelsRepositoryClient(new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.Disabled));
+            IDictionary<string, string> models = await client.ResolveAsync(dtmi).ConfigureAwait(false);
+            var parser = new ModelParser
+            {
+                // Usage of the ModelsRepositoryClientExtensions.ParserDtmiResolver extension.
+                DtmiResolver = client.ParserDtmiResolver
+            };
+            IReadOnlyDictionary<Dtmi, DTEntityInfo> parseResult = await parser.ParseAsync(models.Values.Take(1).ToArray());
+            Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces with {parseResult.Count} entities.");
+        }
+    }
+}

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
@@ -3,9 +3,7 @@
 
 using Azure.Core.Diagnostics;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.Tracing;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace Azure.Iot.ModelsRepository.Samples
@@ -20,34 +18,19 @@ namespace Azure.Iot.ModelsRepository.Samples
                     Console.WriteLine("[{0:HH:mm:ss:fff}][{1}] {2}", DateTimeOffset.Now, e.Level, message),
                 level: EventLevel.Verbose);
 
-            await ResolveExistingAsync();
-            await TryResolveButNotFoundAsync();
-        }
+            // Client init samples
+            ModelResolutionSamples.ClientInitialization();
 
-        private static async Task ResolveExistingAsync()
-        {
-            var dtmi = "dtmi:com:example:TemperatureController;1";
-            var client = new ModelsRepositoryClient();
+            // Model Resolution samples
+            await ModelResolutionSamples.ResolveExistingModelsFromEndpointAsync();
+            await ModelResolutionSamples.ResolveExistingModelsFromLocalAsync();
+            await ModelResolutionSamples.TryResolveFromEndpointButNotFoundAsync();
+            await ModelResolutionSamples.TryResolveFromLocalButNotFoundAsync();
+            await ModelResolutionSamples.TryResolveWithInvalidDtmi();
 
-            IDictionary<string, string> models = await client.ResolveAsync(dtmi).ConfigureAwait(false);
-
-            Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
-        }
-
-        private static async Task TryResolveButNotFoundAsync()
-        {
-            var dtmi = "dtmi:com:example:NotFound;1";
-            var client = new ModelsRepositoryClient();
-
-            try
-            {
-                IDictionary<string, string> models = await client.ResolveAsync(dtmi).ConfigureAwait(false);
-                Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces.");
-            }
-            catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
-            {
-                Console.WriteLine($"{dtmi} was not found in the default public models repository: {ex.Message}");
-            }
+            // Parser integration samples
+            await ParserIntegrationSamples.ParseAndResolveAsync();
+            await ParserIntegrationSamples.ResolveAndParseAsync();
         }
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
@@ -22,10 +22,10 @@ namespace Azure.Iot.ModelsRepository.Samples
             ModelResolutionSamples.ClientInitialization();
 
             // Model Resolution samples
-            await ModelResolutionSamples.ResolveExistingModelsFromEndpointAsync();
-            await ModelResolutionSamples.ResolveExistingModelsFromLocalAsync();
-            await ModelResolutionSamples.TryResolveFromEndpointButNotFoundAsync();
-            await ModelResolutionSamples.TryResolveFromLocalButNotFoundAsync();
+            await ModelResolutionSamples.ResolveExistingModelsFromGlobalRepoAsync();
+            await ModelResolutionSamples.ResolveExistingModelsFromLocalRepoAsync();
+            await ModelResolutionSamples.TryResolveFromGlobalRepoButNotFoundAsync();
+            await ModelResolutionSamples.TryResolveFromLocalRepoButNotFoundAsync();
             await ModelResolutionSamples.TryResolveWithInvalidDtmi();
 
             // Parser integration samples

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/SampleModelsRepo/dtmi/azure/devicemanagement/deviceinformation-1.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/SampleModelsRepo/dtmi/azure/devicemanagement/deviceinformation-1.json
@@ -1,0 +1,64 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:azure:DeviceManagement:DeviceInformation;1",
+  "@type": "Interface",
+  "displayName": "Device Information",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "manufacturer",
+      "displayName": "Manufacturer",
+      "schema": "string",
+      "description": "Company name of the device manufacturer. This could be the same as the name of the original equipment manufacturer (OEM). Ex. Contoso."
+    },
+    {
+      "@type": "Property",
+      "name": "model",
+      "displayName": "Device model",
+      "schema": "string",
+      "description": "Device model name or ID. Ex. Surface Book 2."
+    },
+    {
+      "@type": "Property",
+      "name": "swVersion",
+      "displayName": "Software version",
+      "schema": "string",
+      "description": "Version of the software on your device. This could be the version of your firmware. Ex. 1.3.45"
+    },
+    {
+      "@type": "Property",
+      "name": "osName",
+      "displayName": "Operating system name",
+      "schema": "string",
+      "description": "Name of the operating system on the device. Ex. Windows 10 IoT Core."
+    },
+    {
+      "@type": "Property",
+      "name": "processorArchitecture",
+      "displayName": "Processor architecture",
+      "schema": "string",
+      "description": "Architecture of the processor on the device. Ex. x64 or ARM."
+    },
+    {
+      "@type": "Property",
+      "name": "processorManufacturer",
+      "displayName": "Processor manufacturer",
+      "schema": "string",
+      "description": "Name of the manufacturer of the processor on the device. Ex. Intel."
+    },
+    {
+      "@type": "Property",
+      "name": "totalStorage",
+      "displayName": "Total storage",
+      "schema": "double",
+      "description": "Total available storage on the device in kilobytes. Ex. 2048000 kilobytes."
+    },
+    {
+      "@type": "Property",
+      "name": "totalMemory",
+      "displayName": "Total memory",
+      "schema": "double",
+      "description": "Total available memory on the device in kilobytes. Ex. 256000 kilobytes."
+    }
+  ]
+}

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/SampleModelsRepo/dtmi/com/example/temperaturecontroller-1.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/SampleModelsRepo/dtmi/com/example/temperaturecontroller-1.json
@@ -1,0 +1,60 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:example:TemperatureController;1",
+  "@type": "Interface",
+  "displayName": "Temperature Controller",
+  "description": "Device with two thermostats and remote reboot.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "DataSize"
+      ],
+      "name": "workingSet",
+      "displayName": "Working Set",
+      "description": "Current working set of the device memory in KiB.",
+      "schema": "double",
+      "unit": "kibibyte"
+    },
+    {
+      "@type": "Property",
+      "name": "serialNumber",
+      "displayName": "Serial Number",
+      "description": "Serial number of the device.",
+      "schema": "string"
+    },
+    {
+      "@type": "Command",
+      "name": "reboot",
+      "displayName": "Reboot",
+      "description": "Reboots the device after waiting the number of seconds specified.",
+      "request": {
+        "name": "delay",
+        "displayName": "Delay",
+        "description": "Number of seconds to wait before rebooting the device.",
+        "schema": "integer"
+      }
+    },
+    {
+      "@type": "Component",
+      "schema": "dtmi:com:example:Thermostat;1",
+      "name": "thermostat1",
+      "displayName": "Thermostat One",
+      "description": "Thermostat One of Two."
+    },
+    {
+      "@type": "Component",
+      "schema": "dtmi:com:example:Thermostat;1",
+      "name": "thermostat2",
+      "displayName": "Thermostat Two",
+      "description": "Thermostat Two of Two."
+    },
+    {
+      "@type": "Component",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1",
+      "name": "deviceInformation",
+      "displayName": "Device Information interface",
+      "description": "Optional interface with basic device hardware information."
+    }
+  ]
+}

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/SampleModelsRepo/dtmi/com/example/thermostat-1.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/SampleModelsRepo/dtmi/com/example/thermostat-1.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:example:Thermostat;1",
+  "@type": "Interface",
+  "displayName": "Thermostat",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "temp",
+      "schema": "double"
+    },
+    {
+      "@type": "Property",
+      "name": "setPointTemp",
+      "writable": true,
+      "schema": "double"
+    }
+  ],
+  "@context": "dtmi:dtdl:context;2"
+}

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/DependencyResolutionOption.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/DependencyResolutionOption.cs
@@ -4,22 +4,23 @@
 namespace Azure.Iot.ModelsRepository
 {
     /// <summary>
-    /// The dependency processing options.
+    /// The model dependency resolution options.
     /// </summary>
     public enum DependencyResolutionOption
     {
         /// <summary>
-        /// Do not process external dependencies.
+        /// Disable model dependency resolution.
         /// </summary>
         Disabled,
 
         /// <summary>
-        /// Enable external dependencies.
+        /// Enable model dependency resolution.
         /// </summary>
         Enabled,
 
         /// <summary>
-        /// Try to get external dependencies using .expanded.json.
+        /// Try to get pre-computed model dependencies using .expanded.json.
+        /// If the model expanded form does not exist fall back to normal dependency processing.
         /// </summary>
         TryFromExpanded
     }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/DependencyResolutionOption.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/DependencyResolutionOption.cs
@@ -9,6 +9,12 @@ namespace Azure.Iot.ModelsRepository
     public enum DependencyResolutionOption
     {
         /// <summary>
+        /// Try to get pre-computed model dependencies using .expanded.json.
+        /// If the model expanded form does not exist fall back to normal dependency processing.
+        /// </summary>
+        TryFromExpanded,
+
+        /// <summary>
         /// Disable model dependency resolution.
         /// </summary>
         Disabled,
@@ -17,11 +23,5 @@ namespace Azure.Iot.ModelsRepository
         /// Enable model dependency resolution.
         /// </summary>
         Enabled,
-
-        /// <summary>
-        /// Try to get pre-computed model dependencies using .expanded.json.
-        /// If the model expanded form does not exist fall back to normal dependency processing.
-        /// </summary>
-        TryFromExpanded
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/DtmiConventions.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/DtmiConventions.cs
@@ -45,8 +45,8 @@ namespace Azure.Iot.ModelsRepository
             if (fromExpanded)
             {
                 fullyQualifiedPath = fullyQualifiedPath.Replace(
-                    ModelRepositoryConstants.JsonFileExtension,
-                    ModelRepositoryConstants.ExpandedJsonFileExtension);
+                    ModelsRepositoryConstants.JsonFileExtension,
+                    ModelsRepositoryConstants.ExpandedJsonFileExtension);
             }
 
             return fullyQualifiedPath;

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/FetchResult.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/FetchResult.cs
@@ -15,7 +15,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
         public string Path { get; set; }
 
         public bool FromExpanded => Path.EndsWith(
-            ModelRepositoryConstants.ExpandedJsonFileExtension,
+            ModelsRepositoryConstants.ExpandedJsonFileExtension,
             System.StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelQuery.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelQuery.cs
@@ -43,7 +43,7 @@ namespace Azure.Iot.ModelsRepository
 
         private static string ParseRootDtmi(JsonElement root)
         {
-            if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty(ModelRepositoryConstants.ModelProperties.Dtmi, out JsonElement id))
+            if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty(ModelsRepositoryConstants.ModelProperties.Dtmi, out JsonElement id))
             {
                 if (id.ValueKind == JsonValueKind.String)
                 {
@@ -63,7 +63,7 @@ namespace Azure.Iot.ModelsRepository
                 return dependencies;
             }
 
-            if (!root.TryGetProperty(ModelRepositoryConstants.ModelProperties.Extends, out JsonElement extends))
+            if (!root.TryGetProperty(ModelsRepositoryConstants.ModelProperties.Extends, out JsonElement extends))
             {
                 return dependencies;
             }
@@ -106,7 +106,7 @@ namespace Azure.Iot.ModelsRepository
                 return dependencies;
             }
 
-            if (!root.TryGetProperty(ModelRepositoryConstants.ModelProperties.Contents, out JsonElement contents))
+            if (!root.TryGetProperty(ModelsRepositoryConstants.ModelProperties.Contents, out JsonElement contents))
             {
                 return dependencies;
             }
@@ -133,7 +133,7 @@ namespace Azure.Iot.ModelsRepository
 
             var dependencies = new List<string>();
 
-            if (!root.TryGetProperty(ModelRepositoryConstants.ModelProperties.Schema, out JsonElement componentSchema))
+            if (!root.TryGetProperty(ModelsRepositoryConstants.ModelProperties.Schema, out JsonElement componentSchema))
             {
                 return dependencies;
             }
@@ -169,17 +169,17 @@ namespace Azure.Iot.ModelsRepository
         private static bool IsInterfaceObject(JsonElement root)
         {
             return root.ValueKind == JsonValueKind.Object &&
-                root.TryGetProperty(ModelRepositoryConstants.ModelProperties.Type, out JsonElement objectType) &&
+                root.TryGetProperty(ModelsRepositoryConstants.ModelProperties.Type, out JsonElement objectType) &&
                 objectType.ValueKind == JsonValueKind.String &&
-                objectType.GetString() == ModelRepositoryConstants.ModelProperties.TypeValueInterface;
+                objectType.GetString() == ModelsRepositoryConstants.ModelProperties.TypeValueInterface;
         }
 
         private static bool IsComponentObject(JsonElement root)
         {
             return root.ValueKind == JsonValueKind.Object &&
-                root.TryGetProperty(ModelRepositoryConstants.ModelProperties.Type, out JsonElement objectType) &&
+                root.TryGetProperty(ModelsRepositoryConstants.ModelProperties.Type, out JsonElement objectType) &&
                 objectType.ValueKind == JsonValueKind.String &&
-                objectType.GetString() == ModelRepositoryConstants.ModelProperties.TypeValueComponent;
+                objectType.GetString() == ModelsRepositoryConstants.ModelProperties.TypeValueComponent;
         }
 
         public Dictionary<string, string> ListToDict()

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClient.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClient.cs
@@ -21,7 +21,8 @@ namespace Azure.Iot.ModelsRepository
         private readonly ModelsRepositoryClientOptions _clientOptions;
 
         /// <summary>
-        /// Initializes the ModelsRepositoryClient to point to the Azure IoT Models Repository https://devicemodels.azure.com
+        /// Initializes the ModelsRepositoryClient to point to the
+        /// <see href="https://devicemodels.azure.com">Azure IoT Models Repository</see> service
         /// with the model dependency resolution option of TryFromExpanded.
         /// </summary>
         public ModelsRepositoryClient() : this(DefaultModelsRepository,
@@ -29,7 +30,7 @@ namespace Azure.Iot.ModelsRepository
 
         /// <summary>
         /// Initializes the ModelsRepositoryClient with custom client <paramref name="options"/> while pointing to
-        /// the Azure IoT Models Repository https://devicemodels.azure.com.
+        /// the <see href="https://devicemodels.azure.com">Azure IoT Models Repository</see> service.
         /// </summary>
         /// <param name="options">
         /// ModelsRepositoryClientOptions to configure resolution and client behavior.
@@ -184,7 +185,7 @@ namespace Azure.Iot.ModelsRepository
         public Uri RepositoryUri { get; }
 
         /// <summary>
-        /// The global Azure IoT Models Repository endpoint used by default.
+        /// The global Azure IoT Models Repository service endpoint used by default.
         /// </summary>
         public static Uri DefaultModelsRepository => new Uri(ModelsRepositoryConstants.DefaultModelsRepository);
     }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClient.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClient.cs
@@ -12,7 +12,7 @@ namespace Azure.Iot.ModelsRepository
 {
     /// <summary>
     /// The ModelsRepositoryClient class supports operations against DTDL model repositories following the
-    /// conventions of the Azure IoT Plug and Play Models repository.
+    /// conventions of the Azure IoT Models Repository.
     /// </summary>
     public class ModelsRepositoryClient
     {
@@ -21,14 +21,15 @@ namespace Azure.Iot.ModelsRepository
         private readonly ModelsRepositoryClientOptions _clientOptions;
 
         /// <summary>
-        /// Initializes the ModelsRepositoryClient with default client options while pointing to
-        /// the Azure IoT Plug and Play Models repository https://devicemodels.azure.com for resolution.
+        /// Initializes the ModelsRepositoryClient to point to the Azure IoT Models Repository https://devicemodels.azure.com
+        /// with the model dependency resolution option of TryFromExpanded.
         /// </summary>
-        public ModelsRepositoryClient() : this(DefaultModelsRepository, new ModelsRepositoryClientOptions()) { }
+        public ModelsRepositoryClient() : this(DefaultModelsRepository,
+            new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.TryFromExpanded)) { }
 
         /// <summary>
         /// Initializes the ModelsRepositoryClient with custom client <paramref name="options"/> while pointing to
-        /// the Azure IoT Plug and Play Model repository https://devicemodels.azure.com for resolution.
+        /// the Azure IoT Models Repository https://devicemodels.azure.com.
         /// </summary>
         /// <param name="options">
         /// ModelsRepositoryClientOptions to configure resolution and client behavior.
@@ -37,10 +38,10 @@ namespace Azure.Iot.ModelsRepository
 
         /// <summary>
         /// Initializes the ModelsRepositoryClient with custom client <paramref name="options"/> while pointing to
-        /// a custom <paramref name="repositoryUri"/> for resolution.
+        /// a custom <paramref name="repositoryUri"/>.
         /// </summary>
         /// <param name="repositoryUri">
-        /// The model repository Uri. This can be a remote endpoint or local directory.
+        /// The models repository Uri. This can be a remote endpoint or local directory.
         /// </param>
         /// <param name="options">
         /// ModelsRepositoryClientOptions to configure resolution and client behavior.
@@ -178,11 +179,6 @@ namespace Azure.Iot.ModelsRepository
         }
 
         /// <summary>
-        /// Evaluates whether an input <paramref name="dtmi"/> is valid.
-        /// </summary>
-        public static bool IsValidDtmi(string dtmi) => DtmiConventions.IsDtmi(dtmi);
-
-        /// <summary>
         /// Gets the Uri associated with the ModelsRepositoryClient instance.
         /// </summary>
         public Uri RepositoryUri { get; }
@@ -190,6 +186,6 @@ namespace Azure.Iot.ModelsRepository
         /// <summary>
         /// The global Azure IoT Models Repository endpoint used by default.
         /// </summary>
-        public static Uri DefaultModelsRepository => new Uri(ModelRepositoryConstants.DefaultModelsRepository);
+        public static Uri DefaultModelsRepository => new Uri(ModelsRepositoryConstants.DefaultModelsRepository);
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClientOptions.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Iot.ModelsRepository
         internal const ServiceVersion LatestVersion = ServiceVersion.V2021_02_11;
 
         /// <summary>
-        /// The versions of Azure IoT Models Repository supported by this client.
+        /// The versions of Azure IoT Models Repository service supported by this client.
         /// library.
         /// </summary>
         public enum ServiceVersion

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClientOptions.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Iot.ModelsRepository
         internal const ServiceVersion LatestVersion = ServiceVersion.V2021_02_11;
 
         /// <summary>
-        /// The versions of Azure IoT Model Repository by this client
+        /// The versions of Azure IoT Models Repository supported by this client.
         /// library.
         /// </summary>
         public enum ServiceVersion

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryConstants.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryConstants.cs
@@ -3,7 +3,7 @@
 
 namespace Azure.Iot.ModelsRepository
 {
-    internal static class ModelRepositoryConstants
+    internal static class ModelsRepositoryConstants
     {
         // Set EventSource name to package name replacing '.' with '-'
         public const string ModelRepositoryEventSourceName = "Azure-Iot-ModelsRepository";

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryEventSource.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryEventSource.cs
@@ -10,7 +10,7 @@ namespace Azure.Iot.ModelsRepository
     [EventSource(Name = EventSourceName)]
     internal sealed class ModelsRepositoryEventSource : EventSource
     {
-        private const string EventSourceName = ModelRepositoryConstants.ModelRepositoryEventSourceName;
+        private const string EventSourceName = ModelsRepositoryConstants.ModelRepositoryEventSourceName;
 
         // Event ids defined as constants to makes it easy to keep track of them
         // Consider EventSource name, Guid, Event Id and parameters as public API and follow the appropriate versioning rules.

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/RepositoryHandler.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/RepositoryHandler.cs
@@ -26,7 +26,7 @@ namespace Azure.Iot.ModelsRepository
 
             _clientOptions = options;
             _clientDiagnostics = clientDiagnostics;
-            _modelFetcher = repositoryUri.Scheme == ModelRepositoryConstants.File
+            _modelFetcher = repositoryUri.Scheme == ModelsRepositoryConstants.File
                 ? _modelFetcher = new LocalModelFetcher(_clientDiagnostics, _clientOptions)
                 : _modelFetcher = new RemoteModelFetcher(_clientDiagnostics, _clientOptions);
             _clientId = Guid.NewGuid();
@@ -150,7 +150,7 @@ namespace Azure.Iot.ModelsRepository
                         $"{string.Format(CultureInfo.InvariantCulture, StandardStrings.GenericResolverError, dtmi)} " +
                         string.Format(CultureInfo.InvariantCulture, StandardStrings.InvalidDtmiFormat, dtmi);
 
-                    throw new RequestFailedException(invalidArgMsg, new ArgumentException(invalidArgMsg));
+                    throw new ArgumentException(invalidArgMsg);
                 }
 
                 toProcessModels.Enqueue(dtmi);

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ClientTests.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ClientTests.cs
@@ -33,25 +33,13 @@ namespace Azure.Iot.ModelsRepository.Tests
             new ModelsRepositoryClient(localUri).RepositoryUri.AbsolutePath.Should().Be(localUriStr);
         }
 
-        [TestCase("dtmi:com:example:Thermostat;1", true)]
-        [TestCase("dtmi:contoso:scope:entity;2", true)]
-        [TestCase("dtmi:com:example:Thermostat:1", false)]
-        [TestCase("dtmi:com:example::Thermostat;1", false)]
-        [TestCase("com:example:Thermostat;1", false)]
-        [TestCase("", false)]
-        [TestCase(null, false)]
-        public void ClientIsValidDtmi(string dtmi, bool expected)
-        {
-            ModelsRepositoryClient.IsValidDtmi(dtmi).Should().Be(expected);
-        }
-
         [Test]
         public void EvaluateEventSourceKPIs()
         {
             Type eventSourceType = typeof(ModelsRepositoryEventSource);
 
             eventSourceType.Should().NotBeNull();
-            EventSource.GetName(eventSourceType).Should().Be(ModelRepositoryConstants.ModelRepositoryEventSourceName);
+            EventSource.GetName(eventSourceType).Should().Be(ModelsRepositoryConstants.ModelRepositoryEventSourceName);
             EventSource.GetGuid(eventSourceType).Should().Be(Guid.Parse("7678f8d4-81db-5fd2-39fc-23552d86b171"));
             EventSource.GenerateManifest(eventSourceType, "assemblyPathToIncludeInManifest").Should().NotBeNullOrEmpty();
         }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/DtmiConventionsTests.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/DtmiConventionsTests.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Azure.Iot.ModelsRepository.Tests
 {
-    public class DtmiConversionTests : ModelsRepositoryTestBase
+    public class DtmiConventionsTests : ModelsRepositoryTestBase
     {
         [TestCase("dtmi:com:Example:Model;1", "dtmi/com/example/model-1.json")]
         [TestCase("dtmi:com:example:Model;1", "dtmi/com/example/model-1.json")]
@@ -45,7 +45,19 @@ namespace Azure.Iot.ModelsRepository.Tests
             string expandedModelPath = DtmiConventions.DtmiToQualifiedPath(dtmi, repository, true);
             expandedModelPath
                 .Should()
-                .Be($"{repository}/{expectedPath.Replace(ModelRepositoryConstants.JsonFileExtension, ModelRepositoryConstants.ExpandedJsonFileExtension)}");
+                .Be($"{repository}/{expectedPath.Replace(ModelsRepositoryConstants.JsonFileExtension, ModelsRepositoryConstants.ExpandedJsonFileExtension)}");
+        }
+
+        [TestCase("dtmi:com:example:Thermostat;1", true)]
+        [TestCase("dtmi:contoso:scope:entity;2", true)]
+        [TestCase("dtmi:com:example:Thermostat:1", false)]
+        [TestCase("dtmi:com:example::Thermostat;1", false)]
+        [TestCase("com:example:Thermostat;1", false)]
+        [TestCase("", false)]
+        [TestCase(null, false)]
+        public void ClientIsValidDtmi(string dtmi, bool expected)
+        {
+            DtmiConventions.IsDtmi(dtmi).Should().Be(expected);
         }
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ModelsRepositoryTestBase.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ModelsRepositoryTestBase.cs
@@ -32,7 +32,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             return dtmi;
         }
 
-        public static readonly string FallbackTestRemoteRepo = ModelRepositoryConstants.DefaultModelsRepository;
+        public static readonly string FallbackTestRemoteRepo = ModelsRepositoryConstants.DefaultModelsRepository;
 
         public static string TestDirectoryPath => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ResolveIntegrationTests.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ResolveIntegrationTests.cs
@@ -41,7 +41,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             string expectedExMsg = $"{string.Format(StandardStrings.GenericResolverError, dtmi)} {string.Format(StandardStrings.InvalidDtmiFormat, dtmi)}";
 
             Func<Task> act = async () => await client.ResolveAsync(dtmi);
-            act.Should().Throw<RequestFailedException>().WithMessage(expectedExMsg);
+            act.Should().Throw<ArgumentException>().WithMessage(expectedExMsg);
         }
 
         [TestCase(ModelsRepositoryTestBase.ClientType.Local)]

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveMultipleModelsNoDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveMultipleModelsNoDeps(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-6710aa072309dd4da9eae2b20a6a583d-a0d64c4329a4a74d-00",
+        "traceparent": "00-d21014da68c70d41922d080ff2011599-fda793e9949bf442-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "f15f2d9464e9ec2f0fcb34cdb2ce898a",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "69630",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "7c45bf94-401e-006f-228a-05fc4e000000",
+        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -131,9 +131,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-6710aa072309dd4da9eae2b20a6a583d-5a0f98d0206e2742-00",
+        "traceparent": "00-d21014da68c70d41922d080ff2011599-d458010cc0d90e4a-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "cbcd0f251b4278013cc839ccf7d2faa7",
@@ -146,11 +146,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "48962",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [
@@ -159,7 +159,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "3933dec4-901e-0002-018a-056177000000",
+        "x-ms-request-id": "f6f2fc42-701e-0058-1d49-0b0c51000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveMultipleModelsNoDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveMultipleModelsNoDeps(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-a83d4508bf86464ba54548bd79e9bff7-3e4961a430dc2d4d-00",
+        "traceparent": "00-6992399a3d63d2448f077ffaf32db144-e7db6de2a8c0ed46-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "b259b4dec85c5c4fbd98209dd4d9fd93",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "69630",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "7c45bf94-401e-006f-228a-05fc4e000000",
+        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -131,9 +131,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-a83d4508bf86464ba54548bd79e9bff7-b3d8dd462c18fd46-00",
+        "traceparent": "00-6992399a3d63d2448f077ffaf32db144-65e2fa32b80e8e45-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "7613fd841a1f4524a36ae4b8b12b2596",
@@ -146,11 +146,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "48962",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [
@@ -159,7 +159,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "3933dec4-901e-0002-018a-056177000000",
+        "x-ms-request-id": "f6f2fc42-701e-0058-1d49-0b0c51000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveNoneExistentDtmiFileThrowsException(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveNoneExistentDtmiFileThrowsException(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermojax-999.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-36d291fc90a4334dac3eb38f6466b8e8-91b4698d8e996846-00",
+        "traceparent": "00-3e4288773b9cfa4499aa7c0e17662ea2-734ec10d22335b4e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "15a3190d902fe96003d29f3acfcbafb3",
@@ -20,16 +20,16 @@
         "Access-Control-Expose-Headers": "*",
         "Content-Length": "321",
         "Content-Type": "text/html",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:07 GMT",
         "Server": [
           "Windows-Azure-Web/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-error-code": "WebContentNotFound",
-        "x-ms-request-id": "872d6906-f01e-0014-47f4-062b59000000",
+        "x-ms-request-id": "e1a7b2af-f01e-0014-2bbb-0b2b59000000",
         "x-ms-version": "2018-03-28"
       },
-      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 872d6906-f01e-0014-47f4-062b59000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-02-19T19:24:50.4869209Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
+      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : e1a7b2af-f01e-0014-2bbb-0b2b59000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-02-25T21:14:08.5165049Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
     }
   ],
   "Variables": {

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveNoneExistentDtmiFileThrowsException(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveNoneExistentDtmiFileThrowsException(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermojax-999.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-ade836eb9ce7d2428a323c9d4c253a6f-02b14cddecdc854f-00",
+        "traceparent": "00-f22a5e542857d4478a3a71448f63b277-a4429b9468e21c49-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "800de3d2ffcd1d2e908429ff4f76246c",
@@ -20,16 +20,16 @@
         "Access-Control-Expose-Headers": "*",
         "Content-Length": "321",
         "Content-Type": "text/html",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:07 GMT",
         "Server": [
           "Windows-Azure-Web/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-error-code": "WebContentNotFound",
-        "x-ms-request-id": "2908bd3c-001e-0003-17f4-064a75000000",
+        "x-ms-request-id": "4525a381-901e-0002-70bb-0b6177000000",
         "x-ms-version": "2018-03-28"
       },
-      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 2908bd3c-001e-0003-17f4-064a75000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-02-19T19:24:50.7224903Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
+      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 4525a381-901e-0002-70bb-0b6177000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-02-25T21:14:08.9624693Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
     }
   ],
   "Variables": {

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelNoDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelNoDeps(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-26ed0dcd5e88e34db4cf594009e3aac9-da7273e30058d64b-00",
+        "traceparent": "00-412f6cf1eb7a224fbcc2f1655806081d-84ba1ee7645ec048-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "c0c1d85a27f38f70096f19702012afc3",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "69630",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "7c45bf94-401e-006f-228a-05fc4e000000",
+        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelNoDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelNoDeps(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-2aa19654ba77924693bf45888062474f-8ebc5bffbe11ba45-00",
+        "traceparent": "00-57442806c8cc244d80851d2d37cdcd1c-f51dc30ecfbb314e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "07953379f6e5a76fcad114097666fdb4",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "69630",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "7c45bf94-401e-006f-228a-05fc4e000000",
+        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelTryFromExpanded(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelTryFromExpanded(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.expanded.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-3560143abbe8ee499c3680f3ba22c5e7-3765e2f1fea32243-00",
+        "traceparent": "00-93b1f82acf46c54b825addb63ecb3044-4a26482d4670e740-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "27186f54422b6fe0f3619ea05960422f",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "171032",
+        "Age": "61927",
         "Content-Length": "6751",
         "Content-MD5": "BnZpV2\u002B7Z2t0sxAxOhmBdw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEAC10FCC\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "cf7eff99-301e-0018-2a66-05df40000000",
+        "x-ms-request-id": "24f99709-b01e-0084-472a-0bcc2e000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelTryFromExpanded(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelTryFromExpanded(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.expanded.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-15e5a468265f5b449fea789844d1ad18-dff3192ab634ea42-00",
+        "traceparent": "00-194e8eab4e7a6446b12f629314ab662b-6e28bf12f289f24c-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "4b5c5bcc71726d10e772090d825e6957",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "171032",
+        "Age": "61928",
         "Content-Length": "6751",
         "Content-MD5": "BnZpV2\u002B7Z2t0sxAxOhmBdw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:09 GMT",
         "ETag": "\u00220x8D8A13DEAC10FCC\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "cf7eff99-301e-0018-2a66-05df40000000",
+        "x-ms-request-id": "24f99709-b01e-0084-472a-0bcc2e000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelWithDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelWithDeps(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-4a527f4cab25f940a06f30a678bc25f8-35b93feae4f6a64b-00",
+        "traceparent": "00-d748007074d8f8489fa15b6d8c5bfccf-1138bcc300f4e545-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "8e75074e5f63504fdd5b22d19bafd69b",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "48962",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "8ae2e233-d01e-0092-748a-058600000000",
+        "x-ms-request-id": "f724f502-501e-000e-3449-0b956e000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -102,9 +102,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-4a527f4cab25f940a06f30a678bc25f8-128dfc0ad06f4d41-00",
+        "traceparent": "00-d748007074d8f8489fa15b6d8c5bfccf-a17264e9935bce4e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "0b41dd91b50363fc55b81fb0a6726f7b",
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "69630",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -130,7 +130,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "7c45bf94-401e-006f-228a-05fc4e000000",
+        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -229,9 +229,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-4a527f4cab25f940a06f30a678bc25f8-8da9b3f88c628442-00",
+        "traceparent": "00-d748007074d8f8489fa15b6d8c5bfccf-b7fb32651206c245-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "b23d60559fd92b1a25e232c0eb863114",
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "48962",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [
@@ -257,7 +257,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "3933dec4-901e-0002-018a-056177000000",
+        "x-ms-request-id": "f6f2fc42-701e-0058-1d49-0b0c51000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelWithDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelWithDeps(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-ec017cfa24c04a4fbe7250fccf6e06f7-a478d670ac944749-00",
+        "traceparent": "00-51e632d58077984b84f47262a041c8b5-62992f004968e84c-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "6ef2ca73131d88dfb4cb9839b8b49020",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "48963",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:09 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "8ae2e233-d01e-0092-748a-058600000000",
+        "x-ms-request-id": "f724f502-501e-000e-3449-0b956e000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -102,9 +102,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-ec017cfa24c04a4fbe7250fccf6e06f7-394d03b5791fd04e-00",
+        "traceparent": "00-51e632d58077984b84f47262a041c8b5-d2fb4371bc2fd842-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "f4e554cd3571cb0d0888fba6831c0572",
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "69631",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:09 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -130,7 +130,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "7c45bf94-401e-006f-228a-05fc4e000000",
+        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -229,9 +229,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-ec017cfa24c04a4fbe7250fccf6e06f7-a6a74c3922779a43-00",
+        "traceparent": "00-51e632d58077984b84f47262a041c8b5-c6e07817760a6e46-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "395ffea8b6c6fd04104a9d51bdc5fd00",
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "48963",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:09 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [
@@ -257,7 +257,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "3933dec4-901e-0002-018a-056177000000",
+        "x-ms-request-id": "f6f2fc42-701e-0058-1d49-0b0c51000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelWithDepsDisableDependencyResolution(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelWithDepsDisableDependencyResolution(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-09d862b0af8400499f2d004928630aa9-20fa7316e50cfe49-00",
+        "traceparent": "00-daada95feafdea4984fc047663e9bf6d-ec40daef5e67ec4e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "f5cc9e497d9c30bfc661a702ecfd6a07",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "69630",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "7c45bf94-401e-006f-228a-05fc4e000000",
+        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelWithDepsDisableDependencyResolution(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveSingleModelWithDepsDisableDependencyResolution(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-08620b9b639adb448e2976b7c60e1940-0feae906a27dbb41-00",
+        "traceparent": "00-4d5022e320861e459228a5f42495f453-2c03ef68606c694c-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "191089c1a8e22eefba5e136ffdfb9030",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "69631",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:09 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "7c45bf94-401e-006f-228a-05fc4e000000",
+        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveWithWrongCasingThrowsException(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveWithWrongCasingThrowsException(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-2a3f314388159847b0cfdfeef0de35c8-025aa9e772e73f46-00",
+        "traceparent": "00-b25e7b7ac8428e47a24cd6f79de5bd2e-0708fce4e0658e4f-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "7d5aeeef70b4bb000098920bf8ed424f",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "69630",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:08 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "7c45bf94-401e-006f-228a-05fc4e000000",
+        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveWithWrongCasingThrowsException(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/ResolveIntegrationTests/ResolveWithWrongCasingThrowsException(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-0f80a3c3b8b32b4cb5b2307d9e731d00-a6fe05d0fdb54049-00",
+        "traceparent": "00-0c937557eec2f74f995fa4340ba811ff-4ea6161775e39a4e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210219.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210225.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "5dd1b114246ef390d70b087417f3fcd4",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "155664",
+        "Age": "69631",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 19 Feb 2021 19:24:50 GMT",
+        "Date": "Thu, 25 Feb 2021 21:14:09 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "7c45bf94-401e-006f-228a-05fc4e000000",
+        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [


### PR DESCRIPTION
* Changes simplest ctor to use dependency resolution option of
  TryFromExpanded. We can guarantee the global endpoint has expanded
  form for any model.
* Hides the existing ModelsRepositoryClient.IsValidDtmi(). We will
  revisit exposing after more real-world usage.
* If input dtmis to Resolve() are invalid thrown exception changed from `RequestFailedException` to `ArgumentException`.
* Add some polish/naming updates and docstring improvements.
* Adds samples content including integration with Parser.
* Have more TODOs in the samples arena including the README.
* Have more TODOs in Client surface area with respect to API review feedback. Like rename of Resolve().
