### PR TITLE
Don't cancel second dependent request if the previous pending request is canceled

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
@@ -95,7 +95,7 @@ namespace Azure.Core.Pipeline
                 bool getTokenFromCredential;
                 TaskCompletionSource<HeaderValueInfo> headerValueTcs;
                 TaskCompletionSource<HeaderValueInfo>? backgroundUpdateTcs;
-                bool hasRetriedDueToCancellation = false;
+                int maxCancellationRetries = 3;
 
                 while (true)
                 {
@@ -154,16 +154,16 @@ namespace Azure.Core.Pipeline
 
                     catch (TaskCanceledException)
                     {
-                        // We were waiting on a previous headerValueTcs operation which was canceled.
+                        maxCancellationRetries--;
 
-                        // If we have already retired once, throw.
-                        if (hasRetriedDueToCancellation)
+                        // If the current request has been cancelled or the message has no CancellationToken and we have tried this 3 times, throw.
+                        if (message.CancellationToken.IsCancellationRequested || (message.CancellationToken == default && maxCancellationRetries <= 0))
                         {
                             throw;
                         }
 
+                        // We were waiting on a previous headerValueTcs operation which was canceled.
                         //Retry the call to GetTaskCompletionSources.
-                        hasRetriedDueToCancellation = true;
                         continue;
                     }
                 }

--- a/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
@@ -152,12 +152,12 @@ namespace Azure.Core.Pipeline
 #pragma warning restore AZC0111 // DO NOT use EnsureCompleted in possibly asynchronous scope.
                     }
 
-                    catch (TaskCanceledException)
+                    catch (TaskCanceledException) when (!message.CancellationToken.IsCancellationRequested)
                     {
                         maxCancellationRetries--;
 
-                        // If the current request has been cancelled or the message has no CancellationToken and we have tried this 3 times, throw.
-                        if (message.CancellationToken.IsCancellationRequested || (message.CancellationToken == default && maxCancellationRetries <= 0))
+                        // If the current message has no CancellationToken and we have tried this 3 times, throw.
+                        if (!message.CancellationToken.CanBeCanceled && maxCancellationRetries <= 0)
                         {
                             throw;
                         }

--- a/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
@@ -32,7 +32,8 @@ namespace Azure.Core.Pipeline
         public BearerTokenAuthenticationPolicy(TokenCredential credential, IEnumerable<string> scopes)
             : this(credential, scopes, TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(30)) { }
 
-        internal BearerTokenAuthenticationPolicy(TokenCredential credential, IEnumerable<string> scopes, TimeSpan tokenRefreshOffset, TimeSpan tokenRefreshRetryDelay) {
+        internal BearerTokenAuthenticationPolicy(TokenCredential credential, IEnumerable<string> scopes, TimeSpan tokenRefreshOffset, TimeSpan tokenRefreshRetryDelay)
+        {
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(scopes, nameof(scopes));
 
@@ -94,56 +95,78 @@ namespace Azure.Core.Pipeline
                 bool getTokenFromCredential;
                 TaskCompletionSource<HeaderValueInfo> headerValueTcs;
                 TaskCompletionSource<HeaderValueInfo>? backgroundUpdateTcs;
-                (headerValueTcs, backgroundUpdateTcs, getTokenFromCredential) = GetTaskCompletionSources();
+                bool hasRetriedDueToCancellation = false;
 
-                if (getTokenFromCredential)
+                while (true)
                 {
-                    if (backgroundUpdateTcs != null)
+                    (headerValueTcs, backgroundUpdateTcs, getTokenFromCredential) = GetTaskCompletionSources();
+                    if (getTokenFromCredential)
                     {
+                        if (backgroundUpdateTcs != null)
+                        {
 #pragma warning disable AZC0111 // DO NOT use EnsureCompleted in possibly asynchronous scope.
-                        HeaderValueInfo info = headerValueTcs.Task.EnsureCompleted();
+                            HeaderValueInfo info = headerValueTcs.Task.EnsureCompleted();
 #pragma warning restore AZC0111 // DO NOT use EnsureCompleted in possibly asynchronous scope.
-                        _ = Task.Run(() => GetHeaderValueFromCredentialInBackgroundAsync(backgroundUpdateTcs, info, message, async));
-                        return info.HeaderValue;
-                    }
+                            _ = Task.Run(() => GetHeaderValueFromCredentialInBackgroundAsync(backgroundUpdateTcs, info, message, async));
+                            return info.HeaderValue;
+                        }
 
-                    try
-                    {
-                        HeaderValueInfo info = await GetHeaderValueFromCredentialAsync(message, async, message.CancellationToken).ConfigureAwait(false);
-                        headerValueTcs.SetResult(info);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        headerValueTcs.SetCanceled();
-                        throw;
-                    }
-                    catch (Exception exception)
-                    {
-                        headerValueTcs.SetException(exception);
-                        throw;
-                    }
-                }
-
-                var headerValueTask = headerValueTcs.Task;
-                if (!headerValueTask.IsCompleted)
-                {
-                    if (async)
-                    {
-                        await headerValueTask.AwaitWithCancellation(message.CancellationToken);
-                    }
-                    else
-                    {
                         try
                         {
-                            headerValueTask.Wait(message.CancellationToken);
+                            HeaderValueInfo info = await GetHeaderValueFromCredentialAsync(message, async, message.CancellationToken).ConfigureAwait(false);
+                            headerValueTcs.SetResult(info);
                         }
-                        catch (AggregateException) { } // ignore exception here to rethrow it with EnsureCompleted
+                        catch (OperationCanceledException)
+                        {
+                            headerValueTcs.SetCanceled();
+                            throw;
+                        }
+                        catch (Exception exception)
+                        {
+                            headerValueTcs.SetException(exception);
+                            throw;
+                        }
                     }
-                }
+
+                    var headerValueTask = headerValueTcs.Task;
+                    try
+                    {
+                        if (!headerValueTask.IsCompleted)
+                        {
+                            if (async)
+                            {
+                                await headerValueTask.AwaitWithCancellation(message.CancellationToken);
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    headerValueTask.Wait(message.CancellationToken);
+                                }
+                                catch (AggregateException) { } // ignore exception here to rethrow it with EnsureCompleted
+                            }
+                        }
 
 #pragma warning disable AZC0111 // DO NOT use EnsureCompleted in possibly asynchronous scope.
-                return headerValueTcs.Task.EnsureCompleted().HeaderValue;
+                        return headerValueTcs.Task.EnsureCompleted().HeaderValue;
 #pragma warning restore AZC0111 // DO NOT use EnsureCompleted in possibly asynchronous scope.
+                    }
+
+                    catch (TaskCanceledException)
+                    {
+                        // We were waiting on a previous headerValueTcs operation which was canceled.
+
+                        // If we have already retired once, throw.
+                        if (hasRetriedDueToCancellation)
+                        {
+                            throw;
+                        }
+
+                        //Retry the call to GetTaskCompletionSources.
+                        hasRetriedDueToCancellation = true;
+                        continue;
+                    }
+                }
             }
 
             private (TaskCompletionSource<HeaderValueInfo> tcs, TaskCompletionSource<HeaderValueInfo>? backgroundUpdateTcs, bool getTokenFromCredential) GetTaskCompletionSources()

--- a/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
@@ -237,12 +237,12 @@ namespace Azure.Core.Pipeline
 
                         return info.HeaderValue;
                     }
-                    catch (TaskCanceledException)
+                    catch (TaskCanceledException) when (!message.CancellationToken.IsCancellationRequested)
                     {
                         maxCancellationRetries--;
 
-                        // If the current request has been cancelled or the message has no CancellationToken and we have tried this 3 times, throw.
-                        if (message.CancellationToken.IsCancellationRequested || (message.CancellationToken == default && maxCancellationRetries <= 0))
+                        // If the current message has no CancellationToken and we have tried this 3 times, throw.
+                        if (!message.CancellationToken.CanBeCanceled && maxCancellationRetries <= 0)
                         {
                             throw;
                         }

--- a/sdk/core/Azure.Core/tests/BearerTokenAuthenticationPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/BearerTokenAuthenticationPolicyTests.cs
@@ -572,6 +572,40 @@ namespace Azure.Core.Tests
             Assert.That(response.Status, Is.EqualTo(200));
         }
 
+        [Test]
+        public void BearerTokenChallengeAuthenticationPolicy_CancelledFirstRequestAndCancelledSecondRequest()
+        {
+            var currentTime = DateTime.UtcNow;
+            var requestMre = new ManualResetEventSlim(false);
+            var responseMre = new ManualResetEventSlim(false);
+            var cts1 = new CancellationTokenSource();
+            var cts2 = new CancellationTokenSource();
+            var credential = new TokenCredentialStub((r, c) =>
+            {
+                requestMre.Set();
+                responseMre.Wait(c);
+                return new AccessToken(Guid.NewGuid().ToString(), currentTime.AddMinutes(2));
+            }, IsAsync);
+
+            var policy = new BearerTokenAuthenticationPolicy(credential, "scope");
+            MockTransport transport = CreateMockTransport((req) =>
+            {
+                return new MockResponse(200);
+            });
+
+            var firstRequestTask = SendGetRequest(transport, policy, uri: new Uri("https://example.com"), cancellationToken: cts1.Token);
+            requestMre.Wait();
+
+            var secondRequestTask = SendGetRequest(transport, policy, uri: new Uri("https://example.com"), cancellationToken: cts2.Token);
+            cts1.Cancel();
+            cts2.Cancel();
+
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await firstRequestTask);
+            responseMre.Set();
+
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await secondRequestTask);
+        }
+
         private class TokenCredentialStub : TokenCredential
         {
             public TokenCredentialStub(Func<TokenRequestContext, CancellationToken, AccessToken> handler, bool isAsync)

--- a/sdk/core/Azure.Core/tests/BearerTokenAuthenticationPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/BearerTokenAuthenticationPolicyTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Core.Tests
             var policy = new BearerTokenAuthenticationPolicy(credential, new[] { "scope1", "scope2" });
 
             MockTransport transport = CreateMockTransport(new MockResponse(200));
-            await SendGetRequest(transport, policy, uri:new Uri("https://example.com"));
+            await SendGetRequest(transport, policy, uri: new Uri("https://example.com"));
 
             Assert.True(transport.SingleRequest.Headers.TryGetValue("Authorization", out string authValue));
             Assert.AreEqual("Bearer token", authValue);
@@ -315,7 +315,7 @@ namespace Azure.Core.Tests
                 return new AccessToken(Guid.NewGuid().ToString(), expires.Dequeue());
             }, IsAsync);
 
-            var policy = new BearerTokenAuthenticationPolicy(credential, new[]{ "scope" }, TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(50));
+            var policy = new BearerTokenAuthenticationPolicy(credential, new[] { "scope" }, TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(50));
             MockTransport transport = CreateMockTransport(new MockResponse(200), new MockResponse(200), new MockResponse(200));
 
             await SendGetRequest(transport, policy, uri: new Uri("https://example.com/0"));
@@ -415,7 +415,7 @@ namespace Azure.Core.Tests
                 return new AccessToken(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow.AddSeconds(2));
             }, IsAsync);
 
-            var policy = new BearerTokenAuthenticationPolicy(credential, new[]{ "scope" }, TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(50));
+            var policy = new BearerTokenAuthenticationPolicy(credential, new[] { "scope" }, TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(50));
             MockTransport transport = CreateMockTransport(new MockResponse(200), new MockResponse(200), new MockResponse(200));
 
             await SendGetRequest(transport, policy, uri: new Uri("https://example.com/0"));
@@ -463,7 +463,7 @@ namespace Azure.Core.Tests
             }, IsAsync);
 
             var tokenRefreshRetryDelay = TimeSpan.FromSeconds(2);
-            var policy = new BearerTokenAuthenticationPolicy(credential, new[] {"scope"}, TimeSpan.FromMinutes(2), tokenRefreshRetryDelay);
+            var policy = new BearerTokenAuthenticationPolicy(credential, new[] { "scope" }, TimeSpan.FromMinutes(2), tokenRefreshRetryDelay);
             MockTransport transport = CreateMockTransport(r =>
             {
                 requestMre.Set();
@@ -537,6 +537,39 @@ namespace Azure.Core.Tests
             responseMre.Set();
 
             Assert.CatchAsync<InvalidOperationException>(async () => await firstRequestTask);
+        }
+
+        [Test]
+        public async Task BearerTokenChallengeAuthenticationPolicy_CancelledFirstRequestDoesNotCancelPendingSecondRequest()
+        {
+            var currentTime = DateTime.UtcNow;
+            var requestMre = new ManualResetEventSlim(false);
+            var responseMre = new ManualResetEventSlim(false);
+            var cts = new CancellationTokenSource();
+            var credential = new TokenCredentialStub((r, c) =>
+            {
+                requestMre.Set();
+                responseMre.Wait(c);
+                return new AccessToken(Guid.NewGuid().ToString(), currentTime.AddMinutes(2));
+            }, IsAsync);
+
+            var policy = new BearerTokenAuthenticationPolicy(credential, "scope");
+            MockTransport transport = CreateMockTransport((req) =>
+            {
+                return new MockResponse(200);
+            });
+
+            var firstRequestTask = SendGetRequest(transport, policy, uri: new Uri("https://example.com"), cancellationToken: cts.Token);
+            requestMre.Wait();
+
+            var secondRequestTask = SendGetRequest(transport, policy, uri: new Uri("https://example.com"), cancellationToken: default);
+            cts.Cancel();
+
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await firstRequestTask);
+            responseMre.Set();
+
+            var response = await secondRequestTask;
+            Assert.That(response.Status, Is.EqualTo(200));
         }
 
         private class TokenCredentialStub : TokenCredential

--- a/sdk/core/Azure.Core/tests/BearerTokenChallengeAuthenticationPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/BearerTokenChallengeAuthenticationPolicyTests.cs
@@ -567,6 +567,40 @@ namespace Azure.Core.Tests
             Assert.That(response.Status, Is.EqualTo(200));
         }
 
+        [Test]
+        public void BearerTokenChallengeAuthenticationPolicy_CancelledFirstRequestAndCancelledSecondRequest()
+        {
+            var currentTime = DateTime.UtcNow;
+            var requestMre = new ManualResetEventSlim(false);
+            var responseMre = new ManualResetEventSlim(false);
+            var cts1 = new CancellationTokenSource();
+            var cts2 = new CancellationTokenSource();
+            var credential = new TokenCredentialStub((r, c) =>
+            {
+                requestMre.Set();
+                responseMre.Wait(c);
+                return new AccessToken(Guid.NewGuid().ToString(), currentTime.AddMinutes(2));
+            }, IsAsync);
+
+            var policy = new BearerTokenAuthenticationPolicy(credential, "scope");
+            MockTransport transport = CreateMockTransport((req) =>
+            {
+                return new MockResponse(200);
+            });
+
+            var firstRequestTask = SendGetRequest(transport, policy, uri: new Uri("https://example.com"), cancellationToken: cts1.Token);
+            requestMre.Wait();
+
+            var secondRequestTask = SendGetRequest(transport, policy, uri: new Uri("https://example.com"), cancellationToken: cts2.Token);
+            cts1.Cancel();
+            cts2.Cancel();
+
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await firstRequestTask);
+            responseMre.Set();
+
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await secondRequestTask);
+        }
+
         private class TokenCredentialStub : TokenCredential
         {
             public TokenCredentialStub(Func<TokenRequestContext, CancellationToken, AccessToken> handler, bool isAsync)


### PR DESCRIPTION
fixes #19424