### PR TITLE
Use RecordedTest attribute for a subset of tests

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/BlobChangeFeedAsyncPagableTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/BlobChangeFeedAsyncPagableTests.cs
@@ -73,7 +73,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
         /// This test runs long in recording mode as it waits multiple times for events.
         /// </summary>
         /// <returns></returns>
-        [Test]
+        [RecordedTest]
         [PlaybackOnly("Changefeed E2E tests require previously generated events")]
         public async Task TestTailEvents()
         {
@@ -195,7 +195,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         [PlaybackOnly("Changefeed E2E tests require previously generated events")]
         public async Task CanReadTillEnd()
         {
@@ -214,7 +214,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
             CollectionAssert.IsNotEmpty(list);
         }
 
-        [Test]
+        [RecordedTest]
         [PlaybackOnly("Changefeed E2E tests require previously generated events")]
         public async Task ResumeFromTheMiddleOfTheChunk()
         {
@@ -317,7 +317,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
         /// Changes related to same blobName are guaranteed to end up in same shard.
         /// </summary>
         /// <returns></returns>
-        [Test]
+        [RecordedTest]
         [PlaybackOnly("Changefeed E2E tests require previously generated events")]
         public async Task ResumeFromTheMiddleOfTheChunkWithSomeEmptyShards()
         {
@@ -422,7 +422,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
         /// Easiest way to set this up is to modify lot of random blobs (i.e. with names that contain GUIDs).
         /// </summary>
         /// <returns></returns>
-        [Test]
+        [RecordedTest]
         [PlaybackOnly("Changefeed E2E tests require previously generated events")]
         public async Task ResumeFromTheMiddleOfTheChunkWithManyNonEmptyShards()
         {
@@ -522,7 +522,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
             CollectionAssert.AreEqual(AllEventIds, AllEventIdsFromResumingIteration);
         }
 
-        [Test]
+        [RecordedTest]
         [PlaybackOnly("Changefeed E2E tests require previously generated events")]
         public async Task ResumeFromEndInThePastYieldsEmptyResult()
         {
@@ -561,7 +561,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
             Assert.Greater(AllEventIds.Count, 0);
         }
 
-        [Test]
+        [RecordedTest]
         [PlaybackOnly("Changefeed E2E tests require previously generated events")]
         public async Task ImmediateResumeFromEndOfCurrentHourYieldsEmptyResult()
         {
@@ -606,7 +606,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
         /// to an hour after end time.
         /// </summary>
         /// <returns></returns>
-        [Test]
+        [RecordedTest]
         [PlaybackOnly("Changefeed E2E tests require previously generated events")]
         public async Task TestAlreadyRoundedBoundaries()
         {
@@ -636,7 +636,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
         /// To setup account for this test have a steady stream of events (i.e. some changes every 1 minute) that covers at least from an hour before start time
         /// to an hour after end time.
         /// </summary>
-        [Test]
+        [RecordedTest]
         [PlaybackOnly("Changefeed E2E tests require previously generated events")]
         public async Task TestNonRoundedBoundaries()
         {

--- a/sdk/storage/Azure.Storage.Common/tests/StorageSharedKeyCredentialsTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageSharedKeyCredentialsTests.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Storage.Blobs;
-using Azure.Storage.Test;
 using NUnit.Framework;
 
 namespace Azure.Storage.Test
@@ -19,9 +18,9 @@ namespace Azure.Storage.Test
         }
 
         /// <summary>
-        /// Ensure updating the account key is reflected in the client
+        /// Ensure updating the account key is reflected in the client.
         /// </summary>
-        [Test]
+        [RecordedTest]
         public async Task RollCredentials()
         {
             // Create a service client
@@ -52,7 +51,7 @@ namespace Azure.Storage.Test
         /// Ensure updating the account key is reflected in the client and any
         /// children it created.
         /// </summary>
-        [Test]
+        [RecordedTest]
         public async Task RollCredentialsToChildren()
         {
             // Create a service client

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
@@ -11,14 +11,11 @@ using Azure.Storage.Queues.Tests;
 using NUnit.Framework;
 using Azure.Core;
 using Azure.Storage.Sas;
-using Azure.Core.TestFramework;
-using System.Buffers.Text;
 using System.Text;
 using Moq;
-using System.Threading;
-using System.Runtime.InteropServices;
 using Azure.Storage.Queues.Specialized;
 using Moq.Protected;
+using Azure.Core.TestFramework;
 
 namespace Azure.Storage.Queues.Test
 {
@@ -29,7 +26,7 @@ namespace Azure.Storage.Queues.Test
         {
         }
 
-        [Test]
+        [RecordedTest]
         public void Ctor_ConnectionString()
         {
             var accountName = "accountName";
@@ -56,7 +53,7 @@ namespace Azure.Storage.Queues.Test
             //Assert.AreEqual("accountName", builder.AccountName);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task Ctor_ConnectionString_Sas()
         {
             // Arrange
@@ -109,7 +106,7 @@ namespace Azure.Storage.Queues.Test
             }
         }
 
-        [Test]
+        [RecordedTest]
         public void Ctor_Uri()
         {
             var accountName = "accountName";
@@ -123,7 +120,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(accountName, builder.AccountName);
         }
 
-        [Test]
+        [RecordedTest]
         public void Ctor_TokenCredential_Http()
         {
             // Arrange
@@ -136,7 +133,7 @@ namespace Azure.Storage.Queues.Test
                 new ArgumentException("Cannot use TokenCredential without HTTPS."));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task Ctor_AzureSasCredential()
         {
             // Arrange
@@ -152,7 +149,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNotNull(properties);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task Ctor_AzureSasCredential_VerifyNoSasInUri()
         {
             // Arrange
@@ -167,7 +164,7 @@ namespace Azure.Storage.Queues.Test
                 e => e.Message.Contains($"You cannot use {nameof(AzureSasCredential)} when the resource URI also contains a Shared Access Signature"));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateAsync_WithSharedKey()
         {
             // Arrange
@@ -189,7 +186,7 @@ namespace Azure.Storage.Queues.Test
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateAsync_FromService()
         {
             var name = GetNewQueueName();
@@ -210,7 +207,7 @@ namespace Azure.Storage.Queues.Test
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateAsync_WithOauth()
         {
             // Arrange
@@ -232,7 +229,7 @@ namespace Azure.Storage.Queues.Test
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateAsync_WithAccountSas()
         {
             // Arrange
@@ -254,7 +251,7 @@ namespace Azure.Storage.Queues.Test
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateAsync_WithQueueServiceSas()
         {
             // Arrange
@@ -284,7 +281,7 @@ namespace Azure.Storage.Queues.Test
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateAsync_Error()
         {
             // Arrange
@@ -299,7 +296,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("QueueAlreadyExists", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateIfNotExistsAsync_NotExists()
         {
             // Arrange
@@ -317,7 +314,7 @@ namespace Azure.Storage.Queues.Test
             await queue.DeleteIfExistsAsync();
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateIfNotExistsAsync_Exists()
         {
             // Arrange
@@ -336,7 +333,7 @@ namespace Azure.Storage.Queues.Test
             await queue.DeleteIfExistsAsync();
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateIfNotExistsAsync_ExistsDifferentMetadata()
         {
             // Arrange
@@ -356,7 +353,7 @@ namespace Azure.Storage.Queues.Test
             await queue.DeleteIfExistsAsync();
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateIfNotExistsAsync_Error()
         {
             // Arrange
@@ -371,7 +368,7 @@ namespace Azure.Storage.Queues.Test
                 e => Assert.AreEqual("ResourceNotFound", e.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ExistsAsync_Exists()
         {
             // Arrange
@@ -390,7 +387,7 @@ namespace Azure.Storage.Queues.Test
             await queue.DeleteIfExistsAsync();
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ExistsAsync_NotExists()
         {
             // Arrange
@@ -405,7 +402,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsFalse(response.Value);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ExistsAsync_Error()
         {
             // Arrange
@@ -420,7 +417,7 @@ namespace Azure.Storage.Queues.Test
                 e => Assert.AreEqual("ResourceNotFound", e.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DeleteIfExistsAsync_Exists()
         {
             // Arrange
@@ -436,7 +433,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsTrue(response.Value);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DeleteIfExistsAsync_NotExists()
         {
             // Arrange
@@ -451,7 +448,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsFalse(response.Value);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DeleteIfExistsAsync_Error()
         {
             // Arrange
@@ -466,7 +463,7 @@ namespace Azure.Storage.Queues.Test
                 e => Assert.AreEqual("ResourceNotFound", e.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetPropertiesAsync()
         {
             // Arrange
@@ -479,7 +476,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNotNull(queueProperties);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetPropertiesAsync_Error()
         {
             // Arrange
@@ -495,7 +492,7 @@ namespace Azure.Storage.Queues.Test
 
         #region Secondary Storage
 
-        [Test]
+        [RecordedTest]
         public async Task GetPropertiesAsync_SecondaryStorage()
         {
             QueueClient queueClient = GetQueueClient_SecondaryAccount_ReadEnabledOnRetry(1, out TestExceptionPolicy testExceptionPolicy);
@@ -512,7 +509,7 @@ namespace Azure.Storage.Queues.Test
         }
         #endregion
 
-        [Test]
+        [RecordedTest]
         public async Task SetMetadataAsync_OnCreate()
         {
             // Arrange
@@ -525,7 +522,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual("data", result.Value.Metadata["meta"]);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SetMetadataAsync_Metadata()
         {
             // Arrange
@@ -542,7 +539,7 @@ namespace Azure.Storage.Queues.Test
         }
 
         // Note that this test intentionally does not call queue.CreateAsync()
-        [Test]
+        [RecordedTest]
         public async Task SetMetadataAsync_Error()
         {
             // Arrange
@@ -557,7 +554,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("QueueNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetAccessPolicyAsync()
         {
             // Arrange
@@ -580,7 +577,7 @@ namespace Azure.Storage.Queues.Test
         }
 
         // Note that this test intentionally does not call queue.CreateAsync()
-        [Test]
+        [RecordedTest]
         public async Task GetAccessPolicyAsync_Error()
         {
             // Arrange
@@ -594,7 +591,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("QueueNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SetAccessPolicyAsync()
         {
             await using DisposingQueue test = await GetTestQueueAsync();
@@ -605,7 +602,7 @@ namespace Azure.Storage.Queues.Test
         }
 
         // Note that this test intentionally does not call queue.CreateAsync()
-        [Test]
+        [RecordedTest]
         public async Task SetAccessPolicyAsync_Error()
         {
             // Arrange
@@ -620,7 +617,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("QueueNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DeleteAsync()
         {
             // Arrange
@@ -636,7 +633,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreNotEqual(default, result.Headers.RequestId, $"{nameof(result)} may not be populated");
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DeleteAsync_FromService()
         {
             var name = GetNewQueueName();
@@ -656,7 +653,7 @@ namespace Azure.Storage.Queues.Test
         }
 
         // Note that this test intentionally does not call queue.CreateAsync()
-        [Test]
+        [RecordedTest]
         public async Task DeleteAsync_Error()
         {
             // Arrange
@@ -670,7 +667,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("QueueNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SendMessageAsync()
         {
             // Arrange
@@ -686,7 +683,7 @@ namespace Azure.Storage.Queues.Test
             Assert.NotNull(response.Value);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SendReceiveNullMessageAsync()
         {
             // Arrange
@@ -704,7 +701,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(string.Empty, receivedMessage.MessageText);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task EncodesOutgoingMessage()
         {
             // Arrange
@@ -725,7 +722,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(encodedText, receivedMessage.MessageText);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task EncodesOutgoingMessageAndRespectsSegmentBoundaries()
         {
             // Arrange
@@ -748,7 +745,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual("payload", receivedMessage.Body.ToString());
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DecodesReceivedMessage()
         {
             // Arrange
@@ -769,7 +766,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(messageText, receivedMessage.MessageText);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DecodesPeekedMessage()
         {
             // Arrange
@@ -790,7 +787,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(messageText, receivedMessage.MessageText);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task FailsOnInvalidPeekedMessageIfNoHandlerIsProvided()
         {
             // Arrange
@@ -809,7 +806,7 @@ namespace Azure.Storage.Queues.Test
                 });
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CanHandleInvalidPeekedMessageAndReturnValid()
         {
             // Arrange
@@ -845,7 +842,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(nonEncodedContent, badMessage2.Body.ToString());
         }
 
-        [Test]
+        [RecordedTest]
         public async Task PropagatesExceptionIfInvalidPeekedMessageAndHandlerThrows()
         {
             // Arrange
@@ -877,7 +874,7 @@ namespace Azure.Storage.Queues.Test
                 });
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CanSendAndReceiveNonUTFBytes()
         {
             // Arrange
@@ -898,7 +895,7 @@ namespace Azure.Storage.Queues.Test
             CollectionAssert.AreEqual(content, receivedMessage.Body.ToArray());
         }
 
-        [Test]
+        [RecordedTest]
         public async Task FailsOnInvalidQueueMessageIfNoHandlerIsProvided()
         {
             // Arrange
@@ -917,7 +914,7 @@ namespace Azure.Storage.Queues.Test
                 });
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CanHandleInvalidMessageAndReturnValid()
         {
             // Arrange
@@ -953,7 +950,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(nonEncodedContent, badMessage2.Body.ToString());
         }
 
-        [Test]
+        [RecordedTest]
         public async Task TakesSnapshotOfMessageDecodingFailedHandlersAtConstruction()
         {
             // Arrange
@@ -999,7 +996,7 @@ namespace Azure.Storage.Queues.Test
             Assert.Null(badMessage3);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task PropagatesExceptionIfInvalidQueueMessageAndHandlerThrows()
         {
             // Arrange
@@ -1031,7 +1028,7 @@ namespace Azure.Storage.Queues.Test
                 });
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SendMessageAsync_SAS()
         {
             // Arrange
@@ -1065,7 +1062,7 @@ namespace Azure.Storage.Queues.Test
             Assert.NotNull(response.Value);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SendMessageAsync_SasWithIdentifier()
         {
             // Arrange
@@ -1111,7 +1108,7 @@ namespace Azure.Storage.Queues.Test
             Assert.NotNull(response.Value);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SendMessageAsync_Min()
         {
             // Arrange
@@ -1124,7 +1121,7 @@ namespace Azure.Storage.Queues.Test
             Assert.NotNull(response.Value);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SendMessageAsync_ExtendedExceptionMessage()
         {
             // Arrange
@@ -1144,7 +1141,7 @@ namespace Azure.Storage.Queues.Test
         }
 
         // Note that this test intentionally does not call queue.CreateAsync()
-        [Test]
+        [RecordedTest]
         public async Task SendMessageAsync_Error()
         {
             // Arrange
@@ -1158,7 +1155,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("QueueNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ReceiveMessagesAsync()
         {
             // Arrange
@@ -1177,7 +1174,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(2, response.Value.Count());
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ReceiveMessagesAsync_Min()
         {
             // Arrange
@@ -1195,7 +1192,7 @@ namespace Azure.Storage.Queues.Test
         }
 
         // Note that this test intentionally does not call queue.CreateAsync()
-        [Test]
+        [RecordedTest]
         public async Task ReceiveMessagesAsync_Error()
         {
             // Arrange
@@ -1209,7 +1206,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("QueueNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ReceiveMessageAsync()
         {
             // Arrange
@@ -1226,7 +1223,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(messageText, response.Value.MessageText);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ReceiveMessageAsync_Min()
         {
             // Arrange
@@ -1242,7 +1239,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(messageText, response.Value.MessageText);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ReceiveMessageAsync_EmptyQueue()
         {
             // Arrange
@@ -1257,7 +1254,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNull(response.Value);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ReceiveMessageAsync_EmptyQueue_With_ResponseCast()
         {
             // Arrange
@@ -1273,7 +1270,7 @@ namespace Azure.Storage.Queues.Test
         }
 
         // Note that this test intentionally does not call queue.CreateAsync()
-        [Test]
+        [RecordedTest]
         public async Task ReceiveMessageAsync_Error()
         {
             // Arrange
@@ -1287,7 +1284,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("QueueNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task PeekMessagesAsync()
         {
             // Arrange
@@ -1304,7 +1301,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(2, response.Value.Count());
         }
 
-        [Test]
+        [RecordedTest]
         public async Task PeekMessagesAsync_Min()
         {
             // Arrange
@@ -1322,7 +1319,7 @@ namespace Azure.Storage.Queues.Test
         }
 
         // Note that this test intentionally does not call queue.CreateAsync()
-        [Test]
+        [RecordedTest]
         public async Task PeekMessagesAsync_Error()
         {
             // Arrange
@@ -1336,7 +1333,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("QueueNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task PeekMessageAsync()
         {
             // Arrange
@@ -1353,7 +1350,7 @@ namespace Azure.Storage.Queues.Test
         }
 
         // Note that this test intentionally does not call queue.CreateAsync()
-        [Test]
+        [RecordedTest]
         public async Task PeekMessageAsync_Error()
         {
             // Arrange
@@ -1367,7 +1364,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("QueueNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task PeekMessageAsync_EmptyQueue()
         {
             // Arrange
@@ -1380,7 +1377,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNull(response.Value);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task PeekMessageAsync_EmptyQueue_WithResponseCast()
         {
             // Arrange
@@ -1393,7 +1390,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNull(message);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ClearMessagesAsync()
         {
             // Arrange
@@ -1411,7 +1408,7 @@ namespace Azure.Storage.Queues.Test
         }
 
         // Note that this test intentionally does not call queue.CreateAsync()
-        [Test]
+        [RecordedTest]
         public async Task ClearMessagesAsync_Error()
         {
             // Arrange
@@ -1425,7 +1422,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("QueueNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DeleteMessageAsync()
         {
             // Arrange
@@ -1439,7 +1436,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNotNull(result.Headers.RequestId);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DeleteMessagAsync_Error()
         {
             // Arrange
@@ -1451,7 +1448,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("MessageNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DeleteMessageAsync_DeletePeek()
         {
             // Arrange
@@ -1466,7 +1463,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNotNull(result.Headers.RequestId);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateMessageAsync_Update()
         {
             // Arrange
@@ -1487,7 +1484,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNotNull(result.GetRawResponse().Headers.RequestId);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateMessageAsync_Min()
         {
             // Arrange
@@ -1507,7 +1504,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNotNull(result.GetRawResponse().Headers.RequestId);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateMessageAsync_UpdateDequeuedMessage()
         {
             await using DisposingQueue test = await GetTestQueueAsync();
@@ -1538,7 +1535,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(update.Value.NextVisibleOn, newMessage.NextVisibleOn);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateMessageAsync_UpdatePeek()
         {
             // Arrange
@@ -1559,7 +1556,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(message1, peekedMessage.MessageText);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateMessageAsync_Error()
         {
             // Arrange
@@ -1571,7 +1568,7 @@ namespace Azure.Storage.Queues.Test
                 actualException => Assert.AreEqual("MessageNotFound", actualException.ErrorCode));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateMessageAsync_UpdateVisibilityTimeoutOnlyPreservesContent()
         {
             // Arrange
@@ -1593,7 +1590,7 @@ namespace Azure.Storage.Queues.Test
         }
 
         #region GenerateSasTests
-        [Test]
+        [RecordedTest]
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
@@ -1630,7 +1627,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsTrue(container4.CanGenerateSasUri);
         }
 
-        [Test]
+        [RecordedTest]
         public void CanGenerateSas_Mockable()
         {
             // Act
@@ -1647,7 +1644,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsTrue(directory.Object.CanGenerateSasUri);
         }
 
-        [Test]
+        [RecordedTest]
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
@@ -1677,7 +1674,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(expectedUri.ToUri().ToString(), sasUri.ToString());
         }
 
-        [Test]
+        [RecordedTest]
         public void GenerateSas_Builder()
         {
             var constants = new TestConstants(this);
@@ -1714,7 +1711,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(expectedUri.ToUri().ToString(), sasUri.ToString());
         }
 
-        [Test]
+        [RecordedTest]
         public void GenerateSas_BuilderWrongName()
         {
             // Arrange
@@ -1748,7 +1745,7 @@ namespace Azure.Storage.Queues.Test
         }
         #endregion
 
-        [Test]
+        [RecordedTest]
         public void CanMockQueueServiceClientRetrieval()
         {
             // Arrange
@@ -1764,7 +1761,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreSame(queueServiceClientMock.Object, queueServiceClient);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CanGetParentQueueServiceClient()
         {
             // Arrange
@@ -1779,7 +1776,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(test.Queue.AccountName, queueServiceClient.AccountName);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CanGetParentQueueServiceClient_WithAccountSAS()
         {
             // Arrange
@@ -1797,7 +1794,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(queueClient.AccountName, queueServiceClient.AccountName);
         }
 
-        [Test]
+        [RecordedTest]
         public void CanMockClientConstructors()
         {
             // One has to call .Object to trigger constructor. It's lazy.


### PR DESCRIPTION
The focus of these changes is to evaluate the `[RecordedTest]` attribute for select storage tests.