### PR TITLE
[Storage] Run large payload tests only in nightly run.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/LargeBlobTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/LargeBlobTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.Core.TestFramework;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using NUnit.Framework;
@@ -25,6 +26,7 @@ namespace Azure.Storage.Blobs.Tests
         }
 
         [Test]
+        [LiveOnly]
         public async Task GetBlockListAsync_LongBlock()
         {
             // Arange
@@ -55,6 +57,7 @@ namespace Azure.Storage.Blobs.Tests
         }
 
         [Test]
+        [LiveOnly]
         public async Task CanHandleLongBlockBufferedUpload()
         {
             // Arrange
@@ -88,6 +91,7 @@ namespace Azure.Storage.Blobs.Tests
         }
 
         [Test]
+        [LiveOnly]
         public async Task CanHandleLongBlockBufferedUploadInParallel()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
 using Azure.Storage.Shared;
 using Azure.Storage.Tests.Shared;
 using NUnit.Framework;
@@ -56,6 +57,7 @@ namespace Azure.Storage.Tests
         }
 
         [Test]
+        [LiveOnly]
         public void StreamCanHoldLongData()
         {
             const long dataSize = (long)int.MaxValue + Constants.MB;


### PR DESCRIPTION
Mitigates some of https://github.com/Azure/azure-sdk-for-net/issues/19182 .