### PR TITLE
[Azure Service Bus] Batch.TryAdd should respect service limits of 4500 items max

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageBatch.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageBatch.cs
@@ -118,7 +118,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                         ? OverheadBytesSmallMessage
                         : OverheadBytesLargeMessage);
 
-                if (size > MaxSizeInBytes)
+                if (size > MaxSizeInBytes || BatchMessages.Count >= Options.MaxSizeInNumberOfItems.Value)
                 {
                     return false;
                 }
@@ -126,7 +126,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 _sizeBytes = size;
                 BatchMessages.Add(message);
 
-            return true;
+                return true;
             }
             finally
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/CreateMessageBatchOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/CreateMessageBatchOptions.cs
@@ -16,6 +16,9 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>The requested maximum size to allow for the batch, in bytes.</summary>
         private long? _maxSizeInBytes;
 
+        /// <summary>The requested maximum size to allow for the batch, in number of items.</summary>
+        private int? _maxSizeInNumberOfItems = 4500;
+
         /// <summary>
         ///   The maximum size to allow for a single batch of messages, in bytes.
         /// </summary>
@@ -37,6 +40,30 @@ namespace Azure.Messaging.ServiceBus
                 }
 
                 _maxSizeInBytes = value;
+            }
+        }
+
+        /// <summary>
+        ///   The maximum size to allow for a single batch of messages, in number of items.
+        /// </summary>
+        ///
+        /// <value>
+        ///   The desired limit, in number of items, for the size of the associated service bus message batch.  If <c>null</c>,
+        ///   the maximum size allowed by the active transport will be used.
+        /// </value>
+        ///
+        internal int? MaxSizeInNumberOfItems
+        {
+            get => _maxSizeInNumberOfItems;
+
+            set
+            {
+                if (value.HasValue)
+                {
+                    Argument.AssertInRange(value.Value, 1, 4500, nameof(MaxSizeInNumberOfItems));
+                }
+
+                _maxSizeInNumberOfItems = value;
             }
         }
 


### PR DESCRIPTION
Adhere to the service limits