### PR TITLE
[Azure.Core] AzureNamedKeyCredential

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.11.0-beta.1 (Unreleased)
 
+## Added
+
+- `AzureNamedKeyCredential` has been implemented to cover scenarios where services require that a shared key name and the key value be used as a component of the algorithm to form the authorization token.
+
 ### Key Bug Fixes
 
 - Check the `JsonIgnoreAttribute.Condition` property added in .NET 5 when discovering members with `JsonObjectSerializer`.

--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -27,6 +27,14 @@ namespace Azure
         public string Key { get { throw null; } }
         public void Update(string key) { }
     }
+    public partial class AzureNamedKeyCredential
+    {
+        public AzureNamedKeyCredential(string name, string key) { }
+        public string Name { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public void Deconstruct(out string name, out string key) { throw null; }
+        public void Update(string name, string key) { }
+    }
     public partial class AzureSasCredential
     {
         public AzureSasCredential(string signature) { }

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -27,6 +27,14 @@ namespace Azure
         public string Key { get { throw null; } }
         public void Update(string key) { }
     }
+    public partial class AzureNamedKeyCredential
+    {
+        public AzureNamedKeyCredential(string name, string key) { }
+        public string Name { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public void Deconstruct(out string name, out string key) { throw null; }
+        public void Update(string name, string key) { }
+    }
     public partial class AzureSasCredential
     {
         public AzureSasCredential(string signature) { }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -27,6 +27,14 @@ namespace Azure
         public string Key { get { throw null; } }
         public void Update(string key) { }
     }
+    public partial class AzureNamedKeyCredential
+    {
+        public AzureNamedKeyCredential(string name, string key) { }
+        public string Name { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public void Deconstruct(out string name, out string key) { throw null; }
+        public void Update(string name, string key) { }
+    }
     public partial class AzureSasCredential
     {
         public AzureSasCredential(string signature) { }

--- a/sdk/core/Azure.Core/src/AzureNamedKeyCredential.cs
+++ b/sdk/core/Azure.Core/src/AzureNamedKeyCredential.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using System.Threading;
+using Azure.Core;
+
+namespace Azure
+{
+    /// <summary>
+    /// Credential allowing a named key to be used for authenticating to an Azure Service.
+    /// It provides the ability to update the key without creating a new client.
+    /// </summary>
+    public class AzureNamedKeyCredential
+    {
+        private Tuple<string, string> _namedKey;
+
+        /// <summary>
+        /// Name of the key used to authenticate to an Azure service.
+        /// </summary>
+        public string Name => Volatile.Read(ref _namedKey).Item1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureNamedKeyCredential"/> class.
+        /// </summary>
+        /// <param name="name">The name of the <paramref name="key"/>.</param>
+        /// <param name="key">The key to use for authenticating with the Azure service.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when the <paramref name="name"/> or <paramref name="key"/> is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when the <paramref name="name"/> or <paramref name="key"/> is empty.
+        /// </exception>
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        public AzureNamedKeyCredential(string name, string key) => Update(name, key);
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+
+        /// <summary>
+        /// Updates the named key.  This is intended to be used when you've regenerated your
+        /// service key and want to update long-lived clients.
+        /// </summary>
+        /// <param name="name">The name of the <paramref name="key"/>.</param>
+        /// <param name="key">The key to use for authenticating with the Azure service.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when the <paramref name="name"/> or <paramref name="key"/> is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when the <paramref name="name"/> or <paramref name="key"/> is empty.
+        /// </exception>
+        public void Update(string name, string key)
+        {
+            Argument.AssertNotNullOrEmpty(name, nameof(name));
+            Argument.AssertNotNullOrEmpty(key, nameof(key));
+
+            Volatile.Write(ref _namedKey, Tuple.Create(name, key));
+        }
+
+        /// <summary>
+        /// Allows deconstruction of the credential into the associated name and key as an atomic operation.
+        /// </summary>
+        /// <param name="name">The name of the <paramref name="key"/>.</param>
+        /// <param name="key">The key to use for authenticating with the Azure service.</param>
+        /// <example>
+        /// <code snippet="Snippet:AzureNamedKeyCredential_Deconstruct">
+        /// var credential = new AzureNamedKeyCredential(&quot;SomeName&quot;, &quot;SomeKey&quot;);
+        /// (string name, string key) = credential;
+        /// </code>
+        /// </example>
+        /// <seealso href="https://docs.microsoft.com/dotnet/csharp/deconstruct">Deconstructing tuples and other types</seealso>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Deconstruct(out string name, out string key)
+        {
+            var namedKey = Volatile.Read(ref _namedKey);
+
+            name = namedKey.Item1;
+            key = namedKey.Item2;
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/AzureNamedKeyCredentialTests.cs
+++ b/sdk/core/Azure.Core/tests/AzureNamedKeyCredentialTests.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    [TestFixture]
+    public class AzureNamedKeyCredentialTests
+    {
+        [Test]
+        [TestCase(null, typeof(ArgumentNullException))]
+        [TestCase("", typeof(ArgumentException))]
+        public void ConstructorValidatesTheName(string name, Type expectedExceptionType)
+        {
+            Assert.Throws(expectedExceptionType, () => new AzureNamedKeyCredential(name, "key"));
+        }
+
+        [Test]
+        [TestCase(null, typeof(ArgumentNullException))]
+        [TestCase("", typeof(ArgumentException))]
+        public void ConstructorValidatesTheKey(string key, Type expectedExceptionType)
+        {
+            Assert.Throws(expectedExceptionType, () => new AzureNamedKeyCredential("name", key));
+        }
+
+        [Test]
+        public void AttributesCanBeReadWithDeconstruction()
+        {
+            var expectedName = "real-name";
+            var expectedKey = "real-key";
+            var credential = new AzureNamedKeyCredential(expectedName, expectedKey);
+            var (name, key) = credential;
+
+            Assert.AreEqual(expectedName, name);
+            Assert.AreEqual(expectedKey, key);
+        }
+
+        [Test]
+        public void NameCanBeReadFromTheProperty()
+        {
+            var expectedName = "real-name";
+            var expectedKey = "real-key";
+            var credential = new AzureNamedKeyCredential(expectedName, expectedKey);
+
+            Assert.AreEqual(expectedName, credential.Name);
+        }
+
+        [Test]
+        [TestCase(null, typeof(ArgumentNullException))]
+        [TestCase("", typeof(ArgumentException))]
+        public void UpdateValidatesTheName(string name, Type expectedExceptionType)
+        {
+            var credential = new AzureNamedKeyCredential("initial-name", "initial-key");
+            Assert.Throws(expectedExceptionType, () => credential.Update(name, "key"));
+        }
+
+        [Test]
+        [TestCase(null, typeof(ArgumentNullException))]
+        [TestCase("", typeof(ArgumentException))]
+        public void UpdateValidatesTheKey(string key, Type expectedExceptionType)
+        {
+            var credential = new AzureNamedKeyCredential("initial-name", "initial-key");
+            Assert.Throws(expectedExceptionType, () => credential.Update("name", key));
+        }
+
+        [Test]
+        public void UpdateCanBePerformed()
+        {
+            var expectedName = "expect_name";
+            var expectedKey = "expect_key";
+
+            #region Snippet:AzureNamedKeyCredential_Deconstruct
+            var credential = new AzureNamedKeyCredential("SomeName", "SomeKey");
+            /*@@*/
+            /*@@*/ credential.Update(expectedName, expectedKey);
+            /*@@*/
+            (string name, string key) = credential;
+            #endregion
+
+            Assert.AreEqual(expectedName, credential.Name);
+            Assert.AreEqual(expectedName, name);
+            Assert.AreEqual(expectedKey, key);
+        }
+
+        [Test]
+        public void MultipleUpdatesCanBePerformed()
+        {
+            var expectedName = "expect_name";
+            var expectedKey = "expect_key";
+
+            var credential = new AzureNamedKeyCredential("<< Name >>", "<< Key >>");
+            credential.Update("interimname", "interimkey");
+            credential.Update(expectedName, expectedKey);
+
+            var (name, key) = credential;
+
+            Assert.AreEqual(expectedName, credential.Name);
+            Assert.AreEqual(expectedName, name);
+            Assert.AreEqual(expectedKey, key);
+        }
+    }
+}


### PR DESCRIPTION
# Summary

When using a shared key for authorization, some services require that the name of the key be used as a component of the algorithm to form the authorization token.  For these cases, `AzureKeyCredential` and `AzureSasCredential` aren't adequate as they track only a single value.  The `AzureNamedKeyCredential` is intended to address this gap.

# Last Upstream Rebase

Tuesday, March 16, 3:30pm (EST)

# References and Related

- [AzureNamedKeyCredential Design Goals](https://gist.github.com/jsquire/861fb365fa672dd62530500ad2bc0db9)
- [AzureKeyCredential](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/AzureKeyCredential.cs)
- [AzureSasCredential](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/AzureSasCredential.cs)
- [TokenCredential](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/TokenCredential.cs)
- [Azure.Identity credentials](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity#credentials)