### PR TITLE
Use subscription configuration for communication services custom subscription

### DIFF
--- a/sdk/communication/tests.yml
+++ b/sdk/communication/tests.yml
@@ -9,6 +9,9 @@ extends:
       ACS_Public:
         SubscriptionConfiguration: $(sub-config-communication-services-cloud-test-resources)
     EnvVars:
+      AZURE_TENANT_ID: $(COMMUNICATION_TENANT_ID)
+      AZURE_CLIENT_ID: $(COMMUNICATION_CLIENT_ID)
+      AZURE_CLIENT_SECRET: $(COMMUNICATION_CLIENT_SECRET)
       AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING: $(communication-livetest-connection-string)
       AZURE_PHONE_NUMBER: $(communication-livetest-phone-number)
       INCLUDE_PHONENUMBER_LIVE_TESTS: False

--- a/sdk/communication/tests.yml
+++ b/sdk/communication/tests.yml
@@ -4,11 +4,11 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: communication
+    Clouds: ACS_Public
+    CloudConfig:
+      ACS_Public:
+        SubscriptionConfiguration: $(sub-config-communication-services-cloud-test-resources)
     EnvVars:
-      AZURE_SUBSCRIPTION_ID: $(acs-subscription-id)
       AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING: $(communication-livetest-connection-string)
       AZURE_PHONE_NUMBER: $(communication-livetest-phone-number)
-      AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-      AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-      AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
       INCLUDE_PHONENUMBER_LIVE_TESTS: False


### PR DESCRIPTION
The communication services live tests require provisioning of resource types that require certain billing rules for subscription eligibility. The default live test subscription has an account and agreement type that do not match the rules ([internal link](https://dev.azure.com/skype/SCC/_git/ic3_spool_cosine-dep-spool?path=%2Fsrc%2FBilling%2Fdotnetcore%2FMicrosoft.Azure.Spool.Billing.Common%2FConfiguration%2Fbilling_rp_subscription_eligibility_rules.json&version=GBmaster&_a=contents)).

The live tests previously did use a custom subscription, but given some recent config refactoring, the test config needs to be updated to consume subscription configurations in a new way.