### PR TITLE
Use custom private preview subscription for storage weekly live tests

### DIFF
--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -7,7 +7,13 @@ extends:
     BuildInParallel: true
     TimeoutInMinutes: 180
     Location: canadacentral
-    Clouds: Preview
+    CloudConfig:
+      Public:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+      PrivatePreview:
+        SubscriptionConfiguration: $(sub-config-storage-test-resources)
+    Clouds: Public
+    SupportedClouds: Public,PrivatePreview
     TestSetupSteps:
     - template: /sdk/storage/tests-install-azurite.yml
     EnvVars:


### PR DESCRIPTION
This PR adds an extra subscription to the storage weekly tests (controlled by the storage team) which has certain private preview features enabled.

The diff looks larger than it is because I cleaned up carriage return characters from the file.