### PR TITLE
[Smoke Tests] Fix Build Errors

### DIFF
--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -12,14 +12,17 @@
   <ItemGroup>
     <!-- Add an OverrideDailyVersion attribute to prevent the Update-Dependencies script from overwriting it with a daily build version -->
     <PackageReference Include="Azure.Core" Version="1.9.0" />
-    <PackageReference Include="Azure.Identity" Version="1.4.0-beta.1" />
+    <PackageReference Include="Azure.Identity" Version="1.4.0-beta.3" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.0" />
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.3.0" />
-    <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.2.0-beta.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.9" />
+    <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.2.0-beta.4" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.9.0-beta.1" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.11" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.20.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.10.0" />
+
+    <!-- This is needed to resolve a build conflict and force the correct version -->
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
   <!-- Sample: IoT Hub Connection String Translation -->
   <ItemGroup>

--- a/samples/iothub-connect-to-eventhubs/IotHubToEventHubsSample.csproj
+++ b/samples/iothub-connect-to-eventhubs/IotHubToEventHubsSample.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.3" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.0" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.11" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.20.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Summary

The focus of these changes is to fix the build errors resulting from package version conflicts.

# Last Upstream Rebase

Wednesday, March 3, 10:00am (EST)