### PR TITLE
First wave of namespace changes for IoT device update

### DIFF
--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/Azure.IoT.DeviceUpdate.sln
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/Azure.IoT.DeviceUpdate.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30621.155
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Iot.DeviceUpdate", "src\Azure.Iot.DeviceUpdate.csproj", "{F1AB3BFB-DBBF-4002-A93F-DFB02545C666}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.IoT.DeviceUpdate", "src\Azure.IoT.DeviceUpdate.csproj", "{F1AB3BFB-DBBF-4002-A93F-DFB02545C666}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Iot.DeviceUpdate.Tests", "tests\Azure.Iot.DeviceUpdate.Tests.csproj", "{C039F382-F091-433C-9DAA-CC2FF7CF4644}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.IoT.DeviceUpdate.Tests", "tests\Azure.IoT.DeviceUpdate.Tests.csproj", "{C039F382-F091-433C-9DAA-CC2FF7CF4644}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{24219D07-7E76-4631-9D89-49DCB79F7A84}"
 EndProject

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/CHANGELOG.md
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 1.0.0-beta.2 (Unreleased)
-
+* Update root namespace from Azure.Iot to Azure.IoT
 
 ## 1.0.0-beta.1 (2021-03-03)
 * This is the initial release of Azure Device Update for IoT Hub library. 

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/README.md
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/README.md
@@ -22,7 +22,7 @@ For the best development experience, developers should use the official Microsof
 Install the Device Update for IoT Hub client library for .NET with [NuGet](https://www.nuget.org/ ):
 
 ```PowerShell
-dotnet add package Azure.Iot.DeviceUpdate --version 1.0.0-beta.1
+dotnet add package Azure.IoT.DeviceUpdate --version 1.0.0-beta.2
 ```
 
 ### Authenticate the Client

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/api/Azure.Iot.DeviceUpdate.netstandard2.0.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/api/Azure.Iot.DeviceUpdate.netstandard2.0.cs
@@ -1,66 +1,66 @@
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     public partial class DeploymentsClient
     {
         protected DeploymentsClient() { }
         public DeploymentsClient(string accountEndpoint, string instanceId, Azure.Core.TokenCredential credential) { }
-        public DeploymentsClient(string accountEndpoint, string instanceId, Azure.Core.TokenCredential credential, Azure.Iot.DeviceUpdate.DeviceUpdateClientOptions options) { }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.Deployment> CancelDeployment(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.Deployment>> CancelDeploymentAsync(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.Deployment> CreateOrUpdateDeployment(string deploymentId, Azure.Iot.DeviceUpdate.Models.Deployment deployment, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.Deployment>> CreateOrUpdateDeploymentAsync(string deploymentId, Azure.Iot.DeviceUpdate.Models.Deployment deployment, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public DeploymentsClient(string accountEndpoint, string instanceId, Azure.Core.TokenCredential credential, Azure.IoT.DeviceUpdate.DeviceUpdateClientOptions options) { }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.Deployment> CancelDeployment(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.Deployment>> CancelDeploymentAsync(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.Deployment> CreateOrUpdateDeployment(string deploymentId, Azure.IoT.DeviceUpdate.Models.Deployment deployment, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.Deployment>> CreateOrUpdateDeploymentAsync(string deploymentId, Azure.IoT.DeviceUpdate.Models.Deployment deployment, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response DeleteDeployment(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> DeleteDeploymentAsync(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.Iot.DeviceUpdate.Models.Deployment> GetAllDeployments(string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.Iot.DeviceUpdate.Models.Deployment> GetAllDeploymentsAsync(string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.Deployment> GetDeployment(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.Deployment>> GetDeploymentAsync(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.Iot.DeviceUpdate.Models.DeploymentDeviceState> GetDeploymentDevices(string deploymentId, string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.Iot.DeviceUpdate.Models.DeploymentDeviceState> GetDeploymentDevicesAsync(string deploymentId, string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.DeploymentStatus> GetDeploymentStatus(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.DeploymentStatus>> GetDeploymentStatusAsync(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.Deployment> RetryDeployment(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.Deployment>> RetryDeploymentAsync(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.IoT.DeviceUpdate.Models.Deployment> GetAllDeployments(string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.IoT.DeviceUpdate.Models.Deployment> GetAllDeploymentsAsync(string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.Deployment> GetDeployment(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.Deployment>> GetDeploymentAsync(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.IoT.DeviceUpdate.Models.DeploymentDeviceState> GetDeploymentDevices(string deploymentId, string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.IoT.DeviceUpdate.Models.DeploymentDeviceState> GetDeploymentDevicesAsync(string deploymentId, string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.DeploymentStatus> GetDeploymentStatus(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.DeploymentStatus>> GetDeploymentStatusAsync(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.Deployment> RetryDeployment(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.Deployment>> RetryDeploymentAsync(string deploymentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class DevicesClient
     {
         protected DevicesClient() { }
         public DevicesClient(string accountEndpoint, string instanceId, Azure.Core.TokenCredential credential) { }
-        public DevicesClient(string accountEndpoint, string instanceId, Azure.Core.TokenCredential credential, Azure.Iot.DeviceUpdate.DeviceUpdateClientOptions options) { }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.Group> CreateOrUpdateGroup(string groupId, Azure.Iot.DeviceUpdate.Models.Group group, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.Group>> CreateOrUpdateGroupAsync(string groupId, Azure.Iot.DeviceUpdate.Models.Group group, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public DevicesClient(string accountEndpoint, string instanceId, Azure.Core.TokenCredential credential, Azure.IoT.DeviceUpdate.DeviceUpdateClientOptions options) { }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.Group> CreateOrUpdateGroup(string groupId, Azure.IoT.DeviceUpdate.Models.Group group, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.Group>> CreateOrUpdateGroupAsync(string groupId, Azure.IoT.DeviceUpdate.Models.Group group, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response DeleteGroup(string groupId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> DeleteGroupAsync(string groupId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.Iot.DeviceUpdate.Models.DeviceClass> GetAllDeviceClasses(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.Iot.DeviceUpdate.Models.DeviceClass> GetAllDeviceClassesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.Iot.DeviceUpdate.Models.Device> GetAllDevices(string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.Iot.DeviceUpdate.Models.Device> GetAllDevicesAsync(string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.Iot.DeviceUpdate.Models.DeviceTag> GetAllDeviceTags(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.Iot.DeviceUpdate.Models.DeviceTag> GetAllDeviceTagsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.Iot.DeviceUpdate.Models.Group> GetAllGroups(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.Iot.DeviceUpdate.Models.Group> GetAllGroupsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.Device> GetDevice(string deviceId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.Device>> GetDeviceAsync(string deviceId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.DeviceClass> GetDeviceClass(string deviceClassId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.DeviceClass>> GetDeviceClassAsync(string deviceClassId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.IoT.DeviceUpdate.Models.DeviceClass> GetAllDeviceClasses(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.IoT.DeviceUpdate.Models.DeviceClass> GetAllDeviceClassesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.IoT.DeviceUpdate.Models.Device> GetAllDevices(string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.IoT.DeviceUpdate.Models.Device> GetAllDevicesAsync(string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.IoT.DeviceUpdate.Models.DeviceTag> GetAllDeviceTags(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.IoT.DeviceUpdate.Models.DeviceTag> GetAllDeviceTagsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.IoT.DeviceUpdate.Models.Group> GetAllGroups(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.IoT.DeviceUpdate.Models.Group> GetAllGroupsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.Device> GetDevice(string deviceId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.Device>> GetDeviceAsync(string deviceId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.DeviceClass> GetDeviceClass(string deviceClassId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.DeviceClass>> GetDeviceClassAsync(string deviceClassId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<string> GetDeviceClassDeviceIds(string deviceClassId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<string> GetDeviceClassDeviceIdsAsync(string deviceClassId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.Iot.DeviceUpdate.Models.UpdateId> GetDeviceClassInstallableUpdates(string deviceClassId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.Iot.DeviceUpdate.Models.UpdateId> GetDeviceClassInstallableUpdatesAsync(string deviceClassId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.DeviceTag> GetDeviceTag(string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.DeviceTag>> GetDeviceTagAsync(string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.Group> GetGroup(string groupId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.Group>> GetGroupAsync(string groupId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.Iot.DeviceUpdate.Models.UpdatableDevices> GetGroupBestUpdates(string groupId, string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.Iot.DeviceUpdate.Models.UpdatableDevices> GetGroupBestUpdatesAsync(string groupId, string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.UpdateCompliance> GetGroupUpdateCompliance(string groupId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.UpdateCompliance>> GetGroupUpdateComplianceAsync(string groupId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.UpdateCompliance> GetUpdateCompliance(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.UpdateCompliance>> GetUpdateComplianceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.IoT.DeviceUpdate.Models.UpdateId> GetDeviceClassInstallableUpdates(string deviceClassId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.IoT.DeviceUpdate.Models.UpdateId> GetDeviceClassInstallableUpdatesAsync(string deviceClassId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.DeviceTag> GetDeviceTag(string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.DeviceTag>> GetDeviceTagAsync(string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.Group> GetGroup(string groupId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.Group>> GetGroupAsync(string groupId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.IoT.DeviceUpdate.Models.UpdatableDevices> GetGroupBestUpdates(string groupId, string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.IoT.DeviceUpdate.Models.UpdatableDevices> GetGroupBestUpdatesAsync(string groupId, string filter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.UpdateCompliance> GetGroupUpdateCompliance(string groupId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.UpdateCompliance>> GetGroupUpdateComplianceAsync(string groupId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.UpdateCompliance> GetUpdateCompliance(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.UpdateCompliance>> GetUpdateComplianceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class DeviceUpdateClientOptions : Azure.Core.ClientOptions
     {
-        public DeviceUpdateClientOptions(Azure.Iot.DeviceUpdate.DeviceUpdateClientOptions.ServiceVersion version = Azure.Iot.DeviceUpdate.DeviceUpdateClientOptions.ServiceVersion.V2020_09_01) { }
+        public DeviceUpdateClientOptions(Azure.IoT.DeviceUpdate.DeviceUpdateClientOptions.ServiceVersion version = Azure.IoT.DeviceUpdate.DeviceUpdateClientOptions.ServiceVersion.V2020_09_01) { }
         public enum ServiceVersion
         {
             V2020_09_01 = 1,
@@ -70,30 +70,30 @@ namespace Azure.Iot.DeviceUpdate
     {
         protected UpdatesClient() { }
         public UpdatesClient(string accountEndpoint, string instanceId, Azure.Core.TokenCredential credential) { }
-        public UpdatesClient(string accountEndpoint, string instanceId, Azure.Core.TokenCredential credential, Azure.Iot.DeviceUpdate.DeviceUpdateClientOptions options) { }
+        public UpdatesClient(string accountEndpoint, string instanceId, Azure.Core.TokenCredential credential, Azure.IoT.DeviceUpdate.DeviceUpdateClientOptions options) { }
         public virtual Azure.Response<string> DeleteUpdate(string provider, string name, string version, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<string>> DeleteUpdateAsync(string provider, string name, string version, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.File> GetFile(string provider, string name, string version, string fileId, Azure.Iot.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.File>> GetFileAsync(string provider, string name, string version, string fileId, Azure.Iot.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.File> GetFile(string provider, string name, string version, string fileId, Azure.IoT.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.File>> GetFileAsync(string provider, string name, string version, string fileId, Azure.IoT.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<string> GetFiles(string provider, string name, string version, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<string> GetFilesAsync(string provider, string name, string version, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<string> GetNames(string provider, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<string> GetNamesAsync(string provider, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.Operation> GetOperation(string operationId, Azure.Iot.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.Operation>> GetOperationAsync(string operationId, Azure.Iot.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.Iot.DeviceUpdate.Models.Operation> GetOperations(string filter = null, int? top = default(int?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.Iot.DeviceUpdate.Models.Operation> GetOperationsAsync(string filter = null, int? top = default(int?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.Operation> GetOperation(string operationId, Azure.IoT.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.Operation>> GetOperationAsync(string operationId, Azure.IoT.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.IoT.DeviceUpdate.Models.Operation> GetOperations(string filter = null, int? top = default(int?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.IoT.DeviceUpdate.Models.Operation> GetOperationsAsync(string filter = null, int? top = default(int?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<string> GetProviders(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<string> GetProvidersAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Iot.DeviceUpdate.Models.Update> GetUpdate(string provider, string name, string version, Azure.Iot.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.DeviceUpdate.Models.Update>> GetUpdateAsync(string provider, string name, string version, Azure.Iot.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.DeviceUpdate.Models.Update> GetUpdate(string provider, string name, string version, Azure.IoT.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.DeviceUpdate.Models.Update>> GetUpdateAsync(string provider, string name, string version, Azure.IoT.DeviceUpdate.Models.AccessCondition accessCondition = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<string> GetVersions(string provider, string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<string> GetVersionsAsync(string provider, string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<string> ImportUpdate(Azure.Iot.DeviceUpdate.Models.ImportUpdateInput updateToImport, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<string>> ImportUpdateAsync(Azure.Iot.DeviceUpdate.Models.ImportUpdateInput updateToImport, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<string> ImportUpdate(Azure.IoT.DeviceUpdate.Models.ImportUpdateInput updateToImport, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<string>> ImportUpdateAsync(Azure.IoT.DeviceUpdate.Models.ImportUpdateInput updateToImport, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class AccessCondition
     {
@@ -108,49 +108,49 @@ namespace Azure.Iot.DeviceUpdate.Models
     }
     public partial class Deployment
     {
-        public Deployment(string deploymentId, Azure.Iot.DeviceUpdate.Models.DeploymentType deploymentType, System.DateTimeOffset startDateTime, Azure.Iot.DeviceUpdate.Models.DeviceGroupType deviceGroupType, System.Collections.Generic.IEnumerable<string> deviceGroupDefinition, Azure.Iot.DeviceUpdate.Models.UpdateId updateId) { }
+        public Deployment(string deploymentId, Azure.IoT.DeviceUpdate.Models.DeploymentType deploymentType, System.DateTimeOffset startDateTime, Azure.IoT.DeviceUpdate.Models.DeviceGroupType deviceGroupType, System.Collections.Generic.IEnumerable<string> deviceGroupDefinition, Azure.IoT.DeviceUpdate.Models.UpdateId updateId) { }
         public string DeploymentId { get { throw null; } set { } }
-        public Azure.Iot.DeviceUpdate.Models.DeploymentType DeploymentType { get { throw null; } set { } }
+        public Azure.IoT.DeviceUpdate.Models.DeploymentType DeploymentType { get { throw null; } set { } }
         public string DeviceClassId { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> DeviceGroupDefinition { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.DeviceGroupType DeviceGroupType { get { throw null; } set { } }
+        public Azure.IoT.DeviceUpdate.Models.DeviceGroupType DeviceGroupType { get { throw null; } set { } }
         public bool? IsCanceled { get { throw null; } set { } }
         public bool? IsCompleted { get { throw null; } set { } }
         public bool? IsRetried { get { throw null; } set { } }
         public System.DateTimeOffset StartDateTime { get { throw null; } set { } }
-        public Azure.Iot.DeviceUpdate.Models.UpdateId UpdateId { get { throw null; } set { } }
+        public Azure.IoT.DeviceUpdate.Models.UpdateId UpdateId { get { throw null; } set { } }
     }
     public partial class DeploymentDeviceState
     {
         internal DeploymentDeviceState() { }
         public string DeviceId { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState DeviceState { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState DeviceState { get { throw null; } }
         public bool MovedOnToNewDeployment { get { throw null; } }
         public int RetryCount { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct DeploymentState : System.IEquatable<Azure.Iot.DeviceUpdate.Models.DeploymentState>
+    public readonly partial struct DeploymentState : System.IEquatable<Azure.IoT.DeviceUpdate.Models.DeploymentState>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public DeploymentState(string value) { throw null; }
-        public static Azure.Iot.DeviceUpdate.Models.DeploymentState Active { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.DeploymentState Canceled { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.DeploymentState Superseded { get { throw null; } }
-        public bool Equals(Azure.Iot.DeviceUpdate.Models.DeploymentState other) { throw null; }
+        public static Azure.IoT.DeviceUpdate.Models.DeploymentState Active { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.DeploymentState Canceled { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.DeploymentState Superseded { get { throw null; } }
+        public bool Equals(Azure.IoT.DeviceUpdate.Models.DeploymentState other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Iot.DeviceUpdate.Models.DeploymentState left, Azure.Iot.DeviceUpdate.Models.DeploymentState right) { throw null; }
-        public static implicit operator Azure.Iot.DeviceUpdate.Models.DeploymentState (string value) { throw null; }
-        public static bool operator !=(Azure.Iot.DeviceUpdate.Models.DeploymentState left, Azure.Iot.DeviceUpdate.Models.DeploymentState right) { throw null; }
+        public static bool operator ==(Azure.IoT.DeviceUpdate.Models.DeploymentState left, Azure.IoT.DeviceUpdate.Models.DeploymentState right) { throw null; }
+        public static implicit operator Azure.IoT.DeviceUpdate.Models.DeploymentState (string value) { throw null; }
+        public static bool operator !=(Azure.IoT.DeviceUpdate.Models.DeploymentState left, Azure.IoT.DeviceUpdate.Models.DeploymentState right) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class DeploymentStatus
     {
         internal DeploymentStatus() { }
-        public Azure.Iot.DeviceUpdate.Models.DeploymentState DeploymentState { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.DeploymentState DeploymentState { get { throw null; } }
         public int? DevicesCanceledCount { get { throw null; } }
         public int? DevicesCompletedFailedCount { get { throw null; } }
         public int? DevicesCompletedSucceededCount { get { throw null; } }
@@ -159,33 +159,33 @@ namespace Azure.Iot.DeviceUpdate.Models
         public int? TotalDevices { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct DeploymentType : System.IEquatable<Azure.Iot.DeviceUpdate.Models.DeploymentType>
+    public readonly partial struct DeploymentType : System.IEquatable<Azure.IoT.DeviceUpdate.Models.DeploymentType>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public DeploymentType(string value) { throw null; }
-        public static Azure.Iot.DeviceUpdate.Models.DeploymentType Complete { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.DeploymentType Download { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.DeploymentType Install { get { throw null; } }
-        public bool Equals(Azure.Iot.DeviceUpdate.Models.DeploymentType other) { throw null; }
+        public static Azure.IoT.DeviceUpdate.Models.DeploymentType Complete { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.DeploymentType Download { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.DeploymentType Install { get { throw null; } }
+        public bool Equals(Azure.IoT.DeviceUpdate.Models.DeploymentType other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Iot.DeviceUpdate.Models.DeploymentType left, Azure.Iot.DeviceUpdate.Models.DeploymentType right) { throw null; }
-        public static implicit operator Azure.Iot.DeviceUpdate.Models.DeploymentType (string value) { throw null; }
-        public static bool operator !=(Azure.Iot.DeviceUpdate.Models.DeploymentType left, Azure.Iot.DeviceUpdate.Models.DeploymentType right) { throw null; }
+        public static bool operator ==(Azure.IoT.DeviceUpdate.Models.DeploymentType left, Azure.IoT.DeviceUpdate.Models.DeploymentType right) { throw null; }
+        public static implicit operator Azure.IoT.DeviceUpdate.Models.DeploymentType (string value) { throw null; }
+        public static bool operator !=(Azure.IoT.DeviceUpdate.Models.DeploymentType left, Azure.IoT.DeviceUpdate.Models.DeploymentType right) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class Device
     {
         internal Device() { }
-        public Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState? DeploymentStatus { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState? DeploymentStatus { get { throw null; } }
         public string DeviceClassId { get { throw null; } }
         public string DeviceId { get { throw null; } }
         public string GroupId { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.UpdateId InstalledUpdateId { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.UpdateId LastAttemptedUpdateId { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.UpdateId InstalledUpdateId { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.UpdateId LastAttemptedUpdateId { get { throw null; } }
         public string LastDeploymentId { get { throw null; } }
         public string Manufacturer { get { throw null; } }
         public string Model { get { throw null; } }
@@ -194,49 +194,49 @@ namespace Azure.Iot.DeviceUpdate.Models
     public partial class DeviceClass
     {
         internal DeviceClass() { }
-        public Azure.Iot.DeviceUpdate.Models.UpdateId BestCompatibleUpdateId { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.UpdateId BestCompatibleUpdateId { get { throw null; } }
         public string DeviceClassId { get { throw null; } }
         public string Manufacturer { get { throw null; } }
         public string Model { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct DeviceDeploymentState : System.IEquatable<Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState>
+    public readonly partial struct DeviceDeploymentState : System.IEquatable<Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public DeviceDeploymentState(string value) { throw null; }
-        public static Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState Canceled { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState Failed { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState Incompatible { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState InProgress { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState Succeeded { get { throw null; } }
-        public bool Equals(Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState other) { throw null; }
+        public static Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState Canceled { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState Failed { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState Incompatible { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState InProgress { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState Succeeded { get { throw null; } }
+        public bool Equals(Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState left, Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState right) { throw null; }
-        public static implicit operator Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState (string value) { throw null; }
-        public static bool operator !=(Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState left, Azure.Iot.DeviceUpdate.Models.DeviceDeploymentState right) { throw null; }
+        public static bool operator ==(Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState left, Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState right) { throw null; }
+        public static implicit operator Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState (string value) { throw null; }
+        public static bool operator !=(Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState left, Azure.IoT.DeviceUpdate.Models.DeviceDeploymentState right) { throw null; }
         public override string ToString() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct DeviceGroupType : System.IEquatable<Azure.Iot.DeviceUpdate.Models.DeviceGroupType>
+    public readonly partial struct DeviceGroupType : System.IEquatable<Azure.IoT.DeviceUpdate.Models.DeviceGroupType>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public DeviceGroupType(string value) { throw null; }
-        public static Azure.Iot.DeviceUpdate.Models.DeviceGroupType All { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.DeviceGroupType DeviceGroupDefinitions { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.DeviceGroupType Devices { get { throw null; } }
-        public bool Equals(Azure.Iot.DeviceUpdate.Models.DeviceGroupType other) { throw null; }
+        public static Azure.IoT.DeviceUpdate.Models.DeviceGroupType All { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.DeviceGroupType DeviceGroupDefinitions { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.DeviceGroupType Devices { get { throw null; } }
+        public bool Equals(Azure.IoT.DeviceUpdate.Models.DeviceGroupType other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Iot.DeviceUpdate.Models.DeviceGroupType left, Azure.Iot.DeviceUpdate.Models.DeviceGroupType right) { throw null; }
-        public static implicit operator Azure.Iot.DeviceUpdate.Models.DeviceGroupType (string value) { throw null; }
-        public static bool operator !=(Azure.Iot.DeviceUpdate.Models.DeviceGroupType left, Azure.Iot.DeviceUpdate.Models.DeviceGroupType right) { throw null; }
+        public static bool operator ==(Azure.IoT.DeviceUpdate.Models.DeviceGroupType left, Azure.IoT.DeviceUpdate.Models.DeviceGroupType right) { throw null; }
+        public static implicit operator Azure.IoT.DeviceUpdate.Models.DeviceGroupType (string value) { throw null; }
+        public static bool operator !=(Azure.IoT.DeviceUpdate.Models.DeviceGroupType left, Azure.IoT.DeviceUpdate.Models.DeviceGroupType right) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class DeviceTag
@@ -249,8 +249,8 @@ namespace Azure.Iot.DeviceUpdate.Models
     {
         internal Error() { }
         public string Code { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyList<Azure.Iot.DeviceUpdate.Models.Error> Details { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.InnerError Innererror { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.IoT.DeviceUpdate.Models.Error> Details { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.InnerError Innererror { get { throw null; } }
         public string Message { get { throw null; } }
         public System.DateTimeOffset? OccurredDateTime { get { throw null; } }
         public string Target { get { throw null; } }
@@ -273,28 +273,28 @@ namespace Azure.Iot.DeviceUpdate.Models
     }
     public partial class Group
     {
-        public Group(string groupId, Azure.Iot.DeviceUpdate.Models.GroupType groupType, System.Collections.Generic.IEnumerable<string> tags, string createdDateTime) { }
+        public Group(string groupId, Azure.IoT.DeviceUpdate.Models.GroupType groupType, System.Collections.Generic.IEnumerable<string> tags, string createdDateTime) { }
         public string CreatedDateTime { get { throw null; } set { } }
         public int? DeviceCount { get { throw null; } set { } }
         public string GroupId { get { throw null; } set { } }
-        public Azure.Iot.DeviceUpdate.Models.GroupType GroupType { get { throw null; } set { } }
+        public Azure.IoT.DeviceUpdate.Models.GroupType GroupType { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> Tags { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct GroupType : System.IEquatable<Azure.Iot.DeviceUpdate.Models.GroupType>
+    public readonly partial struct GroupType : System.IEquatable<Azure.IoT.DeviceUpdate.Models.GroupType>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public GroupType(string value) { throw null; }
-        public static Azure.Iot.DeviceUpdate.Models.GroupType IoTHubTag { get { throw null; } }
-        public bool Equals(Azure.Iot.DeviceUpdate.Models.GroupType other) { throw null; }
+        public static Azure.IoT.DeviceUpdate.Models.GroupType IoTHubTag { get { throw null; } }
+        public bool Equals(Azure.IoT.DeviceUpdate.Models.GroupType other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Iot.DeviceUpdate.Models.GroupType left, Azure.Iot.DeviceUpdate.Models.GroupType right) { throw null; }
-        public static implicit operator Azure.Iot.DeviceUpdate.Models.GroupType (string value) { throw null; }
-        public static bool operator !=(Azure.Iot.DeviceUpdate.Models.GroupType left, Azure.Iot.DeviceUpdate.Models.GroupType right) { throw null; }
+        public static bool operator ==(Azure.IoT.DeviceUpdate.Models.GroupType left, Azure.IoT.DeviceUpdate.Models.GroupType right) { throw null; }
+        public static implicit operator Azure.IoT.DeviceUpdate.Models.GroupType (string value) { throw null; }
+        public static bool operator !=(Azure.IoT.DeviceUpdate.Models.GroupType left, Azure.IoT.DeviceUpdate.Models.GroupType right) { throw null; }
         public override string ToString() { throw null; }
     }
     public enum HashType
@@ -303,13 +303,13 @@ namespace Azure.Iot.DeviceUpdate.Models
     }
     public sealed partial class ImportManifest
     {
-        public ImportManifest(Azure.Iot.DeviceUpdate.Models.UpdateId updateId, string updateType, string installedCriteria, System.Collections.Generic.List<Azure.Iot.DeviceUpdate.Models.ImportManifestCompatibilityInfo> compatibility, System.DateTime createdDateTime, System.Version manifestVersion, System.Collections.Generic.List<Azure.Iot.DeviceUpdate.Models.ImportManifestFile> files) { }
-        public System.Collections.Generic.List<Azure.Iot.DeviceUpdate.Models.ImportManifestCompatibilityInfo> Compatibility { get { throw null; } }
+        public ImportManifest(Azure.IoT.DeviceUpdate.Models.UpdateId updateId, string updateType, string installedCriteria, System.Collections.Generic.List<Azure.IoT.DeviceUpdate.Models.ImportManifestCompatibilityInfo> compatibility, System.DateTime createdDateTime, System.Version manifestVersion, System.Collections.Generic.List<Azure.IoT.DeviceUpdate.Models.ImportManifestFile> files) { }
+        public System.Collections.Generic.List<Azure.IoT.DeviceUpdate.Models.ImportManifestCompatibilityInfo> Compatibility { get { throw null; } }
         public System.DateTime CreatedDateTime { get { throw null; } }
-        public System.Collections.Generic.List<Azure.Iot.DeviceUpdate.Models.ImportManifestFile> Files { get { throw null; } }
+        public System.Collections.Generic.List<Azure.IoT.DeviceUpdate.Models.ImportManifestFile> Files { get { throw null; } }
         public string InstalledCriteria { get { throw null; } }
         public System.Version ManifestVersion { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.UpdateId UpdateId { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.UpdateId UpdateId { get { throw null; } }
         public string UpdateType { get { throw null; } }
     }
     public partial class ImportManifestCompatibilityInfo
@@ -320,9 +320,9 @@ namespace Azure.Iot.DeviceUpdate.Models
     }
     public partial class ImportManifestFile
     {
-        public ImportManifestFile(string fileName, long sizeInBytes, System.Collections.Generic.Dictionary<Azure.Iot.DeviceUpdate.Models.HashType, string> hashes) { }
+        public ImportManifestFile(string fileName, long sizeInBytes, System.Collections.Generic.Dictionary<Azure.IoT.DeviceUpdate.Models.HashType, string> hashes) { }
         public string FileName { get { throw null; } set { } }
-        public System.Collections.Generic.Dictionary<Azure.Iot.DeviceUpdate.Models.HashType, string> Hashes { get { throw null; } }
+        public System.Collections.Generic.Dictionary<Azure.IoT.DeviceUpdate.Models.HashType, string> Hashes { get { throw null; } }
         public long SizeInBytes { get { throw null; } set { } }
     }
     public partial class ImportManifestMetadata
@@ -334,68 +334,68 @@ namespace Azure.Iot.DeviceUpdate.Models
     }
     public partial class ImportUpdateInput
     {
-        public ImportUpdateInput(Azure.Iot.DeviceUpdate.Models.ImportManifestMetadata importManifest, System.Collections.Generic.IEnumerable<Azure.Iot.DeviceUpdate.Models.FileImportMetadata> files) { }
-        public System.Collections.Generic.IList<Azure.Iot.DeviceUpdate.Models.FileImportMetadata> Files { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.ImportManifestMetadata ImportManifest { get { throw null; } }
+        public ImportUpdateInput(Azure.IoT.DeviceUpdate.Models.ImportManifestMetadata importManifest, System.Collections.Generic.IEnumerable<Azure.IoT.DeviceUpdate.Models.FileImportMetadata> files) { }
+        public System.Collections.Generic.IList<Azure.IoT.DeviceUpdate.Models.FileImportMetadata> Files { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.ImportManifestMetadata ImportManifest { get { throw null; } }
     }
     public partial class InnerError
     {
         internal InnerError() { }
         public string Code { get { throw null; } }
         public string ErrorDetail { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.InnerError InnerErrorValue { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.InnerError InnerErrorValue { get { throw null; } }
         public string Message { get { throw null; } }
     }
     public partial class Operation
     {
         internal Operation() { }
         public System.DateTimeOffset CreatedDateTime { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.Error Error { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.Error Error { get { throw null; } }
         public string Etag { get { throw null; } }
         public System.DateTimeOffset LastActionDateTime { get { throw null; } }
         public string OperationId { get { throw null; } }
         public string ResourceLocation { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.OperationStatus Status { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.OperationStatus Status { get { throw null; } }
         public string TraceId { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.UpdateId UpdateId { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.UpdateId UpdateId { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct OperationStatus : System.IEquatable<Azure.Iot.DeviceUpdate.Models.OperationStatus>
+    public readonly partial struct OperationStatus : System.IEquatable<Azure.IoT.DeviceUpdate.Models.OperationStatus>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public OperationStatus(string value) { throw null; }
-        public static Azure.Iot.DeviceUpdate.Models.OperationStatus Failed { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.OperationStatus NotStarted { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.OperationStatus Running { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.OperationStatus Succeeded { get { throw null; } }
-        public static Azure.Iot.DeviceUpdate.Models.OperationStatus Undefined { get { throw null; } }
-        public bool Equals(Azure.Iot.DeviceUpdate.Models.OperationStatus other) { throw null; }
+        public static Azure.IoT.DeviceUpdate.Models.OperationStatus Failed { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.OperationStatus NotStarted { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.OperationStatus Running { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.OperationStatus Succeeded { get { throw null; } }
+        public static Azure.IoT.DeviceUpdate.Models.OperationStatus Undefined { get { throw null; } }
+        public bool Equals(Azure.IoT.DeviceUpdate.Models.OperationStatus other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Iot.DeviceUpdate.Models.OperationStatus left, Azure.Iot.DeviceUpdate.Models.OperationStatus right) { throw null; }
-        public static implicit operator Azure.Iot.DeviceUpdate.Models.OperationStatus (string value) { throw null; }
-        public static bool operator !=(Azure.Iot.DeviceUpdate.Models.OperationStatus left, Azure.Iot.DeviceUpdate.Models.OperationStatus right) { throw null; }
+        public static bool operator ==(Azure.IoT.DeviceUpdate.Models.OperationStatus left, Azure.IoT.DeviceUpdate.Models.OperationStatus right) { throw null; }
+        public static implicit operator Azure.IoT.DeviceUpdate.Models.OperationStatus (string value) { throw null; }
+        public static bool operator !=(Azure.IoT.DeviceUpdate.Models.OperationStatus left, Azure.IoT.DeviceUpdate.Models.OperationStatus right) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class UpdatableDevices
     {
         internal UpdatableDevices() { }
         public int DeviceCount { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.UpdateId UpdateId { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.UpdateId UpdateId { get { throw null; } }
     }
     public partial class Update
     {
         internal Update() { }
-        public System.Collections.Generic.IReadOnlyList<Azure.Iot.DeviceUpdate.Models.Compatibility> Compatibility { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.IoT.DeviceUpdate.Models.Compatibility> Compatibility { get { throw null; } }
         public System.DateTimeOffset CreatedDateTime { get { throw null; } }
         public string Etag { get { throw null; } }
         public System.DateTimeOffset ImportedDateTime { get { throw null; } }
         public string InstalledCriteria { get { throw null; } }
         public string ManifestVersion { get { throw null; } }
-        public Azure.Iot.DeviceUpdate.Models.UpdateId UpdateId { get { throw null; } }
+        public Azure.IoT.DeviceUpdate.Models.UpdateId UpdateId { get { throw null; } }
         public string UpdateType { get { throw null; } }
     }
     public partial class UpdateCompliance

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/samples/DeviceUpdateClientSample/ContentFactory.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/samples/DeviceUpdateClientSample/ContentFactory.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Blob;
 using Newtonsoft.Json;

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/samples/DeviceUpdateClientSample/DeviceUpdateClientSample.csproj
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/samples/DeviceUpdateClientSample/DeviceUpdateClientSample.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Azure.Iot.DeviceUpdate.csproj" />
+    <ProjectReference Include="..\..\src\Azure.IoT.DeviceUpdate.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/samples/DeviceUpdateClientSample/Sample.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/samples/DeviceUpdateClientSample/Sample.cs
@@ -6,8 +6,8 @@ using System.Net;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Identity;
-using Azure.Iot.DeviceUpdate;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate;
+using Azure.IoT.DeviceUpdate.Models;
 using Newtonsoft.Json;
 
 namespace ConsoleTest

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Azure.IoT.DeviceUpdate.csproj
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Azure.IoT.DeviceUpdate.csproj
@@ -9,8 +9,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <!-- These supressions should be removed in a production library -->
     <NoWarn>$(NoWarn);CS1591;AZC0001;AZC0012</NoWarn>
-    <AssemblyName>Azure.IoT.DeviceUpdate</AssemblyName>
-    <RootNamespace>Azure.IoT.DeviceUpdate</RootNamespace>
   </PropertyGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Azure.IoT.DeviceUpdate.csproj
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Azure.IoT.DeviceUpdate.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Device Update for IoT Hub client library</AssemblyTitle>
     <Version>1.0.0-beta.2</Version>
@@ -9,6 +9,8 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <!-- These supressions should be removed in a production library -->
     <NoWarn>$(NoWarn);CS1591;AZC0001;AZC0012</NoWarn>
+    <AssemblyName>Azure.IoT.DeviceUpdate</AssemblyName>
+    <RootNamespace>Azure.IoT.DeviceUpdate</RootNamespace>
   </PropertyGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/DeploymentsClient.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/DeploymentsClient.cs
@@ -6,9 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     /// <summary>
     /// Deployment management service client.

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/DevicesClient.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/DevicesClient.cs
@@ -4,7 +4,7 @@
 using Azure.Core;
 using Azure.Core.Pipeline;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     /// <summary>
     /// Device management service client.

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/DeploymentsClient.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/DeploymentsClient.cs
@@ -11,9 +11,9 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     /// <summary> The Deployments service client. </summary>
     public partial class DeploymentsClient

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/DeploymentsRestClient.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/DeploymentsRestClient.cs
@@ -12,9 +12,9 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     internal partial class DeploymentsRestClient
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/DeviceUpdateClientOptions.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/DeviceUpdateClientOptions.cs
@@ -8,7 +8,7 @@
 using System;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     /// <summary> Client options for DeviceUpdateClient. </summary>
     public partial class DeviceUpdateClientOptions : ClientOptions

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/DevicesClient.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/DevicesClient.cs
@@ -11,9 +11,9 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     /// <summary> The Devices service client. </summary>
     public partial class DevicesClient

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/DevicesRestClient.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/DevicesRestClient.cs
@@ -12,9 +12,9 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     internal partial class DevicesRestClient
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/AccessCondition.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/AccessCondition.cs
@@ -5,7 +5,7 @@
 
 #nullable disable
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Parameter group. </summary>
     public partial class AccessCondition

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Compatibility.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Compatibility.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class Compatibility
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Compatibility.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Compatibility.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Update compatibility information. </summary>
     public partial class Compatibility

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Deployment.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Deployment.Serialization.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class Deployment : IUtf8JsonSerializable
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Deployment.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Deployment.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Deployment metadata. </summary>
     public partial class Deployment

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentDeviceState.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentDeviceState.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class DeploymentDeviceState
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentDeviceState.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentDeviceState.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Deployment device status. </summary>
     public partial class DeploymentDeviceState

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentDeviceStatesFilter.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentDeviceStatesFilter.cs
@@ -5,7 +5,7 @@
 
 #nullable disable
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Deployment device state filter. </summary>
     internal partial class DeploymentDeviceStatesFilter

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentFilter.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentFilter.cs
@@ -5,7 +5,7 @@
 
 #nullable disable
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Deployment filter. </summary>
     internal partial class DeploymentFilter

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentState.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentState.cs
@@ -8,7 +8,7 @@
 using System;
 using System.ComponentModel;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Deployment state. </summary>
     public readonly partial struct DeploymentState : IEquatable<DeploymentState>

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentStatus.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentStatus.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class DeploymentStatus
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentStatus.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentStatus.cs
@@ -5,7 +5,7 @@
 
 #nullable disable
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Deployment status metadata. </summary>
     public partial class DeploymentStatus

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentType.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeploymentType.cs
@@ -8,7 +8,7 @@
 using System;
 using System.ComponentModel;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Supported deployment types. </summary>
     public readonly partial struct DeploymentType : IEquatable<DeploymentType>

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Device.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Device.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class Device
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Device.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Device.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Device metadata. </summary>
     public partial class Device

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceClass.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceClass.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class DeviceClass
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceClass.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceClass.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Device class metadata. </summary>
     public partial class DeviceClass

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceDeploymentState.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceDeploymentState.cs
@@ -8,7 +8,7 @@
 using System;
 using System.ComponentModel;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Deployment state. </summary>
     public readonly partial struct DeviceDeploymentState : IEquatable<DeviceDeploymentState>

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceFilter.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceFilter.cs
@@ -5,7 +5,7 @@
 
 #nullable disable
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Operation status filter. </summary>
     internal partial class DeviceFilter

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceGroupType.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceGroupType.cs
@@ -8,7 +8,7 @@
 using System;
 using System.ComponentModel;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Supported deployment group types. </summary>
     public readonly partial struct DeviceGroupType : IEquatable<DeviceGroupType>

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceState.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceState.cs
@@ -8,7 +8,7 @@
 using System;
 using System.ComponentModel;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> The deployment device state. </summary>
     internal readonly partial struct DeviceState : IEquatable<DeviceState>

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceTag.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceTag.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class DeviceTag
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceTag.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/DeviceTag.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Device tag properties. </summary>
     public partial class DeviceTag

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Error.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Error.Serialization.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class Error
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Error.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Error.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Error details. </summary>
     public partial class Error

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/File.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/File.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class File
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/File.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/File.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Update file metadata. </summary>
     public partial class File

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/FileImportMetadata.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/FileImportMetadata.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class FileImportMetadata : IUtf8JsonSerializable
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/FileImportMetadata.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/FileImportMetadata.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Metadata describing an update file. </summary>
     public partial class FileImportMetadata

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Group.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Group.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class Group : IUtf8JsonSerializable
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Group.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Group.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Group details. </summary>
     public partial class Group

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/GroupBestUpdatesFilter.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/GroupBestUpdatesFilter.cs
@@ -5,7 +5,7 @@
 
 #nullable disable
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Group best updates filter. </summary>
     internal partial class GroupBestUpdatesFilter

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/GroupType.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/GroupType.cs
@@ -8,7 +8,7 @@
 using System;
 using System.ComponentModel;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Supported group types. </summary>
     public readonly partial struct GroupType : IEquatable<GroupType>

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/ImportManifestMetadata.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/ImportManifestMetadata.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class ImportManifestMetadata : IUtf8JsonSerializable
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/ImportManifestMetadata.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/ImportManifestMetadata.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Metadata describing the import manifest, a document which describes the files and other metadata about an update version. </summary>
     public partial class ImportManifestMetadata

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/ImportUpdateInput.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/ImportUpdateInput.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class ImportUpdateInput : IUtf8JsonSerializable
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/ImportUpdateInput.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/ImportUpdateInput.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Import update input metadata. </summary>
     public partial class ImportUpdateInput

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/InnerError.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/InnerError.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class InnerError
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/InnerError.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/InnerError.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> An object containing more specific information than the current object about the error. </summary>
     public partial class InnerError

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Operation.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Operation.Serialization.cs
@@ -9,7 +9,7 @@ using System;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class Operation
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Operation.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Operation.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Operation metadata. </summary>
     public partial class Operation

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/OperationFilter.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/OperationFilter.cs
@@ -5,7 +5,7 @@
 
 #nullable disable
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Operation status filter. </summary>
     internal partial class OperationFilter

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/OperationFilterStatus.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/OperationFilterStatus.cs
@@ -8,7 +8,7 @@
 using System;
 using System.ComponentModel;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Operation status filter. </summary>
     internal readonly partial struct OperationFilterStatus : IEquatable<OperationFilterStatus>

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/OperationStatus.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/OperationStatus.cs
@@ -8,7 +8,7 @@
 using System;
 using System.ComponentModel;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Operation status. </summary>
     public readonly partial struct OperationStatus : IEquatable<OperationStatus>

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeploymentDeviceStates.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeploymentDeviceStates.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     internal partial class PageableListOfDeploymentDeviceStates
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeploymentDeviceStates.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeploymentDeviceStates.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> The list of deployment device states. </summary>
     internal partial class PageableListOfDeploymentDeviceStates

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeployments.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeployments.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     internal partial class PageableListOfDeployments
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeployments.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeployments.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> The list of deployments. </summary>
     internal partial class PageableListOfDeployments

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeviceClasses.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeviceClasses.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     internal partial class PageableListOfDeviceClasses
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeviceClasses.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeviceClasses.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> The list of device classes. </summary>
     internal partial class PageableListOfDeviceClasses

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeviceTags.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeviceTags.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     internal partial class PageableListOfDeviceTags
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeviceTags.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDeviceTags.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> The list of device tags. </summary>
     internal partial class PageableListOfDeviceTags

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDevices.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDevices.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     internal partial class PageableListOfDevices
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDevices.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfDevices.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> The list of devices. </summary>
     internal partial class PageableListOfDevices

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfGroups.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfGroups.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     internal partial class PageableListOfGroups
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfGroups.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfGroups.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> The list of groups. </summary>
     internal partial class PageableListOfGroups

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfOperations.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfOperations.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     internal partial class PageableListOfOperations
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfOperations.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfOperations.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> The list of operations with server paging support. </summary>
     internal partial class PageableListOfOperations

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfStrings.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfStrings.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     internal partial class PageableListOfStrings
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfStrings.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfStrings.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> The list of strings with server paging support. </summary>
     internal partial class PageableListOfStrings

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfUpdatableDevices.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfUpdatableDevices.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     internal partial class PageableListOfUpdatableDevices
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfUpdatableDevices.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfUpdatableDevices.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> The list of updatable devices. </summary>
     internal partial class PageableListOfUpdatableDevices

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfUpdateIds.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfUpdateIds.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     internal partial class PageableListOfUpdateIds
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfUpdateIds.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/PageableListOfUpdateIds.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> The list of update identities. </summary>
     internal partial class PageableListOfUpdateIds

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdatableDevices.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdatableDevices.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class UpdatableDevices
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdatableDevices.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdatableDevices.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Update identifier and the number of devices for which the update is applicable. </summary>
     public partial class UpdatableDevices

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Update.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Update.Serialization.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class Update
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Update.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/Update.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Update metadata. </summary>
     public partial class Update

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdateCompliance.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdateCompliance.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class UpdateCompliance
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdateCompliance.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdateCompliance.cs
@@ -5,7 +5,7 @@
 
 #nullable disable
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Update compliance information. </summary>
     public partial class UpdateCompliance

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdateId.Serialization.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdateId.Serialization.cs
@@ -8,7 +8,7 @@
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     public partial class UpdateId : IUtf8JsonSerializable
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdateId.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/Models/UpdateId.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary> Update identifier. </summary>
     public partial class UpdateId

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/UpdatesClient.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/UpdatesClient.cs
@@ -11,9 +11,9 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     /// <summary> The Updates service client. </summary>
     public partial class UpdatesClient

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/UpdatesDeleteUpdateHeaders.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/UpdatesDeleteUpdateHeaders.cs
@@ -8,7 +8,7 @@
 using Azure;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     internal partial class UpdatesDeleteUpdateHeaders
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/UpdatesGetOperationHeaders.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/UpdatesGetOperationHeaders.cs
@@ -8,7 +8,7 @@
 using Azure;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     internal partial class UpdatesGetOperationHeaders
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/UpdatesImportUpdateHeaders.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/UpdatesImportUpdateHeaders.cs
@@ -8,7 +8,7 @@
 using Azure;
 using Azure.Core;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     internal partial class UpdatesImportUpdateHeaders
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/UpdatesRestClient.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Generated/UpdatesRestClient.cs
@@ -12,9 +12,9 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     internal partial class UpdatesRestClient
     {

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/GlobalSuppressions.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/GlobalSuppressions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Usage", "AZC0001:Use one of the following pre-approved namespace groups (https://azure.github.io/azure-sdk/registered_namespaces.html): Azure.AI, Azure.Analytics, Azure.Communication, Azure.Data, Azure.DigitalTwins, Azure.Iot, Azure.Learn, Azure.Media, Azure.Management, Azure.Messaging, Azure.Search, Azure.Security, Azure.Storage, Azure.Template, Azure.Identity, Microsoft.Extensions.Azure", Justification = "<Pending>", Scope = "namespace", Target = "~N:Azure.IoT.DeviceUpdate")]
+[assembly: SuppressMessage("Usage", "AZC0001:Use one of the following pre-approved namespace groups (https://azure.github.io/azure-sdk/registered_namespaces.html): Azure.AI, Azure.Analytics, Azure.Communication, Azure.Data, Azure.DigitalTwins, Azure.Iot, Azure.Learn, Azure.Media, Azure.Management, Azure.Messaging, Azure.Search, Azure.Security, Azure.Storage, Azure.Template, Azure.Identity, Microsoft.Extensions.Azure", Justification = "<Pending>", Scope = "namespace", Target = "~N:Azure.IoT.DeviceUpdate.Models")]

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Models/HashType.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Models/HashType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary>
     /// Supported file hash algorithms.

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Models/ImportManifest.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Models/ImportManifest.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary>
     /// Import Manifest model.

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Models/ImportManifestCompatibilityInfo.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Models/ImportManifestCompatibilityInfo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary>
     /// Update compatibility information.

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Models/ImportManifestFile.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/Models/ImportManifestFile.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace Azure.Iot.DeviceUpdate.Models
+namespace Azure.IoT.DeviceUpdate.Models
 {
     /// <summary>
     /// Import manifest file.

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/UpdatesClient.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/UpdatesClient.cs
@@ -6,9 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 
-namespace Azure.Iot.DeviceUpdate
+namespace Azure.IoT.DeviceUpdate
 {
     /// <summary>
     /// Update management service client.

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/autorest.md
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/src/autorest.md
@@ -1,4 +1,4 @@
-# Azure.Iot.DeviceUpdate
+# Azure.IoT.DeviceUpdate
 
 Run `generate.ps1` or `dotnet msbuild /t:GenerateCode` to generate code.
 

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/Azure.IoT.DeviceUpdate.Tests.csproj
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/Azure.IoT.DeviceUpdate.Tests.csproj
@@ -12,6 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(AzureCoreTestFramework)" />
-    <ProjectReference Include="..\src\Azure.Iot.DeviceUpdate.csproj" />
+    <ProjectReference Include="..\src\Azure.IoT.DeviceUpdate.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/DeploymentsClientTests.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/DeploymentsClientTests.cs
@@ -3,10 +3,10 @@
 
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 using NUnit.Framework;
 
-namespace Azure.Iot.DeviceUpdate.Tests
+namespace Azure.IoT.DeviceUpdate.Tests
 {
     /// <summary>
     /// Deployment management tests.

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/DevicesClientTests.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/DevicesClientTests.cs
@@ -5,10 +5,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 using NUnit.Framework;
 
-namespace Azure.Iot.DeviceUpdate.Tests
+namespace Azure.IoT.DeviceUpdate.Tests
 {
     /// <summary>
     /// Device management tests

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/Samples/DeploymentsClientSamples.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/Samples/DeploymentsClientSamples.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 using NUnit.Framework;
 
-namespace Azure.Iot.DeviceUpdate.Tests
+namespace Azure.IoT.DeviceUpdate.Tests
 {
     /// <summary>
     /// Deployment management tests.

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/Samples/DevicesClientSamples.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/Samples/DevicesClientSamples.cs
@@ -5,10 +5,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 using NUnit.Framework;
 
-namespace Azure.Iot.DeviceUpdate.Tests
+namespace Azure.IoT.DeviceUpdate.Tests
 {
     /// <summary>
     /// Device management samples

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/Samples/UpdatesClientSamples.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/Samples/UpdatesClientSamples.cs
@@ -4,10 +4,10 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 using NUnit.Framework;
 
-namespace Azure.Iot.DeviceUpdate.Tests
+namespace Azure.IoT.DeviceUpdate.Tests
 {
     /// <summary>
     /// Updates management live samples.

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/ServiceClientTestEnvironment.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/ServiceClientTestEnvironment.cs
@@ -3,7 +3,7 @@
 
 using Azure.Core.TestFramework;
 
-namespace Azure.Iot.DeviceUpdate.Tests
+namespace Azure.IoT.DeviceUpdate.Tests
 {
     /// <summary>
     /// A service client test environment.

--- a/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/UpdatesClientTests.cs
+++ b/sdk/deviceupdate/Azure.Iot.DeviceUpdate/tests/UpdatesClientTests.cs
@@ -4,10 +4,10 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
-using Azure.Iot.DeviceUpdate.Models;
+using Azure.IoT.DeviceUpdate.Models;
 using NUnit.Framework;
 
-namespace Azure.Iot.DeviceUpdate.Tests
+namespace Azure.IoT.DeviceUpdate.Tests
 {
     /// <summary>
     /// Updates management tests.

--- a/sdk/deviceupdate/ci.yml
+++ b/sdk/deviceupdate/ci.yml
@@ -29,5 +29,5 @@ extends:
     ServiceDirectory: deviceupdate
     ArtifactName: packages
     Artifacts:
-    - name: Azure.Iot.DeviceUpdate
-      safeName: AzureIotDeviceUpdate
+    - name: Azure.IoT.DeviceUpdate
+      safeName: AzureIoTDeviceUpdate


### PR DESCRIPTION
Change root namespace from Azure.Iot -> Azure.IoT to fulfill POR.