### PR TITLE
[Smoke Tests]  Add Timeout and Update to March Releases

### DIFF
--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -11,10 +11,10 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Add an OverrideDailyVersion attribute to prevent the Update-Dependencies script from overwriting it with a daily build version -->
-    <PackageReference Include="Azure.Core" Version="1.9.0" />
-    <PackageReference Include="Azure.Identity" Version="1.4.0-beta.3" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.0" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.3.0" />
+    <PackageReference Include="Azure.Core" Version="1.10.0" />
+    <PackageReference Include="Azure.Identity" Version="1.4.0-beta.4" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.1" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.3.1" />
     <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.2.0-beta.4" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.9.0-beta.1" />
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.11" />

--- a/common/SmokeTests/smoke-tests.yml
+++ b/common/SmokeTests/smoke-tests.yml
@@ -5,4 +5,4 @@ jobs:
   - template: /eng/pipelines/templates/jobs/smoke-tests.yml
     parameters:
       Daily: true
-      TimeoutInMinutes: 240
+      TimeoutInMinutes: 90

--- a/eng/pipelines/templates/jobs/smoke-tests.yml
+++ b/eng/pipelines/templates/jobs/smoke-tests.yml
@@ -8,6 +8,9 @@ parameters:
   - name: ArtifactName
     type: string
     default: ""
+  - name: TimeoutInMinutes
+    type: number
+    default: 60
 
 jobs:
   - ${{ if eq(parameters.Daily, false) }}:
@@ -109,6 +112,8 @@ jobs:
       azureCloudArmParameters: "@{ storageEndpointSuffix = 'core.windows.net'; azureCloud = 'AzureCloud'; }"
       azureUSGovernmentArmParameters: "@{ storageEndpointSuffix = 'core.usgovcloudapi.net'; azureCloud = 'AzureUSGovernment'; }"
       azureChinaCloudArmParameters: "@{ storageEndpointSuffix = 'core.chinacloudapi.cn'; azureCloud = 'AzureChinaCloud'; }"
+
+    timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
     pool:
       name: $(Pool)

--- a/samples/iothub-connect-to-eventhubs/IotHubToEventHubsSample.csproj
+++ b/samples/iothub-connect-to-eventhubs/IotHubToEventHubsSample.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.1" />
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.11" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.20.1" />
   </ItemGroup>


### PR DESCRIPTION
# Summary

The focus of these changes is to add the standard timeout parameter used in other archtypes to the Smoke Tests template and configure the main job to respect it.

# Last Upstream Rebase

Monday, March 8, 3:00pm (EST)