### PR TITLE
Rework DtmiConventions in models repository SDK

### DIFF
--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/api/Azure.Iot.ModelsRepository.netstandard2.0.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/api/Azure.Iot.ModelsRepository.netstandard2.0.cs
@@ -2,7 +2,7 @@ namespace Azure.Iot.ModelsRepository
 {
     public static partial class DtmiConventions
     {
-        public static string DtmiToQualifiedPath(string dtmi, string basePath, bool fromExpanded = false) { throw null; }
+        public static System.Uri GetModelUri(string dtmi, System.Uri repositoryUri, bool expanded = false) { throw null; }
         public static bool IsValidDtmi(string dtmi) { throw null; }
     }
     public enum ModelDependencyResolution

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/DtmiConventionsSamples.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/DtmiConventionsSamples.cs
@@ -22,29 +22,29 @@ namespace Azure.Iot.ModelsRepository.Samples
             #endregion Snippet:ModelsRepositorySamplesDtmiConventionsIsValidDtmi
         }
 
-        public static void GetDtmiToQualifiedPath()
+        public static void GetModelUri()
         {
-            #region Snippet:ModelsRepositorySamplesDtmiConventionsGetDtmiToQualifiedPath
+            #region Snippet:ModelsRepositorySamplesDtmiConventionsGetModelUri
 
             // This snippet shows obtaining a fully qualified path to a model file.
             
             // Local repository example
-            string localRepository = "/path/to/repository";
+            Uri localRepositoryUri = new Uri("file:///path/to/repository/");
             string fullyQualifiedModelPath = 
-                DtmiConventions.DtmiToQualifiedPath("dtmi:com:example:Thermostat;1", localRepository);
+                DtmiConventions.GetModelUri("dtmi:com:example:Thermostat;1", localRepositoryUri).AbsolutePath;
             
             // Prints '/path/to/repository/dtmi/com/example/thermostat-1.json'
             Console.WriteLine(fullyQualifiedModelPath);
 
             // Remote repository example
-            string remoteRepository = "https://contoso.com/models";
+            Uri remoteRepositoryUri = new Uri("https://contoso.com/models/");
             fullyQualifiedModelPath =
-                DtmiConventions.DtmiToQualifiedPath("dtmi:com:example:Thermostat;1", remoteRepository);
+                DtmiConventions.GetModelUri("dtmi:com:example:Thermostat;1", remoteRepositoryUri).AbsoluteUri;
 
             // Prints 'https://contoso.com/models/dtmi/com/example/thermostat-1.json'
             Console.WriteLine(fullyQualifiedModelPath);
 
-            #endregion Snippet:ModelsRepositorySamplesDtmiConventionsGetDtmiToQualifiedPath
+            #endregion Snippet:ModelsRepositorySamplesDtmiConventionsGetModelUri
         }
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/ModelsRepositoryClientSamples/Program.cs
@@ -35,7 +35,7 @@ namespace Azure.Iot.ModelsRepository.Samples
 
             // DtmiConventions utility samples
             DtmiConventionsSamples.IsValidDtmi();
-            DtmiConventionsSamples.GetDtmiToQualifiedPath();
+            DtmiConventionsSamples.GetModelUri();
         }
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/readme.md
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/samples/readme.md
@@ -134,10 +134,10 @@ IReadOnlyDictionary<Dtmi, DTEntityInfo> parseResult = await parser.ParseAsync(mo
 Console.WriteLine($"{dtmi} resolved in {models.Count} interfaces with {parseResult.Count} entities.");
 ```
 
-## DtmiConventions utility
+## DtmiConventions utility functions
 
-The IoT Models Repository applies a set of conventions for organizing digital twin models. This package exposes a utility class
-called `DtmiConventions` which exposes functions supporting these conventions. These same functions are used throughout the client.
+The IoT Models Repository applies a set of conventions for organizing digital twin models. This package exposes a class
+called `DtmiConventions` which exposes utility functions supporting these conventions. These same functions are used throughout the client.
 
 ```C# Snippet:ModelsRepositorySamplesDtmiConventionsIsValidDtmi
 // This snippet shows how to validate a given DTMI string is well-formed.
@@ -149,21 +149,21 @@ DtmiConventions.IsValidDtmi("dtmi:com:example:Thermostat;1");
 DtmiConventions.IsValidDtmi("dtmi:com:example:Thermostat");
 ```
 
-```C# Snippet:ModelsRepositorySamplesDtmiConventionsGetDtmiToQualifiedPath
+```C# Snippet:ModelsRepositorySamplesDtmiConventionsGetModelUri
 // This snippet shows obtaining a fully qualified path to a model file.
 
 // Local repository example
-string localRepository = "/path/to/repository";
+Uri localRepositoryUri = new Uri("file:///path/to/repository/");
 string fullyQualifiedModelPath = 
-    DtmiConventions.DtmiToQualifiedPath("dtmi:com:example:Thermostat;1", localRepository);
+    DtmiConventions.GetModelUri("dtmi:com:example:Thermostat;1", localRepositoryUri).AbsolutePath;
 
 // Prints '/path/to/repository/dtmi/com/example/thermostat-1.json'
 Console.WriteLine(fullyQualifiedModelPath);
 
 // Remote repository example
-string remoteRepository = "https://contoso.com/models";
+Uri remoteRepositoryUri = new Uri("https://contoso.com/models/");
 fullyQualifiedModelPath =
-    DtmiConventions.DtmiToQualifiedPath("dtmi:com:example:Thermostat;1", remoteRepository);
+    DtmiConventions.GetModelUri("dtmi:com:example:Thermostat;1", remoteRepositoryUri).AbsoluteUri;
 
 // Prints 'https://contoso.com/models/dtmi/com/example/thermostat-1.json'
 Console.WriteLine(fullyQualifiedModelPath);

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/FileModelFetcher.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/FileModelFetcher.cs
@@ -40,10 +40,10 @@ namespace Azure.Iot.ModelsRepository.Fetchers
                 var work = new Queue<string>();
                 if (dependencyResolution == ModelDependencyResolution.TryFromExpanded)
                 {
-                    work.Enqueue(GetPath(dtmi, repositoryUri, true));
+                    work.Enqueue(DtmiConventions.GetModelUri(dtmi, repositoryUri, true).LocalPath);
                 }
 
-                work.Enqueue(GetPath(dtmi, repositoryUri, false));
+                work.Enqueue(DtmiConventions.GetModelUri(dtmi, repositoryUri, false).LocalPath);
 
                 string fnfError = string.Empty;
                 while (work.Count != 0)
@@ -75,12 +75,6 @@ namespace Azure.Iot.ModelsRepository.Fetchers
                 scope.Failed(ex);
                 throw;
             }
-        }
-
-        private static string GetPath(string dtmi, Uri repositoryUri, bool expanded = false)
-        {
-            string registryPath = repositoryUri.AbsolutePath;
-            return DtmiConventions.DtmiToQualifiedPath(dtmi, registryPath, expanded);
         }
     }
 }

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/HttpModelFetcher.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/Fetchers/HttpModelFetcher.cs
@@ -149,18 +149,12 @@ namespace Azure.Iot.ModelsRepository.Fetchers
 
             if (tryExpanded)
             {
-                work.Enqueue(GetPath(dtmi, repositoryUri, true));
+                work.Enqueue(DtmiConventions.GetModelUri(dtmi, repositoryUri, true).AbsoluteUri);
             }
 
-            work.Enqueue(GetPath(dtmi, repositoryUri, false));
+            work.Enqueue(DtmiConventions.GetModelUri(dtmi, repositoryUri, false).AbsoluteUri);
 
             return work;
-        }
-
-        private static string GetPath(string dtmi, Uri repositoryUri, bool expanded = false)
-        {
-            string absoluteUri = repositoryUri.AbsoluteUri;
-            return DtmiConventions.DtmiToQualifiedPath(dtmi, absoluteUri, expanded);
         }
 
         private string EvaluatePath(string path, CancellationToken cancellationToken = default)

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryConstants.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/ModelsRepositoryConstants.cs
@@ -13,7 +13,7 @@ namespace Azure.Iot.ModelsRepository
         // File Extensions
         public const string JsonFileExtension = ".json";
         public const string ExpandedJsonFileExtension = ".expanded.json";
-        public const string File = "file";
+        public const string UriFileSchema = "file";
 
         /// <summary>
         /// The ModelRepositoryConstants.ModelProperties class contains DTDL v2 property names and property values

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/RepositoryHandler.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/src/RepositoryHandler.cs
@@ -26,7 +26,7 @@ namespace Azure.Iot.ModelsRepository
 
             _clientOptions = options;
             _clientDiagnostics = clientDiagnostics;
-            _modelFetcher = repositoryUri.Scheme == ModelsRepositoryConstants.File
+            _modelFetcher = repositoryUri.Scheme == ModelsRepositoryConstants.UriFileSchema
                 ? _modelFetcher = new FileModelFetcher(_clientDiagnostics)
                 : _modelFetcher = new HttpModelFetcher(_clientDiagnostics, _clientOptions);
             _clientId = Guid.NewGuid();

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/DtmiConventionsTests.cs
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/DtmiConventionsTests.cs
@@ -22,28 +22,30 @@ namespace Azure.Iot.ModelsRepository.Tests
 
         [TestCase("dtmi:com:example:Thermostat;1", "https://localhost/repository/", "https://localhost/repository/dtmi/com/example/thermostat-1.json")]
         [TestCase("dtmi:com:example:Thermostat;1", "https://localhost/REPOSITORY", "https://localhost/REPOSITORY/dtmi/com/example/thermostat-1.json")]
-        [TestCase("dtmi:com:example:Thermostat;1", "/path/to/repository/", "/path/to/repository/dtmi/com/example/thermostat-1.json")]
-        [TestCase("dtmi:com:example:Thermostat;1", "/path/to/RepoSitory", "/path/to/RepoSitory/dtmi/com/example/thermostat-1.json")]
-        [TestCase("dtmi:com:example:Thermostat;1", "C:\\path\\to\\repository", "C:/path/to/repository/dtmi/com/example/thermostat-1.json")]
-        [TestCase("dtmi:com:example:Thermostat:1", "https://localhost/repository", null)]
-        [TestCase("dtmi:com:example:Thermostat:1", "/path/to/repository/", null)]
-        [TestCase("dtmi:com:example:Thermostat;1", "", "/dtmi/com/example/thermostat-1.json")]
-        public void DtmiToQualifiedPath(string dtmi, string repository, string expectedPath)
+        [TestCase("dtmi:com:example:Thermostat;1", "file:///path/to/repository/", "file:///path/to/repository/dtmi/com/example/thermostat-1.json")]
+        [TestCase("dtmi:com:example:Thermostat;1", "file://path/to/RepoSitory", "file://path/to/RepoSitory/dtmi/com/example/thermostat-1.json")]
+        [TestCase("dtmi:com:example:Thermostat;1", "C:\\path\\to\\repository\\", "file:///C:/path/to/repository/dtmi/com/example/thermostat-1.json")]
+        [TestCase("dtmi:com:example:Thermostat:1", "https://localhost/repository/", null)]
+        [TestCase("dtmi:com:example:Thermostat:1", "file://path/to/repository/", null)]
+        [TestCase("dtmi:com:example:Thermostat;1", "\\\\server\\repository", "file://server/repository/dtmi/com/example/thermostat-1.json")]
+        public void GetModelUri(string dtmi, string repository, string expectedUri)
         {
-            if (string.IsNullOrEmpty(expectedPath))
+            Uri repositoryUri = new Uri(repository);
+            if (string.IsNullOrEmpty(expectedUri))
             {
-                Action act = () => DtmiConventions.DtmiToQualifiedPath(dtmi, repository);
+                Action act = () => DtmiConventions.GetModelUri(dtmi, repositoryUri);
                 act.Should().Throw<ArgumentException>().WithMessage(string.Format(StandardStrings.InvalidDtmiFormat, dtmi));
                 return;
             }
 
-            string modelPath = DtmiConventions.DtmiToQualifiedPath(dtmi, repository);
-            modelPath.Should().Be(expectedPath);
+            Uri modelUri = DtmiConventions.GetModelUri(dtmi, repositoryUri);
+            modelUri.AbsoluteUri.Should().Be(expectedUri);
 
-            string expectedExpandedPath = expectedPath.Replace(
+            string expectedExpandedUri = expectedUri.Replace(
                 ModelsRepositoryConstants.JsonFileExtension, ModelsRepositoryConstants.ExpandedJsonFileExtension);
-            string expandedModelPath = DtmiConventions.DtmiToQualifiedPath(dtmi, repository, true);
-            expandedModelPath.Should().Be(expectedExpandedPath);
+
+            Uri expandedModelUri = DtmiConventions.GetModelUri(dtmi, repositoryUri, true);
+            expandedModelUri.Should().Be(expectedExpandedUri);
         }
 
         [TestCase("dtmi:com:example:Thermostat;1", true)]

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermojax-999.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-a1484daab77bed4d8a767268efefb953-a06df0d48bfaf244-00",
+        "traceparent": "00-3e931f52ebce9344837521c5b4bfc921-36c5c40a566da04d-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "5869dbe376a9c64b690acc46c7df7b04",
@@ -20,16 +20,16 @@
         "Access-Control-Expose-Headers": "*",
         "Content-Length": "321",
         "Content-Type": "text/html",
-        "Date": "Wed, 10 Mar 2021 02:28:33 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "Server": [
           "Windows-Azure-Web/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-error-code": "WebContentNotFound",
-        "x-ms-request-id": "0c81e866-901e-0012-6955-15d155000000",
+        "x-ms-request-id": "2922db38-e01e-0075-76d0-154279000000",
         "x-ms-version": "2018-03-28"
       },
-      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 0c81e866-901e-0012-6955-15d155000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-03-10T02:28:34.0698934Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
+      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 2922db38-e01e-0075-76d0-154279000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-03-10T17:15:10.5294555Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
     }
   ],
   "Variables": {

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsForNonExistentDtmiFileThrowsException(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermojax-999.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-88653780b16e444c8a78899deb3c5fb8-a964960cf6c7cb44-00",
+        "traceparent": "00-7fdc44b36a76d34aa0020eb4f61052f9-937d7389dd618f4e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "2e91ad571b311f17984f4e70c70864a5",
@@ -20,16 +20,16 @@
         "Access-Control-Expose-Headers": "*",
         "Content-Length": "321",
         "Content-Type": "text/html",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "Server": [
           "Windows-Azure-Web/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-error-code": "WebContentNotFound",
-        "x-ms-request-id": "9f1c1ad5-a01e-004d-6a55-153b79000000",
+        "x-ms-request-id": "00d1bb25-501e-0032-7dd0-154066000000",
         "x-ms-version": "2018-03-28"
       },
-      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 9f1c1ad5-a01e-004d-6a55-153b79000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-03-10T02:28:34.5029583Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
+      "ResponseBody": "\u003C!DOCTYPE html\u003E\u003Chtml\u003E\u003Chead\u003E\u003Ctitle\u003EWebContentNotFound\u003C/title\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003EThe requested content does not exist.\u003C/h1\u003E\u003Cp\u003E\u003Cul\u003E\u003Cli\u003EHttpStatusCode: 404\u003C/li\u003E\u003Cli\u003EErrorCode: WebContentNotFound\u003C/li\u003E\u003Cli\u003ERequestId : 00d1bb25-501e-0032-7dd0-154066000000\u003C/li\u003E\u003Cli\u003ETimeStamp : 2021-03-10T17:15:11.0026224Z\u003C/li\u003E\u003C/ul\u003E\u003C/p\u003E\u003C/body\u003E\u003C/html\u003E"
     }
   ],
   "Variables": {

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-de45e31912e7d6498246c78101caf9df-abe44d86bb569849-00",
+        "traceparent": "00-756fe452ee5e7d40b5659725f184a7a3-73fb17f366cc6c44-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "d59c39d95f9071c9fb36c311ddf28369",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552749",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -131,9 +131,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-de45e31912e7d6498246c78101caf9df-2fa9f61ee64e9541-00",
+        "traceparent": "00-756fe452ee5e7d40b5659725f184a7a3-01537e9fc056f749-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "0f0bac77fe7035e01c21e364e29e0fe3",
@@ -146,11 +146,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552749",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsMultipleDtmisNoDeps(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-67e4dffda2c4ab45b214d056b39f347b-510dd0c211293d45-00",
+        "traceparent": "00-77bf61548708b94783e83105e597e74d-425ed0eb580da649-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "4000049fcf2ea59788ea4dd65e9df822",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552750",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -131,9 +131,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-67e4dffda2c4ab45b214d056b39f347b-0038b38c77a4ce4f-00",
+        "traceparent": "00-77bf61548708b94783e83105e597e74d-e1f22fd11dd5de46-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "bd48ba64ef7464d9cc6616421b97a34b",
@@ -146,11 +146,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552750",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-5f82b54b618186419bccb24feee07ede-41177bd80520794d-00",
+        "traceparent": "00-2d3760ba9c0c274db4947b71935f0d7d-f90f3e9390b0554e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "80baf927f75417d901d33d472e388379",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552749",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiNoDeps(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-af36325ed53774428b384dccf12ec7b6-d55361070439d543-00",
+        "traceparent": "00-cb21034790ec4641ad1b617fa7d2cf0a-4b18a5461743a84f-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "ea1ec3ed68f24ba78f90c70cbbe3f832",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552750",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.expanded.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-d7908d2338d64e428debc10fab3aa9cc-e67c1896828d2c48-00",
+        "traceparent": "00-b80712e56f71ba4b946310a983e05797-f68567fb6164484f-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "e7119021118cf849ebc5c278668716e5",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499552",
+        "Age": "552748",
         "Content-Length": "6751",
         "Content-MD5": "BnZpV2\u002B7Z2t0sxAxOhmBdw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEAC10FCC\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiTryFromExpanded(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.expanded.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-7803a8ed2682fb43a253bbc294e276a9-4cc88d75de754f43-00",
+        "traceparent": "00-fdea50c6c8ad7b4198dc46f4b5198c0b-a24b82e8298e6a42-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "72ac13935c0bd5e9c9d2b215d4d3d079",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499552",
+        "Age": "552749",
         "Content-Length": "6751",
         "Content-MD5": "BnZpV2\u002B7Z2t0sxAxOhmBdw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEAC10FCC\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-4d2504cff89eec499cb44ed3ba038da3-218bd10df7a39d4d-00",
+        "traceparent": "00-1bc386f417ed2148817bc189ce7ccb88-1897adf43665c14e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "2bdeb8748c19bdea0863b77c707f8289",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499552",
+        "Age": "552748",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -102,9 +102,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-4d2504cff89eec499cb44ed3ba038da3-4feac828e0781f40-00",
+        "traceparent": "00-1bc386f417ed2148817bc189ce7ccb88-0e4f9ea1a9b9e840-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "b5dc3925d0fa6c8a99ad66367cc71880",
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552749",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -229,9 +229,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-4d2504cff89eec499cb44ed3ba038da3-7fda31dede317e4f-00",
+        "traceparent": "00-1bc386f417ed2148817bc189ce7ccb88-2b3a586a29f64d41-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "04d50949c3a9a5b251679297c7973d41",
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552749",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDeps(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-9a32a7438c32494d9df657e233051617-e9eae8c323ba774a-00",
+        "traceparent": "00-2bfdb5d5207490448ff9f734f22d6ad4-2c5e70211ba74941-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "ca414829555f92065321cfd3d915b286",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499552",
+        "Age": "552749",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -102,9 +102,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-9a32a7438c32494d9df657e233051617-dd19b060251fde41-00",
+        "traceparent": "00-2bfdb5d5207490448ff9f734f22d6ad4-8bf49f2bbbdd2a47-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "e31aa4de9d588e3f03ab5e665e1a30a6",
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552750",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -229,9 +229,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-9a32a7438c32494d9df657e233051617-01f35d461074384a-00",
+        "traceparent": "00-2bfdb5d5207490448ff9f734f22d6ad4-62699d78cee69442-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "a1c50a41dd36d8c72e8418dd882be79e",
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552750",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-5248da6b4beb8c44a7207ce5da08a3f0-6d42d6b1dbdd654c-00",
+        "traceparent": "00-76ec6dab6f043246a435851de58949e1-13f7affc36eeda4b-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "922f4f6eaa519d59f16b3cadc3cd16f5",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552749",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsDisableDependencyResolution(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-a14c0d57eb14714f8fae31587900a0c7-de579a251a4d6946-00",
+        "traceparent": "00-4c709ad670c201429068a9a66a57d15c-d8a6ee2b3deaa244-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "52cf98cf47771c488c58badde6058bce",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552750",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-ef9a1bc6f9ba994ab2c8c672edf70ce2-d77169aef9c9224b-00",
+        "traceparent": "00-ccdef8fba2f78742bfad2f792d25b8b8-3db89e236a6b664c-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "d6f677c223dd62fa0e0231b2c3c58299",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499552",
+        "Age": "552748",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsDisabled(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-c8ab809c49f611449101c9b2dd2ab2ab-6f416730b71f934b-00",
+        "traceparent": "00-93eb968748aadb4b89d94b7b0d1ba614-ca3a73748ec0df48-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "b92630c966affdb7765e3e0e36531e3a",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499552",
+        "Age": "552749",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-b0ec4147bafb6d449eaa5fc9363b97a3-133d4d5bc7ddd24d-00",
+        "traceparent": "00-1e795b6fd63c2f49b81b322106ee7d00-5b5e5d2ede090240-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "1c1c561069359998a8c0500a3d73d129",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499552",
+        "Age": "552748",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -102,9 +102,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-b0ec4147bafb6d449eaa5fc9363b97a3-4a8f3cce11f1f54c-00",
+        "traceparent": "00-1e795b6fd63c2f49b81b322106ee7d00-7883dde118d8d445-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "7a7699898b5886b07eb45e3a10daed30",
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552749",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -229,9 +229,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-b0ec4147bafb6d449eaa5fc9363b97a3-1722440e0642fe43-00",
+        "traceparent": "00-1e795b6fd63c2f49b81b322106ee7d00-d39384665dfa9d47-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "c7519e75b0335de5862b34c01d1a4dd5",
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552749",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsSingleDtmiWithDepsResolutionOptionOverrideAsEnabled(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/temperaturecontroller-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-7bed932aded3004cbe23b284182e8af9-40956f6c4b22294a-00",
+        "traceparent": "00-476f8d01ff635a488e5acae9b323f6b1-334572a5c3d15f44-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "fded581de13cc25893ff3412434b8bde",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499552",
+        "Age": "552749",
         "Content-Length": "1762",
         "Content-MD5": "w8OrFrbCwZwtVo6WaKDWxQ==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEABA3051\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -102,9 +102,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-7bed932aded3004cbe23b284182e8af9-5f4e7c4f79669e4d-00",
+        "traceparent": "00-476f8d01ff635a488e5acae9b323f6b1-9a7d3333be35a44e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "7f526465451650416c561e6bd4c11112",
@@ -117,11 +117,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552750",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [
@@ -229,9 +229,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-7bed932aded3004cbe23b284182e8af9-ca6116abe149de40-00",
+        "traceparent": "00-476f8d01ff635a488e5acae9b323f6b1-c93128cc3f2dff4e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "f7efee1d81e7f308d1f189d881bb6835",
@@ -244,11 +244,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552750",
         "Content-Length": "2212",
         "Content-MD5": "oCzHP9acH\u002B/\u002BFQOv2V56NA==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEBC614F0\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:59 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote).json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote).json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-7f3d74f07f54c54e878eb67880bece59-17d59caabf9aab47-00",
+        "traceparent": "00-0d3297f3c019b649945c3dce7f49190e-8c7dc4d99773464e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "c734165d00f93fa8ae5fca3f90b9d139",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552749",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:10 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [

--- a/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote)Async.json
+++ b/sdk/modelsrepository/Azure.Iot.ModelsRepository/tests/SessionRecords/GetModelsIntegrationTests/GetModelsWithWrongCasingThrowsException(Remote)Async.json
@@ -4,9 +4,9 @@
       "RequestUri": "https://devicemodels.azure.com/dtmi/com/example/thermostat-1.json",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-528ebc295fec9b479bf17fe0fcc846bf-059f81c5cea12842-00",
+        "traceparent": "00-7d6614c093991e47aeeb36f91c480015-43189febe8d3504e-00",
         "User-Agent": [
-          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210309.1",
+          "azsdk-net-Iot.ModelsRepository/1.0.0-alpha.20210310.1",
           "(.NET Core 4.6.29812.02; Microsoft Windows 10.0.19042 )"
         ],
         "x-ms-client-request-id": "87d45ebe9f20be964956486fbff04612",
@@ -19,11 +19,11 @@
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
         "Access-Control-Expose-Headers": "*",
-        "Age": "499553",
+        "Age": "552750",
         "Content-Length": "2469",
         "Content-MD5": "U0VZgOgpfb6bwvG5UDVZuw==",
         "Content-Type": "application/json",
-        "Date": "Wed, 10 Mar 2021 02:28:34 GMT",
+        "Date": "Wed, 10 Mar 2021 17:15:11 GMT",
         "ETag": "\u00220x8D8A13DEABC53BA\u0022",
         "Last-Modified": "Tue, 15 Dec 2020 21:10:57 GMT",
         "Server": [


### PR DESCRIPTION
Highlights

- Reworked `DtmiToQualifiedPath`  to revolve around Uri. Changed name to `GetModelUri`.
- Model FileFetcher will use LocalPath from the Uri object.
- Update of tests & samples.