### PR TITLE
Servicebus/fix correlation rule filter clone

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/CorrelationRuleFilter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/CorrelationRuleFilter.cs
@@ -52,8 +52,9 @@ namespace Azure.Messaging.ServiceBus.Administration
         }
 
         internal override RuleFilter Clone() =>
-            new CorrelationRuleFilter(CorrelationId)
+            new CorrelationRuleFilter
             {
+                CorrelationId = CorrelationId,
                 MessageId = MessageId,
                 To = To,
                 ReplyTo = ReplyTo,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/RulePropertiesTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/RulePropertiesTests.cs
@@ -23,11 +23,30 @@ namespace Azure.Messaging.ServiceBus.Tests.Management
         }
 
         [Test]
-        public void CanCreateRulePropertiesFromOptions()
+        public void CanCreateRulePropertiesWithSqlFilterFromOptions()
         {
             var options = new CreateRuleOptions("rule")
             {
                 Filter = new SqlRuleFilter("PROPERTY(@propertyName) = @stringPropertyValue"),
+                Action = new SqlRuleAction("SET a='b'")
+            };
+            var properties = new RuleProperties(options);
+
+            Assert.AreEqual(options, new CreateRuleOptions(properties));
+        }
+
+        [Test]
+        public void CanCreateRulePropertiesWithCorrelationFilterFromOptions()
+        {
+            var options = new CreateRuleOptions("rule")
+            {
+                Filter = new CorrelationRuleFilter
+                {
+                    ApplicationProperties =
+                    {
+                        {"propertyName", "value"}
+                    }
+                },
                 Action = new SqlRuleAction("SET a='b'")
             };
             var properties = new RuleProperties(options);


### PR DESCRIPTION
Prevent a null value for CorrelationId from throwing an exception when cloning a CorrelationRuleFilter.

When cloning a CorrelationRuleFilter it would previously pass the CorrelationId as a constructor parameter, where the CorrelationId was required to have a non-empty value. This has the unfortunate effect of causing all cloning operations on filters without a CorrelationId to fail.

Sample repro code:
```csharp
var ruleOptions = new CreateRuleOptions("rule", new CorrelationRuleFilter
{
    Subject = "something"
});
var existingRule = await _client.GetRuleAsync("topic", "subscription", "rule");
if (new CreateRuleOptions(existingRule) == ruleOptions) // Crashes
{
    _logger.LogInformation("Rule already up to date");
}
```