### PR TITLE
Remove converters from lower level models

### DIFF
--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatEventBaseProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatEventBaseProperties.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(AcsChatEventBasePropertiesConverter))]
     public partial class AcsChatEventBaseProperties
     {
         internal static AcsChatEventBaseProperties DeserializeAcsChatEventBaseProperties(JsonElement element)
@@ -44,19 +41,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new AcsChatEventBaseProperties(recipientCommunicationIdentifier.Value, transactionId.Value, threadId.Value);
-        }
-
-        internal partial class AcsChatEventBasePropertiesConverter : JsonConverter<AcsChatEventBaseProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, AcsChatEventBaseProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override AcsChatEventBaseProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeAcsChatEventBaseProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatEventInThreadBaseProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatEventInThreadBaseProperties.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(AcsChatEventInThreadBasePropertiesConverter))]
     public partial class AcsChatEventInThreadBaseProperties
     {
         internal static AcsChatEventInThreadBaseProperties DeserializeAcsChatEventInThreadBaseProperties(JsonElement element)
@@ -27,19 +24,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new AcsChatEventInThreadBaseProperties(threadId.Value);
-        }
-
-        internal partial class AcsChatEventInThreadBasePropertiesConverter : JsonConverter<AcsChatEventInThreadBaseProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, AcsChatEventInThreadBaseProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override AcsChatEventInThreadBaseProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeAcsChatEventInThreadBaseProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatMessageEventBaseProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatMessageEventBaseProperties.Serialization.cs
@@ -7,12 +7,10 @@
 
 using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(AcsChatMessageEventBasePropertiesConverter))]
     public partial class AcsChatMessageEventBaseProperties
     {
         internal static AcsChatMessageEventBaseProperties DeserializeAcsChatMessageEventBaseProperties(JsonElement element)
@@ -95,19 +93,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new AcsChatMessageEventBaseProperties(recipientCommunicationIdentifier.Value, transactionId.Value, threadId.Value, messageId.Value, senderCommunicationIdentifier.Value, senderDisplayName.Value, Optional.ToNullable(composeTime), type.Value, Optional.ToNullable(version));
-        }
-
-        internal partial class AcsChatMessageEventBasePropertiesConverter : JsonConverter<AcsChatMessageEventBaseProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, AcsChatMessageEventBaseProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override AcsChatMessageEventBaseProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeAcsChatMessageEventBaseProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatMessageEventInThreadBaseProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatMessageEventInThreadBaseProperties.Serialization.cs
@@ -7,12 +7,10 @@
 
 using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(AcsChatMessageEventInThreadBasePropertiesConverter))]
     public partial class AcsChatMessageEventInThreadBaseProperties
     {
         internal static AcsChatMessageEventInThreadBaseProperties DeserializeAcsChatMessageEventInThreadBaseProperties(JsonElement element)
@@ -78,19 +76,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new AcsChatMessageEventInThreadBaseProperties(threadId.Value, messageId.Value, senderCommunicationIdentifier.Value, senderDisplayName.Value, Optional.ToNullable(composeTime), type.Value, Optional.ToNullable(version));
-        }
-
-        internal partial class AcsChatMessageEventInThreadBasePropertiesConverter : JsonConverter<AcsChatMessageEventInThreadBaseProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, AcsChatMessageEventInThreadBaseProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override AcsChatMessageEventInThreadBaseProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeAcsChatMessageEventInThreadBaseProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatThreadEventBaseProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatThreadEventBaseProperties.Serialization.cs
@@ -7,12 +7,10 @@
 
 using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(AcsChatThreadEventBasePropertiesConverter))]
     public partial class AcsChatThreadEventBaseProperties
     {
         internal static AcsChatThreadEventBaseProperties DeserializeAcsChatThreadEventBaseProperties(JsonElement element)
@@ -66,19 +64,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new AcsChatThreadEventBaseProperties(recipientCommunicationIdentifier.Value, transactionId.Value, threadId.Value, Optional.ToNullable(createTime), Optional.ToNullable(version));
-        }
-
-        internal partial class AcsChatThreadEventBasePropertiesConverter : JsonConverter<AcsChatThreadEventBaseProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, AcsChatThreadEventBaseProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override AcsChatThreadEventBaseProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeAcsChatThreadEventBaseProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatThreadEventInThreadBaseProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatThreadEventInThreadBaseProperties.Serialization.cs
@@ -7,12 +7,10 @@
 
 using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(AcsChatThreadEventInThreadBasePropertiesConverter))]
     public partial class AcsChatThreadEventInThreadBaseProperties
     {
         internal static AcsChatThreadEventInThreadBaseProperties DeserializeAcsChatThreadEventInThreadBaseProperties(JsonElement element)
@@ -49,19 +47,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new AcsChatThreadEventInThreadBaseProperties(threadId.Value, Optional.ToNullable(createTime), Optional.ToNullable(version));
-        }
-
-        internal partial class AcsChatThreadEventInThreadBasePropertiesConverter : JsonConverter<AcsChatThreadEventInThreadBaseProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, AcsChatThreadEventInThreadBaseProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override AcsChatThreadEventInThreadBaseProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeAcsChatThreadEventInThreadBaseProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatThreadParticipantProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsChatThreadParticipantProperties.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(AcsChatThreadParticipantPropertiesConverter))]
     public partial class AcsChatThreadParticipantProperties
     {
         internal static AcsChatThreadParticipantProperties DeserializeAcsChatThreadParticipantProperties(JsonElement element)
@@ -38,19 +35,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new AcsChatThreadParticipantProperties(displayName.Value, participantCommunicationIdentifier.Value);
-        }
-
-        internal partial class AcsChatThreadParticipantPropertiesConverter : JsonConverter<AcsChatThreadParticipantProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, AcsChatThreadParticipantProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override AcsChatThreadParticipantProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeAcsChatThreadParticipantProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsSmsDeliveryAttemptProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsSmsDeliveryAttemptProperties.Serialization.cs
@@ -7,12 +7,10 @@
 
 using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(AcsSmsDeliveryAttemptPropertiesConverter))]
     public partial class AcsSmsDeliveryAttemptProperties
     {
         internal static AcsSmsDeliveryAttemptProperties DeserializeAcsSmsDeliveryAttemptProperties(JsonElement element)
@@ -54,19 +52,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new AcsSmsDeliveryAttemptProperties(Optional.ToNullable(timestamp), Optional.ToNullable(segmentsSucceeded), Optional.ToNullable(segmentsFailed));
-        }
-
-        internal partial class AcsSmsDeliveryAttemptPropertiesConverter : JsonConverter<AcsSmsDeliveryAttemptProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, AcsSmsDeliveryAttemptProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override AcsSmsDeliveryAttemptProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeAcsSmsDeliveryAttemptProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsSmsEventBaseProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AcsSmsEventBaseProperties.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(AcsSmsEventBasePropertiesConverter))]
     public partial class AcsSmsEventBaseProperties
     {
         internal static AcsSmsEventBaseProperties DeserializeAcsSmsEventBaseProperties(JsonElement element)
@@ -39,19 +36,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new AcsSmsEventBaseProperties(messageId.Value, @from.Value, to.Value);
-        }
-
-        internal partial class AcsSmsEventBasePropertiesConverter : JsonConverter<AcsSmsEventBaseProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, AcsSmsEventBaseProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override AcsSmsEventBaseProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeAcsSmsEventBaseProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AppEventTypeDetail.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AppEventTypeDetail.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(AppEventTypeDetailConverter))]
     public partial class AppEventTypeDetail
     {
         internal static AppEventTypeDetail DeserializeAppEventTypeDetail(JsonElement element)
@@ -32,19 +29,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new AppEventTypeDetail(Optional.ToNullable(action));
-        }
-
-        internal partial class AppEventTypeDetailConverter : JsonConverter<AppEventTypeDetail>
-        {
-            public override void Write(Utf8JsonWriter writer, AppEventTypeDetail model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override AppEventTypeDetail Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeAppEventTypeDetail(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AppServicePlanEventTypeDetail.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/AppServicePlanEventTypeDetail.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(AppServicePlanEventTypeDetailConverter))]
     public partial class AppServicePlanEventTypeDetail
     {
         internal static AppServicePlanEventTypeDetail DeserializeAppServicePlanEventTypeDetail(JsonElement element)
@@ -54,19 +51,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new AppServicePlanEventTypeDetail(Optional.ToNullable(stampKind), Optional.ToNullable(action), Optional.ToNullable(status));
-        }
-
-        internal partial class AppServicePlanEventTypeDetailConverter : JsonConverter<AppServicePlanEventTypeDetail>
-        {
-            public override void Write(Utf8JsonWriter writer, AppServicePlanEventTypeDetail model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override AppServicePlanEventTypeDetail Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeAppServicePlanEventTypeDetail(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CloudEventInternal.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CloudEventInternal.Serialization.cs
@@ -5,15 +5,11 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.Models
 {
-    [JsonConverter(typeof(CloudEventInternalConverter))]
     internal partial class CloudEventInternal : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
@@ -63,101 +59,6 @@ namespace Azure.Messaging.EventGrid.Models
                 writer.WriteObjectValue(item.Value);
             }
             writer.WriteEndObject();
-        }
-
-        internal static CloudEventInternal DeserializeCloudEventInternal(JsonElement element)
-        {
-            string id = default;
-            string source = default;
-            Optional<JsonElement> data = default;
-            Optional<byte[]> dataBase64 = default;
-            string type = default;
-            Optional<DateTimeOffset> time = default;
-            string specversion = default;
-            Optional<string> dataschema = default;
-            Optional<string> datacontenttype = default;
-            Optional<string> subject = default;
-            IDictionary<string, object> additionalProperties = default;
-            Dictionary<string, object> additionalPropertiesDictionary = new Dictionary<string, object>();
-            foreach (var property in element.EnumerateObject())
-            {
-                if (property.NameEquals("id"))
-                {
-                    id = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("source"))
-                {
-                    source = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("data"))
-                {
-                    data = property.Value.Clone();
-                    continue;
-                }
-                if (property.NameEquals("data_base64"))
-                {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        property.ThrowNonNullablePropertyIsNull();
-                        continue;
-                    }
-                    dataBase64 = property.Value.GetBytesFromBase64("D");
-                    continue;
-                }
-                if (property.NameEquals("type"))
-                {
-                    type = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("time"))
-                {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        property.ThrowNonNullablePropertyIsNull();
-                        continue;
-                    }
-                    time = property.Value.GetDateTimeOffset("O");
-                    continue;
-                }
-                if (property.NameEquals("specversion"))
-                {
-                    specversion = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("dataschema"))
-                {
-                    dataschema = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("datacontenttype"))
-                {
-                    datacontenttype = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("subject"))
-                {
-                    subject = property.Value.GetString();
-                    continue;
-                }
-                additionalPropertiesDictionary.Add(property.Name, property.Value.GetObject());
-            }
-            additionalProperties = additionalPropertiesDictionary;
-            return new CloudEventInternal(id, source, data, dataBase64.Value, type, Optional.ToNullable(time), specversion, dataschema.Value, datacontenttype.Value, subject.Value, additionalProperties);
-        }
-
-        internal partial class CloudEventInternalConverter : JsonConverter<CloudEventInternal>
-        {
-            public override void Write(Utf8JsonWriter writer, CloudEventInternal model, JsonSerializerOptions options)
-            {
-                writer.WriteObjectValue(model);
-            }
-            public override CloudEventInternal Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeCloudEventInternal(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CloudEventInternal.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CloudEventInternal.cs
@@ -48,45 +48,18 @@ namespace Azure.Messaging.EventGrid.Models
             AdditionalProperties = new ChangeTrackingDictionary<string, object>();
         }
 
-        /// <summary> Initializes a new instance of CloudEventInternal. </summary>
-        /// <param name="id"> An identifier for the event. The combination of id and source must be unique for each distinct event. </param>
-        /// <param name="source"> Identifies the context in which an event happened. The combination of id and source must be unique for each distinct event. </param>
-        /// <param name="data"> Event data specific to the event type. </param>
-        /// <param name="dataBase64"> Event data specific to the event type, encoded as a base64 string. </param>
-        /// <param name="type"> Type of event related to the originating occurrence. </param>
-        /// <param name="time"> The time (in UTC) the event was generated, in RFC3339 format. </param>
-        /// <param name="specversion"> The version of the CloudEvents specification which the event uses. </param>
-        /// <param name="dataschema"> Identifies the schema that data adheres to. </param>
-        /// <param name="datacontenttype"> Content type of data value. </param>
-        /// <param name="subject"> This describes the subject of the event in the context of the event producer (identified by source). </param>
-        /// <param name="additionalProperties"> . </param>
-        internal CloudEventInternal(string id, string source, JsonElement data, byte[] dataBase64, string type, DateTimeOffset? time, string specversion, string dataschema, string datacontenttype, string subject, IDictionary<string, object> additionalProperties)
-        {
-            Id = id;
-            Source = source;
-            Data = data;
-            DataBase64 = dataBase64;
-            Type = type;
-            Time = time;
-            Specversion = specversion;
-            Dataschema = dataschema;
-            Datacontenttype = datacontenttype;
-            Subject = subject;
-            AdditionalProperties = additionalProperties;
-        }
-
         /// <summary> An identifier for the event. The combination of id and source must be unique for each distinct event. </summary>
-        public string Id { get; set; }
+        public string Id { get; }
         /// <summary> Identifies the context in which an event happened. The combination of id and source must be unique for each distinct event. </summary>
-        public string Source { get; set; }
+        public string Source { get; }
         /// <summary> Event data specific to the event type, encoded as a base64 string. </summary>
         public byte[] DataBase64 { get; set; }
         /// <summary> Type of event related to the originating occurrence. </summary>
-        public string Type { get; set; }
+        public string Type { get; }
         /// <summary> The time (in UTC) the event was generated, in RFC3339 format. </summary>
         public DateTimeOffset? Time { get; set; }
         /// <summary> The version of the CloudEvents specification which the event uses. </summary>
-        public string Specversion { get; set; }
+        public string Specversion { get; }
         /// <summary> Identifies the schema that data adheres to. </summary>
         public string Dataschema { get; set; }
         /// <summary> Content type of data value. </summary>

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CommunicationIdentifierModel.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CommunicationIdentifierModel.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(CommunicationIdentifierModelConverter))]
     public partial class CommunicationIdentifierModel
     {
         internal static CommunicationIdentifierModel DeserializeCommunicationIdentifierModel(JsonElement element)
@@ -60,19 +57,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new CommunicationIdentifierModel(rawId.Value, communicationUser.Value, phoneNumber.Value, microsoftTeamsUser.Value);
-        }
-
-        internal partial class CommunicationIdentifierModelConverter : JsonConverter<CommunicationIdentifierModel>
-        {
-            public override void Write(Utf8JsonWriter writer, CommunicationIdentifierModel model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override CommunicationIdentifierModel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeCommunicationIdentifierModel(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CommunicationUserIdentifierModel.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CommunicationUserIdentifierModel.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(CommunicationUserIdentifierModelConverter))]
     public partial class CommunicationUserIdentifierModel
     {
         internal static CommunicationUserIdentifierModel DeserializeCommunicationUserIdentifierModel(JsonElement element)
@@ -27,19 +24,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new CommunicationUserIdentifierModel(id);
-        }
-
-        internal partial class CommunicationUserIdentifierModelConverter : JsonConverter<CommunicationUserIdentifierModel>
-        {
-            public override void Write(Utf8JsonWriter writer, CommunicationUserIdentifierModel model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override CommunicationUserIdentifierModel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeCommunicationUserIdentifierModel(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/ContainerRegistryArtifactEventTarget.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/ContainerRegistryArtifactEventTarget.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(ContainerRegistryArtifactEventTargetConverter))]
     public partial class ContainerRegistryArtifactEventTarget
     {
         internal static ContainerRegistryArtifactEventTarget DeserializeContainerRegistryArtifactEventTarget(JsonElement element)
@@ -68,19 +65,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new ContainerRegistryArtifactEventTarget(mediaType.Value, Optional.ToNullable(size), digest.Value, repository.Value, tag.Value, name.Value, version.Value);
-        }
-
-        internal partial class ContainerRegistryArtifactEventTargetConverter : JsonConverter<ContainerRegistryArtifactEventTarget>
-        {
-            public override void Write(Utf8JsonWriter writer, ContainerRegistryArtifactEventTarget model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override ContainerRegistryArtifactEventTarget Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeContainerRegistryArtifactEventTarget(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/ContainerRegistryEventActor.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/ContainerRegistryEventActor.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(ContainerRegistryEventActorConverter))]
     public partial class ContainerRegistryEventActor
     {
         internal static ContainerRegistryEventActor DeserializeContainerRegistryEventActor(JsonElement element)
@@ -27,19 +24,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new ContainerRegistryEventActor(name.Value);
-        }
-
-        internal partial class ContainerRegistryEventActorConverter : JsonConverter<ContainerRegistryEventActor>
-        {
-            public override void Write(Utf8JsonWriter writer, ContainerRegistryEventActor model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override ContainerRegistryEventActor Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeContainerRegistryEventActor(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/ContainerRegistryEventRequest.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/ContainerRegistryEventRequest.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(ContainerRegistryEventRequestConverter))]
     public partial class ContainerRegistryEventRequest
     {
         internal static ContainerRegistryEventRequest DeserializeContainerRegistryEventRequest(JsonElement element)
@@ -51,19 +48,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new ContainerRegistryEventRequest(id.Value, addr.Value, host.Value, method.Value, useragent.Value);
-        }
-
-        internal partial class ContainerRegistryEventRequestConverter : JsonConverter<ContainerRegistryEventRequest>
-        {
-            public override void Write(Utf8JsonWriter writer, ContainerRegistryEventRequest model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override ContainerRegistryEventRequest Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeContainerRegistryEventRequest(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/ContainerRegistryEventSource.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/ContainerRegistryEventSource.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(ContainerRegistryEventSourceConverter))]
     public partial class ContainerRegistryEventSource
     {
         internal static ContainerRegistryEventSource DeserializeContainerRegistryEventSource(JsonElement element)
@@ -33,19 +30,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new ContainerRegistryEventSource(addr.Value, instanceID.Value);
-        }
-
-        internal partial class ContainerRegistryEventSourceConverter : JsonConverter<ContainerRegistryEventSource>
-        {
-            public override void Write(Utf8JsonWriter writer, ContainerRegistryEventSource model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override ContainerRegistryEventSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeContainerRegistryEventSource(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/ContainerRegistryEventTarget.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/ContainerRegistryEventTarget.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(ContainerRegistryEventTargetConverter))]
     public partial class ContainerRegistryEventTarget
     {
         internal static ContainerRegistryEventTarget DeserializeContainerRegistryEventTarget(JsonElement element)
@@ -73,19 +70,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new ContainerRegistryEventTarget(mediaType.Value, Optional.ToNullable(size), digest.Value, Optional.ToNullable(length), repository.Value, url.Value, tag.Value);
-        }
-
-        internal partial class ContainerRegistryEventTargetConverter : JsonConverter<ContainerRegistryEventTarget>
-        {
-            public override void Write(Utf8JsonWriter writer, ContainerRegistryEventTarget model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override ContainerRegistryEventTarget Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeContainerRegistryEventTarget(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceConnectionStateEventInfo.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceConnectionStateEventInfo.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(DeviceConnectionStateEventInfoConverter))]
     public partial class DeviceConnectionStateEventInfo
     {
         internal static DeviceConnectionStateEventInfo DeserializeDeviceConnectionStateEventInfo(JsonElement element)
@@ -27,19 +24,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new DeviceConnectionStateEventInfo(sequenceNumber.Value);
-        }
-
-        internal partial class DeviceConnectionStateEventInfoConverter : JsonConverter<DeviceConnectionStateEventInfo>
-        {
-            public override void Write(Utf8JsonWriter writer, DeviceConnectionStateEventInfo model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override DeviceConnectionStateEventInfo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeDeviceConnectionStateEventInfo(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceConnectionStateEventProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceConnectionStateEventProperties.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(DeviceConnectionStateEventPropertiesConverter))]
     public partial class DeviceConnectionStateEventProperties
     {
         internal static DeviceConnectionStateEventProperties DeserializeDeviceConnectionStateEventProperties(JsonElement element)
@@ -50,19 +47,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new DeviceConnectionStateEventProperties(deviceId.Value, moduleId.Value, hubName.Value, deviceConnectionStateEventInfo.Value);
-        }
-
-        internal partial class DeviceConnectionStateEventPropertiesConverter : JsonConverter<DeviceConnectionStateEventProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, DeviceConnectionStateEventProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override DeviceConnectionStateEventProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeDeviceConnectionStateEventProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceLifeCycleEventProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceLifeCycleEventProperties.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(DeviceLifeCycleEventPropertiesConverter))]
     public partial class DeviceLifeCycleEventProperties
     {
         internal static DeviceLifeCycleEventProperties DeserializeDeviceLifeCycleEventProperties(JsonElement element)
@@ -44,19 +41,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new DeviceLifeCycleEventProperties(deviceId.Value, hubName.Value, twin.Value);
-        }
-
-        internal partial class DeviceLifeCycleEventPropertiesConverter : JsonConverter<DeviceLifeCycleEventProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, DeviceLifeCycleEventProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override DeviceLifeCycleEventProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeDeviceLifeCycleEventProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTelemetryEventProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTelemetryEventProperties.Serialization.cs
@@ -5,15 +5,12 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(DeviceTelemetryEventPropertiesConverter))]
     public partial class DeviceTelemetryEventProperties
     {
         internal static DeviceTelemetryEventProperties DeserializeDeviceTelemetryEventProperties(JsonElement element)
@@ -65,19 +62,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new DeviceTelemetryEventProperties(body.Value, Optional.ToDictionary(properties), Optional.ToDictionary(systemProperties));
-        }
-
-        internal partial class DeviceTelemetryEventPropertiesConverter : JsonConverter<DeviceTelemetryEventProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, DeviceTelemetryEventProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override DeviceTelemetryEventProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeDeviceTelemetryEventProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTwinInfo.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTwinInfo.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(DeviceTwinInfoConverter))]
     public partial class DeviceTwinInfo
     {
         internal static DeviceTwinInfo DeserializeDeviceTwinInfo(JsonElement element)
@@ -107,19 +104,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new DeviceTwinInfo(authenticationType.Value, Optional.ToNullable(cloudToDeviceMessageCount), connectionState.Value, deviceId.Value, etag.Value, lastActivityTime.Value, properties.Value, status.Value, statusUpdateTime.Value, Optional.ToNullable(version), x509Thumbprint.Value);
-        }
-
-        internal partial class DeviceTwinInfoConverter : JsonConverter<DeviceTwinInfo>
-        {
-            public override void Write(Utf8JsonWriter writer, DeviceTwinInfo model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override DeviceTwinInfo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeDeviceTwinInfo(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTwinInfoProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTwinInfoProperties.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(DeviceTwinInfoPropertiesConverter))]
     public partial class DeviceTwinInfoProperties
     {
         internal static DeviceTwinInfoProperties DeserializeDeviceTwinInfoProperties(JsonElement element)
@@ -43,19 +40,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new DeviceTwinInfoProperties(desired.Value, reported.Value);
-        }
-
-        internal partial class DeviceTwinInfoPropertiesConverter : JsonConverter<DeviceTwinInfoProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, DeviceTwinInfoProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override DeviceTwinInfoProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeDeviceTwinInfoProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTwinInfoX509Thumbprint.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTwinInfoX509Thumbprint.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(DeviceTwinInfoX509ThumbprintConverter))]
     public partial class DeviceTwinInfoX509Thumbprint
     {
         internal static DeviceTwinInfoX509Thumbprint DeserializeDeviceTwinInfoX509Thumbprint(JsonElement element)
@@ -33,19 +30,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new DeviceTwinInfoX509Thumbprint(primaryThumbprint.Value, secondaryThumbprint.Value);
-        }
-
-        internal partial class DeviceTwinInfoX509ThumbprintConverter : JsonConverter<DeviceTwinInfoX509Thumbprint>
-        {
-            public override void Write(Utf8JsonWriter writer, DeviceTwinInfoX509Thumbprint model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override DeviceTwinInfoX509Thumbprint Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeDeviceTwinInfoX509Thumbprint(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTwinMetadata.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTwinMetadata.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(DeviceTwinMetadataConverter))]
     public partial class DeviceTwinMetadata
     {
         internal static DeviceTwinMetadata DeserializeDeviceTwinMetadata(JsonElement element)
@@ -27,19 +24,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new DeviceTwinMetadata(lastUpdated.Value);
-        }
-
-        internal partial class DeviceTwinMetadataConverter : JsonConverter<DeviceTwinMetadata>
-        {
-            public override void Write(Utf8JsonWriter writer, DeviceTwinMetadata model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override DeviceTwinMetadata Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeDeviceTwinMetadata(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTwinProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/DeviceTwinProperties.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(DeviceTwinPropertiesConverter))]
     public partial class DeviceTwinProperties
     {
         internal static DeviceTwinProperties DeserializeDeviceTwinProperties(JsonElement element)
@@ -43,19 +40,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new DeviceTwinProperties(metadata.Value, Optional.ToNullable(version));
-        }
-
-        internal partial class DeviceTwinPropertiesConverter : JsonConverter<DeviceTwinProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, DeviceTwinProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override DeviceTwinProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeDeviceTwinProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MapsGeofenceEventProperties.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MapsGeofenceEventProperties.Serialization.cs
@@ -5,15 +5,12 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(MapsGeofenceEventPropertiesConverter))]
     public partial class MapsGeofenceEventProperties
     {
         internal static MapsGeofenceEventProperties DeserializeMapsGeofenceEventProperties(JsonElement element)
@@ -81,19 +78,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new MapsGeofenceEventProperties(Optional.ToList(expiredGeofenceGeometryId), Optional.ToList(geometries), Optional.ToList(invalidPeriodGeofenceGeometryId), Optional.ToNullable(isEventPublished));
-        }
-
-        internal partial class MapsGeofenceEventPropertiesConverter : JsonConverter<MapsGeofenceEventProperties>
-        {
-            public override void Write(Utf8JsonWriter writer, MapsGeofenceEventProperties model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override MapsGeofenceEventProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeMapsGeofenceEventProperties(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MapsGeofenceGeometry.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MapsGeofenceGeometry.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(MapsGeofenceGeometryConverter))]
     public partial class MapsGeofenceGeometry
     {
         internal static MapsGeofenceGeometry DeserializeMapsGeofenceGeometry(JsonElement element)
@@ -72,19 +69,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new MapsGeofenceGeometry(deviceId.Value, Optional.ToNullable(distance), geometryId.Value, Optional.ToNullable(nearestLat), Optional.ToNullable(nearestLon), udId.Value);
-        }
-
-        internal partial class MapsGeofenceGeometryConverter : JsonConverter<MapsGeofenceGeometry>
-        {
-            public override void Write(Utf8JsonWriter writer, MapsGeofenceGeometry model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override MapsGeofenceGeometry Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeMapsGeofenceGeometry(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MediaJobError.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MediaJobError.Serialization.cs
@@ -5,15 +5,12 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(MediaJobErrorConverter))]
     public partial class MediaJobError
     {
         internal static MediaJobError DeserializeMediaJobError(JsonElement element)
@@ -77,19 +74,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new MediaJobError(Optional.ToNullable(code), message.Value, Optional.ToNullable(category), Optional.ToNullable(retry), Optional.ToList(details));
-        }
-
-        internal partial class MediaJobErrorConverter : JsonConverter<MediaJobError>
-        {
-            public override void Write(Utf8JsonWriter writer, MediaJobError model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override MediaJobError Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeMediaJobError(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MediaJobErrorDetail.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MediaJobErrorDetail.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(MediaJobErrorDetailConverter))]
     public partial class MediaJobErrorDetail
     {
         internal static MediaJobErrorDetail DeserializeMediaJobErrorDetail(JsonElement element)
@@ -33,19 +30,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new MediaJobErrorDetail(code.Value, message.Value);
-        }
-
-        internal partial class MediaJobErrorDetailConverter : JsonConverter<MediaJobErrorDetail>
-        {
-            public override void Write(Utf8JsonWriter writer, MediaJobErrorDetail model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override MediaJobErrorDetail Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeMediaJobErrorDetail(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MediaJobOutput.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MediaJobOutput.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(MediaJobOutputConverter))]
     public partial class MediaJobOutput
     {
         internal static MediaJobOutput DeserializeMediaJobOutput(JsonElement element)
@@ -63,19 +60,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new MediaJobOutput(odataType.Value, error.Value, label.Value, progress, state);
-        }
-
-        internal partial class MediaJobOutputConverter : JsonConverter<MediaJobOutput>
-        {
-            public override void Write(Utf8JsonWriter writer, MediaJobOutput model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override MediaJobOutput Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeMediaJobOutput(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MediaJobOutputAsset.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MediaJobOutputAsset.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(MediaJobOutputAssetConverter))]
     public partial class MediaJobOutputAsset
     {
         internal static MediaJobOutputAsset DeserializeMediaJobOutputAsset(JsonElement element)
@@ -62,19 +59,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new MediaJobOutputAsset(odataType.Value, error.Value, label.Value, progress, state, assetName.Value);
-        }
-
-        internal partial class MediaJobOutputAssetConverter : JsonConverter<MediaJobOutputAsset>
-        {
-            public override void Write(Utf8JsonWriter writer, MediaJobOutputAsset model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override MediaJobOutputAsset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeMediaJobOutputAsset(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MicrosoftTeamsUserIdentifierModel.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/MicrosoftTeamsUserIdentifierModel.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(MicrosoftTeamsUserIdentifierModelConverter))]
     public partial class MicrosoftTeamsUserIdentifierModel
     {
         internal static MicrosoftTeamsUserIdentifierModel DeserializeMicrosoftTeamsUserIdentifierModel(JsonElement element)
@@ -49,19 +46,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new MicrosoftTeamsUserIdentifierModel(userId, Optional.ToNullable(isAnonymous), Optional.ToNullable(cloud));
-        }
-
-        internal partial class MicrosoftTeamsUserIdentifierModelConverter : JsonConverter<MicrosoftTeamsUserIdentifierModel>
-        {
-            public override void Write(Utf8JsonWriter writer, MicrosoftTeamsUserIdentifierModel model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override MicrosoftTeamsUserIdentifierModel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeMicrosoftTeamsUserIdentifierModel(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/PhoneNumberIdentifierModel.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/PhoneNumberIdentifierModel.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(PhoneNumberIdentifierModelConverter))]
     public partial class PhoneNumberIdentifierModel
     {
         internal static PhoneNumberIdentifierModel DeserializePhoneNumberIdentifierModel(JsonElement element)
@@ -27,19 +24,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new PhoneNumberIdentifierModel(value);
-        }
-
-        internal partial class PhoneNumberIdentifierModelConverter : JsonConverter<PhoneNumberIdentifierModel>
-        {
-            public override void Write(Utf8JsonWriter writer, PhoneNumberIdentifierModel model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override PhoneNumberIdentifierModel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializePhoneNumberIdentifierModel(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/StorageLifecyclePolicyActionSummaryDetail.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/StorageLifecyclePolicyActionSummaryDetail.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(StorageLifecyclePolicyActionSummaryDetailConverter))]
     public partial class StorageLifecyclePolicyActionSummaryDetail
     {
         internal static StorageLifecyclePolicyActionSummaryDetail DeserializeStorageLifecyclePolicyActionSummaryDetail(JsonElement element)
@@ -49,19 +46,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new StorageLifecyclePolicyActionSummaryDetail(Optional.ToNullable(totalObjectsCount), Optional.ToNullable(successCount), errorList.Value);
-        }
-
-        internal partial class StorageLifecyclePolicyActionSummaryDetailConverter : JsonConverter<StorageLifecyclePolicyActionSummaryDetail>
-        {
-            public override void Write(Utf8JsonWriter writer, StorageLifecyclePolicyActionSummaryDetail model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override StorageLifecyclePolicyActionSummaryDetail Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeStorageLifecyclePolicyActionSummaryDetail(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/WebAppServicePlanUpdatedEventDataSku.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/WebAppServicePlanUpdatedEventDataSku.Serialization.cs
@@ -5,14 +5,11 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Messaging.EventGrid.SystemEvents
 {
-    [JsonConverter(typeof(WebAppServicePlanUpdatedEventDataSkuConverter))]
     public partial class WebAppServicePlanUpdatedEventDataSku
     {
         internal static WebAppServicePlanUpdatedEventDataSku DeserializeWebAppServicePlanUpdatedEventDataSku(JsonElement element)
@@ -51,19 +48,6 @@ namespace Azure.Messaging.EventGrid.SystemEvents
                 }
             }
             return new WebAppServicePlanUpdatedEventDataSku(name.Value, tier.Value, size.Value, family.Value, capacity.Value);
-        }
-
-        internal partial class WebAppServicePlanUpdatedEventDataSkuConverter : JsonConverter<WebAppServicePlanUpdatedEventDataSku>
-        {
-            public override void Write(Utf8JsonWriter writer, WebAppServicePlanUpdatedEventDataSku model, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-            public override WebAppServicePlanUpdatedEventDataSku Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeWebAppServicePlanUpdatedEventDataSku(document.RootElement);
-            }
         }
     }
 }


### PR DESCRIPTION
Apparently the converters are not included in the API generated from Export-API.ps1.