### PR TITLE
[Messaging Clients]  Retry IO Exceptions

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/BasicRetryPolicy.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/BasicRetryPolicy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -155,6 +156,7 @@ namespace Azure.Messaging.EventHubs.Core
 
                 case TimeoutException _:
                 case SocketException _:
+                case IOException _:
                 case UnauthorizedAccessException _:
                     return true;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/RetryPolicies/BasicRetryPolicyTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/RetryPolicies/BasicRetryPolicyTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Core;
@@ -27,6 +28,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             yield return new object[] { new TimeoutException() };
             yield return new object[] { new SocketException(500) };
+            yield return new object[] { new IOException() };
             yield return new object[] { new UnauthorizedAccessException() };
 
             // Task/Operation Canceled should use the inner exception as the decision point.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/BasicRetryPolicy.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/BasicRetryPolicy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -142,6 +143,7 @@ namespace Azure.Messaging.ServiceBus.Core
 
                 case TimeoutException _:
                 case SocketException _:
+                case IOException _:
                 case UnauthorizedAccessException _:
                     return true;
 
@@ -151,11 +153,11 @@ namespace Azure.Messaging.ServiceBus.Core
         }
 
         /// <summary>
-        ///   Calculates the delay for an exponential backoff.
+        ///   Calculates the delay for an exponential back-off.
         /// </summary>
         ///
         /// <param name="attemptCount">The number of total attempts that have been made, including the initial attempt before any retries.</param>
-        /// <param name="baseDelaySeconds">The delay to use as a basis for the exponential backoff, in seconds.</param>
+        /// <param name="baseDelaySeconds">The delay to use as a basis for the exponential back-off, in seconds.</param>
         /// <param name="baseJitterSeconds">The delay to use as the basis for a random jitter value, in seconds.</param>
         /// <param name="random">The random number generator to use for the calculation.</param>
         ///
@@ -169,10 +171,10 @@ namespace Azure.Messaging.ServiceBus.Core
             TimeSpan.FromSeconds((Math.Pow(2, attemptCount) * baseDelaySeconds) + (random.NextDouble() * baseJitterSeconds));
 
         /// <summary>
-        ///   Calculates the delay for a fixed backoff.
+        ///   Calculates the delay for a fixed back-off.
         /// </summary>
         ///
-        /// <param name="baseDelaySeconds">The delay to use as a basis for the fixed backoff, in seconds.</param>
+        /// <param name="baseDelaySeconds">The delay to use as a basis for the fixed back-off, in seconds.</param>
         /// <param name="baseJitterSeconds">The delay to use as the basis for a random jitter value, in seconds.</param>
         /// <param name="random">The random number generator to use for the calculation.</param>
         ///

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/BasicRetryPolicyTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/BasicRetryPolicyTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -28,6 +29,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         {
             yield return new object[] { new TimeoutException() };
             yield return new object[] { new SocketException(500) };
+            yield return new object[] { new IOException() };
             yield return new object[] { new UnauthorizedAccessException() };
 
             // Task/Operation Canceled should use the inner exception as the decision point.


### PR DESCRIPTION
# Summary

The focus of these changes is to update the retry policies to classify `System.IOException` instances as transient and allow retrying.

# Last Upstream Rebase

Tuesday, March 2, 5:00pm (EST)
