### PR TITLE
Use ContinueWith to avoid TaskCanceledExceptions when renewing locks

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -7,6 +7,7 @@
     <NoWarn>$(NoWarn);AZC0001;CS1591;SA1636;CA1507</NoWarn>
     <SignAssembly>true</SignAssembly>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
+    <InheritDocTrimLevel>internal</InheritDocTrimLevel>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Verified that exceptions are no longer triggered per message by using Diagnostic tools.

Contributes to https://github.com/Azure/azure-sdk-for-net/issues/19562