### PR TITLE
[TA] Add known issues

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -25,7 +25,7 @@
 - `RecognizePiiEntities` and `TextAnalyticsActions.RecognizePiiEntitiesOptions` were always passing `PiiEntityDomainType.PHI`. Now, it is only passed when requested by the user [19086](https://github.com/Azure/azure-sdk-for-net/issues/19086).
 
 ### Known Issues
-- The parameter `CategoriesFilter` in `RecognizePiiEntitiesOptions` doesn't have an impact when using it in `StartAnalyzeBatchActions`. [19237](https://github.com/Azure/azure-sdk-for-net/issues/19237).
+- The parameter `CategoriesFilter` in `RecognizePiiEntitiesOptions` is currently not working when used in `StartAnalyzeBatchActions`. [19237](https://github.com/Azure/azure-sdk-for-net/issues/19237).
 - `Statistics` for `AnalyzeBatchActionsResult` are not currently returned even if the user passes `IncludeStatistics  = true`. [19268](https://github.com/Azure/azure-sdk-for-net/issues/19268).
 - `StartAnalyzeHealthcareEntities` is in gated preview and can not be used with AAD credentials. For more information, see [the Text Analytics for Health documentation](https://docs.microsoft.com/azure/cognitive-services/text-analytics/how-tos/text-analytics-for-health?tabs=ner#request-access-to-the-public-preview).
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -24,6 +24,10 @@
 ### Fixes
 - `RecognizePiiEntities` and `TextAnalyticsActions.RecognizePiiEntitiesOptions` were always passing `PiiEntityDomainType.PHI`. Now, it is only passed when requested by the user [19086](https://github.com/Azure/azure-sdk-for-net/issues/19086).
 
+### Known Issues
+- The parameter `CategoriesFilter` in `RecognizePiiEntitiesOptions` doesn't have an impact when using it in `StartAnalyzeBatchActions`. [19237](https://github.com/Azure/azure-sdk-for-net/issues/19237).
+- `Statistics` for `AnalyzeBatchActionsResult` are not currently returned even if the user passes `IncludeStatistics  = true`. [19268](https://github.com/Azure/azure-sdk-for-net/issues/19268).
+
 ## 5.1.0-beta.4 (2021-02-10)
 ### New features
 - Added property `Length` to `CategorizedEntity`, `SentenceSentiment`, `LinkedEntityMatch`, `AspectSentiment`, `OpinionSentiment`, and `PiiEntity`.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Known Issues
 - The parameter `CategoriesFilter` in `RecognizePiiEntitiesOptions` doesn't have an impact when using it in `StartAnalyzeBatchActions`. [19237](https://github.com/Azure/azure-sdk-for-net/issues/19237).
 - `Statistics` for `AnalyzeBatchActionsResult` are not currently returned even if the user passes `IncludeStatistics  = true`. [19268](https://github.com/Azure/azure-sdk-for-net/issues/19268).
+- `StartAnalyzeHealthcareEntities` is in gated preview and can not be used with AAD credentials. For more information, see [the Text Analytics for Health documentation](https://docs.microsoft.com/azure/cognitive-services/text-analytics/how-tos/text-analytics-for-health?tabs=ner#request-access-to-the-public-preview).
 
 ## 5.1.0-beta.4 (2021-02-10)
 ### New features

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeBatchActionsResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeBatchActionsResult.cs
@@ -56,7 +56,10 @@ namespace Azure.AI.TextAnalytics
         public IReadOnlyCollection<RecognizeLinkedEntitiesActionResult> RecognizeLinkedEntitiesActionsResults { get; }
 
         /// <summary>
-        /// <summary> if showStats=true was specified in the request this field will contain information about the document payload. </summary>
+        /// Gets statistics about the operation executed and how it was processed
+        /// by the service. This property currently won't return a value even if
+        /// <see cref="AnalyzeBatchActionsOptions.IncludeStatistics"/> to true.
+        /// More information https://github.com/Azure/azure-sdk-for-net/issues/19268
         /// </summary>
         public TextDocumentBatchStatistics Statistics { get; }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeBatchActionsResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeBatchActionsResult.cs
@@ -58,7 +58,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Gets statistics about the operation executed and how it was processed
         /// by the service. This property currently won't return a value even if
-        /// <see cref="AnalyzeBatchActionsOptions.IncludeStatistics"/> to true.
+        /// <see cref="AnalyzeBatchActionsOptions.IncludeStatistics"/> is set to true.
         /// More information https://github.com/Azure/azure-sdk-for-net/issues/19268
         /// </summary>
         public TextDocumentBatchStatistics Statistics { get; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActions.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Azure.AI.TextAnalytics
 {
-    /// <summary> Determines the set of actions to execute on the input documents.</summary>
+    /// <summary> Determines the set of actions that will get executed on the input documents.</summary>
     public class TextAnalyticsActions
     {
         /// <summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActions.cs
@@ -5,31 +5,32 @@ using System.Collections.Generic;
 
 namespace Azure.AI.TextAnalytics
 {
-    /// <summary> Determines the list of actions to be passed as arguments for AnalyzeBatchActionsOperation class. </summary>
+    /// <summary> Determines the set of actions to execute on the input documents.</summary>
     public class TextAnalyticsActions
     {
         /// <summary>
-        /// DisplayName
+        /// Optional display name for the analysis operation.
         /// </summary>
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// ExtractKeyPhrasesOptions
+        /// Extract KeyPhrases actions configurations.
         /// </summary>
         public IReadOnlyCollection<ExtractKeyPhrasesOptions> ExtractKeyPhrasesOptions { get; set; }
 
         /// <summary>
-        /// RecognizeEntitiesOptions
+        /// Recognize Entities actions configurations.
         /// </summary>
         public IReadOnlyCollection<RecognizeEntitiesOptions> RecognizeEntitiesOptions { get; set; }
 
         /// <summary>
-        /// RecognizePiiEntityOptions
+        /// Recognize PII Entities actions configurations.
+        /// Note: `CategoriesFilters` will not have an effect on the action. See https://github.com/Azure/azure-sdk-for-net/issues/19237
         /// </summary>
         public IReadOnlyCollection<RecognizePiiEntitiesOptions> RecognizePiiEntitiesOptions { get; set; }
 
         /// <summary>
-        /// RecognizeLinkedEntitiesOptions
+        /// Recognize Linked Entities actions configurations.
         /// </summary>
         public IReadOnlyCollection<RecognizeLinkedEntitiesOptions> RecognizeLinkedEntitiesOptions { get; set; }
     }


### PR DESCRIPTION
- `CategoriesFilter` not working on analyze https://github.com/Azure/azure-sdk-for-net/issues/19237.
- `Statistics` for `AnalyzeBatchActionsResult` are not currently returned even if the user passes `IncludeStatistics  = true`. https://github.com/Azure/azure-sdk-for-net/issues/19268