### PR TITLE
[Core.Experimental] Add JsonConverter for `JsonData`

### DIFF
--- a/sdk/core/Azure.Core.Experimental/tests/JsonDataTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/JsonDataTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
@@ -276,6 +277,28 @@ namespace Azure.Core.Tests
             Assert.IsFalse("foo" == new JsonData("bar"));
             Assert.IsTrue(new JsonData("bar") != "foo");
             Assert.IsTrue("foo" != new JsonData("bar"));
+        }
+
+        [Test]
+        public void JsonDataInPOCOsWorks()
+        {
+            JsonData orig = new JsonData(new
+            {
+                property = new JsonData("hello")
+            });
+
+            void validate(JsonData d)
+            {
+                Assert.AreEqual(JsonValueKind.Object, d.Kind);
+                Assert.AreEqual(d.Properties.Count(), 1);
+                Assert.AreEqual(d["property"], "hello");
+            }
+
+            validate(orig);
+
+            JsonData roundTrip = JsonSerializer.Deserialize<JsonData>(JsonSerializer.Serialize(orig, orig.GetType()));
+
+            validate(roundTrip);
         }
 
         private T JsonAsType<T>(string json)


### PR DESCRIPTION
The default serialization strategy for a CLR object is not what we
want for `JsonData`, since it works by serializaing all the public
properties of the type, and only a subset of the public properties are
valid for a given `JsonData` (for example, when it represents a
string, the `Properties` property throws `InvalidOperationException`
because `Properties` is only valid when you have a `JsonData`
representing an object.

One place this can really bite you is if you do something like:

```csharp
JsonData array = new JsonData(new [] { "hello", "world" });
JsonData fromPoco = new JsonData(new {
  property = array
});
```

When constructing a JsonData from a POCO, we first serialize it to
JSON and then use that JSON to initialize our `JsonData`, but without
a special converter, trying to serialize the value of the `property`
property will throw an InvalidOperationException.

Provide a converter that lets us control the serialization and
deserialization of `JsonData` so we can just emit or parse the
underlying JSON.