### PR TITLE
Bug in AzureKeyVaultConfigurationProvider.cs

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
@@ -127,13 +127,25 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
 
         private void SetData(Dictionary<string, LoadedSecret> loadedSecrets, bool fireToken)
         {
-            var data = new Dictionary<string, string>(loadedSecrets.Count, StringComparer.OrdinalIgnoreCase);
+            var data = new Dictionary<string, LoadedSecret>(loadedSecrets.Count, StringComparer.OrdinalIgnoreCase);
             foreach (var secretItem in loadedSecrets)
             {
-                data.Add(secretItem.Value.Key, secretItem.Value.Value);
+                string key = secretItem.Value.Key;
+
+                if (data.TryGetValue(key, out LoadedSecret currentSecret))
+                {
+                    if (secretItem.Value.Updated > currentSecret.Updated)
+                    {
+                        data[key] = secretItem.Value;
+                    }
+                }
+                else
+                {
+                    data.Add(key, secretItem.Value);
+                }
             }
 
-            Data = data;
+            Data = data.ToDictionary(d => d.Key, v => v.Value.Value);
             if (fireToken)
             {
                 OnReload();

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
@@ -128,6 +128,12 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         private void SetData(Dictionary<string, LoadedSecret> loadedSecrets, bool fireToken)
         {
             var data = new Dictionary<string, LoadedSecret>(loadedSecrets.Count, StringComparer.OrdinalIgnoreCase);
+
+            // The loadesSecrets dictionary contains LoadedSecrets objects that has
+            // the configuration value and the configuration key (created by the
+            // KeyVaultSecretManager object). It is possible that multiple
+            // LoadedSecrets objects uses the same configuration key. This loop
+            // takes the latest updated value for each key.
             foreach (var secretItem in loadedSecrets)
             {
                 string key = secretItem.Value.Key;

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
@@ -449,7 +449,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
                 },
                 new[]
                 {
-                    CreateSecret("Section--Secret1", "Value1")
+                    CreateSecret("Section--Secret1", "Value2")
                 }
             );
 


### PR DESCRIPTION
In the project `Azure.Extensions.AspNetCore.Configuration.Secrets` the class `KeyVaultSecretManager` is converting the secret name to the configuration key in the `GetKey` method. This method could be overridden.

This means that it is possible to have several secrets names that maps to the same configuration key. The code in `AzureKeyVaultConfigurationProvider` does not seems to have taken this into account and it might crash when the dictionary is generated in the `SetData` method.

This PR fix this problem. When collisions like this occurs, the latest updated value will be used. 
