### PR TITLE
[TSI] Rename Instance error and error details

### DIFF
--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/api/Azure.Iot.TimeSeriesInsights.netstandard2.0.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/api/Azure.Iot.TimeSeriesInsights.netstandard2.0.cs
@@ -101,7 +101,7 @@ namespace Azure.Iot.TimeSeriesInsights
     public partial class HierarchiesBatchResponse
     {
         internal HierarchiesBatchResponse() { }
-        public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.InstancesOperationError> Delete { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError> Delete { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.TimeSeriesHierarchyOrError> Get { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.TimeSeriesHierarchyOrError> Put { get { throw null; } }
     }
@@ -148,46 +148,15 @@ namespace Azure.Iot.TimeSeriesInsights
     public partial class InstancesBatchResponse
     {
         internal InstancesBatchResponse() { }
-        public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.InstancesOperationError> Delete { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError> Delete { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.InstancesOperationResult> Get { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.InstancesOperationResult> Put { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.InstancesOperationResult> Update { get { throw null; } }
     }
-    public partial class InstancesOperationError : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyDictionary<string, object>, System.Collections.IEnumerable
-    {
-        internal InstancesOperationError() { }
-        public string Code { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.InstancesOperationErrorDetails> Details { get { throw null; } }
-        public Azure.Iot.TimeSeriesInsights.InstancesOperationError InnerError { get { throw null; } }
-        public object this[string key] { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<string> Keys { get { throw null; } }
-        public string Message { get { throw null; } }
-        int System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<System.String,System.Object>>.Count { get { throw null; } }
-        public string Target { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<object> Values { get { throw null; } }
-        public bool ContainsKey(string key) { throw null; }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public bool TryGetValue(string key, out object value) { throw null; }
-    }
-    public partial class InstancesOperationErrorDetails : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyDictionary<string, object>, System.Collections.IEnumerable
-    {
-        internal InstancesOperationErrorDetails() { }
-        public string Code { get { throw null; } }
-        public object this[string key] { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<string> Keys { get { throw null; } }
-        public string Message { get { throw null; } }
-        int System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<System.String,System.Object>>.Count { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<object> Values { get { throw null; } }
-        public bool ContainsKey(string key) { throw null; }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public bool TryGetValue(string key, out object value) { throw null; }
-    }
     public partial class InstancesOperationResult
     {
         internal InstancesOperationResult() { }
-        public Azure.Iot.TimeSeriesInsights.InstancesOperationError Error { get { throw null; } }
+        public Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError Error { get { throw null; } }
         public Azure.Iot.TimeSeriesInsights.TimeSeriesInstance Instance { get { throw null; } }
     }
     public partial class InstancesRequestBatchGetOrDelete
@@ -351,7 +320,7 @@ namespace Azure.Iot.TimeSeriesInsights
     public partial class TimeSeriesHierarchyOrError
     {
         internal TimeSeriesHierarchyOrError() { }
-        public Azure.Iot.TimeSeriesInsights.InstancesOperationError Error { get { throw null; } }
+        public Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError Error { get { throw null; } }
         public Azure.Iot.TimeSeriesInsights.TimeSeriesHierarchy Hierarchy { get { throw null; } }
     }
     public partial class TimeSeriesId
@@ -373,12 +342,12 @@ namespace Azure.Iot.TimeSeriesInsights
         protected TimeSeriesInsightsClient() { }
         public TimeSeriesInsightsClient(string environmentFqdn, Azure.Core.TokenCredential credential) { }
         public TimeSeriesInsightsClient(string environmentFqdn, Azure.Core.TokenCredential credential, Azure.Iot.TimeSeriesInsights.TimeSeriesInsightsClientOptions options) { }
-        public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.InstancesOperationError[]> CreateOrReplaceTimeSeriesInstances(System.Collections.Generic.IEnumerable<Azure.Iot.TimeSeriesInsights.TimeSeriesInstance> timeSeriesInstances, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.InstancesOperationError[]>> CreateOrReplaceTimeSeriesInstancesAsync(System.Collections.Generic.IEnumerable<Azure.Iot.TimeSeriesInsights.TimeSeriesInstance> timeSeriesInstances, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.InstancesOperationError[]> DeleteInstances(System.Collections.Generic.IEnumerable<Azure.Iot.TimeSeriesInsights.TimeSeriesId> timeSeriesIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.InstancesOperationError[]> DeleteInstances(System.Collections.Generic.IEnumerable<string> timeSeriesNames, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.InstancesOperationError[]>> DeleteInstancesAsync(System.Collections.Generic.IEnumerable<Azure.Iot.TimeSeriesInsights.TimeSeriesId> timeSeriesIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.InstancesOperationError[]>> DeleteInstancesAsync(System.Collections.Generic.IEnumerable<string> timeSeriesNames, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError[]> CreateOrReplaceTimeSeriesInstances(System.Collections.Generic.IEnumerable<Azure.Iot.TimeSeriesInsights.TimeSeriesInstance> timeSeriesInstances, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError[]>> CreateOrReplaceTimeSeriesInstancesAsync(System.Collections.Generic.IEnumerable<Azure.Iot.TimeSeriesInsights.TimeSeriesInstance> timeSeriesInstances, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError[]> DeleteInstances(System.Collections.Generic.IEnumerable<Azure.Iot.TimeSeriesInsights.TimeSeriesId> timeSeriesIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError[]> DeleteInstances(System.Collections.Generic.IEnumerable<string> timeSeriesNames, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError[]>> DeleteInstancesAsync(System.Collections.Generic.IEnumerable<Azure.Iot.TimeSeriesInsights.TimeSeriesId> timeSeriesIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError[]>> DeleteInstancesAsync(System.Collections.Generic.IEnumerable<string> timeSeriesNames, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.InstancesOperationResult[]> GetInstances(System.Collections.Generic.IEnumerable<Azure.Iot.TimeSeriesInsights.TimeSeriesId> timeSeriesIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.InstancesOperationResult[]> GetInstances(System.Collections.Generic.IEnumerable<string> timeSeriesNames, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.Iot.TimeSeriesInsights.TimeSeriesInstance> GetInstances(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -391,10 +360,10 @@ namespace Azure.Iot.TimeSeriesInsights
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.SearchSuggestion[]>> GetSearchSuggestionsAsync(string searchString, int? maxNumberOfSuggestions = default(int?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.Iot.TimeSeriesInsights.TimeSeriesType> GetTimeSeriesTypes(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.Iot.TimeSeriesInsights.TimeSeriesType> GetTimeSeriesTypesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesTypeOperationResult[]> GetTimeSeriesTypesbyId(System.Collections.Generic.IEnumerable<string> timeSeriesTypeIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesTypeOperationResult[]>> GetTimeSeriesTypesbyIdAsync(System.Collections.Generic.IEnumerable<string> timeSeriesTypeIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesTypeOperationResult[]> GetTimeSeriesTypesbyNames(System.Collections.Generic.IEnumerable<string> timeSeriesTypeNames, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesTypeOperationResult[]>> GetTimeSeriesTypesbyNamesAsync(System.Collections.Generic.IEnumerable<string> timeSeriesTypeNames, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesTypeOperationResult[]> GetTimeSeriesTypesById(System.Collections.Generic.IEnumerable<string> timeSeriesTypeIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesTypeOperationResult[]>> GetTimeSeriesTypesByIdAsync(System.Collections.Generic.IEnumerable<string> timeSeriesTypeIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesTypeOperationResult[]> GetTimeSeriesTypesByNames(System.Collections.Generic.IEnumerable<string> timeSeriesTypeNames, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesTypeOperationResult[]>> GetTimeSeriesTypesByNamesAsync(System.Collections.Generic.IEnumerable<string> timeSeriesTypeNames, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.InstancesOperationResult[]> ReplaceTimeSeriesInstances(System.Collections.Generic.IEnumerable<Azure.Iot.TimeSeriesInsights.TimeSeriesInstance> timeSeriesInstances, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.TimeSeriesInsights.InstancesOperationResult[]>> ReplaceTimeSeriesInstancesAsync(System.Collections.Generic.IEnumerable<Azure.Iot.TimeSeriesInsights.TimeSeriesInstance> timeSeriesInstances, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Iot.TimeSeriesInsights.TimeSeriesModelSettings> UpdateModelSettingsDefaultTypeId(string defaultTypeId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -428,6 +397,37 @@ namespace Azure.Iot.TimeSeriesInsights
         public string Name { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.TimeSeriesIdProperty> TimeSeriesIdProperties { get { throw null; } }
     }
+    public partial class TimeSeriesOperationError : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyDictionary<string, object>, System.Collections.IEnumerable
+    {
+        internal TimeSeriesOperationError() { }
+        public string Code { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.TimeSeriesOperationErrorDetails> Details { get { throw null; } }
+        public Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError InnerError { get { throw null; } }
+        public object this[string key] { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> Keys { get { throw null; } }
+        public string Message { get { throw null; } }
+        int System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<System.String,System.Object>>.Count { get { throw null; } }
+        public string Target { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<object> Values { get { throw null; } }
+        public bool ContainsKey(string key) { throw null; }
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public bool TryGetValue(string key, out object value) { throw null; }
+    }
+    public partial class TimeSeriesOperationErrorDetails : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyDictionary<string, object>, System.Collections.IEnumerable
+    {
+        internal TimeSeriesOperationErrorDetails() { }
+        public string Code { get { throw null; } }
+        public object this[string key] { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> Keys { get { throw null; } }
+        public string Message { get { throw null; } }
+        int System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<System.String,System.Object>>.Count { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<object> Values { get { throw null; } }
+        public bool ContainsKey(string key) { throw null; }
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public bool TryGetValue(string key, out object value) { throw null; }
+    }
     public partial class TimeSeriesType
     {
         public TimeSeriesType(string name, System.Collections.Generic.IDictionary<string, Azure.Iot.TimeSeriesInsights.TimeSeriesVariable> variables) { }
@@ -439,7 +439,7 @@ namespace Azure.Iot.TimeSeriesInsights
     public partial class TimeSeriesTypeOperationResult
     {
         internal TimeSeriesTypeOperationResult() { }
-        public Azure.Iot.TimeSeriesInsights.InstancesOperationError Error { get { throw null; } }
+        public Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError Error { get { throw null; } }
         public Azure.Iot.TimeSeriesInsights.TimeSeriesType TimeSeriesType { get { throw null; } }
     }
     public partial class TimeSeriesVariable
@@ -457,7 +457,7 @@ namespace Azure.Iot.TimeSeriesInsights
     public partial class TypesBatchResponse
     {
         internal TypesBatchResponse() { }
-        public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.InstancesOperationError> Delete { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.TimeSeriesOperationError> Delete { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.TimeSeriesTypeOperationResult> Get { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Iot.TimeSeriesInsights.TimeSeriesTypeOperationResult> Put { get { throw null; } }
     }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Customized/Models/InstancesBatchResponse.Serialization.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Customized/Models/InstancesBatchResponse.Serialization.cs
@@ -24,7 +24,7 @@ namespace Azure.Iot.TimeSeriesInsights
             Optional<IReadOnlyList<InstancesOperationResult>> @get = default;
             Optional<IReadOnlyList<InstancesOperationResult>> put = default;
             Optional<IReadOnlyList<InstancesOperationResult>> update = default;
-            Optional<IReadOnlyList<InstancesOperationError>> delete = default;
+            Optional<IReadOnlyList<TimeSeriesOperationError>> delete = default;
             foreach (JsonProperty property in element.EnumerateObject())
             {
                 if (property.NameEquals("get"))
@@ -79,10 +79,10 @@ namespace Azure.Iot.TimeSeriesInsights
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    List<InstancesOperationError> array = new List<InstancesOperationError>();
+                    List<TimeSeriesOperationError> array = new List<TimeSeriesOperationError>();
                     foreach (JsonElement item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.ValueKind != JsonValueKind.Null ? InstancesOperationError.DeserializeInstancesOperationError(item) : null);
+                        array.Add(item.ValueKind != JsonValueKind.Null ? TimeSeriesOperationError.DeserializeTimeSeriesOperationError(item) : null);
                     }
                     delete = array;
                     continue;

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Customized/Models/InstancesOperationError.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Customized/Models/InstancesOperationError.cs
@@ -6,13 +6,13 @@ using Azure.Core;
 namespace Azure.Iot.TimeSeriesInsights
 {
     /// <summary>
-    /// A particular API error with an error code and a message.
+    /// Time Series Insights operation error with an error code and a message.
     /// </summary>
     [CodeGenModel("TsiErrorBody")]
-    public partial class InstancesOperationError
+    public partial class TimeSeriesOperationError
     {
         // This class declaration changes the class name; do not remove.
         // The class name change is to make it clearer to the user that this type represents
-        // an instances operation error.
+        // a Time Series Insights operation error.
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Customized/Models/InstancesOperationErrorDetails.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Customized/Models/InstancesOperationErrorDetails.cs
@@ -6,13 +6,13 @@ using Azure.Core;
 namespace Azure.Iot.TimeSeriesInsights
 {
     /// <summary>
-    /// Error details for Time Series Insights instances operations.
+    /// Error details for Time Series Insights operations.
     /// </summary>
     [CodeGenModel("TsiErrorDetails")]
-    public partial class InstancesOperationErrorDetails
+    public partial class TimeSeriesOperationErrorDetails
     {
         // This class declaration changes the class name; do not remove.
         // The class name change is to make it clearer to the user that this type represents
-        // error details for an instances operation.
+        // error details for an Time Series Insights operation.
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/HierarchiesBatchResponse.Serialization.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/HierarchiesBatchResponse.Serialization.cs
@@ -17,7 +17,7 @@ namespace Azure.Iot.TimeSeriesInsights
         {
             Optional<IReadOnlyList<TimeSeriesHierarchyOrError>> @get = default;
             Optional<IReadOnlyList<TimeSeriesHierarchyOrError>> put = default;
-            Optional<IReadOnlyList<InstancesOperationError>> delete = default;
+            Optional<IReadOnlyList<TimeSeriesOperationError>> delete = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("get"))
@@ -57,10 +57,10 @@ namespace Azure.Iot.TimeSeriesInsights
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    List<InstancesOperationError> array = new List<InstancesOperationError>();
+                    List<TimeSeriesOperationError> array = new List<TimeSeriesOperationError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InstancesOperationError.DeserializeInstancesOperationError(item));
+                        array.Add(TimeSeriesOperationError.DeserializeTimeSeriesOperationError(item));
                     }
                     delete = array;
                     continue;

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/HierarchiesBatchResponse.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/HierarchiesBatchResponse.cs
@@ -18,14 +18,14 @@ namespace Azure.Iot.TimeSeriesInsights
         {
             Get = new ChangeTrackingList<TimeSeriesHierarchyOrError>();
             Put = new ChangeTrackingList<TimeSeriesHierarchyOrError>();
-            Delete = new ChangeTrackingList<InstancesOperationError>();
+            Delete = new ChangeTrackingList<TimeSeriesOperationError>();
         }
 
         /// <summary> Initializes a new instance of HierarchiesBatchResponse. </summary>
         /// <param name="get"> List of hierarchy or error objects corresponding by position to the &quot;get&quot; array in the request. Hierarchy object is set when operation is successful and error object is set when operation is unsuccessful. </param>
         /// <param name="put"> List of hierarchy or error object corresponding by position to the &quot;put&quot; array in the request. Hierarchy object is set when operation is successful and error object is set when operation is unsuccessful. </param>
         /// <param name="delete"> List of error objects corresponding by position to the &quot;delete&quot; array in the request - null when the operation is successful. </param>
-        internal HierarchiesBatchResponse(IReadOnlyList<TimeSeriesHierarchyOrError> @get, IReadOnlyList<TimeSeriesHierarchyOrError> put, IReadOnlyList<InstancesOperationError> delete)
+        internal HierarchiesBatchResponse(IReadOnlyList<TimeSeriesHierarchyOrError> @get, IReadOnlyList<TimeSeriesHierarchyOrError> put, IReadOnlyList<TimeSeriesOperationError> delete)
         {
             Get = @get;
             Put = put;
@@ -37,6 +37,6 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <summary> List of hierarchy or error object corresponding by position to the &quot;put&quot; array in the request. Hierarchy object is set when operation is successful and error object is set when operation is unsuccessful. </summary>
         public IReadOnlyList<TimeSeriesHierarchyOrError> Put { get; }
         /// <summary> List of error objects corresponding by position to the &quot;delete&quot; array in the request - null when the operation is successful. </summary>
-        public IReadOnlyList<InstancesOperationError> Delete { get; }
+        public IReadOnlyList<TimeSeriesOperationError> Delete { get; }
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/InstancesBatchResponse.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/InstancesBatchResponse.cs
@@ -19,7 +19,7 @@ namespace Azure.Iot.TimeSeriesInsights
             Get = new ChangeTrackingList<InstancesOperationResult>();
             Put = new ChangeTrackingList<InstancesOperationResult>();
             Update = new ChangeTrackingList<InstancesOperationResult>();
-            Delete = new ChangeTrackingList<InstancesOperationError>();
+            Delete = new ChangeTrackingList<TimeSeriesOperationError>();
         }
 
         /// <summary> Initializes a new instance of InstancesBatchResponse. </summary>
@@ -27,7 +27,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <param name="put"> List of error objects corresponding by position to the &quot;put&quot; array in the request. Error object is set when operation is unsuccessful. </param>
         /// <param name="update"> List of error objects corresponding by position to the &quot;update&quot; array in the request. Instance object is set when operation is successful and error object is set when operation is unsuccessful. </param>
         /// <param name="delete"> List of error objects corresponding by position to the &quot;delete&quot; array in the request. Null means the instance has been deleted, or did not exist. Error object is set when operation is unsuccessful (e.g. when there are events associated with this time series instance). </param>
-        internal InstancesBatchResponse(IReadOnlyList<InstancesOperationResult> @get, IReadOnlyList<InstancesOperationResult> put, IReadOnlyList<InstancesOperationResult> update, IReadOnlyList<InstancesOperationError> delete)
+        internal InstancesBatchResponse(IReadOnlyList<InstancesOperationResult> @get, IReadOnlyList<InstancesOperationResult> put, IReadOnlyList<InstancesOperationResult> update, IReadOnlyList<TimeSeriesOperationError> delete)
         {
             Get = @get;
             Put = put;
@@ -42,6 +42,6 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <summary> List of error objects corresponding by position to the &quot;update&quot; array in the request. Instance object is set when operation is successful and error object is set when operation is unsuccessful. </summary>
         public IReadOnlyList<InstancesOperationResult> Update { get; }
         /// <summary> List of error objects corresponding by position to the &quot;delete&quot; array in the request. Null means the instance has been deleted, or did not exist. Error object is set when operation is unsuccessful (e.g. when there are events associated with this time series instance). </summary>
-        public IReadOnlyList<InstancesOperationError> Delete { get; }
+        public IReadOnlyList<TimeSeriesOperationError> Delete { get; }
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/InstancesOperationResult.Serialization.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/InstancesOperationResult.Serialization.cs
@@ -15,7 +15,7 @@ namespace Azure.Iot.TimeSeriesInsights
         internal static InstancesOperationResult DeserializeInstancesOperationResult(JsonElement element)
         {
             Optional<TimeSeriesInstance> instance = default;
-            Optional<InstancesOperationError> error = default;
+            Optional<TimeSeriesOperationError> error = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("instance"))
@@ -35,7 +35,7 @@ namespace Azure.Iot.TimeSeriesInsights
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    error = InstancesOperationError.DeserializeInstancesOperationError(property.Value);
+                    error = TimeSeriesOperationError.DeserializeTimeSeriesOperationError(property.Value);
                     continue;
                 }
             }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/InstancesOperationResult.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/InstancesOperationResult.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <summary> Initializes a new instance of InstancesOperationResult. </summary>
         /// <param name="instance"> Time series instance object - set when the operation is successful (except put operation). </param>
         /// <param name="error"> Error object - set when the operation is unsuccessful. </param>
-        internal InstancesOperationResult(TimeSeriesInstance instance, InstancesOperationError error)
+        internal InstancesOperationResult(TimeSeriesInstance instance, TimeSeriesOperationError error)
         {
             Instance = instance;
             Error = error;
@@ -27,6 +27,6 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <summary> Time series instance object - set when the operation is successful (except put operation). </summary>
         public TimeSeriesInstance Instance { get; }
         /// <summary> Error object - set when the operation is unsuccessful. </summary>
-        public InstancesOperationError Error { get; }
+        public TimeSeriesOperationError Error { get; }
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesHierarchyOrError.Serialization.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesHierarchyOrError.Serialization.cs
@@ -15,7 +15,7 @@ namespace Azure.Iot.TimeSeriesInsights
         internal static TimeSeriesHierarchyOrError DeserializeTimeSeriesHierarchyOrError(JsonElement element)
         {
             Optional<TimeSeriesHierarchy> hierarchy = default;
-            Optional<InstancesOperationError> error = default;
+            Optional<TimeSeriesOperationError> error = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("hierarchy"))
@@ -35,7 +35,7 @@ namespace Azure.Iot.TimeSeriesInsights
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    error = InstancesOperationError.DeserializeInstancesOperationError(property.Value);
+                    error = TimeSeriesOperationError.DeserializeTimeSeriesOperationError(property.Value);
                     continue;
                 }
             }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesHierarchyOrError.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesHierarchyOrError.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <summary> Initializes a new instance of TimeSeriesHierarchyOrError. </summary>
         /// <param name="hierarchy"> Time series hierarchy object - set when the operation is successful. </param>
         /// <param name="error"> Error object - set when the operation is unsuccessful. </param>
-        internal TimeSeriesHierarchyOrError(TimeSeriesHierarchy hierarchy, InstancesOperationError error)
+        internal TimeSeriesHierarchyOrError(TimeSeriesHierarchy hierarchy, TimeSeriesOperationError error)
         {
             Hierarchy = hierarchy;
             Error = error;
@@ -27,6 +27,6 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <summary> Time series hierarchy object - set when the operation is successful. </summary>
         public TimeSeriesHierarchy Hierarchy { get; }
         /// <summary> Error object - set when the operation is unsuccessful. </summary>
-        public InstancesOperationError Error { get; }
+        public TimeSeriesOperationError Error { get; }
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesOperationError.Serialization.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesOperationError.Serialization.cs
@@ -11,15 +11,15 @@ using Azure.Core;
 
 namespace Azure.Iot.TimeSeriesInsights
 {
-    public partial class InstancesOperationError
+    public partial class TimeSeriesOperationError
     {
-        internal static InstancesOperationError DeserializeInstancesOperationError(JsonElement element)
+        internal static TimeSeriesOperationError DeserializeTimeSeriesOperationError(JsonElement element)
         {
             Optional<string> code = default;
             Optional<string> message = default;
             Optional<string> target = default;
-            Optional<InstancesOperationError> innerError = default;
-            Optional<IReadOnlyList<InstancesOperationErrorDetails>> details = default;
+            Optional<TimeSeriesOperationError> innerError = default;
+            Optional<IReadOnlyList<TimeSeriesOperationErrorDetails>> details = default;
             IReadOnlyDictionary<string, object> additionalProperties = default;
             Dictionary<string, object> additionalPropertiesDictionary = new Dictionary<string, object>();
             foreach (var property in element.EnumerateObject())
@@ -46,7 +46,7 @@ namespace Azure.Iot.TimeSeriesInsights
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    innerError = DeserializeInstancesOperationError(property.Value);
+                    innerError = DeserializeTimeSeriesOperationError(property.Value);
                     continue;
                 }
                 if (property.NameEquals("details"))
@@ -56,10 +56,10 @@ namespace Azure.Iot.TimeSeriesInsights
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    List<InstancesOperationErrorDetails> array = new List<InstancesOperationErrorDetails>();
+                    List<TimeSeriesOperationErrorDetails> array = new List<TimeSeriesOperationErrorDetails>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InstancesOperationErrorDetails.DeserializeInstancesOperationErrorDetails(item));
+                        array.Add(TimeSeriesOperationErrorDetails.DeserializeTimeSeriesOperationErrorDetails(item));
                     }
                     details = array;
                     continue;
@@ -67,7 +67,7 @@ namespace Azure.Iot.TimeSeriesInsights
                 additionalPropertiesDictionary.Add(property.Name, property.Value.GetObject());
             }
             additionalProperties = additionalPropertiesDictionary;
-            return new InstancesOperationError(code.Value, message.Value, target.Value, innerError.Value, Optional.ToList(details), additionalProperties);
+            return new TimeSeriesOperationError(code.Value, message.Value, target.Value, innerError.Value, Optional.ToList(details), additionalProperties);
         }
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesOperationError.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesOperationError.cs
@@ -11,23 +11,30 @@ using Azure.Core;
 
 namespace Azure.Iot.TimeSeriesInsights
 {
-    /// <summary> Additional error information. </summary>
-    public partial class InstancesOperationErrorDetails : IReadOnlyDictionary<string, object>
+    /// <summary> A particular API error with an error code and a message. </summary>
+    public partial class TimeSeriesOperationError : IReadOnlyDictionary<string, object>
     {
-        /// <summary> Initializes a new instance of InstancesOperationErrorDetails. </summary>
-        internal InstancesOperationErrorDetails()
+        /// <summary> Initializes a new instance of TimeSeriesOperationError. </summary>
+        internal TimeSeriesOperationError()
         {
+            Details = new ChangeTrackingList<TimeSeriesOperationErrorDetails>();
             AdditionalProperties = new ChangeTrackingDictionary<string, object>();
         }
 
-        /// <summary> Initializes a new instance of InstancesOperationErrorDetails. </summary>
+        /// <summary> Initializes a new instance of TimeSeriesOperationError. </summary>
         /// <param name="code"> Language-independent, human-readable string that defines a service-specific error code. This code serves as a more specific indicator for the HTTP error code specified in the response. Can be used to programmatically handle specific error cases. </param>
         /// <param name="message"> Human-readable, language-independent representation of the error. It is intended as an aid to developers and is not suitable for exposure to end users. </param>
+        /// <param name="target"> Target of the particular error (for example, the name of the property in error). May be null. </param>
+        /// <param name="innerError"> Contains more specific error that narrows down the cause. May be null. </param>
+        /// <param name="details"> Contains additional error information. May be null. </param>
         /// <param name="additionalProperties"> . </param>
-        internal InstancesOperationErrorDetails(string code, string message, IReadOnlyDictionary<string, object> additionalProperties)
+        internal TimeSeriesOperationError(string code, string message, string target, TimeSeriesOperationError innerError, IReadOnlyList<TimeSeriesOperationErrorDetails> details, IReadOnlyDictionary<string, object> additionalProperties)
         {
             Code = code;
             Message = message;
+            Target = target;
+            InnerError = innerError;
+            Details = details;
             AdditionalProperties = additionalProperties;
         }
 
@@ -35,6 +42,12 @@ namespace Azure.Iot.TimeSeriesInsights
         public string Code { get; }
         /// <summary> Human-readable, language-independent representation of the error. It is intended as an aid to developers and is not suitable for exposure to end users. </summary>
         public string Message { get; }
+        /// <summary> Target of the particular error (for example, the name of the property in error). May be null. </summary>
+        public string Target { get; }
+        /// <summary> Contains more specific error that narrows down the cause. May be null. </summary>
+        public TimeSeriesOperationError InnerError { get; }
+        /// <summary> Contains additional error information. May be null. </summary>
+        public IReadOnlyList<TimeSeriesOperationErrorDetails> Details { get; }
         internal IReadOnlyDictionary<string, object> AdditionalProperties { get; }
         /// <inheritdoc />
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesOperationErrorDetails.Serialization.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesOperationErrorDetails.Serialization.cs
@@ -11,9 +11,9 @@ using Azure.Core;
 
 namespace Azure.Iot.TimeSeriesInsights
 {
-    public partial class InstancesOperationErrorDetails
+    public partial class TimeSeriesOperationErrorDetails
     {
-        internal static InstancesOperationErrorDetails DeserializeInstancesOperationErrorDetails(JsonElement element)
+        internal static TimeSeriesOperationErrorDetails DeserializeTimeSeriesOperationErrorDetails(JsonElement element)
         {
             Optional<string> code = default;
             Optional<string> message = default;
@@ -34,7 +34,7 @@ namespace Azure.Iot.TimeSeriesInsights
                 additionalPropertiesDictionary.Add(property.Name, property.Value.GetObject());
             }
             additionalProperties = additionalPropertiesDictionary;
-            return new InstancesOperationErrorDetails(code.Value, message.Value, additionalProperties);
+            return new TimeSeriesOperationErrorDetails(code.Value, message.Value, additionalProperties);
         }
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesOperationErrorDetails.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesOperationErrorDetails.cs
@@ -11,30 +11,23 @@ using Azure.Core;
 
 namespace Azure.Iot.TimeSeriesInsights
 {
-    /// <summary> A particular API error with an error code and a message. </summary>
-    public partial class InstancesOperationError : IReadOnlyDictionary<string, object>
+    /// <summary> Additional error information. </summary>
+    public partial class TimeSeriesOperationErrorDetails : IReadOnlyDictionary<string, object>
     {
-        /// <summary> Initializes a new instance of InstancesOperationError. </summary>
-        internal InstancesOperationError()
+        /// <summary> Initializes a new instance of TimeSeriesOperationErrorDetails. </summary>
+        internal TimeSeriesOperationErrorDetails()
         {
-            Details = new ChangeTrackingList<InstancesOperationErrorDetails>();
             AdditionalProperties = new ChangeTrackingDictionary<string, object>();
         }
 
-        /// <summary> Initializes a new instance of InstancesOperationError. </summary>
+        /// <summary> Initializes a new instance of TimeSeriesOperationErrorDetails. </summary>
         /// <param name="code"> Language-independent, human-readable string that defines a service-specific error code. This code serves as a more specific indicator for the HTTP error code specified in the response. Can be used to programmatically handle specific error cases. </param>
         /// <param name="message"> Human-readable, language-independent representation of the error. It is intended as an aid to developers and is not suitable for exposure to end users. </param>
-        /// <param name="target"> Target of the particular error (for example, the name of the property in error). May be null. </param>
-        /// <param name="innerError"> Contains more specific error that narrows down the cause. May be null. </param>
-        /// <param name="details"> Contains additional error information. May be null. </param>
         /// <param name="additionalProperties"> . </param>
-        internal InstancesOperationError(string code, string message, string target, InstancesOperationError innerError, IReadOnlyList<InstancesOperationErrorDetails> details, IReadOnlyDictionary<string, object> additionalProperties)
+        internal TimeSeriesOperationErrorDetails(string code, string message, IReadOnlyDictionary<string, object> additionalProperties)
         {
             Code = code;
             Message = message;
-            Target = target;
-            InnerError = innerError;
-            Details = details;
             AdditionalProperties = additionalProperties;
         }
 
@@ -42,12 +35,6 @@ namespace Azure.Iot.TimeSeriesInsights
         public string Code { get; }
         /// <summary> Human-readable, language-independent representation of the error. It is intended as an aid to developers and is not suitable for exposure to end users. </summary>
         public string Message { get; }
-        /// <summary> Target of the particular error (for example, the name of the property in error). May be null. </summary>
-        public string Target { get; }
-        /// <summary> Contains more specific error that narrows down the cause. May be null. </summary>
-        public InstancesOperationError InnerError { get; }
-        /// <summary> Contains additional error information. May be null. </summary>
-        public IReadOnlyList<InstancesOperationErrorDetails> Details { get; }
         internal IReadOnlyDictionary<string, object> AdditionalProperties { get; }
         /// <inheritdoc />
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesTypeOperationResult.Serialization.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesTypeOperationResult.Serialization.cs
@@ -15,7 +15,7 @@ namespace Azure.Iot.TimeSeriesInsights
         internal static TimeSeriesTypeOperationResult DeserializeTimeSeriesTypeOperationResult(JsonElement element)
         {
             Optional<TimeSeriesType> timeSeriesType = default;
-            Optional<InstancesOperationError> error = default;
+            Optional<TimeSeriesOperationError> error = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("timeSeriesType"))
@@ -35,7 +35,7 @@ namespace Azure.Iot.TimeSeriesInsights
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    error = InstancesOperationError.DeserializeInstancesOperationError(property.Value);
+                    error = TimeSeriesOperationError.DeserializeTimeSeriesOperationError(property.Value);
                     continue;
                 }
             }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesTypeOperationResult.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TimeSeriesTypeOperationResult.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <summary> Initializes a new instance of TimeSeriesTypeOperationResult. </summary>
         /// <param name="timeSeriesType"> Time series type object - set when the operation is successful. </param>
         /// <param name="error"> Error object - set when the operation is unsuccessful. </param>
-        internal TimeSeriesTypeOperationResult(TimeSeriesType timeSeriesType, InstancesOperationError error)
+        internal TimeSeriesTypeOperationResult(TimeSeriesType timeSeriesType, TimeSeriesOperationError error)
         {
             TimeSeriesType = timeSeriesType;
             Error = error;
@@ -27,6 +27,6 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <summary> Time series type object - set when the operation is successful. </summary>
         public TimeSeriesType TimeSeriesType { get; }
         /// <summary> Error object - set when the operation is unsuccessful. </summary>
-        public InstancesOperationError Error { get; }
+        public TimeSeriesOperationError Error { get; }
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TsiError.Serialization.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TsiError.Serialization.cs
@@ -14,7 +14,7 @@ namespace Azure.Iot.TimeSeriesInsights
     {
         internal static TsiError DeserializeTsiError(JsonElement element)
         {
-            Optional<InstancesOperationError> error = default;
+            Optional<TimeSeriesOperationError> error = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("error"))
@@ -24,7 +24,7 @@ namespace Azure.Iot.TimeSeriesInsights
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    error = InstancesOperationError.DeserializeInstancesOperationError(property.Value);
+                    error = TimeSeriesOperationError.DeserializeTimeSeriesOperationError(property.Value);
                     continue;
                 }
             }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TsiError.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TsiError.cs
@@ -17,12 +17,12 @@ namespace Azure.Iot.TimeSeriesInsights
 
         /// <summary> Initializes a new instance of TsiError. </summary>
         /// <param name="error"> A particular API error with an error code and a message. </param>
-        internal TsiError(InstancesOperationError error)
+        internal TsiError(TimeSeriesOperationError error)
         {
             Error = error;
         }
 
         /// <summary> A particular API error with an error code and a message. </summary>
-        public InstancesOperationError Error { get; }
+        public TimeSeriesOperationError Error { get; }
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TypesBatchResponse.Serialization.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TypesBatchResponse.Serialization.cs
@@ -17,7 +17,7 @@ namespace Azure.Iot.TimeSeriesInsights
         {
             Optional<IReadOnlyList<TimeSeriesTypeOperationResult>> @get = default;
             Optional<IReadOnlyList<TimeSeriesTypeOperationResult>> put = default;
-            Optional<IReadOnlyList<InstancesOperationError>> delete = default;
+            Optional<IReadOnlyList<TimeSeriesOperationError>> delete = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("get"))
@@ -57,10 +57,10 @@ namespace Azure.Iot.TimeSeriesInsights
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    List<InstancesOperationError> array = new List<InstancesOperationError>();
+                    List<TimeSeriesOperationError> array = new List<TimeSeriesOperationError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InstancesOperationError.DeserializeInstancesOperationError(item));
+                        array.Add(TimeSeriesOperationError.DeserializeTimeSeriesOperationError(item));
                     }
                     delete = array;
                     continue;

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TypesBatchResponse.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/Generated/Models/TypesBatchResponse.cs
@@ -18,14 +18,14 @@ namespace Azure.Iot.TimeSeriesInsights
         {
             Get = new ChangeTrackingList<TimeSeriesTypeOperationResult>();
             Put = new ChangeTrackingList<TimeSeriesTypeOperationResult>();
-            Delete = new ChangeTrackingList<InstancesOperationError>();
+            Delete = new ChangeTrackingList<TimeSeriesOperationError>();
         }
 
         /// <summary> Initializes a new instance of TypesBatchResponse. </summary>
         /// <param name="get"> List of types or error objects corresponding by position to the &quot;get&quot; array in the request. Type object is set when operation is successful and error object is set when operation is unsuccessful. </param>
         /// <param name="put"> List of types or error objects corresponding by position to the &quot;put&quot; array in the request. Type object is set when operation is successful and error object is set when operation is unsuccessful. </param>
         /// <param name="delete"> List of error objects corresponding by position to the &quot;delete&quot; array in the request - null when the operation is successful. </param>
-        internal TypesBatchResponse(IReadOnlyList<TimeSeriesTypeOperationResult> @get, IReadOnlyList<TimeSeriesTypeOperationResult> put, IReadOnlyList<InstancesOperationError> delete)
+        internal TypesBatchResponse(IReadOnlyList<TimeSeriesTypeOperationResult> @get, IReadOnlyList<TimeSeriesTypeOperationResult> put, IReadOnlyList<TimeSeriesOperationError> delete)
         {
             Get = @get;
             Put = put;
@@ -37,6 +37,6 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <summary> List of types or error objects corresponding by position to the &quot;put&quot; array in the request. Type object is set when operation is successful and error object is set when operation is unsuccessful. </summary>
         public IReadOnlyList<TimeSeriesTypeOperationResult> Put { get; }
         /// <summary> List of error objects corresponding by position to the &quot;delete&quot; array in the request - null when the operation is successful. </summary>
-        public IReadOnlyList<InstancesOperationError> Delete { get; }
+        public IReadOnlyList<TimeSeriesOperationError> Delete { get; }
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/TimeSeriesInsightsClient.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/TimeSeriesInsightsClient.cs
@@ -1118,7 +1118,7 @@ namespace Azure.Iot.TimeSeriesInsights
         }
 
         /// <summary>
-        /// Gets Time Series Insight types in pages synchronously.
+        /// Gets Time Series Insights types in pages synchronously.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The pageable list <see cref="Pageable{TimeSeriesType}"/> of Time Series types with the http response.</returns>
@@ -1333,7 +1333,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <summary>
         /// Gets Time Series Insights types by type Ids synchronously.
         /// </summary>
-        /// <param name="timeSeriesTypeIds">List of Time Series type Ids of the Time Series types to return..</param>
+        /// <param name="timeSeriesTypeIds">List of Time Series type Ids of the Time Series types to return.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>
         /// List of type or error objects corresponding by position to the array in the request.

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/TimeSeriesInsightsClient.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/src/TimeSeriesInsightsClient.cs
@@ -653,7 +653,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>
         /// List of error objects corresponding by position to the <paramref name="timeSeriesInstances"/> array in the request.
-        /// A <seealso cref="InstancesOperationError"/> object will be set when operation is unsuccessful.
+        /// A <seealso cref="TimeSeriesOperationError"/> object will be set when operation is unsuccessful.
         /// </returns>
         /// <remarks>
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/samples">our repo samples</see>.
@@ -664,7 +664,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <exception cref="ArgumentException">
         /// The exception is thrown when <paramref name="timeSeriesInstances"/> is empty.
         /// </exception>
-        public virtual async Task<Response<InstancesOperationError[]>> CreateOrReplaceTimeSeriesInstancesAsync(
+        public virtual async Task<Response<TimeSeriesOperationError[]>> CreateOrReplaceTimeSeriesInstancesAsync(
             IEnumerable<TimeSeriesInstance> timeSeriesInstances,
             CancellationToken cancellationToken = default)
         {
@@ -689,7 +689,7 @@ namespace Azure.Iot.TimeSeriesInsights
 
                 // Extract the errors array from the response. If there was an error with creating or replacing one of the instances,
                 // it will be placed at the same index location that corresponds to its place in the input array.
-                IEnumerable<InstancesOperationError> errorResults = executeBatchResponse.Value.Put.Select((result) => result.Error);
+                IEnumerable<TimeSeriesOperationError> errorResults = executeBatchResponse.Value.Put.Select((result) => result.Error);
 
                 return Response.FromValue(errorResults.ToArray(), executeBatchResponse.GetRawResponse());
             }
@@ -708,7 +708,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>
         /// List of error objects corresponding by position to the <paramref name="timeSeriesInstances"/> array in the request.
-        /// A <seealso cref="InstancesOperationError"/> object will be set when operation is unsuccessful.
+        /// A <seealso cref="TimeSeriesOperationError"/> object will be set when operation is unsuccessful.
         /// </returns>
         /// <seealso cref="CreateOrReplaceTimeSeriesInstancesAsync(IEnumerable{TimeSeriesInstance}, CancellationToken)">
         /// See the asynchronous version of this method for examples.
@@ -719,7 +719,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <exception cref="ArgumentException">
         /// The exception is thrown when <paramref name="timeSeriesInstances"/> is empty.
         /// </exception>
-        public virtual Response<InstancesOperationError[]> CreateOrReplaceTimeSeriesInstances(
+        public virtual Response<TimeSeriesOperationError[]> CreateOrReplaceTimeSeriesInstances(
             IEnumerable<TimeSeriesInstance> timeSeriesInstances,
             CancellationToken cancellationToken = default)
         {
@@ -742,7 +742,7 @@ namespace Azure.Iot.TimeSeriesInsights
 
                 // Extract the errors array from the response. If there was an error with creating or replacing one of the instances,
                 // it will be placed at the same index location that corresponds to its place in the input array.
-                IEnumerable<InstancesOperationError> errorResults = executeBatchResponse.Value.Put.Select((result) => result.Error);
+                IEnumerable<TimeSeriesOperationError> errorResults = executeBatchResponse.Value.Put.Select((result) => result.Error);
 
                 return Response.FromValue(errorResults.ToArray(), executeBatchResponse.GetRawResponse());
             }
@@ -869,7 +869,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <exception cref="ArgumentException">
         /// The exception is thrown when <paramref name="timeSeriesNames"/> is empty.
         /// </exception>
-        public virtual async Task<Response<InstancesOperationError[]>> DeleteInstancesAsync(
+        public virtual async Task<Response<TimeSeriesOperationError[]>> DeleteInstancesAsync(
             IEnumerable<string> timeSeriesNames,
             CancellationToken cancellationToken = default)
         {
@@ -921,7 +921,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <exception cref="ArgumentException">
         /// The exception is thrown when <paramref name="timeSeriesNames"/> is empty.
         /// </exception>
-        public virtual Response<InstancesOperationError[]> DeleteInstances(
+        public virtual Response<TimeSeriesOperationError[]> DeleteInstances(
             IEnumerable<string> timeSeriesNames,
             CancellationToken cancellationToken = default)
         {
@@ -972,7 +972,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <exception cref="ArgumentException">
         /// The exception is thrown when <paramref name="timeSeriesIds"/> is empty.
         /// </exception>
-        public virtual async Task<Response<InstancesOperationError[]>> DeleteInstancesAsync(
+        public virtual async Task<Response<TimeSeriesOperationError[]>> DeleteInstancesAsync(
             IEnumerable<TimeSeriesId> timeSeriesIds,
             CancellationToken cancellationToken = default)
         {
@@ -1024,7 +1024,7 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <exception cref="ArgumentException">
         /// The exception is thrown when <paramref name="timeSeriesIds"/> is empty.
         /// </exception>
-        public virtual Response<InstancesOperationError[]> DeleteInstances(
+        public virtual Response<TimeSeriesOperationError[]> DeleteInstances(
             IEnumerable<TimeSeriesId> timeSeriesIds,
             CancellationToken cancellationToken = default)
         {
@@ -1058,10 +1058,10 @@ namespace Azure.Iot.TimeSeriesInsights
         }
 
         /// <summary>
-        /// Gets time series insight types in pages asynchronously.
+        /// Gets Time Series Insights types in pages asynchronously.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The pageable list <see cref="AsyncPageable{TimeSeriesType}"/> of Time Series instances types with the http response.</returns>
+        /// <returns>The pageable list <see cref="AsyncPageable{TimeSeriesType}"/> of Time Series types with the http response.</returns>
         public virtual AsyncPageable<TimeSeriesType> GetTimeSeriesTypesAsync(
             CancellationToken cancellationToken = default)
         {
@@ -1118,10 +1118,10 @@ namespace Azure.Iot.TimeSeriesInsights
         }
 
         /// <summary>
-        /// Gets time series insight types in pages synchronously.
+        /// Gets Time Series Insight types in pages synchronously.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The pageable list <see cref="Pageable{TimeSeriesType}"/> of Time Series instances types with the http response.</returns>
+        /// <returns>The pageable list <see cref="Pageable{TimeSeriesType}"/> of Time Series types with the http response.</returns>
         /// <seealso cref="GetTimeSeriesTypesAsync(CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
@@ -1176,9 +1176,9 @@ namespace Azure.Iot.TimeSeriesInsights
         }
 
         /// <summary>
-        /// Gets Time Series types by Time Series Types Names asynchronously.
+        /// Gets Time Series Insights types by type names asynchronously.
         /// </summary>
-        /// <param name="timeSeriesTypeNames">List of names of the Time Series Types to return.</param>
+        /// <param name="timeSeriesTypeNames">List of names of the Time Series types to return.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>
         /// List of type or error objects corresponding by position to the array in the request.
@@ -1193,11 +1193,11 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <exception cref="ArgumentException">
         /// The exception is thrown when <paramref name="timeSeriesTypeNames"/> is empty.
         /// </exception>
-        public virtual async Task<Response<TimeSeriesTypeOperationResult[]>> GetTimeSeriesTypesbyNamesAsync(
+        public virtual async Task<Response<TimeSeriesTypeOperationResult[]>> GetTimeSeriesTypesByNamesAsync(
             IEnumerable<string> timeSeriesTypeNames,
             CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetTimeSeriesTypes)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetTimeSeriesTypesByNames)}");
             scope.Start();
 
             try
@@ -1228,15 +1228,15 @@ namespace Azure.Iot.TimeSeriesInsights
         }
 
         /// <summary>
-        /// Gets Time Series types by Time Series Types Names synchronously.
+        /// Gets Time Series Insights types by type names synchronously.
         /// </summary>
-        /// <param name="timeSeriesTypeNames">List of names of the Time Series Types to return.</param>
+        /// <param name="timeSeriesTypeNames">List of names of the Time Series types to return.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>
         /// List of type or error objects corresponding by position to the array in the request.
         /// Type object is set when operation is successful and error object is set when operation is unsuccessful.
         /// </returns>
-        /// <seealso cref="GetTimeSeriesTypesbyNamesAsync(IEnumerable{string}, CancellationToken)">
+        /// <seealso cref="GetTimeSeriesTypesByNamesAsync(IEnumerable{string}, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
         /// <exception cref="ArgumentNullException">
@@ -1245,11 +1245,11 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <exception cref="ArgumentException">
         /// The exception is thrown when <paramref name="timeSeriesTypeNames"/> is empty.
         /// </exception>
-        public virtual Response<TimeSeriesTypeOperationResult[]> GetTimeSeriesTypesbyNames(
+        public virtual Response<TimeSeriesTypeOperationResult[]> GetTimeSeriesTypesByNames(
             IEnumerable<string> timeSeriesTypeNames,
             CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetTimeSeriesTypes)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetTimeSeriesTypesByNames)}");
             scope.Start();
 
             try
@@ -1279,9 +1279,9 @@ namespace Azure.Iot.TimeSeriesInsights
         }
 
         /// <summary>
-        /// Gets Time Series types by Time Series Type Ids asynchronously.
+        /// Gets Time Series Insights types by type Ids asynchronously.
         /// </summary>
-        /// <param name="timeSeriesTypeIds">List of Time Series Type Ids of the Time Series Types to return.</param>
+        /// <param name="timeSeriesTypeIds">List of Time Series type Ids of the Time Series types to return.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>
         /// List of type or error objects corresponding by position to the array in the request.
@@ -1296,11 +1296,11 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <exception cref="ArgumentException">
         /// The exception is thrown when <paramref name="timeSeriesTypeIds"/> is empty.
         /// </exception>
-        public virtual async Task<Response<TimeSeriesTypeOperationResult[]>> GetTimeSeriesTypesbyIdAsync(
+        public virtual async Task<Response<TimeSeriesTypeOperationResult[]>> GetTimeSeriesTypesByIdAsync(
             IEnumerable<string> timeSeriesTypeIds,
             CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetTimeSeriesTypes)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetTimeSeriesTypesById)}");
             scope.Start();
 
             try
@@ -1331,15 +1331,15 @@ namespace Azure.Iot.TimeSeriesInsights
         }
 
         /// <summary>
-        /// Gets Time Series types by Time Series Type Ids synchronously.
+        /// Gets Time Series Insights types by type Ids synchronously.
         /// </summary>
-        /// <param name="timeSeriesTypeIds">List of Time Series Type Ids of the Time Series Types to return..</param>
+        /// <param name="timeSeriesTypeIds">List of Time Series type Ids of the Time Series types to return..</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>
         /// List of type or error objects corresponding by position to the array in the request.
         /// Type object is set when operation is successful and error object is set when operation is unsuccessful.
         /// </returns>
-        /// <seealso cref="GetTimeSeriesTypesbyIdAsync(IEnumerable{string}, CancellationToken)">
+        /// <seealso cref="GetTimeSeriesTypesByIdAsync(IEnumerable{string}, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
         /// <exception cref="ArgumentNullException">
@@ -1348,11 +1348,11 @@ namespace Azure.Iot.TimeSeriesInsights
         /// <exception cref="ArgumentException">
         /// The exception is thrown when <paramref name="timeSeriesTypeIds"/> is empty.
         /// </exception>
-        public virtual Response<TimeSeriesTypeOperationResult[]> GetTimeSeriesTypesbyId(
+        public virtual Response<TimeSeriesTypeOperationResult[]> GetTimeSeriesTypesById(
             IEnumerable<string> timeSeriesTypeIds,
             CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetTimeSeriesTypes)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetTimeSeriesTypesById)}");
             scope.Start();
 
             try

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/TimeSeriesIdTests.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/TimeSeriesIdTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Iot.TimeSeriesInsights.Tests
             try
             {
                 // Create TSI instances
-                Response<InstancesOperationError[]> createInstancesResult = await client
+                Response<TimeSeriesOperationError[]> createInstancesResult = await client
                     .CreateOrReplaceTimeSeriesInstancesAsync(timeSeriesInstances)
                     .ConfigureAwait(false);
 
@@ -78,7 +78,7 @@ namespace Azure.Iot.TimeSeriesInsights.Tests
                 // clean up
                 try
                 {
-                    Response<InstancesOperationError[]> deleteInstancesResponse = await client
+                    Response<TimeSeriesOperationError[]> deleteInstancesResponse = await client
                         .DeleteInstancesAsync(timeSeriesInstances.Select((instance) => instance.TimeSeriesId))
                         .ConfigureAwait(false);
 

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/TimeSeriesInsightsInstancesTests.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/TimeSeriesInsightsInstancesTests.cs
@@ -48,7 +48,7 @@ namespace Azure.Iot.TimeSeriesInsights.Tests
             try
             {
                 // Create TSI instances
-                Response<InstancesOperationError[]> createInstancesResult = await client
+                Response<TimeSeriesOperationError[]> createInstancesResult = await client
                     .CreateOrReplaceTimeSeriesInstancesAsync(timeSeriesInstances)
                     .ConfigureAwait(false);
 
@@ -146,7 +146,7 @@ namespace Azure.Iot.TimeSeriesInsights.Tests
                 // clean up
                 try
                 {
-                    Response<InstancesOperationError[]> deleteInstancesResponse = await client
+                    Response<TimeSeriesOperationError[]> deleteInstancesResponse = await client
                         .DeleteInstancesAsync(timeSeriesInstancesIds)
                         .ConfigureAwait(false);
 


### PR DESCRIPTION
This PR includes the following:

- Rename InstancesOperationError and InstancesOperationErrorDetails to more generic name since it is used for other operations and not only for instances
- Address comments for Types Get APIs.