### PR TITLE
[FormRecognizer] Changing Test attribute to RecordedTest in live tests

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -7,8 +7,8 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
+using Azure.Core.TestFramework;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
 
 namespace Azure.AI.FormRecognizer.Tests
 {
@@ -30,7 +30,7 @@ namespace Azure.AI.FormRecognizer.Tests
         {
         }
 
-        [Test]
+        [RecordedTest]
         public void FormRecognizerClientCannotAuthenticateWithFakeApiKey()
         {
             var client = CreateFormRecognizerClient(apiKey: "fakeKey");
@@ -44,7 +44,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
         #region StartRecognizeContent
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeContentCanAuthenticateWithTokenCredential()
         {
             var client = CreateFormRecognizerClient(useTokenCredential: true);
@@ -69,7 +69,7 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies that the <see cref="FormRecognizerClient" /> is able to connect to the Form
         /// Recognizer cognitive service and perform operations.
         /// </summary>
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task StartRecognizeContentPopulatesFormPagePdf(bool useStream)
@@ -176,7 +176,7 @@ namespace Azure.AI.FormRecognizer.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task StartRecognizeContentPopulatesFormPageJpg(bool useStream)
@@ -289,7 +289,7 @@ namespace Azure.AI.FormRecognizer.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task StartRecognizeContentCanParseMultipageForm(bool useStream)
@@ -330,7 +330,7 @@ namespace Azure.AI.FormRecognizer.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeContentCanParseBlankPage()
         {
             var client = CreateFormRecognizerClient();
@@ -353,7 +353,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, blankPage.SelectionMarks.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeContentCanParseMultipageFormWithBlankPage()
         {
             var client = CreateFormRecognizerClient();
@@ -392,7 +392,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, blankPage.Tables.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public void StartRecognizeContentThrowsForDamagedFile()
         {
             var client = CreateFormRecognizerClient();
@@ -410,7 +410,7 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies that the <see cref="FormRecognizerClient" /> is able to connect to the Form
         /// Recognizer cognitive service and handle returned errors.
         /// </summary>
-        [Test]
+        [RecordedTest]
         public void StartRecognizeContentFromUriThrowsForNonExistingContent()
         {
             var client = CreateFormRecognizerClient();
@@ -420,7 +420,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("FailedToDownloadImage", ex.ErrorCode);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task StartRecognizeContentWithSelectionMarks(bool useStream)
@@ -450,7 +450,7 @@ namespace Azure.AI.FormRecognizer.Tests
             ValidateFormPage(formPage, includeFieldElements: true, expectedPageNumber: 1);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase("1", 1)]
         [TestCase("1-2", 2)]
         public async Task StartRecognizeContentWithOnePageArgument(string pages, int expected)
@@ -469,7 +469,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(expected, formPages.Count);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase("1", "3", 2)]
         [TestCase("1-2", "3", 3)]
         public async Task StartRecognizeContentWithMultiplePageArgument(string page1, string page2, int expected)
@@ -488,7 +488,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(expected, formPages.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeContentWithLanguage()
         {
             var client = CreateFormRecognizerClient();
@@ -505,7 +505,7 @@ namespace Azure.AI.FormRecognizer.Tests
             ValidateFormPage(formPage, includeFieldElements: true, expectedPageNumber: 1);
         }
 
-        [Test]
+        [RecordedTest]
         public void StartRecognizeContentWithNoSupporttedLanguage()
         {
             var client = CreateFormRecognizerClient();
@@ -519,7 +519,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
         #region StartRecognizeReceipts
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeReceiptsCanAuthenticateWithTokenCredential()
         {
             var client = CreateFormRecognizerClient(useTokenCredential: true);
@@ -549,7 +549,7 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies that the <see cref="FormRecognizerClient" /> is able to connect to the Form
         /// Recognizer cognitive service and perform analysis of receipts.
         /// </summary>
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false, Ignore = "Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public async Task StartRecognizeReceiptsPopulatesExtractedReceiptJpg(bool useStream)
@@ -660,7 +660,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.That(form.Fields["Total"].Value.AsFloat(), Is.EqualTo(1203.39).Within(0.0001));
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false, Ignore = "Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public async Task StartRecognizeReceiptsPopulatesExtractedReceiptPng(bool useStream)
@@ -774,7 +774,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.That(form.Fields["Total"].Value.AsFloat(), Is.EqualTo(14.50).Within(0.0001));
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false, Ignore = "Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public async Task StartRecognizeReceiptsCanParseMultipageForm(bool useStream)
@@ -830,7 +830,7 @@ namespace Azure.AI.FormRecognizer.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeReceiptsCanParseBlankPage()
         {
             var client = CreateFormRecognizerClient();
@@ -861,7 +861,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, blankPage.Tables.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeReceiptsCanParseMultipageFormWithBlankPage()
         {
             var client = CreateFormRecognizerClient();
@@ -913,7 +913,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, blankPage.Tables.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public void StartRecognizeReceiptsThrowsForDamagedFile()
         {
             var client = CreateFormRecognizerClient();
@@ -931,7 +931,7 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies that the <see cref="FormRecognizerClient" /> is able to connect to the Form
         /// Recognizer cognitive service and handle returned errors.
         /// </summary>
-        [Test]
+        [RecordedTest]
         [Ignore("Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public void StartRecognizeReceiptsFromUriThrowsForNonExistingContent()
         {
@@ -942,7 +942,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("FailedToDownloadImage", ex.ErrorCode);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeReceiptsWithSupportedLocale()
         {
             var client = CreateFormRecognizerClient();
@@ -978,7 +978,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, receiptPage.Tables.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public void StartRecognizeReceiptsWithWrongLocale()
         {
             var client = CreateFormRecognizerClient();
@@ -997,7 +997,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
         #region StartRecognizeBusinessCards
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeBusinessCardsCanAuthenticateWithTokenCredential()
         {
             var client = CreateFormRecognizerClient(useTokenCredential: true);
@@ -1023,7 +1023,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 expectedLastPageNumber: 1);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false, Ignore = "Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public async Task StartRecognizeBusinessCardsPopulatesExtractedJpg(bool useStream)
@@ -1130,7 +1130,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("Contoso", companyNames.FirstOrDefault().Value.AsString());
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false, Ignore = "Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public async Task StartRecognizeBusinessCardsPopulatesExtractedPng(bool useStream)
@@ -1237,7 +1237,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("Contoso", companyNames.FirstOrDefault().Value.AsString());
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeBusinessCardsIncludeFieldElements()
         {
             var client = CreateFormRecognizerClient();
@@ -1261,7 +1261,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 expectedLastPageNumber: 1);
        }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeBusinessCardsCanParseBlankPage()
         {
             var client = CreateFormRecognizerClient();
@@ -1293,7 +1293,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, blankPage.SelectionMarks.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public void StartRecognizeBusinessCardsThrowsForDamagedFile()
         {
             var client = CreateFormRecognizerClient();
@@ -1311,7 +1311,7 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies that the <see cref="FormRecognizerClient" /> is able to connect to the Form
         /// Recognizer cognitive service and handle returned errors.
         /// </summary>
-        [Test]
+        [RecordedTest]
         [Ignore("Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public void StartRecognizeBusinessCardsFromUriThrowsForNonExistingContent()
         {
@@ -1322,7 +1322,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("FailedToDownloadImage", ex.ErrorCode);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false, Ignore = "Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public async Task StartRecognizeBusinessCardsCanParseMultipageForm(bool useStream)
@@ -1384,7 +1384,7 @@ namespace Azure.AI.FormRecognizer.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeBusinessCardsWithSupportedLocale()
         {
             var client = CreateFormRecognizerClient();
@@ -1420,7 +1420,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, businessCardPage.Tables.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public void StartRecognizeBusinessCardsWithWrongLocale()
         {
             var client = CreateFormRecognizerClient();
@@ -1439,7 +1439,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
         #region StartRecognizeInvoices
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeInvoicesCanAuthenticateWithTokenCredential()
         {
             var client = CreateFormRecognizerClient(useTokenCredential: true);
@@ -1465,7 +1465,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 expectedLastPageNumber: 1);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false, Ignore = "Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public async Task StartRecognizeInvoicesPopulatesExtractedPdf(bool useStream)
@@ -1533,7 +1533,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(2017, dueDate.Year);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false, Ignore = "Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public async Task StartRecognizeInvoicesPopulatesExtractedTiff(bool useStream)
@@ -1607,7 +1607,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(2017, dueDate.Year);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeInvoicesIncludeFieldElements()
         {
             var client = CreateFormRecognizerClient();
@@ -1631,7 +1631,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 expectedLastPageNumber: 1);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeInvoicesCanParseBlankPage()
         {
             var client = CreateFormRecognizerClient();
@@ -1662,7 +1662,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, blankPage.SelectionMarks.Count);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false, Ignore = "Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public async Task StartRecognizeInvoicesCanParseMultipageForm(bool useStream)
@@ -1723,7 +1723,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 expectedLastPageNumber: 2);
         }
 
-        [Test]
+        [RecordedTest]
         public void StartRecognizeInvoicesThrowsForDamagedFile()
         {
             var client = CreateFormRecognizerClient();
@@ -1741,7 +1741,7 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies that the <see cref="FormRecognizerClient" /> is able to connect to the Form
         /// Recognizer cognitive service and handle returned errors.
         /// </summary>
-        [Test]
+        [RecordedTest]
         [Ignore("Flaky behavior. Issue https://github.com/Azure/azure-sdk-for-net/issues/18813")]
         public void StartRecognizeInvoicesFromUriThrowsForNonExistingContent()
         {
@@ -1752,7 +1752,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("FailedToDownloadImage", ex.ErrorCode);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeInvoicesWithSupportedLocale()
         {
             var client = CreateFormRecognizerClient();
@@ -1788,7 +1788,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(1, receiptPage.Tables.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public void StartRecognizeInvoicesWithWrongLocale()
         {
             var client = CreateFormRecognizerClient();
@@ -1807,7 +1807,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
         #region StartRecognizeCustomForms
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task StartRecognizeCustomFormsCanAuthenticateWithTokenCredential(bool useTrainingLabels)
@@ -1854,7 +1854,7 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies that the <see cref="FormRecognizerClient" /> is able to connect to the Form
         /// Recognizer cognitive service and perform analysis based on a custom labeled model.
         /// </summary>
-        [Test]
+        [RecordedTest]
         [TestCase(true, true)]
         [TestCase(true, false)]
         [TestCase(false, true)]
@@ -1913,7 +1913,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("948284", form.Fields[name].ValueData.Text);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task StartRecognizeCustomFormsWithLabelsAndSelectionMarks(bool includeFieldElements)
@@ -1949,7 +1949,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("Selected", form.Fields[name].ValueData.Text);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task StartRecognizeCustomFormsWithLabelsCanParseMultipageForm(bool useStream)
@@ -2008,7 +2008,7 @@ namespace Azure.AI.FormRecognizer.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeCustomFormsWithLabelsCanParseBlankPage()
         {
             var client = CreateFormRecognizerClient();
@@ -2041,7 +2041,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, blankPage.Tables.Count);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task StartRecognizeCustomFormsWithLabelsCanParseMultipageFormWithBlankPage(bool useStream)
@@ -2096,7 +2096,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, blankPage.Tables.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeCustomFormsWithLabelsCanParseDifferentTypeOfForm()
         {
             var client = CreateFormRecognizerClient();
@@ -2127,7 +2127,7 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies that the <see cref="FormRecognizerClient" /> is able to connect to the Form
         /// Recognizer cognitive service and perform analysis based on a custom labeled model.
         /// </summary>
-        [Test]
+        [RecordedTest]
         [TestCase(true, true)]
         [TestCase(true, false)]
         [TestCase(false, true)]
@@ -2189,7 +2189,7 @@ namespace Azure.AI.FormRecognizer.Tests
             // Assert.AreEqual("Hero Limited", form.Fields[name].LabelData.Text);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false, Ignore = "https://github.com/Azure/azure-sdk-for-net/issues/12319")]
         public async Task StartRecognizeCustomFormsWithoutLabelsCanParseMultipageForm(bool useStream)
@@ -2245,7 +2245,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("Southridge Video", secondFormFieldInPage.ValueData.Text);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecognizeCustomFormsWithoutLabelsCanParseBlankPage()
         {
             var client = CreateFormRecognizerClient();
@@ -2279,7 +2279,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, blankPage.Tables.Count);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false, Ignore = "https://github.com/Azure/azure-sdk-for-net/issues/12319")]
         public async Task StartRecognizeCustomFormsWithoutLabelsCanParseMultipageFormWithBlankPage(bool useStream)
@@ -2343,7 +2343,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, blankPage.Tables.Count);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task StartRecognizeCustomFormsThrowsForDamagedFile(bool useTrainingLabels)
@@ -2370,7 +2370,7 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies that the <see cref="FormRecognizerClient" /> is able to connect to the Form
         /// Recognizer cognitive service and handle returned errors.
         /// </summary>
-        [Test]
+        [RecordedTest]
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/19375")]
         [TestCase(true)]
         [TestCase(false)]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -30,14 +30,14 @@ namespace Azure.AI.FormRecognizer.Tests
         {
         }
 
-        [Test]
+        [RecordedTest]
         public void FormTrainingClientCannotAuthenticateWithFakeApiKey()
         {
             var client = CreateFormTrainingClient(apiKey: "fakeKey");
             Assert.ThrowsAsync<RequestFailedException>(async () => await client.GetAccountPropertiesAsync());
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartTrainingCanAuthenticateWithTokenCredential()
         {
             var client = CreateFormTrainingClient(useTokenCredential: true);
@@ -54,7 +54,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(0, model.Errors.Count);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true, true)]
         [TestCase(true, false)]
         [TestCase(false, true)]
@@ -105,7 +105,7 @@ namespace Azure.AI.FormRecognizer.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task CheckFormTypeinSubmodelAndRecognizedForm(bool labeled)
@@ -132,7 +132,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(form.FormType, model.Submodels.FirstOrDefault().FormType);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(false)]
         [TestCase(true)]
         public async Task StartCreateComposedModel(bool useTokenCredential)
@@ -202,7 +202,7 @@ namespace Azure.AI.FormRecognizer.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartCreateComposedModelFailsWithInvalidId()
         {
             var client = CreateFormTrainingClient();
@@ -216,7 +216,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("1001", ex.ErrorCode);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartTrainingSucceedsWithValidPrefix()
         {
             var client = CreateFormTrainingClient();
@@ -231,7 +231,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(CustomFormModelStatus.Ready, operation.Value.Status);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartTrainingFailsWithInvalidPrefix()
         {
             var client = CreateFormTrainingClient();
@@ -244,7 +244,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("2014", ex.ErrorCode);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartTrainingWithLabelsModelName()
         {
             var client = CreateFormTrainingClient();
@@ -259,7 +259,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(modelName, operation.Value.ModelName);
         }
 
-        [Test]
+        [RecordedTest]
         [Ignore("Current bug on the service side returns null for model name.")]
         public async Task StartTrainingWithNoLabelsModelName()
         {
@@ -275,7 +275,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(modelName, operation.Value.ModelName);
         }
 
-        [Test]
+        [RecordedTest]
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/19375")]
         public async Task StartTrainingError()
         {
@@ -291,7 +291,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.Throws<RequestFailedException>(() => operation.Value.GetType());
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true, true)]
         [TestCase(false, true)]
         [TestCase(true, false)]
@@ -365,7 +365,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("1022", ex.ErrorCode);
         }
 
-        [Test]
+        [RecordedTest]
         public void DeleteModelFailsWhenModelDoesNotExist()
         {
             var client = CreateFormTrainingClient();
@@ -375,7 +375,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("1022", ex.ErrorCode);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task CopyModel(bool useTokenCredential)
@@ -402,7 +402,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreNotEqual(trainedModel.ModelId, modelCopied.ModelId);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CopyModelWithLabelsAndModelName()
         {
             var sourceClient = CreateFormTrainingClient();
@@ -430,7 +430,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(modelName, modelCopiedFullInfo.ModelName);
         }
 
-        [Test]
+        [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
         public async Task CopyComposedModel(bool useTokenCredential)
@@ -469,7 +469,7 @@ namespace Azure.AI.FormRecognizer.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         [Ignore("Current bug on the service side returns null for model name.")]
         public async Task CopyModelWithoutLabelsAndModelName()
         {
@@ -498,7 +498,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(modelName, modelCopiedFullInfo.ModelName);
         }
 
-        [Test]
+        [RecordedTest]
         public void CopyModelError()
         {
             var sourceClient = CreateFormTrainingClient();
@@ -514,7 +514,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual("1002", ex.ErrorCode);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartCopyModelFailsWithWrongRegion()
         {
             var sourceClient = CreateFormTrainingClient();
@@ -530,7 +530,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetCopyAuthorization()
         {
             var targetClient = CreateFormTrainingClient();
@@ -546,7 +546,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(region, targetAuth.Region);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SerializeDeserializeCopyAuthorizationAsync()
         {
             var targetClient = CreateFormTrainingClient();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsLiveTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Training;
+using Azure.Core.TestFramework;
 using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Tests
@@ -28,7 +29,7 @@ namespace Azure.AI.FormRecognizer.Tests
         {
         }
 
-        [Test]
+        [RecordedTest]
         public async Task RecognizeContentOperationCanPollFromNewObject()
         {
             var client = CreateFormRecognizerClient(out var nonInstrumentedClient);
@@ -43,7 +44,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(1, sameOperation.Value.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task RecognizeReceiptsOperationCanPollFromNewObject()
         {
             var client = CreateFormRecognizerClient(out var nonInstrumentedClient);
@@ -58,7 +59,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(1, sameOperation.Value.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task RecognizeInvoicesOperationCanPollFromNewObject()
         {
             var client = CreateFormRecognizerClient(out var nonInstrumentedClient);
@@ -73,7 +74,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(1, sameOperation.Value.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task RecognizeCustomFormsOperationCanPollFromNewObject()
         {
             var client = CreateFormRecognizerClient(out var nonInstrumentedClient);
@@ -94,7 +95,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(1, sameOperation.Value.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task TrainingOperationCanPollFromNewObject()
         {
             var client = CreateFormTrainingClient(out var nonInstrumentedClient);
@@ -109,7 +110,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(CustomFormModelStatus.Ready, sameOperation.Value.Status);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateComposedModelOperationCanPollFromNewObject()
         {
             var client = CreateFormTrainingClient(out var nonInstrumentedClient);
@@ -126,7 +127,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(CustomFormModelStatus.Ready, sameOperation.Value.Status);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CopyModelOperationCanPollFromNewObject()
         {
             var client = CreateFormTrainingClient(out var nonInstrumentedClient);


### PR DESCRIPTION
The `RecordedTest` attribute will try to re-record a test if it fails during Playback. It will still fail to let the developer know it's being re-recorded, but it will succeed on the next runs.