### PR TITLE
Update servicebus to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/servicebus/tests.data.yml
+++ b/sdk/servicebus/tests.data.yml
@@ -7,4 +7,5 @@ extends:
     ServiceDirectory: servicebus
     SDKType: data
     TimeoutInMinutes: 120
+    Clouds: 'Public,Canary'
     SupportedClouds: 'Public,Preview,UsGov,China,Canary'

--- a/sdk/servicebus/tests.data.yml
+++ b/sdk/servicebus/tests.data.yml
@@ -6,6 +6,6 @@ extends:
     MaxParallel: 4
     ServiceDirectory: servicebus
     SDKType: data
-    TimeoutInMinutes: 120
+    TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
     SupportedClouds: 'Public,Preview,UsGov,China,Canary'

--- a/sdk/servicebus/tests.data.yml
+++ b/sdk/servicebus/tests.data.yml
@@ -7,4 +7,4 @@ extends:
     ServiceDirectory: servicebus
     SDKType: data
     TimeoutInMinutes: 120
-    Clouds: 'Public,Canary'
+    SupportedClouds: 'Public,Preview,UsGov,China,Canary'

--- a/sdk/servicebus/tests.data.yml
+++ b/sdk/servicebus/tests.data.yml
@@ -8,4 +8,4 @@ extends:
     SDKType: data
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
-    SupportedClouds: 'Public,Preview,UsGov,China,Canary'
+    SupportedClouds: 'Public,UsGov,China,Canary'

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -6,6 +6,6 @@ extends:
     MaxParallel: 4
     ServiceDirectory: servicebus
     SDKType: client
-    TimeoutInMinutes: 120
+    TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
     SupportedClouds: 'Public,Preview,UsGov,China,Canary'

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -7,4 +7,5 @@ extends:
     ServiceDirectory: servicebus
     SDKType: client
     TimeoutInMinutes: 120
+    Clouds: 'Public,Canary'
     SupportedClouds: 'Public,Preview,UsGov,China,Canary'

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -7,4 +7,4 @@ extends:
     ServiceDirectory: servicebus
     SDKType: client
     TimeoutInMinutes: 120
-    Clouds: 'Public,Canary'
+    SupportedClouds: 'Public,Preview,UsGov,China,Canary'

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -8,4 +8,4 @@ extends:
     SDKType: client
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
-    SupportedClouds: 'Public,Preview,UsGov,China,Canary'
+    SupportedClouds: 'Public,UsGov,China,Canary'


### PR DESCRIPTION
These changes contain fixes for the servicebus to be able to run live tests against AzureUsGovernment and AzureChina clouds. The sovereign cloud live tests will be green with the changes.
@benbp @danieljurek @jongio