### PR TITLE
[Perf] Print loaded instead of referenced assembly versions

### DIFF
--- a/common/Perf/Azure.Test.Perf/PerfProgram.cs
+++ b/common/Perf/Azure.Test.Perf/PerfProgram.cs
@@ -185,7 +185,7 @@ namespace Azure.Test.Perf
                 .Where(a => a.GetName().Name.StartsWith("Azure", StringComparison.OrdinalIgnoreCase) ||
                             a.GetName().Name.StartsWith("Microsoft.Azure", StringComparison.OrdinalIgnoreCase))
                 // Exclude this perf framework
-                .Where(a => a != typeof(PerfProgram).Assembly)
+                .Where(a => a != Assembly.GetExecutingAssembly())
                 // Exclude assembly containing the perf test itself
                 .Where(a => a != testType.Assembly)
                 // Exclude Azure.Core.TestFramework since it is only used to setup environment and should not impact results

--- a/common/Perf/Azure.Test.Perf/PerfProgram.cs
+++ b/common/Perf/Azure.Test.Perf/PerfProgram.cs
@@ -178,9 +178,11 @@ namespace Azure.Test.Perf
         {
             Console.WriteLine("=== Versions ===");
 
-            Console.WriteLine($"Runtime: {Environment.Version}");
+            Console.WriteLine($"Runtime:         {Environment.Version}");
 
-            var azureAssemblies = AppDomain.CurrentDomain.GetAssemblies()
+            var referencedAssemblies = testType.Assembly.GetReferencedAssemblies();
+
+            var azureLoadedAssemblies = AppDomain.CurrentDomain.GetAssemblies()
                 // Include all Track1 and Track2 assemblies
                 .Where(a => a.GetName().Name.StartsWith("Azure", StringComparison.OrdinalIgnoreCase) ||
                             a.GetName().Name.StartsWith("Microsoft.Azure", StringComparison.OrdinalIgnoreCase))
@@ -192,10 +194,17 @@ namespace Azure.Test.Perf
                 .Where(a => !a.GetName().Name.Equals("Azure.Core.TestFramework", StringComparison.OrdinalIgnoreCase))
                 .OrderBy(a => a.GetName().Name);
 
-            foreach (var a in azureAssemblies)
+            foreach (var a in azureLoadedAssemblies)
             {
+                var name = a.GetName().Name;
+                var referencedVersion = referencedAssemblies.Where(r => r.Name == name).SingleOrDefault()?.Version;
+                var loadedVersion = a.GetName().Version;
                 var informationalVersion = FileVersionInfo.GetVersionInfo(a.Location).ProductVersion;
-                Console.WriteLine($"{a.GetName().Name}: {a.GetName().Version} ({informationalVersion})");
+
+                Console.WriteLine($"{name}:");
+                Console.WriteLine($"  Referenced:    {referencedVersion}");
+                Console.WriteLine($"  Loaded:        {loadedVersion}");
+                Console.WriteLine($"  Informational: {informationalVersion}");
             }
 
             Console.WriteLine();


### PR DESCRIPTION
This PR contains three changes:

1. Assemblies are retrieved using `AppDomain.CurrentDomain.GetAssemblies()` instead of `Assembly.GetReferencedAssemblies()`.  The latter can be misleading since the referenced assembly version may match the loaded assembly version.  I ran into this when switching between `PackageReference` and `ProjectReference` for a dependency.
2. Since assemblies are not loaded until needed, the versions must be printed after testing is complete, to ensure they have all been loaded.  I would prefer to print the assembly versions earlier in the test run, but accuracy is more important.
3. Additional assemblies are excluded from output (Azure.Core.TestFramework and the assembly containing the perf test itself).