### PR TITLE
[Perf/DataLake] Move stream disposal to Dispose()

### DIFF
--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Append.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Append.cs
@@ -60,6 +60,14 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
 
             FileSystemClient = serviceClient.GetFileSystemClient(FileSystemName);
             FileClient = FileSystemClient.GetFileClient(Path.GetRandomFileName());
+
+            Payload = RandomStream.Create(Options.Size);
+        }
+
+        public override void Dispose(bool disposing)
+        {
+            Payload.Dispose();
+            base.Dispose(disposing);
         }
 
         /// <summary>
@@ -95,7 +103,6 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         public async override Task SetupAsync()
         {
             await base.SetupAsync();
-            Payload = RandomStream.Create(Options.Size);
 
             // Create the test file that will be used as the basis for uploading.
 
@@ -103,18 +110,6 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
 
             await FileClient.CreateIfNotExistsAsync();
             await FileClient.UploadAsync(randomStream, true);
-        }
-
-        /// <summary>
-        ///   Performs the tasks needed to clean up the environment for an instance
-        ///   of the test scenario.  When multiple instances are run in parallel, cleanup
-        ///   will be run once for each after execution has completed.
-        /// </summary>
-        ///
-        public async override Task CleanupAsync()
-        {
-            await base.CleanupAsync();
-            Payload.Dispose();
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Upload.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Upload.cs
@@ -86,17 +86,6 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         }
 
         /// <summary>
-        ///   Performs the tasks needed to initialize and set up the environment for an instance
-        ///   of the test scenario.  When multiple instances are run in parallel, setup will be
-        ///   run once for each prior to its execution.
-        /// </summary>
-        ///
-        public async override Task SetupAsync()
-        {
-            await base.SetupAsync();
-        }
-
-        /// <summary>
         ///   Executes the performance test scenario synchronously.
         /// </summary>
         ///

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Upload.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Upload.cs
@@ -51,6 +51,14 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         {
             var serviceClient = new DataLakeServiceClient(TestEnvironment.DataLakeServiceUri, TestEnvironment.DataLakeCredential);
             FileSystemClient = serviceClient.GetFileSystemClient(FileSystemName);
+
+            Payload = RandomStream.Create(Options.Size);
+        }
+
+        public override void Dispose(bool disposing)
+        {
+            Payload.Dispose();
+            base.Dispose(disposing);
         }
 
         /// <summary>
@@ -86,19 +94,6 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         public async override Task SetupAsync()
         {
             await base.SetupAsync();
-            Payload = RandomStream.Create(Options.Size);
-        }
-
-        /// <summary>
-        ///   Performs the tasks needed to clean up the environment for an instance
-        ///   of the test scenario.  When multiple instances are run in parallel, cleanup
-        ///   will be run once for each after execution has completed.
-        /// </summary>
-        ///
-        public async override Task CleanupAsync()
-        {
-            await base.CleanupAsync();
-            Payload.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
- Slightly more correct to create/dispose in ctor/Dispose() instead of Setup/Cleanup()