### PR TITLE
Add a using statement to reference CloudEvent

### DIFF
--- a/samples/linecounter/Controllers/HomeController.cs
+++ b/samples/linecounter/Controllers/HomeController.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;


### PR DESCRIPTION
`CloudEvent` has moved to the ns `Azure.Messaging` in Azure.Core with 799fd1a