### PR TITLE
Use separate subscription for canary build for digital twins live tests

### DIFF
--- a/sdk/digitaltwins/tests.yml
+++ b/sdk/digitaltwins/tests.yml
@@ -4,5 +4,13 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: digitaltwins
-    Location: westus2
-    Clouds: Preview
+    # Enable canary and public cloud testing in separate subscriptions, so that the tests-weekly builds
+    # don't exceed the 10 azure digital twin instance hard limit
+    CloudConfig:
+      Public:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        Location: westus2
+      Canary:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+        Location: eastus2euap
+    Clouds: Public,Canary


### PR DESCRIPTION
The azure digital twins weekly live test is running into issues since there is a hard limit per subscription of 10 instances. This PR changes the canary tests to take place in the preview subscription, in order to avoid this overlap. Similarly, the public tests no longer need to be run in the preview subscription only, since the service is now GA.