### PR TITLE
[Event Hubs Client] v5.4.0-beta.1 Release Preparation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 5.4.0-beta.1 (2021-03-17)
+
+### Changes
+
+- Updating package bindings for `Azure.Messaging.EventHubs` to synchronize on v5.4.0-beta.1.
+
 ## 5.3.1 (2021-03-09)
 
 ### Changes

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.3.1</Version>
-    <ApiCompatVersion>5.3.0</ApiCompatVersion>
+    <Version>5.4.0-beta.1</Version>
+    <ApiCompatVersion>5.3.1</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
@@ -12,7 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" />
+    <!--NOTE: This was done to allow a single step build/publish; the main development branch will continue to use the package. -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
+
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Release History
 
-## 5.4.0-beta.1 (Unreleased)
+## 5.4.0-beta.1 (2021-03-17)
 
+### Changes
+
+#### New Features
+
+- Returned the idempotent publishing feature to the public API surface.
 
 ## 5.3.1 (2021-03-09)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -16,6 +16,7 @@ namespace Azure.Messaging.EventHubs
         public long Offset { get { throw null; } }
         public string PartitionKey { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
+        public int? PublishedSequenceNumber { get { throw null; } }
         public long SequenceNumber { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, object> SystemProperties { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -125,6 +126,7 @@ namespace Azure.Messaging.EventHubs
         public static Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties LastEnqueuedEventProperties(long? lastSequenceNumber, long? lastOffset, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
         public static Azure.Messaging.EventHubs.Consumer.PartitionContext PartitionContext(string partitionId, Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties lastEnqueuedEventProperties = default(Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties)) { throw null; }
         public static Azure.Messaging.EventHubs.PartitionProperties PartitionProperties(string eventHubName, string partitionId, bool isEmpty, long beginningSequenceNumber, long lastSequenceNumber, long lastOffset, System.DateTimeOffset lastEnqueuedTime) { throw null; }
+        public static Azure.Messaging.EventHubs.Producer.PartitionPublishingProperties PartitionPublishingProperties(bool isIdempotentPublishingEnabled, long? producerGroupId, short? ownerLevel, int? lastPublishedSequenceNumber) { throw null; }
     }
     public enum EventHubsRetryMode
     {
@@ -485,6 +487,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public int Count { get { throw null; } }
         public long MaximumSizeInBytes { get { throw null; } }
         public long SizeInBytes { get { throw null; } }
+        public int? StartingPublishedSequenceNumber { get { throw null; } set { } }
         public void Dispose() { }
         public bool TryAdd(Azure.Messaging.EventHubs.EventData eventData) { throw null; }
     }
@@ -511,6 +514,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public override int GetHashCode() { throw null; }
         public virtual System.Threading.Tasks.Task<string[]> GetPartitionIdsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.EventHubs.PartitionProperties> GetPartitionPropertiesAsync(string partitionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.EventHubs.Producer.PartitionPublishingProperties> GetPartitionPublishingPropertiesAsync(string partitionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendAsync(Azure.Messaging.EventHubs.Producer.EventDataBatch eventBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> eventBatch, Azure.Messaging.EventHubs.Producer.SendEventOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> eventBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -521,7 +525,36 @@ namespace Azure.Messaging.EventHubs.Producer
     {
         public EventHubProducerClientOptions() { }
         public Azure.Messaging.EventHubs.EventHubConnectionOptions ConnectionOptions { get { throw null; } set { } }
+        public bool EnableIdempotentPartitions { get { throw null; } set { } }
+        public System.Collections.Generic.Dictionary<string, Azure.Messaging.EventHubs.Producer.PartitionPublishingOptions> PartitionOptions { get { throw null; } }
         public Azure.Messaging.EventHubs.EventHubsRetryOptions RetryOptions { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
+    }
+    public partial class PartitionPublishingOptions
+    {
+        public PartitionPublishingOptions() { }
+        public short? OwnerLevel { get { throw null; } set { } }
+        public long? ProducerGroupId { get { throw null; } set { } }
+        public int? StartingSequenceNumber { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
+    }
+    public partial class PartitionPublishingProperties
+    {
+        protected internal PartitionPublishingProperties(bool isIdempotentPublishingEnabled, long? producerGroupId, short? ownerLevel, int? lastPublishedSequenceNumber) { }
+        public bool IsIdempotentPublishingEnabled { get { throw null; } }
+        public int? LastPublishedSequenceNumber { get { throw null; } }
+        public short? OwnerLevel { get { throw null; } }
+        public long? ProducerGroupId { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -80,7 +80,7 @@ namespace Azure.Messaging.EventHubs
         ///   of the producer are enabled.  For example, it is used by idempotent publishing.
         /// </remarks>
         ///
-        internal int? PublishedSequenceNumber { get; private set; }
+        public int? PublishedSequenceNumber { get; private set; }
 
         /// <summary>
         ///   The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
@@ -59,10 +59,10 @@ namespace Azure.Messaging.EventHubs
         /// <param name="ownerLevel">The owner level associated with the partition.</param>
         /// <param name="lastPublishedSequenceNumber">The sequence number assigned to the event that was last successfully published to the partition.</param>
         ///
-        internal static PartitionPublishingProperties PartitionPublishingProperties(bool isIdempotentPublishingEnabled,
-                                                                                    long? producerGroupId,
-                                                                                    short? ownerLevel,
-                                                                                    int? lastPublishedSequenceNumber) =>
+        public static PartitionPublishingProperties PartitionPublishingProperties(bool isIdempotentPublishingEnabled,
+                                                                                  long? producerGroupId,
+                                                                                  short? ownerLevel,
+                                                                                  int? lastPublishedSequenceNumber) =>
             new PartitionPublishingProperties(isIdempotentPublishingEnabled, producerGroupId, ownerLevel, lastPublishedSequenceNumber);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -60,7 +60,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   of the producer are enabled.  For example, it is used by idempotent publishing.
         /// </remarks>
         ///
-        internal int? StartingPublishedSequenceNumber { get; set; } // Setter should be internal when member is made public
+        public int? StartingPublishedSequenceNumber { get; set; } // Setter should be internal when member is made public
 
         /// <summary>
         ///   The count of events contained in the batch.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -454,8 +454,8 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   partition; calling this method for a partition before events have been published to it will return an empty set of properties.
         /// </remarks>
         ///
-        internal virtual async Task<PartitionPublishingProperties> GetPartitionPublishingPropertiesAsync(string partitionId,
-                                                                                                         CancellationToken cancellationToken = default)
+        public virtual async Task<PartitionPublishingProperties> GetPartitionPublishingPropertiesAsync(string partitionId,
+                                                                                                       CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(EventHubProducerClient));
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClientOptions.cs
@@ -29,7 +29,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <value><c>true</c> if the producer should enable idempotent partition publishing; otherwise, <c>false</c>.</value>
         ///
-        internal bool EnableIdempotentPartitions { get; set; }
+        public bool EnableIdempotentPartitions { get; set; }
 
         /// <summary>
         ///   The set of options that can be specified to influence publishing behavior specific to the configured Event Hub partition.  These
@@ -44,7 +44,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   These options are ignored when publishing to the Event Hubs gateway for automatic routing or when using a partition key.
         /// </remarks>
         ///
-        internal Dictionary<string, PartitionPublishingOptions> PartitionOptions { get; } = new Dictionary<string, PartitionPublishingOptions>();
+        public Dictionary<string, PartitionPublishingOptions> PartitionOptions { get; } = new Dictionary<string, PartitionPublishingOptions>();
 
         /// <summary>
         ///   The options used for configuring the connection to the Event Hubs service.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingOptions.cs
@@ -15,7 +15,7 @@ namespace Azure.Messaging.EventHubs.Producer
     ///   routing or when using a partition key.
     /// </remarks>
     ///
-    internal class PartitionPublishingOptions
+    public class PartitionPublishingOptions
     {
         /// <summary>
         ///   The identifier of the producer group that this producer is associated with when publishing to the associated partition.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
@@ -9,7 +9,7 @@ namespace Azure.Messaging.EventHubs.Producer
     ///   A set of information for an Event Hub.
     /// </summary>
     ///
-    internal class PartitionPublishingProperties
+    public class PartitionPublishingProperties
     {
         /// <summary>An empty set of properties.</summary>
         private static PartitionPublishingProperties s_emptyInstance;


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare for a beta release based on the current GA (5.3.1) but adding the idempotent publishing feature to the public API surface.  The core changes made in these efforts is intended to reverse the changes made to the idempotent publishing feature in the two related pull requests.

# Upstream Base

`tag: Azure.Messaging.EventHubs.Processor_5.3.1`

# References and Related

- [[Event Hubs Client] Internalize Idempotent Publishing (#18016)](https://github.com/Azure/azure-sdk-for-net/pull/18016)
- [[Event Hubs Client] Minor Fixes (#18054)](https://github.com/Azure/azure-sdk-for-net/pull/18054)