### PR TITLE
Increase timeout for Key Vault live tests

### DIFF
--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -4,7 +4,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: keyvault
-    TimeoutInMinutes: 120
+    TimeoutInMinutes: 180
     EnvVars:
       # Runs samples with live tests.
       # THIS VARIABLE IS A ONE-OFF WORKAROUND FOR KEYVAULT TESTS SPECIFICALLY, DON'T COPY IT


### PR DESCRIPTION
Some of our longer tests cannot run concurrently, and additional
certificate-based tests (which tend to be LONG-running operations) have
been added that are timing out live runs.
