### PR TITLE
Etag.ToString() returns empty string if value is null

### DIFF
--- a/sdk/core/Azure.Core/src/ETag.cs
+++ b/sdk/core/Azure.Core/src/ETag.cs
@@ -102,7 +102,7 @@ namespace Azure
         {
             if (_value == null)
             {
-                return "<null>";
+                return string.Empty;
             }
 
             var _needsQuoateWrap = !IsValidQuotedFormat(_value);

--- a/sdk/core/Azure.Core/tests/ETagTests.cs
+++ b/sdk/core/Azure.Core/tests/ETagTests.cs
@@ -120,8 +120,18 @@ namespace Azure.Core.Tests
         [TestCase("h")]
         public void InvalidFormatThrows(string format)
         {
-            ETag tag  = new ETag("foo");
+            ETag tag = new ETag("foo");
             Assert.Throws<ArgumentException>(() => tag.ToString(format));
+        }
+
+        [Theory]
+        [TestCase(null)]
+        [TestCase(default)]
+        public void NullValueHasNoStringValue(string value)
+        {
+            ETag tag = new ETag(value);
+
+            Assert.That(tag.ToString(), Is.Empty);
         }
     }
 }


### PR DESCRIPTION
fixes #18190