### PR TITLE
A handful of renames for yet to be released ModelsRepositoryClient.

### DIFF
--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/api/Azure.Iot.ModelsRepository.netstandard2.0.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/api/Azure.Iot.ModelsRepository.netstandard2.0.cs
@@ -1,6 +1,6 @@
 namespace Azure.Iot.ModelsRepository
 {
-    public enum DependencyResolutionOption
+    public enum ModelDependencyResolution
     {
         Disabled = 0,
         Enabled = 1,
@@ -11,17 +11,16 @@ namespace Azure.Iot.ModelsRepository
         public ModelsRepositoryClient() { }
         public ModelsRepositoryClient(Azure.Iot.ModelsRepository.ModelsRepositoryClientOptions options) { }
         public ModelsRepositoryClient(System.Uri repositoryUri, Azure.Iot.ModelsRepository.ModelsRepositoryClientOptions options = null) { }
-        public static System.Uri DefaultModelsRepository { get { throw null; } }
         public System.Uri RepositoryUri { get { throw null; } }
-        public virtual System.Collections.Generic.IDictionary<string, string> GetModels(System.Collections.Generic.IEnumerable<string> dtmis, Azure.Iot.ModelsRepository.DependencyResolutionOption? resolutionOption = default(Azure.Iot.ModelsRepository.DependencyResolutionOption?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Collections.Generic.IDictionary<string, string> GetModels(string dtmi, Azure.Iot.ModelsRepository.DependencyResolutionOption? resolutionOption = default(Azure.Iot.ModelsRepository.DependencyResolutionOption?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, string>> GetModelsAsync(System.Collections.Generic.IEnumerable<string> dtmis, Azure.Iot.ModelsRepository.DependencyResolutionOption? resolutionOption = default(Azure.Iot.ModelsRepository.DependencyResolutionOption?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, string>> GetModelsAsync(string dtmi, Azure.Iot.ModelsRepository.DependencyResolutionOption? resolutionOption = default(Azure.Iot.ModelsRepository.DependencyResolutionOption?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Collections.Generic.IDictionary<string, string> GetModels(System.Collections.Generic.IEnumerable<string> dtmis, Azure.Iot.ModelsRepository.ModelDependencyResolution? dependencyResolution = default(Azure.Iot.ModelsRepository.ModelDependencyResolution?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Collections.Generic.IDictionary<string, string> GetModels(string dtmi, Azure.Iot.ModelsRepository.ModelDependencyResolution? dependencyResolution = default(Azure.Iot.ModelsRepository.ModelDependencyResolution?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, string>> GetModelsAsync(System.Collections.Generic.IEnumerable<string> dtmis, Azure.Iot.ModelsRepository.ModelDependencyResolution? dependencyResolution = default(Azure.Iot.ModelsRepository.ModelDependencyResolution?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, string>> GetModelsAsync(string dtmi, Azure.Iot.ModelsRepository.ModelDependencyResolution? dependencyResolution = default(Azure.Iot.ModelsRepository.ModelDependencyResolution?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class ModelsRepositoryClientOptions : Azure.Core.ClientOptions
     {
-        public ModelsRepositoryClientOptions(Azure.Iot.ModelsRepository.ModelsRepositoryClientOptions.ServiceVersion version = Azure.Iot.ModelsRepository.ModelsRepositoryClientOptions.ServiceVersion.V2021_02_11, Azure.Iot.ModelsRepository.DependencyResolutionOption resolutionOption = Azure.Iot.ModelsRepository.DependencyResolutionOption.Enabled) { }
-        public Azure.Iot.ModelsRepository.DependencyResolutionOption DependencyResolution { get { throw null; } }
+        public ModelsRepositoryClientOptions(Azure.Iot.ModelsRepository.ModelsRepositoryClientOptions.ServiceVersion version = Azure.Iot.ModelsRepository.ModelsRepositoryClientOptions.ServiceVersion.V2021_02_11, Azure.Iot.ModelsRepository.ModelDependencyResolution dependencyResolution = Azure.Iot.ModelsRepository.ModelDependencyResolution.Enabled) { }
+        public Azure.Iot.ModelsRepository.ModelDependencyResolution DependencyResolution { get { throw null; } }
         public Azure.Iot.ModelsRepository.ModelsRepositoryClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
         {

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelResolutionSamples.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelResolutionSamples.cs
@@ -38,7 +38,7 @@ namespace Azure.Iot.ModelsRepository.Samples
             // The client will also work with a local filesystem URI. This example shows initalization
             // with a local URI and disabling model dependency resolution.
             client = new ModelsRepositoryClient(new Uri(ClientSamplesLocalModelsRepository),
-                new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.Disabled));
+                new ModelsRepositoryClientOptions(dependencyResolution: ModelDependencyResolution.Disabled));
             Console.WriteLine($"Initialized client pointing to local path: {client.RepositoryUri}");
 
             #endregion Snippet:ModelsRepositorySamplesCreateServiceClientWithLocalRepository

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelResolutionSamples.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ModelResolutionSamples.cs
@@ -20,7 +20,8 @@ namespace Azure.Iot.ModelsRepository.Samples
             #region Snippet:ModelsRepositorySamplesCreateServiceClientWithGlobalEndpoint
 
             // When no URI is provided for instantiation, the Azure IoT Models Repository global endpoint
-            // https://devicemodels.azure.com/ is used and the dependency model resolution option is set to TryFromExpanded.
+            // https://devicemodels.azure.com/ is used and the model dependency resolution
+            // configuration is set to TryFromExpanded.
             var client = new ModelsRepositoryClient(new ModelsRepositoryClientOptions());
             Console.WriteLine($"Initialized client pointing to global endpoint: {client.RepositoryUri}");
 
@@ -52,7 +53,7 @@ namespace Azure.Iot.ModelsRepository.Samples
             var client = new ModelsRepositoryClient();
 
             // The output of GetModelsAsync() will include at least the definition for the target dtmi.
-            // If the dependency model resolution option is not disabled, then models in which the
+            // If the model dependency resolution configuration is not disabled, then models in which the
             // target dtmi depends on will also be included in the returned IDictionary<string, string>.
             var dtmi = "dtmi:com:example:TemperatureController;1";
             IDictionary<string, string> models = await client.GetModelsAsync(dtmi).ConfigureAwait(false);
@@ -73,7 +74,7 @@ namespace Azure.Iot.ModelsRepository.Samples
 
             // When given an IEnumerable of dtmis, the output of GetModelsAsync() will include at 
             // least the definitions of each dtmi enumerated in the IEnumerable.
-            // If the dependency model resolution option is not disabled, then models in which each
+            // If the model dependency resolution configuration is not disabled, then models in which each
             // enumerated dtmi depends on will also be included in the returned IDictionary<string, string>.
             var dtmis = new[] { "dtmi:com:example:TemperatureController;1", "dtmi:com:example:azuresphere:sampledevice;1" };
             IDictionary<string, string> models = await client.GetModelsAsync(dtmis).ConfigureAwait(false);
@@ -94,7 +95,7 @@ namespace Azure.Iot.ModelsRepository.Samples
             var client = new ModelsRepositoryClient(new Uri(ClientSamplesLocalModelsRepository));
 
             // The output of GetModelsAsync() will include at least the definition for the target dtmi.
-            // If the dependency model resolution option is not disabled, then models in which the
+            // If the model dependency resolution configuration is not disabled, then models in which the
             // target dtmi depends on will also be included in the returned IDictionary<string, string>.
             var dtmi = "dtmi:com:example:TemperatureController;1";
             IDictionary<string, string> models = await client.GetModelsAsync(dtmi).ConfigureAwait(false);

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ParserIntegrationSamples.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/ParserIntegrationSamples.cs
@@ -29,7 +29,7 @@ namespace Azure.Iot.ModelsRepository.Samples
         {
             #region Snippet:ModelsRepositorySamplesParserIntegrationParseAndGetModelsAsync
 
-            var client = new ModelsRepositoryClient(new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.Disabled));
+            var client = new ModelsRepositoryClient(new ModelsRepositoryClientOptions(dependencyResolution: ModelDependencyResolution.Disabled));
             var dtmi = "dtmi:com:example:TemperatureController;1";
             IDictionary<string, string> models = await client.GetModelsAsync(dtmi).ConfigureAwait(false);
             var parser = new ModelParser

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/readme.md
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/readme.md
@@ -18,7 +18,8 @@ The samples project demonstrates the following:
 
 ```C# Snippet:ModelsRepositorySamplesCreateServiceClientWithGlobalEndpoint
 // When no URI is provided for instantiation, the Azure IoT Models Repository global endpoint
-// https://devicemodels.azure.com/ is used and the dependency model resolution option is set to TryFromExpanded.
+// https://devicemodels.azure.com/ is used and the model dependency resolution
+// configuration is set to TryFromExpanded.
 var client = new ModelsRepositoryClient(new ModelsRepositoryClientOptions());
 Console.WriteLine($"Initialized client pointing to global endpoint: {client.RepositoryUri}");
 ```
@@ -27,7 +28,7 @@ Console.WriteLine($"Initialized client pointing to global endpoint: {client.Repo
 // The client will also work with a local filesystem URI. This example shows initalization
 // with a local URI and disabling model dependency resolution.
 client = new ModelsRepositoryClient(new Uri(ClientSamplesLocalModelsRepository),
-    new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.Disabled));
+    new ModelsRepositoryClientOptions(dependencyResolution: ModelDependencyResolution.Disabled));
 Console.WriteLine($"Initialized client pointing to local path: {client.RepositoryUri}");
 ```
 
@@ -53,7 +54,7 @@ After publishing, your model(s) will be available for consumption from the globa
 var client = new ModelsRepositoryClient();
 
 // The output of GetModelsAsync() will include at least the definition for the target dtmi.
-// If the dependency model resolution option is not disabled, then models in which the
+// If the model dependency resolution configuration is not disabled, then models in which the
 // target dtmi depends on will also be included in the returned IDictionary<string, string>.
 var dtmi = "dtmi:com:example:TemperatureController;1";
 IDictionary<string, string> models = await client.GetModelsAsync(dtmi).ConfigureAwait(false);
@@ -72,7 +73,7 @@ To support this workflow and similar use cases, the client supports initializati
 var client = new ModelsRepositoryClient(new Uri(ClientSamplesLocalModelsRepository));
 
 // The output of GetModelsAsync() will include at least the definition for the target dtmi.
-// If the dependency model resolution option is not disabled, then models in which the
+// If the model dependency resolution configuration is not disabled, then models in which the
 // target dtmi depends on will also be included in the returned IDictionary<string, string>.
 var dtmi = "dtmi:com:example:TemperatureController;1";
 IDictionary<string, string> models = await client.GetModelsAsync(dtmi).ConfigureAwait(false);
@@ -91,7 +92,7 @@ var client = new ModelsRepositoryClient();
 
 // When given an IEnumerable of dtmis, the output of GetModelsAsync() will include at 
 // least the definitions of each dtmi enumerated in the IEnumerable.
-// If the dependency model resolution option is not disabled, then models in which each
+// If the model dependency resolution configuration is not disabled, then models in which each
 // enumerated dtmi depends on will also be included in the returned IDictionary<string, string>.
 var dtmis = new[] { "dtmi:com:example:TemperatureController;1", "dtmi:com:example:azuresphere:sampledevice;1" };
 IDictionary<string, string> models = await client.GetModelsAsync(dtmis).ConfigureAwait(false);
@@ -121,7 +122,7 @@ Alternatively, the following snippet shows parsing a model, then fetching depend
 This is achieved by configuring the `ModelParser` to use the sample [ParserDtmiResolver][modelsrepository_sample_extension] client extension.
 
 ```C# Snippet:ModelsRepositorySamplesParserIntegrationParseAndGetModelsAsync
-var client = new ModelsRepositoryClient(new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.Disabled));
+var client = new ModelsRepositoryClient(new ModelsRepositoryClientOptions(dependencyResolution: ModelDependencyResolution.Disabled));
 var dtmi = "dtmi:com:example:TemperatureController;1";
 IDictionary<string, string> models = await client.GetModelsAsync(dtmi).ConfigureAwait(false);
 var parser = new ModelParser

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/FileModelFetcher.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/FileModelFetcher.cs
@@ -13,32 +13,32 @@ using Azure.Core.Pipeline;
 namespace Azure.Iot.ModelsRepository.Fetchers
 {
     /// <summary>
-    /// The LocalModelFetcher is an implementation of IModelFetcher
+    /// The FileModelFetcher is an implementation of IModelFetcher
     /// for supporting local filesystem based model content fetching.
     /// </summary>
-    internal class LocalModelFetcher : IModelFetcher
+    internal class FileModelFetcher : IModelFetcher
     {
         private readonly ClientDiagnostics _clientDiagnostics;
 
-        public LocalModelFetcher(ClientDiagnostics clientDiagnostics)
+        public FileModelFetcher(ClientDiagnostics clientDiagnostics)
         {
             _clientDiagnostics = clientDiagnostics;
         }
 
-        public Task<FetchResult> FetchAsync(string dtmi, Uri repositoryUri, DependencyResolutionOption resolutionOption, CancellationToken cancellationToken = default)
+        public Task<FetchResult> FetchAsync(string dtmi, Uri repositoryUri, ModelDependencyResolution dependencyResolution, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(Fetch(dtmi, repositoryUri, resolutionOption, cancellationToken));
+            return Task.FromResult(Fetch(dtmi, repositoryUri, dependencyResolution, cancellationToken));
         }
 
-        public FetchResult Fetch(string dtmi, Uri repositoryUri, DependencyResolutionOption resolutionOption, CancellationToken cancellationToken = default)
+        public FetchResult Fetch(string dtmi, Uri repositoryUri, ModelDependencyResolution dependencyResolution, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("LocalModelFetcher.Fetch");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("FileModelFetcher.Fetch");
             scope.Start();
 
             try
             {
                 var work = new Queue<string>();
-                if (resolutionOption == DependencyResolutionOption.TryFromExpanded)
+                if (dependencyResolution == ModelDependencyResolution.TryFromExpanded)
                 {
                     work.Enqueue(GetPath(dtmi, repositoryUri, true));
                 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/FileModelFetcher.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/FileModelFetcher.cs
@@ -32,7 +32,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
 
         public FetchResult Fetch(string dtmi, Uri repositoryUri, ModelDependencyResolution dependencyResolution, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("FileModelFetcher.Fetch");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(FileModelFetcher)}.{nameof(Fetch)}");
             scope.Start();
 
             try

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/HttpModelFetcher.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/HttpModelFetcher.cs
@@ -15,28 +15,28 @@ using System.Threading.Tasks;
 namespace Azure.Iot.ModelsRepository.Fetchers
 {
     /// <summary>
-    /// The RemoteModelFetcher is an implementation of IModelFetcher
+    /// The HttpModelFetcher is an implementation of IModelFetcher
     /// for supporting http[s] based model content fetching.
     /// </summary>
-    internal class RemoteModelFetcher : IModelFetcher
+    internal class HttpModelFetcher : IModelFetcher
     {
         private readonly HttpPipeline _pipeline;
         private readonly ClientDiagnostics _clientDiagnostics;
 
-        public RemoteModelFetcher(ClientDiagnostics clientDiagnostics, ModelsRepositoryClientOptions clientOptions)
+        public HttpModelFetcher(ClientDiagnostics clientDiagnostics, ModelsRepositoryClientOptions clientOptions)
         {
             _pipeline = CreatePipeline(clientOptions);
             _clientDiagnostics = clientDiagnostics;
         }
 
         public FetchResult Fetch(
-            string dtmi, Uri repositoryUri, DependencyResolutionOption resolutionOption, CancellationToken cancellationToken = default)
+            string dtmi, Uri repositoryUri, ModelDependencyResolution dependencyResolution, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("RemoteModelFetcher.Fetch");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("HttpModelFetcher.Fetch");
             scope.Start();
             try
             {
-                Queue<string> work = PrepareWork(dtmi, repositoryUri, resolutionOption == DependencyResolutionOption.TryFromExpanded);
+                Queue<string> work = PrepareWork(dtmi, repositoryUri, dependencyResolution == ModelDependencyResolution.TryFromExpanded);
 
                 string remoteFetchError = string.Empty;
 
@@ -74,13 +74,13 @@ namespace Azure.Iot.ModelsRepository.Fetchers
         }
 
         public async Task<FetchResult> FetchAsync(
-            string dtmi, Uri repositoryUri, DependencyResolutionOption resolutionOption, CancellationToken cancellationToken = default)
+            string dtmi, Uri repositoryUri, ModelDependencyResolution dependencyResolution, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("RemoteModelFetcher.Fetch");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("HttpModelFetcher.Fetch");
             scope.Start();
             try
             {
-                Queue<string> work = PrepareWork(dtmi, repositoryUri, resolutionOption == DependencyResolutionOption.TryFromExpanded);
+                Queue<string> work = PrepareWork(dtmi, repositoryUri, dependencyResolution == ModelDependencyResolution.TryFromExpanded);
 
                 string remoteFetchError = string.Empty;
                 RequestFailedException requestFailedExceptionThrown = null;
@@ -165,7 +165,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
 
         private string EvaluatePath(string path, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("RemoteModelFetcher.EvaluatePath");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("HttpModelFetcher.EvaluatePath");
             scope.Start();
 
             try
@@ -193,7 +193,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
 
         private async Task<string> EvaluatePathAsync(string path, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("RemoteModelFetcher.EvaluatePath");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("HttpModelFetcher.EvaluatePath");
             scope.Start();
 
             try

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/HttpModelFetcher.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/HttpModelFetcher.cs
@@ -32,7 +32,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
         public FetchResult Fetch(
             string dtmi, Uri repositoryUri, ModelDependencyResolution dependencyResolution, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("HttpModelFetcher.Fetch");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(HttpModelFetcher)}.{nameof(Fetch)}");
             scope.Start();
             try
             {
@@ -76,7 +76,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
         public async Task<FetchResult> FetchAsync(
             string dtmi, Uri repositoryUri, ModelDependencyResolution dependencyResolution, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("HttpModelFetcher.Fetch");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(HttpModelFetcher)}.{nameof(Fetch)}");
             scope.Start();
             try
             {
@@ -165,7 +165,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
 
         private string EvaluatePath(string path, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("HttpModelFetcher.EvaluatePath");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(HttpModelFetcher)}.{nameof(EvaluatePath)}");
             scope.Start();
 
             try
@@ -193,7 +193,7 @@ namespace Azure.Iot.ModelsRepository.Fetchers
 
         private async Task<string> EvaluatePathAsync(string path, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("HttpModelFetcher.EvaluatePath");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(HttpModelFetcher)}.{nameof(EvaluatePath)}");
             scope.Start();
 
             try

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/IModelFetcher.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/IModelFetcher.cs
@@ -13,8 +13,8 @@ namespace Azure.Iot.ModelsRepository.Fetchers
     /// </summary>
     internal interface IModelFetcher
     {
-        Task<FetchResult> FetchAsync(string dtmi, Uri repositoryUri, DependencyResolutionOption resolutionOption, CancellationToken cancellationToken = default);
+        Task<FetchResult> FetchAsync(string dtmi, Uri repositoryUri, ModelDependencyResolution dependencyResolution, CancellationToken cancellationToken = default);
 
-        FetchResult Fetch(string dtmi, Uri repositoryUri, DependencyResolutionOption resolutionOption, CancellationToken cancellationToken = default);
+        FetchResult Fetch(string dtmi, Uri repositoryUri, ModelDependencyResolution dependencyResolution, CancellationToken cancellationToken = default);
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelDependencyResolution.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelDependencyResolution.cs
@@ -6,7 +6,7 @@ namespace Azure.Iot.ModelsRepository
     /// <summary>
     /// The model dependency resolution options.
     /// </summary>
-    public enum DependencyResolutionOption
+    public enum ModelDependencyResolution
     {
         /// <summary>
         /// Disable model dependency resolution.
@@ -21,7 +21,7 @@ namespace Azure.Iot.ModelsRepository
 
         /// <summary>
         /// Try to get pre-computed model dependencies using .expanded.json.
-        /// If the model expanded form does not exist fall back to DependencyResolutionOption.Enabled processing.
+        /// If the model expanded form does not exist fall back to ModelDependencyResolution.Enabled processing.
         /// </summary>
         TryFromExpanded
     }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClient.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClient.cs
@@ -25,17 +25,18 @@ namespace Azure.Iot.ModelsRepository
         /// <see href="https://devicemodels.azure.com">Azure IoT Models Repository</see> service
         /// with the model dependency resolution option of TryFromExpanded.
         /// </summary>
-        public ModelsRepositoryClient() : this(DefaultModelsRepository,
-            new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.TryFromExpanded)) { }
+        public ModelsRepositoryClient() : this(new Uri(ModelsRepositoryConstants.DefaultModelsRepository),
+            new ModelsRepositoryClientOptions(dependencyResolution: ModelDependencyResolution.TryFromExpanded)) { }
 
         /// <summary>
         /// Initializes the ModelsRepositoryClient with custom client <paramref name="options"/> while pointing to
         /// the <see href="https://devicemodels.azure.com">Azure IoT Models Repository</see> service.
         /// </summary>
         /// <param name="options">
-        /// ModelsRepositoryClientOptions to configure resolution and client behavior.
+        /// ModelsRepositoryClientOptions to configure model dependency resolution and client behavior.
         /// </param>
-        public ModelsRepositoryClient(ModelsRepositoryClientOptions options) : this(DefaultModelsRepository, options) { }
+        public ModelsRepositoryClient(ModelsRepositoryClientOptions options) :
+            this(new Uri(ModelsRepositoryConstants.DefaultModelsRepository), options) { }
 
         /// <summary>
         /// Initializes the ModelsRepositoryClient with custom client <paramref name="options"/> while pointing to
@@ -45,7 +46,7 @@ namespace Azure.Iot.ModelsRepository
         /// The models repository Uri. This can be a remote endpoint or local directory.
         /// </param>
         /// <param name="options">
-        /// ModelsRepositoryClientOptions to configure resolution and client behavior.
+        /// ModelsRepositoryClientOptions to configure model dependency resolution and client behavior.
         /// </param>
         public ModelsRepositoryClient(Uri repositoryUri, ModelsRepositoryClientOptions options = default)
         {
@@ -69,20 +70,20 @@ namespace Azure.Iot.ModelsRepository
         /// </returns>
         /// <exception cref="RequestFailedException">Thrown when a resolution failure occurs.</exception>
         /// <param name="dtmi">A well-formed DTDL model Id. For example 'dtmi:com:example:Thermostat;1'.</param>
-        /// <param name="resolutionOption">A DependencyResolutionOption value to force model resolution behavior.</param>
+        /// <param name="dependencyResolution">A ModelDependencyResolution value to force model resolution behavior.</param>
         /// <param name="cancellationToken">The cancellationToken.</param>
         [SuppressMessage(
             "Usage",
             "AZC0015:Unexpected client method return type.",
-            Justification = "Item lookup is optimized with a dictionary type, we do not expect any more than ~20 items to be returned. TODO: azabbasi: discuss this issue with the review board.")]
+            Justification = "Item lookup is optimized with a dictionary type, we do not expect any more than ~20 items to be returned.")]
         public virtual async Task<IDictionary<string, string>> GetModelsAsync(
-            string dtmi, DependencyResolutionOption? resolutionOption = null, CancellationToken cancellationToken = default)
+            string dtmi, ModelDependencyResolution? dependencyResolution = null, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepositoryClient)}.{nameof(GetModels)}");
             scope.Start();
             try
             {
-                return await _repositoryHandler.ProcessAsync(dtmi, resolutionOption ?? _clientOptions.DependencyResolution, cancellationToken).ConfigureAwait(false);
+                return await _repositoryHandler.ProcessAsync(dtmi, dependencyResolution ?? _clientOptions.DependencyResolution, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -100,21 +101,21 @@ namespace Azure.Iot.ModelsRepository
         /// </returns>
         /// <exception cref="RequestFailedException">Thrown when a resolution failure occurs.</exception>
         /// <param name="dtmi">A well-formed DTDL model Id. For example 'dtmi:com:example:Thermostat;1'.</param>
-        /// <param name="resolutionOption">A DependencyResolutionOption value to force model resolution behavior.</param>
+        /// <param name="dependencyResolution">A ModelDependencyResolution value to force model resolution behavior.</param>
         /// <param name="cancellationToken">The cancellationToken.</param>
         [SuppressMessage(
             "Usage",
             "AZC0015:Unexpected client method return type.",
-            Justification = "Item lookup is optimized with a dictionary type, we do not expect any more than ~20 items to be returned. TODO: azabbasi: discuss this issue with the review board.")]
+            Justification = "Item lookup is optimized with a dictionary type, we do not expect any more than ~20 items to be returned.")]
         public virtual IDictionary<string, string> GetModels(
-            string dtmi, DependencyResolutionOption? resolutionOption = null, CancellationToken cancellationToken = default)
+            string dtmi, ModelDependencyResolution? dependencyResolution = null, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepositoryClient)}.{nameof(GetModels)}");
             scope.Start();
 
             try
             {
-                return _repositoryHandler.Process(dtmi, resolutionOption ?? _clientOptions.DependencyResolution, cancellationToken);
+                return _repositoryHandler.Process(dtmi, dependencyResolution ?? _clientOptions.DependencyResolution, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -132,21 +133,21 @@ namespace Azure.Iot.ModelsRepository
         /// </returns>
         /// <exception cref="RequestFailedException">Thrown when a resolution failure occurs.</exception>
         /// <param name="dtmis">A collection of well-formed DTDL model Ids.</param>
-        /// <param name="resolutionOption">A DependencyResolutionOption value to force model resolution behavior.</param>
+        /// <param name="dependencyResolution">A ModelDependencyResolution value to force model resolution behavior.</param>
         /// <param name="cancellationToken">The cancellationToken.</param>
         [SuppressMessage(
             "Usage",
             "AZC0015:Unexpected client method return type.",
-            Justification = "Item lookup is optimized with a dictionary type, we do not expect any more than ~20 items to be returned. TODO: azabbasi: discuss this issue with the review board.")]
+            Justification = "Item lookup is optimized with a dictionary type, we do not expect any more than ~20 items to be returned.")]
         public virtual async Task<IDictionary<string, string>> GetModelsAsync(
-            IEnumerable<string> dtmis, DependencyResolutionOption? resolutionOption = null, CancellationToken cancellationToken = default)
+            IEnumerable<string> dtmis, ModelDependencyResolution? dependencyResolution = null, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepositoryClient)}.{nameof(GetModels)}");
             scope.Start();
 
             try
             {
-                return await _repositoryHandler.ProcessAsync(dtmis, resolutionOption ?? _clientOptions.DependencyResolution, cancellationToken).ConfigureAwait(false);
+                return await _repositoryHandler.ProcessAsync(dtmis, dependencyResolution ?? _clientOptions.DependencyResolution, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -164,21 +165,21 @@ namespace Azure.Iot.ModelsRepository
         /// </returns>
         /// <exception cref="RequestFailedException">Thrown when a resolution failure occurs.</exception>
         /// <param name="dtmis">A collection of well-formed DTDL model Ids.</param>
-        /// <param name="resolutionOption">A DependencyResolutionOption value to force model resolution behavior.</param>
+        /// <param name="dependencyResolution">A ModelDependencyResolution value to force model resolution behavior.</param>
         /// <param name="cancellationToken">The cancellationToken.</param>
         [SuppressMessage(
             "Usage",
             "AZC0015:Unexpected client method return type.",
-            Justification = "Item lookup is optimized with a dictionary type, we do not expect any more than ~20 items to be returned. TODO: azabbasi: discuss this issue with the review board.")]
+            Justification = "Item lookup is optimized with a dictionary type, we do not expect any more than ~20 items to be returned.")]
         public virtual IDictionary<string, string> GetModels(
-            IEnumerable<string> dtmis, DependencyResolutionOption? resolutionOption = null, CancellationToken cancellationToken = default)
+            IEnumerable<string> dtmis, ModelDependencyResolution? dependencyResolution = null, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ModelsRepositoryClient)}.{nameof(GetModels)}");
             scope.Start();
 
             try
             {
-                return _repositoryHandler.Process(dtmis, resolutionOption ?? _clientOptions.DependencyResolution, cancellationToken);
+                return _repositoryHandler.Process(dtmis, dependencyResolution ?? _clientOptions.DependencyResolution, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -191,10 +192,5 @@ namespace Azure.Iot.ModelsRepository
         /// Gets the Uri associated with the ModelsRepositoryClient instance.
         /// </summary>
         public Uri RepositoryUri { get; }
-
-        /// <summary>
-        /// The global Azure IoT Models Repository service endpoint used by default.
-        /// </summary>
-        public static Uri DefaultModelsRepository => new Uri(ModelsRepositoryConstants.DefaultModelsRepository);
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClientOptions.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClientOptions.cs
@@ -39,18 +39,18 @@ namespace Azure.Iot.ModelsRepository
         /// The <see cref="ServiceVersion"/> of the service API used when
         /// making requests.
         /// </param>
-        /// <param name="resolutionOption">The dependency processing options.</param>
+        /// <param name="dependencyResolution">The model dependency processing options.</param>
         public ModelsRepositoryClientOptions(
             ServiceVersion version = LatestVersion,
-            DependencyResolutionOption resolutionOption = DependencyResolutionOption.Enabled)
+            ModelDependencyResolution dependencyResolution = ModelDependencyResolution.Enabled)
         {
-            DependencyResolution = resolutionOption;
+            DependencyResolution = dependencyResolution;
             Version = version;
         }
 
         /// <summary>
-        /// The dependency processing options.
+        /// The model dependency processing options.
         /// </summary>
-        public DependencyResolutionOption DependencyResolution { get; }
+        public ModelDependencyResolution DependencyResolution { get; }
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClientOptions.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryClientOptions.cs
@@ -39,7 +39,7 @@ namespace Azure.Iot.ModelsRepository
         /// The <see cref="ServiceVersion"/> of the service API used when
         /// making requests.
         /// </param>
-        /// <param name="dependencyResolution">The model dependency processing options.</param>
+        /// <param name="dependencyResolution">The model dependency resolution options.</param>
         public ModelsRepositoryClientOptions(
             ServiceVersion version = LatestVersion,
             ModelDependencyResolution dependencyResolution = ModelDependencyResolution.Enabled)
@@ -49,7 +49,7 @@ namespace Azure.Iot.ModelsRepository
         }
 
         /// <summary>
-        /// The model dependency processing options.
+        /// The model dependency resolution options.
         /// </summary>
         public ModelDependencyResolution DependencyResolution { get; }
     }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ClientTests.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/ClientTests.cs
@@ -16,8 +16,9 @@ namespace Azure.Iot.ModelsRepository.Tests
         {
             string remoteUriStr = "https://dtmi.com";
             Uri remoteUri = new Uri(remoteUriStr);
+            Uri defaultRepositoryUri = new Uri(ModelsRepositoryConstants.DefaultModelsRepository);
 
-            new ModelsRepositoryClient().RepositoryUri.Should().Be(ModelsRepositoryClient.DefaultModelsRepository);
+            new ModelsRepositoryClient().RepositoryUri.Should().Be(defaultRepositoryUri);
             new ModelsRepositoryClient(remoteUri).RepositoryUri.Should().Be(remoteUri);
 
             string localUriStr = TestLocalModelRepository;

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/GetModelsIntegrationTests.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/GetModelsIntegrationTests.cs
@@ -224,7 +224,7 @@ namespace Azure.Iot.ModelsRepository.Tests
         {
             const string dtmi = "dtmi:com:example:Thermostat;1";
 
-            ModelsRepositoryClientOptions options = new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.Disabled);
+            ModelsRepositoryClientOptions options = new ModelsRepositoryClientOptions(dependencyResolution: ModelDependencyResolution.Disabled);
             ModelsRepositoryClient client = GetClient(clientType, options);
 
             IDictionary<string, string> result = await client.GetModelsAsync(dtmi);
@@ -243,7 +243,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             ModelsRepositoryClient client = GetClient(clientType);
 
             // We would expect 3 models without the resolution option override.
-            IDictionary<string, string> result = await client.GetModelsAsync(dtmi, resolutionOption: DependencyResolutionOption.Disabled);
+            IDictionary<string, string> result = await client.GetModelsAsync(dtmi, dependencyResolution: ModelDependencyResolution.Disabled);
             var expectedDtmis = $"{dtmi}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             result.Keys.Count.Should().Be(expectedDtmis.Length);
@@ -263,10 +263,10 @@ namespace Azure.Iot.ModelsRepository.Tests
             const string expectedDeps = "dtmi:com:example:Thermostat;1,dtmi:azure:DeviceManagement:DeviceInformation;1";
 
             ModelsRepositoryClient client = GetClient(
-                clientType, new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.Disabled));
+                clientType, new ModelsRepositoryClientOptions(dependencyResolution: ModelDependencyResolution.Disabled));
 
             // We would expect 1 model without the resolution option override.
-            IDictionary<string, string> result = await client.GetModelsAsync(dtmi, resolutionOption: DependencyResolutionOption.Enabled);
+            IDictionary<string, string> result = await client.GetModelsAsync(dtmi, dependencyResolution: ModelDependencyResolution.Enabled);
             var expectedDtmis = $"{dtmi},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             result.Keys.Count.Should().Be(expectedDtmis.Length);
@@ -285,10 +285,10 @@ namespace Azure.Iot.ModelsRepository.Tests
             const string expectedDeps = "dtmi:com:example:Thermostat;1,dtmi:azure:DeviceManagement:DeviceInformation;1";
 
             ModelsRepositoryClient client = GetClient(
-                clientType, new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.Disabled));
+                clientType, new ModelsRepositoryClientOptions(dependencyResolution: ModelDependencyResolution.Disabled));
 
             // We would expect 1 model without the resolution option override.
-            IDictionary<string, string> result = await client.GetModelsAsync(dtmi, resolutionOption: DependencyResolutionOption.TryFromExpanded);
+            IDictionary<string, string> result = await client.GetModelsAsync(dtmi, dependencyResolution: ModelDependencyResolution.TryFromExpanded);
             var expectedDtmis = $"{dtmi},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             result.Keys.Count.Should().Be(expectedDtmis.Length);
@@ -309,7 +309,7 @@ namespace Azure.Iot.ModelsRepository.Tests
 
             var expectedDtmis = $"{dtmi},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
-            ModelsRepositoryClientOptions options = new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.TryFromExpanded);
+            ModelsRepositoryClientOptions options = new ModelsRepositoryClientOptions(dependencyResolution: ModelDependencyResolution.TryFromExpanded);
             ModelsRepositoryClient client = GetClient(clientType, options);
 
             IDictionary<string, string> result = await client.GetModelsAsync(dtmi);
@@ -337,7 +337,7 @@ namespace Azure.Iot.ModelsRepository.Tests
             string[] nonExpandedDtmis = dtmisNonExpanded.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
             string[] totalDtmis = expandedDtmis.Concat(nonExpandedDtmis).ToArray();
 
-            ModelsRepositoryClientOptions options = new ModelsRepositoryClientOptions(resolutionOption: DependencyResolutionOption.TryFromExpanded);
+            ModelsRepositoryClientOptions options = new ModelsRepositoryClientOptions(dependencyResolution: ModelDependencyResolution.TryFromExpanded);
             ModelsRepositoryClient client = GetClient(ModelsRepositoryTestBase.ClientType.Local, options);
 
             // Multi-resolve dtmi:com:example:TemperatureController;1 + dtmi:com:example:ColdStorage;1

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermojax-999.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-9fe4b3ec7c490840b9644f3daa669919-c6408cc31ee1d944-00",
+        "traceparent": "00-d763be3f7d65a54395a096e6ade81a65-c1ec3a227b8feb4e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "5869dbe376a9c64b690acc46c7df7b04",
@@ -20,16 +20,16 @@
         "Access-Control-Expose-Headers": "*",
         "Content-Length": "321",
         "Content-Type": "text/html",
-        "Date": "Fri, 26 Feb 2021 21:43:10 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:40 GMT",
         "Server": [
           "Windows-Azure-Web/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-error-code": "WebContentNotFound",
-        "x-ms-request-id": "20926d3c-201e-002d-0788-0c795b000000",
+        "x-ms-request-id": "37c616c5-901e-006a-4026-157b44000000",
         "x-ms-version": "2018-03-28"
       },
-      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 20926d3c-201e-002d-0788-0c795b000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-02-26T21:43:10.5728596Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
+      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 37c616c5-901e-006a-4026-157b44000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-03-09T20:58:40.9365459Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
     }
   ],
   "Variables": {

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote).json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermojax-999.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-d763be3f7d65a54395a096e6ade81a65-c1ec3a227b8feb4e-00",
+        "traceparent": "00-39698a5c751c1549a9615c94e519ad4a-2b5ecf9caefb9949-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -20,16 +20,16 @@
         "Access-Control-Expose-Headers": "*",
         "Content-Length": "321",
         "Content-Type": "text/html",
-        "Date": "Tue, 09 Mar 2021 20:58:40 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:26 GMT",
         "Server": [
           "Windows-Azure-Web/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-error-code": "WebContentNotFound",
-        "x-ms-request-id": "37c616c5-901e-006a-4026-157b44000000",
+        "x-ms-request-id": "6a07288a-d01e-0042-012a-15b266000000",
         "x-ms-version": "2018-03-28"
       },
-      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 37c616c5-901e-006a-4026-157b44000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-03-09T20:58:40.9365459Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
+      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 6a07288a-d01e-0042-012a-15b266000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-03-09T21:26:26.9162169Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
     }
   ],
   "Variables": {

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermojax-999.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-410ea4c18fcff042aedae986f56ca722-77bef434f970b24b-00",
+        "traceparent": "00-ca4957509ec90e41b694581723567878-b7d48d7a84d5284a-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "2e91ad571b311f17984f4e70c70864a5",
@@ -20,16 +20,16 @@
         "Access-Control-Expose-Headers": "*",
         "Content-Length": "321",
         "Content-Type": "text/html",
-        "Date": "Fri, 26 Feb 2021 21:43:10 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "Server": [
           "Windows-Azure-Web/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-error-code": "WebContentNotFound",
-        "x-ms-request-id": "546d12a6-401e-003b-2a88-0c3375000000",
+        "x-ms-request-id": "cb7ba678-b01e-003c-0e26-15e27b000000",
         "x-ms-version": "2018-03-28"
       },
-      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 546d12a6-401e-003b-2a88-0c3375000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-02-26T21:43:11.1323421Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
+      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : cb7ba678-b01e-003c-0e26-15e27b000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-03-09T20:58:41.4826214Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
     }
   ],
   "Variables": {

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote)Async.json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermojax-999.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-ca4957509ec90e41b694581723567878-b7d48d7a84d5284a-00",
+        "traceparent": "00-5d41a71f247fbe49a8477057d7ef4c80-d8e7382d05792248-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -20,16 +20,16 @@
         "Access-Control-Expose-Headers": "*",
         "Content-Length": "321",
         "Content-Type": "text/html",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "Server": [
           "Windows-Azure-Web/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-error-code": "WebContentNotFound",
-        "x-ms-request-id": "cb7ba678-b01e-003c-0e26-15e27b000000",
+        "x-ms-request-id": "f4ddfc01-401e-0043-6c2a-159964000000",
         "x-ms-version": "2018-03-28"
       },
-      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : cb7ba678-b01e-003c-0e26-15e27b000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-03-09T20:58:41.4826214Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
+      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : f4ddfc01-401e-0043-6c2a-159964000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-03-09T21:26:27.3980024Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
     }
   ],
   "Variables": {

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-ab4f47d9df7ade4681d70c375d352aac-af3800c78294bc44-00",
+        "traceparent": "00-765f1005f0698246bd0114e4b66bee9a-31cede851f90df4a-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "d59c39d95f9071c9fb36c311ddf28369",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157772",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:10 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -131,9 +131,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-ab4f47d9df7ade4681d70c375d352aac-3b94c2cd46237243-00",
+        "traceparent": "00-765f1005f0698246bd0114e4b66bee9a-81fafd566942444a-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "0f0bac77fe7035e01c21e364e29e0fe3",
@@ -146,11 +146,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137104",
+        "Age": "479760",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:10 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [
@@ -159,7 +159,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f6f2fc42-701e-0058-1d49-0b0c51000000",
+        "x-ms-request-id": "4b2737f3-201e-002d-07c9-10795b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote).json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-765f1005f0698246bd0114e4b66bee9a-31cede851f90df4a-00",
+        "traceparent": "00-c424bd51aea25d468788cd86649804c9-eb7bc936a3ca764c-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -131,7 +131,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-765f1005f0698246bd0114e4b66bee9a-81fafd566942444a-00",
+        "traceparent": "00-c424bd51aea25d468788cd86649804c9-912d6e2021da7a4c-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -146,11 +146,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-bfadd265fdfc164db371e1c04bc6310c-4ae4f37b7f53a842-00",
+        "traceparent": "00-258dcea9334dca4ca68a05cb44ddfe29-1d34c29ca412f341-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "4000049fcf2ea59788ea4dd65e9df822",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157773",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -131,9 +131,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-bfadd265fdfc164db371e1c04bc6310c-403b1598a77b294d-00",
+        "traceparent": "00-258dcea9334dca4ca68a05cb44ddfe29-68852a10a124a347-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "bd48ba64ef7464d9cc6616421b97a34b",
@@ -146,11 +146,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137105",
+        "Age": "479760",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [
@@ -159,7 +159,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f6f2fc42-701e-0058-1d49-0b0c51000000",
+        "x-ms-request-id": "4b2737f3-201e-002d-07c9-10795b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote)Async.json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-258dcea9334dca4ca68a05cb44ddfe29-1d34c29ca412f341-00",
+        "traceparent": "00-ad5460680759eb48a2ba234a4090d7ee-e082b9c9c2e30249-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -131,7 +131,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-258dcea9334dca4ca68a05cb44ddfe29-68852a10a124a347-00",
+        "traceparent": "00-ad5460680759eb48a2ba234a4090d7ee-3f576620bf548e45-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -146,11 +146,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-ac8252b629ca4c489da578e665cffc40-b5b22fe18ca4014f-00",
+        "traceparent": "00-571e0c04143f444cbc1076110a42fd01-1a528e34ceea104f-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "80baf927f75417d901d33d472e388379",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157772",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:10 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote).json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-571e0c04143f444cbc1076110a42fd01-1a528e34ceea104f-00",
+        "traceparent": "00-d94ec4a8c879f64c89f28df7775b6063-73c1554034732c4f-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-2a7a0d22fb9e8f4d9a643d8de239997e-b934bc8412df1641-00",
+        "traceparent": "00-6860846adeb66443b5ea8585b4a36eb4-d1b86b6bfd504d4e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "ea1ec3ed68f24ba78f90c70cbbe3f832",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157773",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote)Async.json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-6860846adeb66443b5ea8585b4a36eb4-d1b86b6bfd504d4e-00",
+        "traceparent": "00-846dbdbc22c7e246b125896f5dbc86ae-90701e56990f6142-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.expanded.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-288b8b5e7c5c294abcedd87d3fad2d4b-815a10f19dfae44c-00",
+        "traceparent": "00-a60c8d6fa974fa4cba4152bc14573134-abb731d79dd5634a-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "e7119021118cf849ebc5c278668716e5",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "150069",
+        "Age": "479759",
         "Content-Length": "6751",
         "Content-MD5": "BnZpV2\u002B7Z2t0sxAxOhmBdw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:10 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEAC10FCC\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "24f99709-b01e-0084-472a-0bcc2e000000",
+        "x-ms-request-id": "2af4bc5f-b01e-0054-74c9-10f848000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote).json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.expanded.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-a60c8d6fa974fa4cba4152bc14573134-abb731d79dd5634a-00",
+        "traceparent": "00-7309c9bafb3f5f47a105e3cc9d554bd8-feea22b7a098d846-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479759",
+        "Age": "481425",
         "Content-Length": "6751",
         "Content-MD5": "BnZpV2\u002B7Z2t0sxAxOhmBdw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEAC10FCC\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.expanded.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-b77b61745242074d8a53ab4fb54eb475-b7fbe3ca60531642-00",
+        "traceparent": "00-689453d90bfd76479e7027aa54f326a2-ec66d1b773f34d40-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "72ac13935c0bd5e9c9d2b215d4d3d079",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "150070",
+        "Age": "479759",
         "Content-Length": "6751",
         "Content-MD5": "BnZpV2\u002B7Z2t0sxAxOhmBdw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEAC10FCC\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "24f99709-b01e-0084-472a-0bcc2e000000",
+        "x-ms-request-id": "2af4bc5f-b01e-0054-74c9-10f848000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote)Async.json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.expanded.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-689453d90bfd76479e7027aa54f326a2-ec66d1b773f34d40-00",
+        "traceparent": "00-6f3b109a7b79634e959031f2c77634fc-24981986c2494c48-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479759",
+        "Age": "481425",
         "Content-Length": "6751",
         "Content-MD5": "BnZpV2\u002B7Z2t0sxAxOhmBdw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEAC10FCC\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-219dea03e22b0b4890633b997c1f6507-322a5cf1eb96244d-00",
+        "traceparent": "00-77943ee93517f343969010d3d7ea9cfc-7d6b9811b6a61e41-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "2bdeb8748c19bdea0863b77c707f8289",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137104",
+        "Age": "479759",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:10 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f724f502-501e-000e-3449-0b956e000000",
+        "x-ms-request-id": "acd9a7e9-f01e-0004-3ac9-109b7b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -102,9 +102,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-219dea03e22b0b4890633b997c1f6507-be32b9d713855344-00",
+        "traceparent": "00-77943ee93517f343969010d3d7ea9cfc-cb02a27cc780dd42-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "b5dc3925d0fa6c8a99ad66367cc71880",
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157772",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:10 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -130,7 +130,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -229,9 +229,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-219dea03e22b0b4890633b997c1f6507-351d0a30eeaa7b47-00",
+        "traceparent": "00-77943ee93517f343969010d3d7ea9cfc-bbf72f0032737144-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "04d50949c3a9a5b251679297c7973d41",
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137104",
+        "Age": "479760",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:10 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [
@@ -257,7 +257,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f6f2fc42-701e-0058-1d49-0b0c51000000",
+        "x-ms-request-id": "4b2737f3-201e-002d-07c9-10795b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote).json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-77943ee93517f343969010d3d7ea9cfc-7d6b9811b6a61e41-00",
+        "traceparent": "00-c46e8f9ff392474387291c1abad76ddd-63b4bc2410d59f45-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479759",
+        "Age": "481425",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -102,7 +102,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-77943ee93517f343969010d3d7ea9cfc-cb02a27cc780dd42-00",
+        "traceparent": "00-c46e8f9ff392474387291c1abad76ddd-455d18bf559bbf4e-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -229,7 +229,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-77943ee93517f343969010d3d7ea9cfc-bbf72f0032737144-00",
+        "traceparent": "00-c46e8f9ff392474387291c1abad76ddd-88bbfcc6e182d240-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-2ee3424568247e4cb25339ba64860f66-6bd87b9c608f9848-00",
+        "traceparent": "00-eac90d64cea5ff4e8cb169483df419a2-1dd0588f7783d146-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "ca414829555f92065321cfd3d915b286",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137105",
+        "Age": "479759",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f724f502-501e-000e-3449-0b956e000000",
+        "x-ms-request-id": "acd9a7e9-f01e-0004-3ac9-109b7b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -102,9 +102,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-2ee3424568247e4cb25339ba64860f66-a25a2ff16b028246-00",
+        "traceparent": "00-eac90d64cea5ff4e8cb169483df419a2-cd7c3c20b443cc42-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "e31aa4de9d588e3f03ab5e665e1a30a6",
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157773",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -130,7 +130,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -229,9 +229,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-2ee3424568247e4cb25339ba64860f66-f613412cdf23e841-00",
+        "traceparent": "00-eac90d64cea5ff4e8cb169483df419a2-30f5a49270ac4141-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "a1c50a41dd36d8c72e8418dd882be79e",
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137105",
+        "Age": "479760",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [
@@ -257,7 +257,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f6f2fc42-701e-0058-1d49-0b0c51000000",
+        "x-ms-request-id": "4b2737f3-201e-002d-07c9-10795b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote)Async.json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-eac90d64cea5ff4e8cb169483df419a2-1dd0588f7783d146-00",
+        "traceparent": "00-6a4cd06e2b96b14aaf81e7b14987e202-a9b0894d39f9fc4f-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479759",
+        "Age": "481425",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -102,7 +102,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-eac90d64cea5ff4e8cb169483df419a2-cd7c3c20b443cc42-00",
+        "traceparent": "00-6a4cd06e2b96b14aaf81e7b14987e202-f41f1dc75d302645-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -229,7 +229,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-eac90d64cea5ff4e8cb169483df419a2-30f5a49270ac4141-00",
+        "traceparent": "00-6a4cd06e2b96b14aaf81e7b14987e202-c6a812cf3591174f-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-4871a7bfc1a1084cadc209768899ba78-c1a9acaefe578e43-00",
+        "traceparent": "00-9b51ae81f7380b43a20de7f659d3eb19-ab0b280d3807c649-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "922f4f6eaa519d59f16b3cadc3cd16f5",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157773",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote).json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-9b51ae81f7380b43a20de7f659d3eb19-ab0b280d3807c649-00",
+        "traceparent": "00-8d270e276b75b743bee1a9980ba64ee3-11536f0fe0f7e34b-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-56d3005017b40a45a6c7996292fdd79f-716dee04445e1b48-00",
+        "traceparent": "00-4172f3add53ca147a02d11ec73fa54a7-1dbb63eb3e69184c-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "52cf98cf47771c488c58badde6058bce",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157773",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote)Async.json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-4172f3add53ca147a02d11ec73fa54a7-1dbb63eb3e69184c-00",
+        "traceparent": "00-e87d29601ebee14e8dfbfacae7725506-760335278302d443-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-545bb12b309caf428a2ddc030ebd8b67-7b504ae676f85741-00",
+        "traceparent": "00-9e338d8baf6bdb4790043c26131e7888-6a7a5885b77ab349-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "d6f677c223dd62fa0e0231b2c3c58299",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137105",
+        "Age": "479759",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f724f502-501e-000e-3449-0b956e000000",
+        "x-ms-request-id": "acd9a7e9-f01e-0004-3ac9-109b7b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote).json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-9e338d8baf6bdb4790043c26131e7888-6a7a5885b77ab349-00",
+        "traceparent": "00-25f3aad851e71940ad7307eaef98b6b7-3ea1c0dc63ba7d4b-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479759",
+        "Age": "481425",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-d816995eacf05e41ab4e799941631cd5-aa69bb3eb25f2541-00",
+        "traceparent": "00-fc8abc7aa86975429a79d70a626982f2-39a747148fcd8b4d-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "b92630c966affdb7765e3e0e36531e3a",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137105",
+        "Age": "479759",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f724f502-501e-000e-3449-0b956e000000",
+        "x-ms-request-id": "acd9a7e9-f01e-0004-3ac9-109b7b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote)Async.json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-fc8abc7aa86975429a79d70a626982f2-39a747148fcd8b4d-00",
+        "traceparent": "00-d2f91c3cd818b642b52558df09795a71-70f518e40805ff40-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479759",
+        "Age": "481425",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-a8e743df839c7d45a34ca0ad36deb718-816c80d8fa23524d-00",
+        "traceparent": "00-f4be9b1d741a414b845705ab934db306-558ed552179b254f-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "1c1c561069359998a8c0500a3d73d129",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137105",
+        "Age": "479759",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f724f502-501e-000e-3449-0b956e000000",
+        "x-ms-request-id": "acd9a7e9-f01e-0004-3ac9-109b7b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -102,9 +102,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-a8e743df839c7d45a34ca0ad36deb718-5b493beda752e844-00",
+        "traceparent": "00-f4be9b1d741a414b845705ab934db306-18169c5c87f8be46-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "7a7699898b5886b07eb45e3a10daed30",
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157773",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -130,7 +130,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -229,9 +229,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-a8e743df839c7d45a34ca0ad36deb718-f7622f29bbe29c43-00",
+        "traceparent": "00-f4be9b1d741a414b845705ab934db306-4338f70e48283345-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "c7519e75b0335de5862b34c01d1a4dd5",
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137105",
+        "Age": "479760",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [
@@ -257,7 +257,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f6f2fc42-701e-0058-1d49-0b0c51000000",
+        "x-ms-request-id": "4b2737f3-201e-002d-07c9-10795b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote).json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-f4be9b1d741a414b845705ab934db306-558ed552179b254f-00",
+        "traceparent": "00-8e5957091e649544bf26c2a395f5ebd0-de440fcf8ef44a4f-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479759",
+        "Age": "481425",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -102,7 +102,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-f4be9b1d741a414b845705ab934db306-18169c5c87f8be46-00",
+        "traceparent": "00-8e5957091e649544bf26c2a395f5ebd0-f52cd74e41dcac40-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -229,7 +229,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-f4be9b1d741a414b845705ab934db306-4338f70e48283345-00",
+        "traceparent": "00-8e5957091e649544bf26c2a395f5ebd0-a3f1160f4a7fd34f-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-d9972c3ca5ad23469c85564bf2588a37-e57913eab917694f-00",
+        "traceparent": "00-5f237b71c6789f4a8cb6334663a1a367-2a1e8642c769ad4e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "fded581de13cc25893ff3412434b8bde",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137105",
+        "Age": "479759",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f724f502-501e-000e-3449-0b956e000000",
+        "x-ms-request-id": "acd9a7e9-f01e-0004-3ac9-109b7b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -102,9 +102,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-d9972c3ca5ad23469c85564bf2588a37-5d53f8fa98f92e47-00",
+        "traceparent": "00-5f237b71c6789f4a8cb6334663a1a367-1bd3e8656bb71b45-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "7f526465451650416c561e6bd4c11112",
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157773",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -130,7 +130,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [
@@ -229,9 +229,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-d9972c3ca5ad23469c85564bf2588a37-6dd5302d40fbc042-00",
+        "traceparent": "00-5f237b71c6789f4a8cb6334663a1a367-d9fe3db25f4d8f49-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "f7efee1d81e7f308d1f189d881bb6835",
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "137105",
+        "Age": "479760",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [
@@ -257,7 +257,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "f6f2fc42-701e-0058-1d49-0b0c51000000",
+        "x-ms-request-id": "4b2737f3-201e-002d-07c9-10795b000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote)Async.json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-5f237b71c6789f4a8cb6334663a1a367-2a1e8642c769ad4e-00",
+        "traceparent": "00-f85d3269a4d07c4693fa9b350dd24fe8-383fc237579d2546-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479759",
+        "Age": "481425",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -102,7 +102,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-5f237b71c6789f4a8cb6334663a1a367-1bd3e8656bb71b45-00",
+        "traceparent": "00-f85d3269a4d07c4693fa9b350dd24fe8-a61ee5d0c2917f4d-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -229,7 +229,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-5f237b71c6789f4a8cb6334663a1a367-d9fe3db25f4d8f49-00",
+        "traceparent": "00-f85d3269a4d07c4693fa9b350dd24fe8-df244576234c824b-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-b4f40e26bf5197459db6e856d876de4a-dc7469eba3b1ba44-00",
+        "traceparent": "00-b2b75b490bf90141aac6a1f1fffe5727-8325f789d174f14e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "c734165d00f93fa8ae5fca3f90b9d139",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157773",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote).json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-b2b75b490bf90141aac6a1f1fffe5727-8325f789d174f14e-00",
+        "traceparent": "00-ddb2dcfa0089a14a9cc8c0d5e504e422-d035f4dedf8a5840-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-c6d63bd22c57074db4f08783d97c0102-d18846cb67dbc648-00",
+        "traceparent": "00-cf14f5191c97af4fa4f9f52bd1a66775-b701238b1cd48c4b-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210226.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "87d45ebe9f20be964956486fbff04612",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "157773",
+        "Age": "479760",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Feb 2021 21:43:11 GMT",
+        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -32,7 +32,7 @@
         ],
         "X-Cache": "HIT",
         "x-ms-error-code": "ConditionNotMet",
-        "x-ms-request-id": "c4512b5c-b01e-0068-7319-0b2d40000000",
+        "x-ms-request-id": "2effc87c-a01e-0025-6fc9-10214a000000",
         "x-ms-version": "2018-03-28"
       },
       "ResponseBody": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote)Async.json
@@ -4,7 +4,7 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-cf14f5191c97af4fa4f9f52bd1a66775-b701238b1cd48c4b-00",
+        "traceparent": "00-a7f3cebee29f374383db138cc1857360-ceda46d96e8f3d48-00",
         "User-Agent": [
           "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
           "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "479760",
+        "Age": "481426",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Tue, 09 Mar 2021 20:58:41 GMT",
+        "Date": "Tue, 09 Mar 2021 21:26:27 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Update-ApiSurface.ps1
+++ b/sdk/modelsrepository/Update-ApiSurface.ps1
@@ -1,0 +1,1 @@
+..\..\eng\scripts\Export-API.ps1 modelsrepository


### PR DESCRIPTION
- Renamed `RemoteModelFetcher` to `HttpModelFetcher`
- Renamed `LocalModelFetcher` to `FileModelFetcher`
- Renamed `DependencyResolutionOption` enum to `ModelDependencyResolution`
- Renamed parameter `resolutionOption` to `dependencyResolution`
- Removed `DefaultModelsRepository` static property from client.