### PR TITLE
Throw on transfer options facade overflow

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/StorageTransferOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageTransferOptions.cs
@@ -19,7 +19,7 @@ namespace Azure.Storage
         [EditorBrowsable(EditorBrowsableState.Never)]
         public int? MaximumTransferLength
         {
-            get => (int?)MaximumTransferSize;
+            get => checked((int?)MaximumTransferSize);
             set => MaximumTransferSize = value;
         }
 
@@ -43,7 +43,7 @@ namespace Azure.Storage
         [EditorBrowsable(EditorBrowsableState.Never)]
         public int? InitialTransferLength
         {
-            get => (int?)InitialTransferSize;
+            get => checked((int?)InitialTransferSize);
             set => InitialTransferSize = value;
         }
 

--- a/sdk/storage/Azure.Storage.Common/tests/StorageTransferOptionsTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageTransferOptionsTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Azure.Storage.Tests
+{
+    public class StorageTransferOptionsTests
+    {
+        /// <summary>
+        /// Tests non-throwing cases for backwards compatibility of int? facade
+        /// <see cref="StorageTransferOptions.MaximumTransferLength"/>.
+        /// </summary>
+        /// <param name="realSize"></param>
+        [TestCase(default)]
+        [TestCase(1)]
+        [TestCase(int.MaxValue)]
+        public void MaxTransferLengthBackCompatTest(long? realSize)
+        {
+            var options = new StorageTransferOptions
+            {
+                MaximumTransferSize = realSize
+            };
+
+            Assert.AreEqual(options.MaximumTransferSize, realSize);
+            Assert.AreEqual(options.MaximumTransferLength, realSize);
+        }
+
+        /// <summary>
+        /// Tests throwing cases for backwards compatibility of int? facade
+        /// <see cref="StorageTransferOptions.MaximumTransferLength"/>.
+        /// </summary>
+        /// <param name="realSize"></param>
+        [TestCase(int.MaxValue + 1L)]
+        [TestCase(long.MaxValue)]
+        public void MaxTransferLengthBackCompatOverflowTest(long? realSize)
+        {
+            var options = new StorageTransferOptions
+            {
+                MaximumTransferSize = realSize
+            };
+
+            Assert.AreEqual(options.MaximumTransferSize, realSize);
+            Assert.Throws<OverflowException>(() => _ = options.MaximumTransferLength);
+        }
+
+        /// <summary>
+        /// Tests non-throwing cases for backwards compatibility of int? facade
+        /// <see cref="StorageTransferOptions.MaximumTransferLength"/>.
+        /// </summary>
+        /// <param name="realSize"></param>
+        [TestCase(default)]
+        [TestCase(1)]
+        [TestCase(int.MaxValue)]
+        public void InitialTransferLengthBackCompatTest(long? realSize)
+        {
+            var options = new StorageTransferOptions
+            {
+                InitialTransferSize = realSize
+            };
+
+            Assert.AreEqual(options.InitialTransferSize, realSize);
+            Assert.AreEqual(options.InitialTransferLength, realSize);
+        }
+
+        /// <summary>
+        /// Tests throwing cases for backwards compatibility of int? facade
+        /// <see cref="StorageTransferOptions.MaximumTransferLength"/>.
+        /// </summary>
+        /// <param name="realSize"></param>
+        [TestCase(int.MaxValue + 1L)]
+        [TestCase(long.MaxValue)]
+        public void InitialTransferLengthBackCompatOverflowTest(long? realSize)
+        {
+            var options = new StorageTransferOptions
+            {
+                InitialTransferSize = realSize
+            };
+
+            Assert.AreEqual(options.InitialTransferSize, realSize);
+            Assert.Throws<OverflowException>(() => _ = options.InitialTransferLength);
+        }
+    }
+}


### PR DESCRIPTION
Backwards compatible `int?` facades on StorageTransferOptions silently ignore int overflow, producing negative length values. This change checks overflow on cast, throwing OverflowException when encountered. This brings StorageTransferOptions in line with how other int facades handle this situation.