### PR TITLE
[Perf] Use retryable APIs in Storage test setup

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Infrastructure/ContainerTest.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Infrastructure/ContainerTest.cs
@@ -23,12 +23,12 @@ namespace Azure.Storage.Blobs.Perf
         public override async Task GlobalSetupAsync()
         {
             await base.GlobalSetupAsync();
-            await BlobContainerClient.CreateAsync();
+            await BlobContainerClient.CreateIfNotExistsAsync();
         }
 
         public override async Task GlobalCleanupAsync()
         {
-            await BlobContainerClient.DeleteAsync();
+            await BlobContainerClient.DeleteIfExistsAsync();
             await base.GlobalCleanupAsync();
         }
     }

--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Infrastructure/DownloadSasUriTest.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Infrastructure/DownloadSasUriTest.cs
@@ -36,7 +36,7 @@ namespace Azure.Storage.Blobs.Perf.Infrastructure
             await base.GlobalSetupAsync();
 
             using var stream = RandomStream.Create(Options.Size);
-            await _blobClient.UploadAsync(stream);
+            await _blobClient.UploadAsync(stream, overwrite: true);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/DownloadBlob.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/DownloadBlob.cs
@@ -28,7 +28,7 @@ namespace Azure.Storage.Blobs.Perf.Scenarios
             using Stream stream = RandomStream.Create(Options.Size);
 
             // No need to delete file in GlobalCleanup(), since ContainerTest.GlobalCleanup() deletes the whole container
-            await _blobClient.UploadAsync(stream);
+            await _blobClient.UploadAsync(stream, overwrite: true);
         }
 
         public override void Run(CancellationToken cancellationToken)

--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs
@@ -27,7 +27,7 @@ namespace Azure.Storage.Blobs.Perf.Scenarios
             for (var i = 0; i < uploadTasks.Length; i++)
             {
                 var blobName = $"Azure.Storage.Blobs.Perf.Scenarios.DownloadBlob-{Guid.NewGuid()}";
-                uploadTasks[i] = BlobContainerClient.UploadBlobAsync(blobName, Stream.Null);
+                uploadTasks[i] = BlobContainerClient.GetBlobClient(blobName).UploadAsync(Stream.Null, overwrite: true);
             }
             await Task.WhenAll(uploadTasks);
         }

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Append.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Append.cs
@@ -101,7 +101,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
 
             using var randomStream = RandomStream.Create(1024);
 
-            await FileClient.CreateAsync();
+            await FileClient.CreateIfNotExistsAsync();
             await FileClient.UploadAsync(randomStream, true);
         }
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Read.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Read.cs
@@ -70,13 +70,13 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         public async override Task GlobalSetupAsync()
         {
             await base.GlobalSetupAsync();
-            await FileSystemClient.CreateAsync();
+            await FileSystemClient.CreateIfNotExistsAsync();
 
             // Create the test file that will be used for reading.
 
             using var randomStream = RandomStream.Create(Options.Size);
 
-            await FileClient.CreateAsync();
+            await FileClient.CreateIfNotExistsAsync();
             await FileClient.UploadAsync(randomStream, true);
         }
 
@@ -89,7 +89,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         public async override Task GlobalCleanupAsync()
         {
             await base.GlobalCleanupAsync();
-            await FileSystemClient.DeleteAsync();
+            await FileSystemClient.DeleteIfExistsAsync();
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Upload.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Upload.cs
@@ -62,7 +62,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         public async override Task GlobalSetupAsync()
         {
             await base.GlobalSetupAsync();
-            await FileSystemClient.CreateAsync();
+            await FileSystemClient.CreateIfNotExistsAsync();
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         public async override Task GlobalCleanupAsync()
         {
             await base.GlobalCleanupAsync();
-            await FileSystemClient.DeleteAsync();
+            await FileSystemClient.DeleteIfExistsAsync();
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
             var fileClient = FileSystemClient.GetFileClient(Path.GetRandomFileName());
             Payload.Position = 0;
 
-            fileClient.Create(cancellationToken: cancellationToken);
+            fileClient.CreateIfNotExists(cancellationToken: cancellationToken);
             fileClient.Upload(Payload, true, cancellationToken);
         }
 
@@ -127,7 +127,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
             var fileClient = FileSystemClient.GetFileClient(Path.GetRandomFileName());
             Payload.Position = 0;
 
-            await fileClient.CreateAsync(cancellationToken: cancellationToken);
+            await fileClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
             await fileClient.UploadAsync(Payload, true, cancellationToken);
         }
     }

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/UploadFile.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/UploadFile.cs
@@ -62,7 +62,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         public async override Task GlobalSetupAsync()
         {
             await base.GlobalSetupAsync();
-            await FileSystemClient.CreateAsync();
+            await FileSystemClient.CreateIfNotExistsAsync();
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         public async override Task GlobalCleanupAsync()
         {
             await base.GlobalCleanupAsync();
-            await FileSystemClient.DeleteAsync();
+            await FileSystemClient.DeleteIfExistsAsync();
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         {
             var fileClient = FileSystemClient.GetFileClient(Path.GetRandomFileName());
 
-            fileClient.Create(cancellationToken: cancellationToken);
+            fileClient.CreateIfNotExists(cancellationToken: cancellationToken);
             fileClient.Upload(UploadPath, true, cancellationToken: cancellationToken);
         }
 
@@ -143,7 +143,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         {
             var fileClient = FileSystemClient.GetFileClient(Path.GetRandomFileName());
 
-            await fileClient.CreateAsync(cancellationToken: cancellationToken);
+            await fileClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
             await fileClient.UploadAsync(UploadPath, true, cancellationToken);
         }
     }

--- a/sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Scenarios/DownloadFile.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Scenarios/DownloadFile.cs
@@ -52,10 +52,10 @@ namespace Azure.Storage.Files.Shares.Perf.Scenarios
             // See https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata for
             // restrictions on file share naming.
             _shareClient = new ShareClient(PerfTestEnvironment.Instance.FileSharesConnectionString, Guid.NewGuid().ToString());
-            await _shareClient.CreateAsync();
+            await _shareClient.CreateIfNotExistsAsync();
 
             ShareDirectoryClient DirectoryClient = _shareClient.GetDirectoryClient(Path.GetRandomFileName());
-            await DirectoryClient.CreateAsync();
+            await DirectoryClient.CreateIfNotExistsAsync();
 
             _fileClient = DirectoryClient.GetFileClient(Path.GetRandomFileName());
             await _fileClient.CreateAsync(_stream.Length, cancellationToken: CancellationToken.None);
@@ -65,7 +65,7 @@ namespace Azure.Storage.Files.Shares.Perf.Scenarios
 
         public override async Task CleanupAsync()
         {
-            await _shareClient.DeleteAsync();
+            await _shareClient.DeleteIfExistsAsync();
             await base.CleanupAsync();
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Scenarios/UploadFile.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Scenarios/UploadFile.cs
@@ -52,10 +52,10 @@ namespace Azure.Storage.Files.Shares.Perf.Scenarios
             // See https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata for
             // restrictions on file share naming.
             _shareClient = new ShareClient(PerfTestEnvironment.Instance.FileSharesConnectionString, Guid.NewGuid().ToString());
-            await _shareClient.CreateAsync();
+            await _shareClient.CreateIfNotExistsAsync();
 
             ShareDirectoryClient DirectoryClient = _shareClient.GetDirectoryClient(Path.GetRandomFileName());
-            await DirectoryClient.CreateAsync();
+            await DirectoryClient.CreateIfNotExistsAsync();
 
             _fileClient = DirectoryClient.GetFileClient(Path.GetRandomFileName());
             await _fileClient.CreateAsync(_stream.Length, cancellationToken: CancellationToken.None);
@@ -63,7 +63,7 @@ namespace Azure.Storage.Files.Shares.Perf.Scenarios
 
         public override async Task CleanupAsync()
         {
-            await _shareClient.DeleteAsync();
+            await _shareClient.DeleteIfExistsAsync();
             await base.CleanupAsync();
         }
 


### PR DESCRIPTION
- Prevents errors if client needs to retry a request that has already been accepted by the service