### PR TITLE
BearerTokenChallengeAuthenticationPolicy refactor

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/ARMChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/ARMChallengeAuthenticationPolicy.cs
@@ -30,8 +30,8 @@ namespace Azure.Core.Pipeline
         public ARMChallengeAuthenticationPolicy(TokenCredential credential, IEnumerable<string> scopes)
             : base(credential, scopes, TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(30)) { }
 
-        /// <inheritdoc cref="BearerTokenChallengeAuthenticationPolicy.TryAuthenticateRequestFromChallengeAsync(HttpMessage, bool)" />
-        protected override async ValueTask<bool> TryAuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
+        /// <inheritdoc cref="BearerTokenChallengeAuthenticationPolicy.AuthenticateRequestFromChallengeAsync(HttpMessage, bool)" />
+        protected override async ValueTask<bool> AuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
         {
             var challenge = AuthorizationChallengeParser.GetChallengeParameterFromResponse(message.Response, "Bearer", "claims");
             if (challenge == null)

--- a/sdk/core/Azure.Core/src/Shared/ARMChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/ARMChallengeAuthenticationPolicy.cs
@@ -30,8 +30,8 @@ namespace Azure.Core.Pipeline
         public ARMChallengeAuthenticationPolicy(TokenCredential credential, IEnumerable<string> scopes)
             : base(credential, scopes, TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(30)) { }
 
-        /// <inheritdoc cref="BearerTokenChallengeAuthenticationPolicy.AuthenticateRequestFromChallengeAsync(HttpMessage, bool)" />
-        protected override async ValueTask<bool> AuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
+        /// <inheritdoc cref="BearerTokenChallengeAuthenticationPolicy.AuthenticateRequestOnChallengeAsync(HttpMessage, bool)" />
+        protected override async ValueTask<bool> AuthenticateRequestOnChallengeAsync(HttpMessage message, bool async)
         {
             var challenge = AuthorizationChallengeParser.GetChallengeParameterFromResponse(message.Response, "Bearer", "claims");
             if (challenge == null)

--- a/sdk/core/Azure.Core/src/Shared/ARMChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/ARMChallengeAuthenticationPolicy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 
 #nullable enable
@@ -29,17 +30,9 @@ namespace Azure.Core.Pipeline
         public ARMChallengeAuthenticationPolicy(TokenCredential credential, IEnumerable<string> scopes)
             : base(credential, scopes, TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(30)) { }
 
-        /// <summary>
-        /// Executed in the event a 401 response with a WWW-Authenticate authentication challenge header is received after the initial request.
-        /// </summary>
-        /// <remarks>Handles claims authentication challenges.</remarks>
-        /// <param name="message">The <see cref="HttpMessage"/> to be authenticated.</param>
-        /// <param name="context">If the return value is <c>true</c>, a <see cref="TokenRequestContext"/>.</param>
-        /// <returns>A boolean indicated whether the request contained a valid challenge and a <see cref="TokenRequestContext"/> was successfully initialized with it.</returns>
-        protected override bool TryGetTokenRequestContextFromChallenge(HttpMessage message, out TokenRequestContext context)
+        /// <inheritdoc cref="BearerTokenChallengeAuthenticationPolicy.TryAuthenticateRequestFromChallengeAsync(HttpMessage, bool)" />
+        protected override async ValueTask<bool> TryAuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
         {
-            context = default;
-
             var challenge = AuthorizationChallengeParser.GetChallengeParameterFromResponse(message.Response, "Bearer", "claims");
             if (challenge == null)
             {
@@ -47,7 +40,8 @@ namespace Azure.Core.Pipeline
             }
 
             string claimsChallenge = Base64Url.DecodeString(challenge.ToString());
-           context = new TokenRequestContext(Scopes, message.Request.ClientRequestId, claimsChallenge);
+            var context = new TokenRequestContext(Scopes, message.Request.ClientRequestId, claimsChallenge);
+            await AuthenticateRequestAsync(message, context, async);
             return true;
         }
     }

--- a/sdk/core/Azure.Core/src/Shared/ARMChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/ARMChallengeAuthenticationPolicy.cs
@@ -41,7 +41,7 @@ namespace Azure.Core.Pipeline
 
             string claimsChallenge = Base64Url.DecodeString(challenge.ToString());
             var context = new TokenRequestContext(Scopes, message.Request.ClientRequestId, claimsChallenge);
-            await AuthenticateRequestAsync(message, context, async);
+            await SetAuthorizationHeader(message, context, async);
             return true;
         }
     }

--- a/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
@@ -49,14 +49,12 @@ namespace Azure.Core.Pipeline
         /// <inheritdoc />
         public override async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            await AuthenticateRequestAsync(message, true).ConfigureAwait(false);
             await ProcessAsync(message, pipeline, true).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            AuthenticateRequestAsync(message, false).EnsureCompleted();
             ProcessAsync(message, pipeline, false).EnsureCompleted();
         }
 
@@ -94,10 +92,12 @@ namespace Azure.Core.Pipeline
 
             if (async)
             {
+                await AuthenticateRequestAsync(message, true).ConfigureAwait(false);
                 await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
             }
             else
             {
+                AuthenticateRequestAsync(message, false).EnsureCompleted();
                 ProcessNext(message, pipeline);
             }
 

--- a/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
@@ -20,7 +20,6 @@ namespace Azure.Core.Pipeline
     {
         private readonly AccessTokenCache _accessTokenCache;
         protected string[] Scopes { get; private set; }
-        private readonly ValueTask<bool> _falseValueTask = new ValueTask<bool>(Task.FromResult(false));
 
         /// <summary>
         /// Creates a new instance of <see cref="BearerTokenChallengeAuthenticationPolicy"/> using provided token credential and scope to authenticate for.
@@ -81,7 +80,7 @@ namespace Azure.Core.Pipeline
         /// <returns>A boolean indicating whether the request was successfully authenticated and should be sent to the transport.</returns>
         protected virtual ValueTask<bool> AuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
         {
-            return _falseValueTask;
+            return default(ValueTask<bool>);
         }
 
         private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)

--- a/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
@@ -47,9 +47,9 @@ namespace Azure.Core.Pipeline
         }
 
         /// <inheritdoc />
-        public override async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        public override ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            await ProcessAsync(message, pipeline, true).ConfigureAwait(false);
+            return ProcessAsync(message, pipeline, true);
         }
 
         /// <inheritdoc />

--- a/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
@@ -78,7 +78,7 @@ namespace Azure.Core.Pipeline
         /// <param name="message">The <see cref="HttpMessage"/> to be authenticated.</param>
         /// <param name="async">Indicates whether the method was called from an asynchronous context.</param>
         /// <returns>A boolean indicating whether the request was successfully authenticated and should be sent to the transport.</returns>
-        protected virtual ValueTask<bool> AuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
+        protected virtual ValueTask<bool> AuthenticateRequestOnChallengeAsync(HttpMessage message, bool async)
         {
             return _falseValueTask;
         }
@@ -111,7 +111,7 @@ namespace Azure.Core.Pipeline
                 // Attempt to get the TokenRequestContext based on the challenge.
                 // If we fail to get the context, the challenge was not present or invalid.
                 // If we succeed in getting the context, authenticate the request and pass it up the policy chain.
-                if (await AuthenticateRequestFromChallengeAsync(message, async).ConfigureAwait(false))
+                if (await AuthenticateRequestOnChallengeAsync(message, async).ConfigureAwait(false))
                 {
                     if (async)
                     {

--- a/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
@@ -90,7 +90,7 @@ namespace Azure.Core.Pipeline
                 throw new InvalidOperationException("Bearer token authentication is not permitted for non TLS protected (https) endpoints.");
             }
 
-            if (Scopes.Length > 0)
+            if (Scopes.Length > 0 && !message.Request.Headers.Contains(HttpHeader.Names.Authorization))
             {
                var context = new TokenRequestContext(Scopes, message.Request.ClientRequestId);
                await AuthenticateRequestAsync(message, context, async).ConfigureAwait(false);

--- a/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
@@ -19,7 +19,8 @@ namespace Azure.Core.Pipeline
     internal class BearerTokenChallengeAuthenticationPolicy : HttpPipelinePolicy
     {
         private readonly AccessTokenCache _accessTokenCache;
-        protected string[] Scopes { get; set; }
+        protected string[] Scopes { get; private set; }
+        private readonly ValueTask<bool> _falseValueTask = new ValueTask<bool>(Task.FromResult(false));
 
         /// <summary>
         /// Creates a new instance of <see cref="BearerTokenChallengeAuthenticationPolicy"/> using provided token credential and scope to authenticate for.
@@ -48,13 +49,27 @@ namespace Azure.Core.Pipeline
         /// <inheritdoc />
         public override ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
+            PreProcessAsync(message, pipeline, true);
             return ProcessAsync(message, pipeline, true);
         }
 
         /// <inheritdoc />
         public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
+            PreProcessAsync(message, pipeline, false);
             ProcessAsync(message, pipeline, false).EnsureCompleted();
+        }
+
+        /// <summary>
+        /// Executes a pre-processing step on the <paramref name="message"/> before <see cref="ProcessAsync(HttpMessage, ReadOnlyMemory{HttpPipelinePolicy})"/> or <see cref="Process(HttpMessage, ReadOnlyMemory{HttpPipelinePolicy})"/> is called.
+        /// </summary>
+        /// <param name="message">The <see cref="HttpMessage"/> this policy would be applied to.</param>
+        /// <param name="pipeline">The set of <see cref="HttpPipelinePolicy"/> to execute after current one.</param>
+        /// <param name="async">Indicates whether the method was called from an asynchronous context.</param>
+        /// <returns>The <see cref="ValueTask"/> representing the asynchronous operation.</returns>
+        protected virtual ValueTask PreProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
+        {
+            return default;
         }
 
         /// <summary>
@@ -62,12 +77,11 @@ namespace Azure.Core.Pipeline
         /// </summary>
         /// <remarks>Service client libraries may derive from this and extend to handle service specific authentication challenges.</remarks>
         /// <param name="message">The <see cref="HttpMessage"/> to be authenticated.</param>
-        /// <param name="context">If the return value is <c>true</c>, a <see cref="TokenRequestContext"/>.</param>
-        /// <returns>A boolean indicated whether the request contained a valid challenge and a <see cref="TokenRequestContext"/> was successfully initialized with it.</returns>
-        protected virtual bool TryGetTokenRequestContextFromChallenge(HttpMessage message, out TokenRequestContext context)
+        /// <param name="async">Indicates whether the method was called from an asynchronous context.</param>
+        /// <returns>A boolean indicating whether the requeset was successfully authenticated and should be sent to the transport.</returns>
+        protected virtual ValueTask<bool> TryAuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
         {
-            context = default;
-            return false;
+            return _falseValueTask;
         }
 
         private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
@@ -82,19 +96,17 @@ namespace Azure.Core.Pipeline
             // If the message already has a challenge response due to a sub-class pre-processing the request, get the context from the challenge.
             if (message.HasResponse && message.Response.Status == (int)HttpStatusCode.Unauthorized && message.Response.Headers.Contains(HttpHeader.Names.WWWAuthenticate))
             {
-                if (!TryGetTokenRequestContextFromChallenge(message, out context))
+                if (!await TryAuthenticateRequestFromChallengeAsync(message, async).ConfigureAwait(false))
                 {
                     // We were unsuccessful in handling the challenge, so bail out now.
                     return;
                 }
-                Scopes = context.Scopes;
             }
             else
             {
                 context = new TokenRequestContext(Scopes, message.Request.ClientRequestId);
+                await AuthenticateRequestAsync(message, context, async).ConfigureAwait(false);
             }
-
-            await AuthenticateRequestAsync(message, context, async).ConfigureAwait(false);
 
             if (async)
             {
@@ -111,13 +123,8 @@ namespace Azure.Core.Pipeline
                 // Attempt to get the TokenRequestContext based on the challenge.
                 // If we fail to get the context, the challenge was not present or invalid.
                 // If we succeed in getting the context, authenticate the request and pass it up the policy chain.
-                if (TryGetTokenRequestContextFromChallenge(message, out context))
+                if (await TryAuthenticateRequestFromChallengeAsync(message, async).ConfigureAwait(false))
                 {
-                    // Ensure the scopes are consistent with what was set by <see cref="TryGetTokenRequestContextFromChallenge" />.
-                    Scopes = context.Scopes;
-
-                    await AuthenticateRequestAsync(message, context, async).ConfigureAwait(false);
-
                     if (async)
                     {
                         await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
@@ -130,7 +137,7 @@ namespace Azure.Core.Pipeline
             }
         }
 
-        private async Task AuthenticateRequestAsync(HttpMessage message, TokenRequestContext context, bool async)
+        protected async Task AuthenticateRequestAsync(HttpMessage message, TokenRequestContext context, bool async)
         {
             string headerValue;
             if (async)

--- a/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
@@ -78,8 +78,8 @@ namespace Azure.Core.Pipeline
         /// <remarks>Service client libraries may derive from this and extend to handle service specific authentication challenges.</remarks>
         /// <param name="message">The <see cref="HttpMessage"/> to be authenticated.</param>
         /// <param name="async">Indicates whether the method was called from an asynchronous context.</param>
-        /// <returns>A boolean indicating whether the requeset was successfully authenticated and should be sent to the transport.</returns>
-        protected virtual ValueTask<bool> TryAuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
+        /// <returns>A boolean indicating whether the request was successfully authenticated and should be sent to the transport.</returns>
+        protected virtual ValueTask<bool> AuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
         {
             return _falseValueTask;
         }
@@ -96,7 +96,7 @@ namespace Azure.Core.Pipeline
             // If the message already has a challenge response due to a sub-class pre-processing the request, get the context from the challenge.
             if (message.HasResponse && message.Response.Status == (int)HttpStatusCode.Unauthorized && message.Response.Headers.Contains(HttpHeader.Names.WWWAuthenticate))
             {
-                if (!await TryAuthenticateRequestFromChallengeAsync(message, async).ConfigureAwait(false))
+                if (!await AuthenticateRequestFromChallengeAsync(message, async).ConfigureAwait(false))
                 {
                     // We were unsuccessful in handling the challenge, so bail out now.
                     return;
@@ -123,7 +123,7 @@ namespace Azure.Core.Pipeline
                 // Attempt to get the TokenRequestContext based on the challenge.
                 // If we fail to get the context, the challenge was not present or invalid.
                 // If we succeed in getting the context, authenticate the request and pass it up the policy chain.
-                if (await TryAuthenticateRequestFromChallengeAsync(message, async).ConfigureAwait(false))
+                if (await AuthenticateRequestFromChallengeAsync(message, async).ConfigureAwait(false))
                 {
                     if (async)
                     {

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -27,30 +27,27 @@ namespace Azure.Security.KeyVault
                 throw new InvalidOperationException("Bearer token authentication is not permitted for non TLS protected (https) endpoints.");
             }
 
-            // if this policy doesn't have _scope cached try to get it from the static challenge cache.
+            // If this policy doesn't have _scope cached try to get it from the static challenge cache.
+            if (_scope == null)
+            {
+                string authority = GetRequestAuthority(message.Request);
+                _scopeCache.TryGetValue(authority, out _scope);
+            }
+
             if (_scope != null)
-            {
-                await SetAuthorizationHeader(message, new TokenRequestContext(_scope.Scopes, message.Request.ClientRequestId), async).ConfigureAwait(false);
-                return;
-            }
-
-            string authority = GetRequestAuthority(message.Request);
-
-            if (!_scopeCache.TryGetValue(authority, out _scope) || _scope == null)
-            {
-                // The body is removed from the initial request because Key Vault supports other authentication schemes which also protect the body of the request.
-                // As a result, before we know the auth scheme we need to avoid sending an unprotected body to Key Vault.
-                // We don't currently support this enhanced auth scheme in the SDK but we still don't want to send any unprotected data to vaults which require it.
-
-                message.SetProperty(KeyVaultStashedContentKey, message.Request.Content);
-                message.Request.Content = null;
-            }
-            else
             {
                 // We fetched the scope from the cache, but we have not initialized the Scopes in the base yet.
                 var context = new TokenRequestContext(_scope.Scopes, message.Request.ClientRequestId);
                 await SetAuthorizationHeader(message, context, async).ConfigureAwait(false);
+                return;
             }
+
+            // The body is removed from the initial request because Key Vault supports other authentication schemes which also protect the body of the request.
+            // As a result, before we know the auth scheme we need to avoid sending an unprotected body to Key Vault.
+            // We don't currently support this enhanced auth scheme in the SDK but we still don't want to send any unprotected data to vaults which require it.
+
+            message.SetProperty(KeyVaultStashedContentKey, message.Request.Content);
+            message.Request.Content = null;
         }
 
         protected override async ValueTask<bool> AuthenticateRequestOnChallengeAsync(HttpMessage message, bool async)

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -59,6 +59,11 @@ namespace Azure.Security.KeyVault
             if (message.Request.Content == null && _contentCache.TryRemove(message, out var content))
             {
                 message.Request.Content = content;
+                if (_contentCache.Count > 10)
+                {
+                    // This should never occur, but it is just a safeguard against a leak of dictionary entries.
+                    _contentCache.Clear();
+                }
             }
 
             string authority = GetRequestAuthority(message.Request);

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -19,16 +19,6 @@ namespace Azure.Security.KeyVault
         public ChallengeBasedAuthenticationPolicy(TokenCredential credential) : base(credential, Array.Empty<string>())
         { }
 
-        public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
-        {
-            base.Process(message, pipeline);
-        }
-
-        public override async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
-        {
-            await base.ProcessAsync(message, pipeline).ConfigureAwait(false);
-        }
-
         /// <inheritdoc cref="BearerTokenChallengeAuthenticationPolicy.AuthenticateRequestFromChallengeAsync(HttpMessage, bool)" />
         protected override async Task PreProcessAsync(HttpMessage message, bool async)
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -20,7 +20,7 @@ namespace Azure.Security.KeyVault
         { }
 
         /// <inheritdoc cref="BearerTokenChallengeAuthenticationPolicy.AuthenticateRequestOnChallengeAsync(HttpMessage, bool)" />
-        protected override async Task PreProcessAsync(HttpMessage message, bool async)
+        protected override async Task AuthenticateRequestAsync(HttpMessage message, bool async)
         {
             if (message.Request.Uri.Scheme != Uri.UriSchemeHttps)
             {
@@ -30,7 +30,7 @@ namespace Azure.Security.KeyVault
             // if this policy doesn't have _scope cached try to get it from the static challenge cache.
             if (_scope != null)
             {
-                await AuthenticateRequestAsync(message, new TokenRequestContext(_scope.Scopes, message.Request.ClientRequestId), async).ConfigureAwait(false);
+                await SetAuthorizationHeader(message, new TokenRequestContext(_scope.Scopes, message.Request.ClientRequestId), async).ConfigureAwait(false);
                 return;
             }
 
@@ -50,7 +50,7 @@ namespace Azure.Security.KeyVault
             {
                 // We fetched the scope from the cache, but we have not initialized the Scopes in the base yet.
                 var context = new TokenRequestContext(_scope.Scopes, message.Request.ClientRequestId);
-                await AuthenticateRequestAsync(message, context, async).ConfigureAwait(false);
+                await SetAuthorizationHeader(message, context, async).ConfigureAwait(false);
             }
         }
 
@@ -86,7 +86,7 @@ namespace Azure.Security.KeyVault
             }
 
             var context = new TokenRequestContext(_scope.Scopes, message.Request.ClientRequestId);
-            await AuthenticateRequestAsync(message, context, async).ConfigureAwait(false);
+            await SetAuthorizationHeader(message, context, async).ConfigureAwait(false);
             return true;
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -28,7 +28,7 @@ namespace Azure.Security.KeyVault
             await base.ProcessAsync(message, pipeline).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="BearerTokenChallengeAuthenticationPolicy.TryAuthenticateRequestFromChallengeAsync(HttpMessage, bool)" />
+        /// <inheritdoc cref="BearerTokenChallengeAuthenticationPolicy.AuthenticateRequestFromChallengeAsync(HttpMessage, bool)" />
         protected override async ValueTask PreProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
             if (message.Request.Uri.Scheme != Uri.UriSchemeHttps)
@@ -74,7 +74,7 @@ namespace Azure.Security.KeyVault
             }
         }
 
-        protected override async ValueTask<bool> TryAuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
+        protected override async ValueTask<bool> AuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
         {
             string authority = GetRequestAuthority(message.Request);
             string scope = AuthorizationChallengeParser.GetChallengeParameterFromResponse(message.Response, "Bearer", "resource");

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -35,9 +35,8 @@ namespace Azure.Security.KeyVault
             }
 
             string authority = GetRequestAuthority(message.Request);
-            _scopeCache.TryGetValue(authority, out _scope);
 
-            if (_scope == null)
+            if (!_scopeCache.TryGetValue(authority, out _scope) || _scope == null)
             {
                 // The body is removed from the initial request because Key Vault supports other authentication schemes which also protect the body of the request.
                 // As a result, before we know the auth scheme we need to avoid sending an unprotected body to Key Vault.

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -19,7 +19,7 @@ namespace Azure.Security.KeyVault
         public ChallengeBasedAuthenticationPolicy(TokenCredential credential) : base(credential, Array.Empty<string>())
         { }
 
-        /// <inheritdoc cref="BearerTokenChallengeAuthenticationPolicy.AuthenticateRequestFromChallengeAsync(HttpMessage, bool)" />
+        /// <inheritdoc cref="BearerTokenChallengeAuthenticationPolicy.AuthenticateRequestOnChallengeAsync(HttpMessage, bool)" />
         protected override async Task PreProcessAsync(HttpMessage message, bool async)
         {
             if (message.Request.Uri.Scheme != Uri.UriSchemeHttps)
@@ -54,7 +54,7 @@ namespace Azure.Security.KeyVault
             }
         }
 
-        protected override async ValueTask<bool> AuthenticateRequestFromChallengeAsync(HttpMessage message, bool async)
+        protected override async ValueTask<bool> AuthenticateRequestOnChallengeAsync(HttpMessage message, bool async)
         {
             if (message.Request.Content == null && message.TryGetProperty(KeyVaultStashedContentKey, out var content))
             {


### PR DESCRIPTION
The focus of these changes is to refine the `BearerTokenChallengeAuthenticationPolicy` in the following ways:
-  Adding the protected virtual methods `AuthenticateRequestAsync`, and `AuthenticateRequestFromChallengeAsync` to allow subclasses to override how calls are authenticated originally and on WWW-Authenticate challenges
-  Add protected method `SetAuthorizationHeader`  in the base class so that subclass implementations can call it from `AuthenticateRequestAsync` and  `AuthenticateRequestFromChallengeAsync` and take advantage of the token cache without exposing it directly.
- `TryGetTokenRequestContextFromChallenge` becomes `AuthenticateRequestFromChallengeAsync` with the following changes to the semantics
  - Implementers are now expected to call `SetAuthorizationHeader` after parsing the challenge successfully
  - The return value is now `bool` to indicate whether the request was successfully authenticated and should be sent up the pipeline by the base
  - Sub-class implementations no longer need to set the Scope in the base now that they are authenticating the request directly