### PR TITLE
AzureCliCredential throws CredentialUnavailableException when interactive login is required

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.0-beta.4 (Unreleased)
+## 1.4.0-beta.4 (2021-03-09)
 
 ### Fixes and Improvements
 

--- a/sdk/identity/Azure.Identity/src/AzureCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/AzureCliCredential.cs
@@ -33,6 +33,7 @@ namespace Azure.Identity
         private static readonly string DefaultWorkingDirWindows = Environment.GetFolderPath(Environment.SpecialFolder.System);
         private const string DefaultPathNonWindows = "/usr/bin:/usr/local/bin";
         private const string DefaultWorkingDirNonWindows = "/bin/";
+        private const string RefreshTokeExpired = "The provided authorization code or refresh token has expired due to inactivity. Send a new interactive authorization request for this user and resource.";
         private static readonly string DefaultPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? DefaultPathWindows : DefaultPathNonWindows;
         private static readonly string DefaultWorkingDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? DefaultWorkingDirWindows : DefaultWorkingDirNonWindows;
 
@@ -131,7 +132,7 @@ namespace Azure.Identity
                     throw new CredentialUnavailableException(AzNotLogIn);
                 }
 
-                bool isRefreshTokenFailedError = exception.Message.IndexOf(AzureCliFailedError, StringComparison.OrdinalIgnoreCase) != -1 && exception.Message.IndexOf("The provided authorization code or refresh token has expired due to inactivity. Send a new interactive authorization request for this user and resource.", StringComparison.OrdinalIgnoreCase) != -1;
+                bool isRefreshTokenFailedError = exception.Message.IndexOf(AzureCliFailedError, StringComparison.OrdinalIgnoreCase) != -1 && exception.Message.IndexOf(RefreshTokeExpired, StringComparison.OrdinalIgnoreCase) != -1;
 
                 if (isRefreshTokenFailedError)
                 {

--- a/sdk/identity/Azure.Identity/src/AzureCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/AzureCliCredential.cs
@@ -20,11 +20,11 @@ namespace Azure.Identity
     /// </summary>
     public class AzureCliCredential : TokenCredential
     {
-        private const string AzureCLINotInstalled = "Azure CLI not installed";
-        private const string AzNotLogIn = "Please run 'az login' to set up account";
+        internal const string AzureCLINotInstalled = "Azure CLI not installed";
+        internal const string AzNotLogIn = "Please run 'az login' to set up account";
         private const string WinAzureCLIError = "'az' is not recognized";
         private const string AzureCliTimeoutError = "Azure CLI authentication timed out.";
-        private const string AzureCliFailedError = "Azure CLI authentication failed due to an unknown error.";
+        internal const string AzureCliFailedError = "Azure CLI authentication failed due to an unknown error.";
         private const int CliProcessTimeoutMs = 13000;
 
         // The default install paths are used to find Azure CLI if no path is specified. This is to prevent executing out of the current working directory.

--- a/sdk/identity/Azure.Identity/tests/AzureCliCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzureCliCredentialTests.cs
@@ -50,33 +50,25 @@ namespace Azure.Identity.Tests
             Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
         }
 
-        [Test]
-        public void AuthenticateWithCliCredential_AzureCliNotInstalled([Values("'az' is not recognized", "az: command not found", "az: not found")] string errorMessage)
+        public static IEnumerable<object[]> AzureCliExceptionScenarios()
         {
-            string expectedMessage = "Azure CLI not installed";
+            // params
+            // az thrown Exception message, expected message, expected  exception
+            yield return new object[] { "'az' is not recognized", AzureCliCredential.AzureCLINotInstalled, typeof(CredentialUnavailableException) };
+            yield return new object[] { "az: command not found", AzureCliCredential.AzureCLINotInstalled, typeof(CredentialUnavailableException) };
+            yield return new object[] { "az: not found", AzureCliCredential.AzureCLINotInstalled, typeof(CredentialUnavailableException) };
+            yield return new object[] { "Please run 'az login'", AzureCliCredential.AzNotLogIn, typeof(CredentialUnavailableException) };
+            yield return new object[] { "random unknown exception", AzureCliCredential.AzureCliFailedError + " random unknown exception", typeof(AuthenticationFailedException) };
+        }
+
+        [Test]
+        [TestCaseSource(nameof(AzureCliExceptionScenarios))]
+        public void AuthenticateWithCliCredential_ExceptionScenarios(string errorMessage, string expectedMessage, Type exceptionType)
+        {
             var testProcess = new TestProcess { Error = errorMessage };
             AzureCliCredential credential = InstrumentClient(new AzureCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync(exceptionType, async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
             Assert.AreEqual(expectedMessage, ex.Message);
-        }
-
-        [Test]
-        public void AuthenticateWithCliCredential_AzNotLogIn()
-        {
-            string expectedExMessage = $"Please run 'az login' to set up account";
-            var testProcess = new TestProcess { Error = "Please run 'az login'" };
-            AzureCliCredential credential = InstrumentClient(new AzureCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
-            Assert.AreEqual(expectedExMessage, ex.Message);
-        }
-
-        [Test]
-        public void AuthenticateWithCliCredential_AzureCliUnknownError()
-        {
-            string mockResult = "mock-result";
-            var testProcess = new TestProcess { Error = mockResult };
-            AzureCliCredential credential = InstrumentClient(new AzureCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
-            Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
         }
 
         [Test]

--- a/sdk/identity/Azure.Identity/tests/AzureCliCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzureCliCredentialTests.cs
@@ -50,6 +50,7 @@ namespace Azure.Identity.Tests
             Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
         }
 
+        private const string RefreshTokenExpiredError = "Azure CLI authentication failed due to an unknown error. ERROR: Get Token request returned http error: 400 and server response: {\"error\":\"invalid_grant\",\"error_description\":\"AADSTS70008: The provided authorization code or refresh token has expired due to inactivity. Send a new interactive authorization request for this user and resource.";
         public static IEnumerable<object[]> AzureCliExceptionScenarios()
         {
             // params
@@ -58,6 +59,7 @@ namespace Azure.Identity.Tests
             yield return new object[] { "az: command not found", AzureCliCredential.AzureCLINotInstalled, typeof(CredentialUnavailableException) };
             yield return new object[] { "az: not found", AzureCliCredential.AzureCLINotInstalled, typeof(CredentialUnavailableException) };
             yield return new object[] { "Please run 'az login'", AzureCliCredential.AzNotLogIn, typeof(CredentialUnavailableException) };
+            yield return new object[] { RefreshTokenExpiredError, AzureCliCredential.InteractiveLoginRequired, typeof(CredentialUnavailableException) };
             yield return new object[] { "random unknown exception", AzureCliCredential.AzureCliFailedError + " random unknown exception", typeof(AuthenticationFailedException) };
         }
 


### PR DESCRIPTION
fixes #19201 