### PR TITLE
Reorder create API step and support publish step rerun

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -80,21 +80,22 @@ jobs:
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+      - template: /eng/common/pipelines/templates/steps/create-apireview.yml
+        parameters:
+          Artifacts: ${{parameters.Artifacts}}
+
       - template: ../steps/archetype-sdk-docs.yml
         parameters:
           ServiceDirectory: ${{parameters.ServiceDirectory}}
           Artifacts: ${{parameters.Artifacts}}
           DocGenerationDir: "$(Build.SourcesDirectory)/doc/ApiDocGeneration"
           LibType: 'client'
-      - task: PublishPipelineArtifact@1
-        condition: succeeded()
-        inputs:
-          artifactName: packages
-          path: $(Build.ArtifactStagingDirectory)
 
-      - template: /eng/common/pipelines/templates/steps/create-apireview.yml
+      - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
         parameters:
-          Artifacts: ${{parameters.Artifacts}}
+          ArtifactPath: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: 'packages'
 
   - job: "Analyze"
     condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], true))


### PR DESCRIPTION
Changes in this PR:
1. Run create review step before publishing artifacts
2. Use common template to publish artifact which has error handling to support rerun on publishing step.