### PR TITLE
Don't append api/events to Uri

### DIFF
--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridKeyCredentialPolicy.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridKeyCredentialPolicy.cs
@@ -8,16 +8,13 @@ namespace Azure.Messaging.EventGrid
 {
     internal class EventGridKeyCredentialPolicy : HttpPipelineSynchronousPolicy
     {
-        private readonly string _name;
         private readonly AzureKeyCredential _credential;
         public const string SystemPublisherKey = "AzureSystemPublisher";
 
-        public EventGridKeyCredentialPolicy(AzureKeyCredential credential, string name)
+        public EventGridKeyCredentialPolicy(AzureKeyCredential credential)
         {
             Argument.AssertNotNull(credential, nameof(credential));
-            Argument.AssertNotNullOrEmpty(name, nameof(name));
             _credential = credential;
-            _name = name;
         }
 
         public override void OnSendingRequest(HttpMessage message)
@@ -29,7 +26,7 @@ namespace Azure.Messaging.EventGrid
             // in the request in this case.
             if (_credential.Key != SystemPublisherKey)
             {
-                message.Request.Headers.SetValue(_name, _credential.Key);
+                message.Request.Headers.SetValue(Constants.SasKeyName, _credential.Key);
             }
         }
     }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridPublisherClient.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridPublisherClient.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Core.Serialization;
 using Azure.Messaging.EventGrid.Models;
 
 namespace Azure.Messaging.EventGrid
@@ -19,15 +18,9 @@ namespace Azure.Messaging.EventGrid
     /// </summary>
     public class EventGridPublisherClient
     {
-        private readonly EventGridRestClient _serviceRestClient;
         private readonly ClientDiagnostics _clientDiagnostics;
-        private string _hostName => _endpoint.Authority;
-        private readonly Uri _endpoint;
-        private readonly AzureKeyCredential _key;
+        private readonly RequestUriBuilder _uriBuilder;
         private readonly HttpPipeline _pipeline;
-        private readonly string _apiVersion;
-
-        private static readonly JsonObjectSerializer s_jsonSerializer = new JsonObjectSerializer();
 
         /// <summary>Initalizes a new instance of the <see cref="EventGridPublisherClient"/> class for mocking.</summary>
         protected EventGridPublisherClient()
@@ -50,11 +43,10 @@ namespace Azure.Messaging.EventGrid
         {
             Argument.AssertNotNull(credential, nameof(credential));
             options ??= new EventGridPublisherClientOptions();
-            _apiVersion = options.Version.GetVersionString();
-            _endpoint = endpoint;
-            _key = credential;
-            _pipeline = HttpPipelineBuilder.Build(options, new EventGridKeyCredentialPolicy(credential, Constants.SasKeyName));
-            _serviceRestClient = new EventGridRestClient(new ClientDiagnostics(options), _pipeline, options.Version.GetVersionString());
+            _uriBuilder = new RequestUriBuilder();
+            _uriBuilder.Reset(endpoint);
+            _uriBuilder.AppendQuery("api-version", options.Version.GetVersionString(), true);
+            _pipeline = HttpPipelineBuilder.Build(options, new EventGridKeyCredentialPolicy(credential));
             _clientDiagnostics = new ClientDiagnostics(options);
         }
 
@@ -69,9 +61,10 @@ namespace Azure.Messaging.EventGrid
         {
             Argument.AssertNotNull(credential, nameof(credential));
             options ??= new EventGridPublisherClientOptions();
-            _endpoint = endpoint;
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, new EventGridSharedAccessSignatureCredentialPolicy(credential));
-            _serviceRestClient = new EventGridRestClient(new ClientDiagnostics(options), pipeline, options.Version.GetVersionString());
+            _uriBuilder = new RequestUriBuilder();
+            _uriBuilder.Reset(endpoint);
+            _uriBuilder.AppendQuery("api-version", options.Version.GetVersionString(), true);
+            _pipeline = HttpPipelineBuilder.Build(options, new EventGridSharedAccessSignatureCredentialPolicy(credential));
             _clientDiagnostics = new ClientDiagnostics(options);
         }
 
@@ -123,20 +116,6 @@ namespace Azure.Messaging.EventGrid
             }
         }
 
-        private Request CreateEventRequest(HttpMessage message, string contentType)
-        {
-            Request request = message.Request;
-            request.Method = RequestMethod.Post;
-            var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_hostName, false);
-            uri.AppendPath("/api/events", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
-            request.Uri = uri;
-            request.Headers.Add("Content-Type", contentType);
-            return request;
-        }
-
         /// <summary> Publishes a set of EventGridEvents to an Event Grid topic. </summary>
         /// <param name="eventGridEvent"> The event to be published to Event Grid. </param>
         /// <param name="cancellationToken"> An optional cancellation token instance to signal the request to cancel the operation.</param>
@@ -177,13 +156,13 @@ namespace Azure.Messaging.EventGrid
                 // List of events cannot be null
                 Argument.AssertNotNull(events, nameof(events));
 
-                List<EventGridEventInternal> eventsWithSerializedPayloads = new List<EventGridEventInternal>();
+                using HttpMessage message = _pipeline.CreateMessage();
+                Request request = CreateEventRequest(message, "application/json");
+                var content = new Utf8JsonRequestContent();
+                content.JsonWriter.WriteStartArray();
                 foreach (EventGridEvent egEvent in events)
                 {
-                    // Individual events cannot be null
-                    Argument.AssertNotNull(egEvent, nameof(egEvent));
                     JsonDocument data = JsonDocument.Parse(egEvent.Data.ToStream());
-
                     EventGridEventInternal newEGEvent = new EventGridEventInternal(
                         egEvent.Id,
                         egEvent.Subject,
@@ -194,24 +173,27 @@ namespace Azure.Messaging.EventGrid
                     {
                         Topic = egEvent.Topic
                     };
-
-                    eventsWithSerializedPayloads.Add(newEGEvent);
+                    content.JsonWriter.WriteObjectValue(newEGEvent);
                 }
+
+                content.JsonWriter.WriteEndArray();
+                request.Content = content;
+
                 if (async)
                 {
-                    // Publish asynchronously if called via an async path
-                    return await _serviceRestClient.PublishEventsAsync(
-                        _hostName,
-                        eventsWithSerializedPayloads,
-                        cancellationToken).ConfigureAwait(false);
+                    await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    return _serviceRestClient.PublishEvents(
-                        _hostName,
-                        eventsWithSerializedPayloads,
-                        cancellationToken);
+                    _pipeline.Send(message, cancellationToken);
                 }
+                return message.Response.Status switch
+                {
+                    200 => message.Response,
+                    _ => async ?
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false) :
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response)
+                };
             }
             catch (Exception e)
             {
@@ -313,44 +295,6 @@ namespace Azure.Messaging.EventGrid
         public virtual Response SendEvents(IEnumerable<BinaryData> customEvents, CancellationToken cancellationToken = default)
             => PublishCustomEventsInternal(customEvents, false /*async*/, cancellationToken).EnsureCompleted();
 
-        private async Task<Response> PublishCustomEventsInternal(IEnumerable<object> events, bool async, CancellationToken cancellationToken = default)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(EventGridPublisherClient)}.{nameof(SendEvents)}");
-            scope.Start();
-
-            try
-            {
-                List<CustomModelSerializer> serializedEvents = new List<CustomModelSerializer>();
-                foreach (object customEvent in events)
-                {
-                    serializedEvents.Add(
-                        new CustomModelSerializer(
-                            customEvent,
-                            s_jsonSerializer,
-                            cancellationToken));
-                }
-                if (async)
-                {
-                    return await _serviceRestClient.PublishCustomEventEventsAsync(
-                    _hostName,
-                    serializedEvents,
-                    cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    return _serviceRestClient.PublishCustomEventEvents(
-                    _hostName,
-                    serializedEvents,
-                    cancellationToken);
-                }
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
-
         private async Task<Response> PublishCustomEventsInternal(IEnumerable<BinaryData> events, bool async, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(EventGridPublisherClient)}.{nameof(SendEvents)}");
@@ -393,6 +337,15 @@ namespace Azure.Messaging.EventGrid
                 scope.Failed(e);
                 throw;
             }
+        }
+
+        private Request CreateEventRequest(HttpMessage message, string contentType)
+        {
+            Request request = message.Request;
+            request.Method = RequestMethod.Post;
+            request.Uri = _uriBuilder;
+            request.Headers.Add("Content-Type", contentType);
+            return request;
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/EventGridClientLiveTests.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/EventGridClientLiveTests.cs
@@ -33,6 +33,48 @@ namespace Azure.Messaging.EventGrid.Tests
         }
 
         [RecordedTest]
+        public void CannotPublishEventMissingApiEventsPathFromUri()
+        {
+            EventGridPublisherClientOptions options = InstrumentClientOptions(new EventGridPublisherClientOptions());
+            Uri host = new UriBuilder("https", new Uri(TestEnvironment.TopicHost).Host).Uri;
+            EventGridPublisherClient client = InstrumentClient(
+                new EventGridPublisherClient(
+                    host,
+                    new AzureKeyCredential(TestEnvironment.TopicKey),
+                    options));
+
+            Assert.ThrowsAsync<RequestFailedException>(async () => await client.SendEventAsync(new BinaryData(jsonSerializable: "data")));
+        }
+
+        [RecordedTest]
+        public void CannotPublishCloudEventMissingApiEventsPathFromUri()
+        {
+            EventGridPublisherClientOptions options = InstrumentClientOptions(new EventGridPublisherClientOptions());
+            Uri host = new UriBuilder("https", new Uri(TestEnvironment.TopicHost).Host).Uri;
+            EventGridPublisherClient client = InstrumentClient(
+                new EventGridPublisherClient(
+                    host,
+                    new AzureKeyCredential(TestEnvironment.TopicKey),
+                    options));
+
+            Assert.ThrowsAsync<RequestFailedException>(async () => await client.SendEventAsync(new BinaryData(jsonSerializable: "data")));
+        }
+
+        [RecordedTest]
+        public void CannotPublishCustomEventMissingApiEventsPathFromUri()
+        {
+            EventGridPublisherClientOptions options = InstrumentClientOptions(new EventGridPublisherClientOptions());
+            Uri host = new UriBuilder("https", new Uri(TestEnvironment.TopicHost).Host).Uri;
+            EventGridPublisherClient client = InstrumentClient(
+                new EventGridPublisherClient(
+                    host,
+                    new AzureKeyCredential(TestEnvironment.TopicKey),
+                    options));
+
+            Assert.ThrowsAsync<RequestFailedException>(async () => await client.SendEventAsync(new BinaryData(jsonSerializable: "data")));
+        }
+
+        [RecordedTest]
         public async Task CanPublishSingleEvent()
         {
             EventGridPublisherClientOptions options = InstrumentClientOptions(new EventGridPublisherClientOptions());

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishCloudEventMissingApiEventsPathFromUri.json
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishCloudEventMissingApiEventsPathFromUri.json
@@ -1,0 +1,47 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "aeg-sas-key": "Sanitized",
+        "Content-Length": "8",
+        "Content-Type": "application/json",
+        "traceparent": "00-9e8caaae090e4b4c83e76902f3f58bf7-8bd120a566e2024c-00",
+        "User-Agent": [
+          "azsdk-net-Messaging.EventGrid/4.0.0-alpha.20210309.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "30393e10565ac622694e08114455f61a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[\u0022data\u0022]",
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "633",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 10 Mar 2021 03:21:12 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "x-ms-request-id": "d27367fb-4b45-4607-b76c-e7da84f7ec27"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "NotFound",
+          "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u0027d27367fb-4b45-4607-b76c-e7da84f7ec27:3/10/2021 3:21:13 AM (UTC)\u0027 to our forums for assistance or raise a support ticket.",
+          "details": [
+            {
+              "code": "ResourceNotFound",
+              "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u0027d27367fb-4b45-4607-b76c-e7da84f7ec27:3/10/2021 3:21:13 AM (UTC)\u0027 to our forums for assistance or raise a support ticket."
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "EVENT_GRID_TOPIC_ENDPOINT": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/api/events",
+    "EVENT_GRID_TOPIC_KEY": "Kg==",
+    "RandomSeed": "1761678806"
+  }
+}

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishCloudEventMissingApiEventsPathFromUriAsync.json
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishCloudEventMissingApiEventsPathFromUriAsync.json
@@ -1,0 +1,47 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "aeg-sas-key": "Sanitized",
+        "Content-Length": "8",
+        "Content-Type": "application/json",
+        "traceparent": "00-0a79cc483360f14ba99544f4b7d02202-1e5cfb9e83c35045-00",
+        "User-Agent": [
+          "azsdk-net-Messaging.EventGrid/4.0.0-alpha.20210309.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "d76e4959e2c026ddbb097b9903bc3269",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[\u0022data\u0022]",
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "633",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 10 Mar 2021 03:21:20 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "x-ms-request-id": "71c046fc-be9b-4c52-a11d-0a22ea13a7c0"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "NotFound",
+          "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u002771c046fc-be9b-4c52-a11d-0a22ea13a7c0:3/10/2021 3:21:20 AM (UTC)\u0027 to our forums for assistance or raise a support ticket.",
+          "details": [
+            {
+              "code": "ResourceNotFound",
+              "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u002771c046fc-be9b-4c52-a11d-0a22ea13a7c0:3/10/2021 3:21:20 AM (UTC)\u0027 to our forums for assistance or raise a support ticket."
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "EVENT_GRID_TOPIC_ENDPOINT": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/api/events",
+    "EVENT_GRID_TOPIC_KEY": "Kg==",
+    "RandomSeed": "946898432"
+  }
+}

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishCustomEventMissingApiEventsPathFromUri.json
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishCustomEventMissingApiEventsPathFromUri.json
@@ -1,0 +1,47 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "aeg-sas-key": "Sanitized",
+        "Content-Length": "8",
+        "Content-Type": "application/json",
+        "traceparent": "00-2f4081357b8dbf44ba2b038baa59333a-885e05342d986a4c-00",
+        "User-Agent": [
+          "azsdk-net-Messaging.EventGrid/4.0.0-alpha.20210309.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "c6d450c1976174c778a54eb9cde57b92",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[\u0022data\u0022]",
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "633",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 10 Mar 2021 03:19:20 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "x-ms-request-id": "93e91a01-d95c-404c-9f32-4853c14e46c4"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "NotFound",
+          "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u002793e91a01-d95c-404c-9f32-4853c14e46c4:3/10/2021 3:19:21 AM (UTC)\u0027 to our forums for assistance or raise a support ticket.",
+          "details": [
+            {
+              "code": "ResourceNotFound",
+              "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u002793e91a01-d95c-404c-9f32-4853c14e46c4:3/10/2021 3:19:21 AM (UTC)\u0027 to our forums for assistance or raise a support ticket."
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "EVENT_GRID_TOPIC_ENDPOINT": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/api/events",
+    "EVENT_GRID_TOPIC_KEY": "Kg==",
+    "RandomSeed": "1862252317"
+  }
+}

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishCustomEventMissingApiEventsPathFromUriAsync.json
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishCustomEventMissingApiEventsPathFromUriAsync.json
@@ -1,0 +1,47 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "aeg-sas-key": "Sanitized",
+        "Content-Length": "8",
+        "Content-Type": "application/json",
+        "traceparent": "00-3ce29eccd446734a9e0be4729d35e002-761972bb265ca148-00",
+        "User-Agent": [
+          "azsdk-net-Messaging.EventGrid/4.0.0-alpha.20210309.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "5508bf66d9bfbc386fb2fed1dd5b9ba1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[\u0022data\u0022]",
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "633",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 10 Mar 2021 03:21:21 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "x-ms-request-id": "b696d898-c969-4260-a461-acfb1e181278"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "NotFound",
+          "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u0027b696d898-c969-4260-a461-acfb1e181278:3/10/2021 3:21:21 AM (UTC)\u0027 to our forums for assistance or raise a support ticket.",
+          "details": [
+            {
+              "code": "ResourceNotFound",
+              "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u0027b696d898-c969-4260-a461-acfb1e181278:3/10/2021 3:21:21 AM (UTC)\u0027 to our forums for assistance or raise a support ticket."
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "EVENT_GRID_TOPIC_ENDPOINT": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/api/events",
+    "EVENT_GRID_TOPIC_KEY": "Kg==",
+    "RandomSeed": "540586852"
+  }
+}

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishEventMissingApiEventsPathFromUri.json
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishEventMissingApiEventsPathFromUri.json
@@ -1,0 +1,47 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "aeg-sas-key": "Sanitized",
+        "Content-Length": "8",
+        "Content-Type": "application/json",
+        "traceparent": "00-12809ed86a261c499eb2a5e5b980fe08-609a4e9afe8a5144-00",
+        "User-Agent": [
+          "azsdk-net-Messaging.EventGrid/4.0.0-alpha.20210309.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "b7d9b32e5dc4164da9f5a5bc45cd1bb9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[\u0022data\u0022]",
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "633",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 10 Mar 2021 03:21:13 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "x-ms-request-id": "9c019bd2-efaf-4af3-8a01-0e64989d97dc"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "NotFound",
+          "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u00279c019bd2-efaf-4af3-8a01-0e64989d97dc:3/10/2021 3:21:14 AM (UTC)\u0027 to our forums for assistance or raise a support ticket.",
+          "details": [
+            {
+              "code": "ResourceNotFound",
+              "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u00279c019bd2-efaf-4af3-8a01-0e64989d97dc:3/10/2021 3:21:14 AM (UTC)\u0027 to our forums for assistance or raise a support ticket."
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "EVENT_GRID_TOPIC_ENDPOINT": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/api/events",
+    "EVENT_GRID_TOPIC_KEY": "Kg==",
+    "RandomSeed": "2009989451"
+  }
+}

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishEventMissingApiEventsPathFromUriAsync.json
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/SessionRecords/EventGridClientLiveTests/CannotPublishEventMissingApiEventsPathFromUriAsync.json
@@ -1,0 +1,47 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "aeg-sas-key": "Sanitized",
+        "Content-Length": "8",
+        "Content-Type": "application/json",
+        "traceparent": "00-f0eb8f15459aa84b87706837da4e7c24-94155738f3b29d49-00",
+        "User-Agent": [
+          "azsdk-net-Messaging.EventGrid/4.0.0-alpha.20210309.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "1bb2ce984110b6404443d2cf71ebc160",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[\u0022data\u0022]",
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "633",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 10 Mar 2021 03:21:22 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "x-ms-request-id": "fd35f631-242a-41db-9b3d-a36ca3411dc2"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "NotFound",
+          "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u0027fd35f631-242a-41db-9b3d-a36ca3411dc2:3/10/2021 3:21:22 AM (UTC)\u0027 to our forums for assistance or raise a support ticket.",
+          "details": [
+            {
+              "code": "ResourceNotFound",
+              "message": "No HTTP resource was found that matches the request URI \u0027https://joloveventgridtopic.westus2-1.eventgrid.azure.net/?api-version=2018-01-01\u0027. Report \u0027fd35f631-242a-41db-9b3d-a36ca3411dc2:3/10/2021 3:21:22 AM (UTC)\u0027 to our forums for assistance or raise a support ticket."
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "EVENT_GRID_TOPIC_ENDPOINT": "https://joloveventgridtopic.westus2-1.eventgrid.azure.net/api/events",
+    "EVENT_GRID_TOPIC_KEY": "Kg==",
+    "RandomSeed": "1383047398"
+  }
+}


### PR DESCRIPTION
The portal, Azure CLI, and Azure Powershell all include the api/events path in the topic URI, so there is no need to append it. Appending it could be problematic in the future if other Uri formats are expected.

Also, some cleanup of unused code.