### PR TITLE
[Smoke Tests] Increase Timeout

### DIFF
--- a/common/SmokeTests/smoke-tests.yml
+++ b/common/SmokeTests/smoke-tests.yml
@@ -5,3 +5,4 @@ jobs:
   - template: /eng/pipelines/templates/jobs/smoke-tests.yml
     parameters:
       Daily: true
+      TimeoutInMinutes: 240


### PR DESCRIPTION
# Summary

The focus of these changes is to increase the timeout for smoke test deployment and execution.  The Gov Clouds have been very, very slow when deploying test resources, causing the run to timeout before tests can run.

# Last Upstream Rebase

Friday, March 5, 3:00pm (EST)
