### PR TITLE
Resolve a few flaky Key Vault tests

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateOperation.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -273,26 +272,17 @@ namespace Azure.Security.KeyVault.Certificates
         private class UpdateStatusActivity : IDisposable
         {
             private readonly CertificateOperation _operation;
-            private readonly long _start;
 
             public UpdateStatusActivity(CertificateOperation operation)
             {
                 _operation = operation;
 
                 EventSource.BeginUpdateStatus(_operation.Properties);
-                _start = Stopwatch.GetTimestamp();
             }
 
             public void Dispose()
             {
-                // Skip calculation if event source is not currently enabled.
-                if (EventSource.IsEnabled())
-                {
-                    long end = Stopwatch.GetTimestamp();
-                    double elapsed = (end - _start) / Stopwatch.Frequency;
-
-                    EventSource.EndUpdateStatus(_operation.Properties, elapsed);
-                }
+                EventSource.EndUpdateStatus(_operation.Properties);
             }
 
             private static CertificatesEventSource EventSource => CertificatesEventSource.Singleton;

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateOperation.cs
@@ -279,16 +279,13 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 _operation = operation;
 
-                if (EventSource.IsEnabled())
-                {
-                    EventSource.BeginUpdateStatus(_operation.Properties);
-
-                    _start = Stopwatch.GetTimestamp();
-                }
+                EventSource.BeginUpdateStatus(_operation.Properties);
+                _start = Stopwatch.GetTimestamp();
             }
 
             public void Dispose()
             {
+                // Skip calculation if event source is not currently enabled.
                 if (EventSource.IsEnabled())
                 {
                     long end = Stopwatch.GetTimestamp();

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatesEventSource.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatesEventSource.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics.Tracing;
+using Azure.Core.Diagnostics;
+
+namespace Azure.Security.KeyVault.Certificates
+{
+    [EventSource(Name = EventSourceName)]
+    internal sealed class CertificatesEventSource : EventSource
+    {
+        internal const int BeginUpdateStatusEvent = 1;
+        internal const int EndUpdateStatusEvent = 2;
+
+        private const string EventSourceName = "Azure-Security-KeyVault-Certificates";
+        private const string Deleted = "(deleted)";
+        private const string NoError = "(none)";
+
+        private CertificatesEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue) { }
+
+        public static CertificatesEventSource Singleton { get; } = new CertificatesEventSource();
+
+        [NonEvent]
+        public void BeginUpdateStatus(CertificateOperationProperties properties) =>
+            BeginUpdateStatus(properties?.Id.ToString(), properties?.Status, properties?.Error?.Message);
+
+        [Event(BeginUpdateStatusEvent, Level = EventLevel.Verbose, Message = "Updating certificate operation status: {0}, current status: {1}, error: {2}")]
+        public void BeginUpdateStatus(string id, string status, string error) => WriteEvent(BeginUpdateStatusEvent, id ?? Deleted, status, error ?? NoError);
+
+        [NonEvent]
+        public void EndUpdateStatus(CertificateOperationProperties properties, double elapsed) =>
+            EndUpdateStatus(properties?.Id.ToString(), properties?.Status, properties?.Error?.Message, elapsed);
+
+        [Event(EndUpdateStatusEvent, Level = EventLevel.Verbose, Message = "Updated certificate operation status: {0}, ending status: {1}, error: {2}, elapsed: {3:00.0}s")]
+        public void EndUpdateStatus(string id, string status, string error, double elapsed) => WriteEvent(EndUpdateStatusEvent, id ?? Deleted, status, error ?? NoError, elapsed);
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatesEventSource.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatesEventSource.cs
@@ -28,10 +28,10 @@ namespace Azure.Security.KeyVault.Certificates
         public void BeginUpdateStatus(string id, string status, string error) => WriteEvent(BeginUpdateStatusEvent, id ?? Deleted, status, error ?? NoError);
 
         [NonEvent]
-        public void EndUpdateStatus(CertificateOperationProperties properties, double elapsed) =>
-            EndUpdateStatus(properties?.Id.ToString(), properties?.Status, properties?.Error?.Message, elapsed);
+        public void EndUpdateStatus(CertificateOperationProperties properties) =>
+            EndUpdateStatus(properties?.Id.ToString(), properties?.Status, properties?.Error?.Message);
 
-        [Event(EndUpdateStatusEvent, Level = EventLevel.Verbose, Message = "Updated certificate operation status: {0}, ending status: {1}, error: {2}, elapsed: {3:00.0}s")]
-        public void EndUpdateStatus(string id, string status, string error, double elapsed) => WriteEvent(EndUpdateStatusEvent, id ?? Deleted, status, error ?? NoError, elapsed);
+        [Event(EndUpdateStatusEvent, Level = EventLevel.Verbose, Message = "Updated certificate operation status: {0}, ending status: {1}, error: {2}")]
+        public void EndUpdateStatus(string id, string status, string error) => WriteEvent(EndUpdateStatusEvent, id ?? Deleted, status, error ?? NoError);
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -228,8 +228,8 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
                 RegisterForCleanup(certName);
 
-                using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-                TimeSpan pollingInterval = TimeSpan.FromSeconds((Mode == RecordedTestMode.Playback) ? 0 : 1);
+                using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+                TimeSpan pollingInterval = TimeSpan.FromSeconds((Mode == RecordedTestMode.Playback) ? 0 : 2);
 
                 while (!operation.HasCompleted)
                 {
@@ -321,8 +321,8 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CertificateOperation operation = new CertificateOperation(Client, certName);
 
             // Need to call the real async wait method or the sync version of this test fails because it's using the instrumented Client directly.
-            using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-            TimeSpan pollingInterval = TimeSpan.FromSeconds((Mode == RecordedTestMode.Playback) ? 0 : 1);
+            using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+            TimeSpan pollingInterval = TimeSpan.FromSeconds((Mode == RecordedTestMode.Playback) ? 0 : 2);
 
             await operation.WaitForCompletionAsync(pollingInterval, cts.Token);
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -110,7 +110,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
 
             OperationCanceledException ex = Assert.ThrowsAsync<OperationCanceledException>(
-                () => WaitForCompletion(operation),
+                async () => await WaitForCompletion(operation),
                 $"Expected exception {nameof(OperationCanceledException)} not thrown. Operation status: {operation?.Properties?.Status}, error: {operation?.Properties?.Error?.Message}");
 
             Assert.AreEqual("The operation was canceled so no value is available.", ex.Message);
@@ -142,7 +142,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
 
             OperationCanceledException ex = Assert.ThrowsAsync<OperationCanceledException>(
-                () => WaitForCompletion(operation),
+                async () => await WaitForCompletion(operation),
                 $"Expected exception {nameof(OperationCanceledException)} not thrown. Operation status: {operation?.Properties?.Status}, error: {operation?.Properties?.Error?.Message}");
             Assert.AreEqual("The operation was canceled so no value is available.", ex.Message);
 
@@ -165,7 +165,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             await operation.DeleteAsync();
 
-            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(() => WaitForCompletion(operation));
+            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForCompletion(operation));
             Assert.AreEqual("The operation was deleted so no value is available.", ex.Message);
 
             Assert.IsTrue(operation.HasCompleted);
@@ -195,7 +195,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
                 Assert.Inconclusive("The create operation completed before it could be canceled.");
             }
 
-            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(() => WaitForCompletion(operation));
+            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForCompletion(operation));
             Assert.AreEqual("The operation was deleted so no value is available.", ex.Message);
 
             Assert.IsTrue(operation.HasCompleted);

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateOperationTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateOperationTests.cs
@@ -1,0 +1,325 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Security.KeyVault.Certificates.Tests
+{
+    [NonParallelizable]
+    public class CertificateOperationTests : ClientTestBase
+    {
+        private const string VaultUri = "https://test.vault.azure.net";
+        private const string CertificateId = "https://test.vault.azure.net/certificates/test-cert";
+        private const string CertificateName = "test-cert";
+
+        private static readonly string s_policyJson = $@"{{""id"":""{CertificateId}/policy"",""issuer"":{{""name"":""Self""}}}}";
+        private static readonly CertificatePolicy s_policy;
+
+        private TestEventListener _listener;
+
+        public CertificateOperationTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        static CertificateOperationTests()
+        {
+            var policy = new CertificatePolicy();
+            ((IJsonDeserializable)policy).ReadProperties(JsonDocument.Parse(s_policyJson).RootElement);
+
+            s_policy = policy;
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _listener = new TestEventListener();
+            _listener.EnableEvents(CertificatesEventSource.Singleton, EventLevel.Verbose);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _listener.Dispose();
+        }
+
+        [Test]
+        public async Task UpdateStatusCompleted()
+        {
+            var transport = new MockTransport(new[]
+            {
+                new MockResponse(202).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""completed""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/1"",""policy"":{s_policyJson}}}"),
+            });
+
+            CertificateClient client = CreateClient(transport);
+            CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
+
+            await WaitForOperationAsync(operation);
+
+            // Begin
+            IEnumerable<EventWrittenEventArgs> messages = _listener.EventsById(CertificatesEventSource.BeginUpdateStatusEvent);
+            Assert.AreEqual(1, messages.Count());
+
+            EventWrittenEventArgs message = messages.Last();
+            Assert.AreEqual(EventLevel.Verbose, message.Level);
+            Assert.AreEqual("BeginUpdateStatus", message.EventName);
+            Assert.AreEqual($"{CertificateId}/pending", message.GetProperty<string>("id"));
+            Assert.AreEqual("inProgress", message.GetProperty<string>("status"));
+            Assert.AreEqual("(none)", message.GetProperty<string>("error"));
+
+            // End
+            messages = _listener.EventsById(CertificatesEventSource.EndUpdateStatusEvent);
+            Assert.AreEqual(1, messages.Count());
+
+            message = messages.Last();
+            Assert.AreEqual(EventLevel.Verbose, message.Level);
+            Assert.AreEqual("EndUpdateStatus", message.EventName);
+            Assert.AreEqual($"{CertificateId}/pending", message.GetProperty<string>("id"));
+            Assert.AreEqual("completed", message.GetProperty<string>("status"));
+            Assert.AreEqual("(none)", message.GetProperty<string>("error"));
+        }
+
+        [Test]
+        public async Task UpdateStatusEventuallyCompleted()
+        {
+            var transport = new MockTransport(new[]
+            {
+                new MockResponse(202).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""completed""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/1"",""policy"":{s_policyJson}}}"),
+            });
+
+            CertificateClient client = CreateClient(transport);
+            CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
+
+            await WaitForOperationAsync(operation);
+
+            // Begin
+            IEnumerable<EventWrittenEventArgs> messages = _listener.EventsById(CertificatesEventSource.BeginUpdateStatusEvent);
+            Assert.AreEqual(10, messages.Count());
+
+            EventWrittenEventArgs message = messages.Last();
+            Assert.AreEqual(EventLevel.Verbose, message.Level);
+            Assert.AreEqual("BeginUpdateStatus", message.EventName);
+            Assert.AreEqual($"{CertificateId}/pending", message.GetProperty<string>("id"));
+            Assert.AreEqual("inProgress", message.GetProperty<string>("status"));
+            Assert.AreEqual("(none)", message.GetProperty<string>("error"));
+
+            // End
+            messages = _listener.EventsById(CertificatesEventSource.EndUpdateStatusEvent);
+            Assert.AreEqual(10, messages.Count());
+
+            message = messages.Last();
+            Assert.AreEqual(EventLevel.Verbose, message.Level);
+            Assert.AreEqual("EndUpdateStatus", message.EventName);
+            Assert.AreEqual($"{CertificateId}/pending", message.GetProperty<string>("id"));
+            Assert.AreEqual("completed", message.GetProperty<string>("status"));
+            Assert.AreEqual("(none)", message.GetProperty<string>("error"));
+        }
+
+        [Test]
+        public async Task UpdateStatusCanceled()
+        {
+            var transport = new MockTransport(new[]
+            {
+                new MockResponse(202).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""cancelled""}}"),
+            });
+
+            CertificateClient client = CreateClient(transport);
+            CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
+
+            Exception ex = Assert.ThrowsAsync<OperationCanceledException>(async () => await WaitForOperationAsync(operation));
+            Assert.AreEqual("The operation was canceled so no value is available.", ex.Message);
+
+            // Begin
+            IEnumerable<EventWrittenEventArgs> messages = _listener.EventsById(CertificatesEventSource.BeginUpdateStatusEvent);
+            Assert.AreEqual(5, messages.Count());
+
+            EventWrittenEventArgs message = messages.Last();
+            Assert.AreEqual(EventLevel.Verbose, message.Level);
+            Assert.AreEqual("BeginUpdateStatus", message.EventName);
+            Assert.AreEqual($"{CertificateId}/pending", message.GetProperty<string>("id"));
+            Assert.AreEqual("inProgress", message.GetProperty<string>("status"));
+            Assert.AreEqual("(none)", message.GetProperty<string>("error"));
+
+            // End
+            messages = _listener.EventsById(CertificatesEventSource.EndUpdateStatusEvent);
+            Assert.AreEqual(5, messages.Count());
+
+            message = messages.Last();
+            Assert.AreEqual(EventLevel.Verbose, message.Level);
+            Assert.AreEqual("EndUpdateStatus", message.EventName);
+            Assert.AreEqual($"{CertificateId}/pending", message.GetProperty<string>("id"));
+            Assert.AreEqual("cancelled", message.GetProperty<string>("status"));
+            Assert.AreEqual("(none)", message.GetProperty<string>("error"));
+        }
+
+        [Test]
+        public async Task UpdateStatusDeleted()
+        {
+            var transport = new MockTransport(new[]
+            {
+                new MockResponse(202).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+
+                new MockResponse(404),
+            });
+
+            CertificateClient client = CreateClient(transport);
+            CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
+
+            Exception ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForOperationAsync(operation));
+            Assert.AreEqual("The operation was deleted so no value is available.", ex.Message);
+
+            // Begin
+            IEnumerable<EventWrittenEventArgs> messages = _listener.EventsById(CertificatesEventSource.BeginUpdateStatusEvent);
+            Assert.AreEqual(5, messages.Count());
+
+            EventWrittenEventArgs message = messages.Last();
+            Assert.AreEqual(EventLevel.Verbose, message.Level);
+            Assert.AreEqual("BeginUpdateStatus", message.EventName);
+            Assert.AreEqual($"{CertificateId}/pending", message.GetProperty<string>("id"));
+            Assert.AreEqual("inProgress", message.GetProperty<string>("status"));
+            Assert.AreEqual("(none)", message.GetProperty<string>("error"));
+
+            // End
+            messages = _listener.EventsById(CertificatesEventSource.EndUpdateStatusEvent);
+            Assert.AreEqual(5, messages.Count());
+
+            message = messages.Last();
+            Assert.AreEqual(EventLevel.Verbose, message.Level);
+            Assert.AreEqual("EndUpdateStatus", message.EventName);
+            Assert.AreEqual("(deleted)", message.GetProperty<string>("id"));
+            Assert.AreEqual(string.Empty, message.GetProperty<string>("status"));
+            Assert.AreEqual("(none)", message.GetProperty<string>("error"));
+        }
+
+        [Test]
+        public async Task UpdateStatusErred()
+        {
+            var transport = new MockTransport(new[]
+            {
+                new MockResponse(202).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""inProgress""}}"),
+
+                new MockResponse(200).WithContent($@"{{""id"":""{CertificateId}/pending"",""status"":""failed"",""error"":{{""code"":""mock failure code"",""message"":""mock failure message""}}}}"),
+            });
+
+            CertificateClient client = CreateClient(transport);
+            CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
+
+            Exception ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForOperationAsync(operation));
+            Assert.AreEqual("The certificate operation failed: mock failure message", ex.Message);
+
+            // Begin
+            IEnumerable<EventWrittenEventArgs> messages = _listener.EventsById(CertificatesEventSource.BeginUpdateStatusEvent);
+            Assert.AreEqual(5, messages.Count());
+
+            EventWrittenEventArgs message = messages.Last();
+            Assert.AreEqual(EventLevel.Verbose, message.Level);
+            Assert.AreEqual("BeginUpdateStatus", message.EventName);
+            Assert.AreEqual($"{CertificateId}/pending", message.GetProperty<string>("id"));
+            Assert.AreEqual("inProgress", message.GetProperty<string>("status"));
+            Assert.AreEqual("(none)", message.GetProperty<string>("error"));
+
+            // End
+            messages = _listener.EventsById(CertificatesEventSource.EndUpdateStatusEvent);
+            Assert.AreEqual(5, messages.Count());
+
+            message = messages.Last();
+            Assert.AreEqual(EventLevel.Verbose, message.Level);
+            Assert.AreEqual("EndUpdateStatus", message.EventName);
+            Assert.AreEqual($"{CertificateId}/pending", message.GetProperty<string>("id"));
+            Assert.AreEqual("failed", message.GetProperty<string>("status"));
+            Assert.AreEqual("mock failure message", message.GetProperty<string>("error"));
+        }
+
+        private CertificateClient CreateClient(HttpPipelineTransport transport)
+        {
+            CertificateClientOptions options = new CertificateClientOptions
+            {
+                Transport = transport,
+            };
+
+            return InstrumentClient(
+                new CertificateClient(
+                    new Uri(VaultUri),
+                    new MockCredential(),
+                    options
+                    ));
+        }
+
+        private async ValueTask<KeyVaultCertificateWithPolicy> WaitForOperationAsync(CertificateOperation operation)
+        {
+            var rand = new Random();
+            TimeSpan PollingInterval() => TimeSpan.FromMilliseconds(rand.Next(1, 50));
+
+            if (IsAsync)
+            {
+                return await operation.WaitForCompletionAsync(PollingInterval(), default);
+            }
+            else
+            {
+                while (!operation.HasCompleted)
+                {
+                    operation.UpdateStatus();
+                    await Task.Delay(PollingInterval());
+                }
+
+                return operation.Value;
+            }
+        }
+
+        public class MockCredential : TokenCredential
+        {
+            private readonly AccessToken _token = new AccessToken("mockToken", DateTimeOffset.UtcNow.AddHours(1));
+
+            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                return _token;
+            }
+
+            public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                return new ValueTask<AccessToken>(_token);
+            }
+        }
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         [Ignore("Temporarily disable until https://github.com/Azure/azure-sdk-for-net/pull/19612")]
         public void VerifyECDecoderPrime256v1Imported() =>
-            VerifyECDecoder(EcPrime256v1PrivateKeyImported, CertificateKeyCurveName.P256K, @"DFTTJrKrtao7G/B0bK5yv+mX0/3Sefv2MS1gzd6DfYH2ASe9Tw7rSbLjZ8wM0p7I/opbIG1+zHhpYqOGnQNQyw==", EcPrime256v1CertificateImported);
+            VerifyECDecoder(EcPrime256v1PrivateKeyImported, CertificateKeyCurveName.P256, @"DFTTJrKrtao7G/B0bK5yv+mX0/3Sefv2MS1gzd6DfYH2ASe9Tw7rSbLjZ8wM0p7I/opbIG1+zHhpYqOGnQNQyw==", EcPrime256v1CertificateImported);
 
         [Test]
         public void VerifyECDecoderSecp256k1() =>

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
@@ -94,7 +94,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             catch (Exception ex) when (
                 (ex is CryptographicException || (ex is TargetInvocationException && ex.InnerException is CryptographicException)) &&
                 RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
-                keyCurveName == CertificateKeyCurveName.P256)
+                keyCurveName == CertificateKeyCurveName.P256 || keyCurveName == CertificateKeyCurveName.P256K)
             {
                 Assert.Ignore("The curve is not supported by the current platform");
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
@@ -16,8 +16,15 @@ namespace Azure.Security.KeyVault.Certificates.Tests
     public class LightweightPkcs8DecoderTests
     {
         [Test]
-        public void VerifyECDecoderPrime256v1Imported() =>
+        public void VerifyECDecoderPrime256v1Imported()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Assert.Ignore("The curve is not supported by the current platform");
+            }
+
             VerifyECDecoder(EcPrime256v1PrivateKeyImported, CertificateKeyCurveName.P256, @"DFTTJrKrtao7G/B0bK5yv+mX0/3Sefv2MS1gzd6DfYH2ASe9Tw7rSbLjZ8wM0p7I/opbIG1+zHhpYqOGnQNQyw==", EcPrime256v1CertificateImported);
+        }
 
         [Test]
         public void VerifyECDecoderSecp256k1() =>

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
@@ -94,7 +94,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             catch (Exception ex) when (
                 (ex is CryptographicException || (ex is TargetInvocationException && ex.InnerException is CryptographicException)) &&
                 RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
-                keyCurveName == CertificateKeyCurveName.P256K)
+                keyCurveName == CertificateKeyCurveName.P256)
             {
                 Assert.Ignore("The curve is not supported by the current platform");
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
@@ -16,7 +16,6 @@ namespace Azure.Security.KeyVault.Certificates.Tests
     public class LightweightPkcs8DecoderTests
     {
         [Test]
-        [Ignore("Temporarily disable until https://github.com/Azure/azure-sdk-for-net/pull/19612")]
         public void VerifyECDecoderPrime256v1Imported() =>
             VerifyECDecoder(EcPrime256v1PrivateKeyImported, CertificateKeyCurveName.P256, @"DFTTJrKrtao7G/B0bK5yv+mX0/3Sefv2MS1gzd6DfYH2ASe9Tw7rSbLjZ8wM0p7I/opbIG1+zHhpYqOGnQNQyw==", EcPrime256v1CertificateImported);
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/PemReaderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/PemReaderTests.cs
@@ -104,10 +104,8 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         {
 #if NET461
             Assert.Ignore("Loading X509Certificate2 with private EC key not supported on this platform");
-#elif NETCOREAPP2_1
-            Assert.Ignore("Different OIDs in the certificate and private key prevent this from passing currently");
 #endif
-            using X509Certificate2 certificate = PemReader.LoadCertificate(ECDsaPrime256v1Certificate.AsSpan(), keyType: PemReader.KeyType.ECDsa);
+            using X509Certificate2 certificate = PemReader.LoadCertificate(s_ecdsaFullCertificate.AsSpan(), keyType: PemReader.KeyType.ECDsa);
             Assert.AreEqual("CN=Azure SDK", certificate.Subject);
             Assert.IsTrue(certificate.HasPrivateKey);
         }
@@ -180,32 +178,6 @@ rJUjjPW4aQuo0GyzL4v1M1U2pByKsVCYAikuLmQKS2zXLoyW3ana1aQYyh2/3cXm
 lkApwUZg00+9hRWxv0DTh/mRS2zu5i/9W+cZbIcRah0JHgOzAjvsyY9RHjqZ9r7c
 Md7RrFHxnAKJj5TZJJJOf5h3OaaF3A5W8gf9Bc68aGQLFT5Y2afIawkYNSULypc3
 pn29yMivL7r48dlo
------END CERTIFICATE-----";
-
-        private const string ECDsaPrime256v1Certificate = @"
------BEGIN PRIVATE KEY-----
-MIIBMgIBADCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA////////////
-/////////////////////////v///C8wBgQBAAQBBwRBBHm+Zn753LusVaBilc6H
-CwcCm/zbLc4o2VnygVsW+BeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ
-1LgCIQD////////////////////+uq7c5q9IoDu/0l6M0DZBQQIBAQRtMGsCAQEE
-INIX6ZEliNAwvZAq3GkJHNHSvQOlIzFMkifg/C8DfVAhoUQDQgAEnxIn+jXd3Pfw
-IcpGkQx9b1L/BYXHDzNINDOTwmOku3fG+zI6vT3R3VkHfcd7GR9aJxp1tdxMnIkF
-xU2Z1eNVXqANMAsGA1UdDzEEAwIAgA==
------END PRIVATE KEY-----
------BEGIN CERTIFICATE-----
-MIICPzCCAeWgAwIBAgIQdclPKrRQTmCpZ0p2lM2pmDAKBggqhkjOPQQDAjAUMRIw
-EAYDVQQDEwlBenVyZSBTREswHhcNMjEwMzAzMDEwOTIxWhcNMjIwMzAzMDExOTIx
-WjAUMRIwEAYDVQQDEwlBenVyZSBTREswgfUwga4GByqGSM49AgEwgaICAQEwLAYH
-KoZIzj0BAQIhAP////////////////////////////////////7///wvMAYEAQAE
-AQcEQQR5vmZ++dy7rFWgYpXOhwsHApv82y3OKNlZ8oFbFvgXmEg62ncmo8RlXaT7
-/A4RCKj9F7RIpoVUGZxH0I/7ENS4AiEA/////////////////////rqu3OavSKA7
-v9JejNA2QUECAQEDQgAEnxIn+jXd3PfwIcpGkQx9b1L/BYXHDzNINDOTwmOku3fG
-+zI6vT3R3VkHfcd7GR9aJxp1tdxMnIkFxU2Z1eNVXqN8MHowDgYDVR0PAQH/BAQD
-AgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8G
-A1UdIwQYMBaAFAJEtqOacY6KuA8KAyt3dgByxWGlMB0GA1UdDgQWBBQCRLajmnGO
-irgPCgMrd3YAcsVhpTAKBggqhkjOPQQDAgNIADBFAiEAlGVRNxgGsOpmBAGud2v1
-aSnz2Zm8A9EV1a+5EVp8Rz8CIFkJYAXOL/n0xo4fp+7yR+9SwVa3c6wNimYSfhoU
-+YpQ
 -----END CERTIFICATE-----";
 
         private static readonly string s_ecdsaFullCertificate = ECDsaPrivateKey + ECDsaCertificate;

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/PemReaderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/PemReaderTests.cs
@@ -99,7 +99,6 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         }
 
         [Test]
-        [Ignore("Temporarily disable until https://github.com/Azure/azure-sdk-for-net/pull/19612")]
         public void LoadECDsaPrime256v1Certificate()
         {
 #if NET461

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/TestExtensionMethods.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/TestExtensionMethods.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Cryptography;
+using Azure.Core.TestFramework;
 using Azure.Security.KeyVault.Keys.Cryptography;
 
 namespace Azure.Security.KeyVault.Certificates.Tests
@@ -35,5 +36,11 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             "P-521" => 521,
             _ => throw new NotSupportedException($"{keyCurveName} is not supported"),
         };
+
+        public static MockResponse WithContent(this MockResponse response, string content)
+        {
+            response.SetContent(content);
+            return response;
+        }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
@@ -904,13 +904,17 @@ namespace Azure.Security.KeyVault.Keys.Tests
                 RegisterForCleanup(Key.Name);
             }
 
+            List<Task> deletingKeys = new List<Task>();
             foreach (KeyVaultKey deletedKey in createdKeys)
             {
-                await WaitForDeletedKey(deletedKey.Name);
+                // WaitForDeletedKey disables recording, so we can wait concurrently.
+                // Wait a little longer for deleting keys since tests occasionally fail after max attempts.
+                deletingKeys.Add(WaitForDeletedKey(deletedKey.Name, delay: TimeSpan.FromSeconds(5)));
             }
 
-            List<DeletedKey> allKeys = await Client.GetDeletedKeysAsync().ToEnumerableAsync();
+            await Task.WhenAll(deletingKeys);
 
+            List<DeletedKey> allKeys = await Client.GetDeletedKeysAsync().ToEnumerableAsync();
             foreach (KeyVaultKey createdKey in createdKeys)
             {
                 KeyVaultKey returnedKey = allKeys.Single(s => s.Properties.Name == createdKey.Name);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
@@ -251,7 +251,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             }
         }
 
-        protected Task WaitForDeletedKey(string name)
+        protected Task WaitForDeletedKey(string name, TimeSpan? delay = null)
         {
             if (Mode == RecordedTestMode.Playback)
             {
@@ -260,7 +260,8 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             using (Recording.DisableRecording())
             {
-                return TestRetryHelper.RetryAsync(async () => await Client.GetDeletedKeyAsync(name), delay: PollingInterval);
+                delay ??= PollingInterval;
+                return TestRetryHelper.RetryAsync(async () => await Client.GetDeletedKeyAsync(name), delay: delay.Value);
             }
         }
 


### PR DESCRIPTION
* Wait longer for deleted keys. Resolves a recent issue found during live tests.
* Fix net5.0 tests on OSX.
* Add EventSource for CertificateOperation. Adds more logging to better diagnose how #17718 is happening.