### PR TITLE
[TSI]: Test Improvements

### DIFF
--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/Azure.Iot.TimeSeriesInsights.Tests.csproj
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/Azure.Iot.TimeSeriesInsights.Tests.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Devices" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/E2eTestBase.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/E2eTestBase.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using FluentAssertions;
+using Microsoft.Azure.Devices;
 using Microsoft.Azure.Devices.Client;
 using NUnit.Framework;
 
@@ -23,6 +25,8 @@ namespace Azure.Iot.TimeSeriesInsights.Tests
 
         // Based on testing, the max length of models can be 27 only and works well for other resources as well. This can be updated when required.
         protected static readonly int MaxIdLength = 27;
+
+        private static readonly SemaphoreSlim s_semaphore = new SemaphoreSlim(1, 1);
 
         public E2eTestBase(bool isAsync)
          : base(isAsync, TestSettings.Instance.TestMode)
@@ -62,11 +66,35 @@ namespace Azure.Iot.TimeSeriesInsights.Tests
                     InstrumentClientOptions(new TimeSeriesInsightsClientOptions())));
         }
 
-        protected DeviceClient GetDeviceClient()
+        protected async Task<DeviceClient> GetDeviceClient()
         {
-            return DeviceClient.CreateFromConnectionString(
-                TestEnvironment.IoTHubConnectionString,
-                Microsoft.Azure.Devices.Client.TransportType.Mqtt);
+            try
+            {
+                await s_semaphore.WaitAsync().ConfigureAwait(false);
+
+                // Create a device
+                var iotHubConnectionString = TestEnvironment.IoTHubConnectionString;
+                using var registryManager = RegistryManager.CreateFromConnectionString(iotHubConnectionString);
+                string deviceId = await GetUniqueDeviceIdAsync((deviceId) => registryManager.GetDeviceAsync(deviceId)).ConfigureAwait(false);
+                var requestDevice = new Device(deviceId);
+
+                // Add the device to the device manager
+                Device device = await registryManager.AddDeviceAsync(requestDevice).ConfigureAwait(false);
+                await Task.Delay(5000).ConfigureAwait(false);
+                await registryManager.CloseAsync().ConfigureAwait(false);
+
+                // Create a device client
+                string iotHubHostName = HostNameHelper.GetHostName(iotHubConnectionString);
+                string deviceConnectinString = $"HostName={iotHubHostName};DeviceId={device.Id};SharedAccessKey={device.Authentication.SymmetricKey.PrimaryKey}";
+                DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(deviceConnectinString, Microsoft.Azure.Devices.Client.TransportType.Mqtt);
+                await deviceClient.OpenAsync().ConfigureAwait(false);
+
+                return deviceClient;
+            }
+            finally
+            {
+                s_semaphore.Release();
+            }
         }
 
         protected async Task<TimeSeriesId> GetUniqueTimeSeriesInstanceIdAsync(TimeSeriesInsightsClient tsiClient, int numOfIdKeys)
@@ -78,7 +106,7 @@ namespace Azure.Iot.TimeSeriesInsights.Tests
                 var id = new List<string>();
                 for (int i = 0; i < numOfIdKeys; i++)
                 {
-                    id.Add(Recording.GenerateAlphaNumericId(string.Empty, 5));
+                    id.Add(Recording.GenerateAlphaNumericId(string.Empty));
                 }
 
                 TimeSeriesId tsId = numOfIdKeys switch
@@ -100,6 +128,23 @@ namespace Azure.Iot.TimeSeriesInsights.Tests
             }
 
             throw new Exception($"Unique Id could not be found");
+        }
+
+        private async Task<string> GetUniqueDeviceIdAsync(Func<string, Task<Device>> getDevice)
+        {
+            var id = Recording.GenerateAlphaNumericId("TSI_E2E_");
+
+            for (int i = 0; i < MaxTries; i++)
+            {
+                Device device = await getDevice(id).ConfigureAwait(false);
+                if (device == null)
+                {
+                    return id;
+                }
+                id = Recording.GenerateAlphaNumericId("TSI_E2E_");
+            }
+
+            throw new Exception($"Unique Id could not be found.");
         }
     }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/E2eTestBase.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/E2eTestBase.cs
@@ -73,7 +73,7 @@ namespace Azure.Iot.TimeSeriesInsights.Tests
                 await s_semaphore.WaitAsync().ConfigureAwait(false);
 
                 // Create a device
-                var iotHubConnectionString = TestEnvironment.IoTHubConnectionString;
+                string iotHubConnectionString = TestEnvironment.IoTHubConnectionString;
                 using var registryManager = RegistryManager.CreateFromConnectionString(iotHubConnectionString);
                 string deviceId = await GetUniqueDeviceIdAsync((deviceId) => registryManager.GetDeviceAsync(deviceId)).ConfigureAwait(false);
                 var requestDevice = new Device(deviceId);
@@ -132,7 +132,7 @@ namespace Azure.Iot.TimeSeriesInsights.Tests
 
         private async Task<string> GetUniqueDeviceIdAsync(Func<string, Task<Device>> getDevice)
         {
-            var id = Recording.GenerateAlphaNumericId("TSI_E2E_");
+            string id = Recording.GenerateAlphaNumericId("TSI_E2E_");
 
             for (int i = 0; i < MaxTries; i++)
             {

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/HostNameHelper.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/HostNameHelper.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace Azure.Iot.TimeSeriesInsights.Tests
+{
+    internal static class HostNameHelper
+    {
+        // Look for "HostName=", and then grab all the characters until just before the next semi-colon.
+        private static readonly Regex s_hostNameRegex = new Regex("(?<=HostName=).*?(?=;)", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Extracts the IoT Hub host name from the specified connection string
+        /// </summary>
+        public static string GetHostName(string iotHubConnectionString)
+        {
+            return s_hostNameRegex.Match(iotHubConnectionString).Value;
+        }
+    }
+}

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTest.json
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTest.json
@@ -7,10 +7,10 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "62625e55c314c90de4e2858ca5f0f52e",
+        "x-ms-client-request-id": "ef63691385727b9688002835c8689398",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -19,27 +19,27 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "922cefa2-888d-4d57-9ce9-ba375ed5d53f"
+        "x-ms-request-id": "4a267610-97e4-48f8-86ad-2f11d3d44bb4"
       },
       "ResponseBody": {
         "modelSettings": {
           "name": "testModel",
           "timeSeriesIdProperties": [
             {
-              "name": "building",
+              "name": "Building",
               "type": "String"
             },
             {
-              "name": "floor",
+              "name": "Floor",
               "type": "String"
             },
             {
-              "name": "room",
+              "name": "Room",
               "type": "String"
             }
           ],
@@ -56,10 +56,10 @@
         "Content-Length": "20",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "726ff2397d2941a18771f4bfda14a747",
+        "x-ms-client-request-id": "e9e34653ee4b3d7c1ba8c60893ff774c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -70,27 +70,27 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "31451aaf-f233-491b-a2cd-d835663ad1cf"
+        "x-ms-request-id": "3a38f82e-a9db-4ded-b552-5222c2fbf2bf"
       },
       "ResponseBody": {
         "modelSettings": {
           "name": "testModel",
           "timeSeriesIdProperties": [
             {
-              "name": "building",
+              "name": "Building",
               "type": "String"
             },
             {
-              "name": "floor",
+              "name": "Floor",
               "type": "String"
             },
             {
-              "name": "room",
+              "name": "Room",
               "type": "String"
             }
           ],
@@ -100,7 +100,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "2052630005",
+    "RandomSeed": "485981652",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTestAsync.json
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTestAsync.json
@@ -7,10 +7,10 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "62625e55c314c90de4e2858ca5f0f52e",
+        "x-ms-client-request-id": "109421c05d532568d8488e0e9f09d874",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -19,27 +19,27 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a7a7d002-baf4-4826-9258-baef2b04a83f"
+        "x-ms-request-id": "74469a40-c5cc-482f-ab83-ed83786b6a3c"
       },
       "ResponseBody": {
         "modelSettings": {
           "name": "testModel",
           "timeSeriesIdProperties": [
             {
-              "name": "building",
+              "name": "Building",
               "type": "String"
             },
             {
-              "name": "floor",
+              "name": "Floor",
               "type": "String"
             },
             {
-              "name": "room",
+              "name": "Room",
               "type": "String"
             }
           ],
@@ -56,10 +56,10 @@
         "Content-Length": "20",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "726ff2397d2941a18771f4bfda14a747",
+        "x-ms-client-request-id": "68b27672e57b986add7ab98984c8fd29",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -70,27 +70,27 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "629a5ead-cb19-430f-8c3b-8df667086b69"
+        "x-ms-request-id": "1b89797f-0e01-46a7-9ed6-e57cb98509fb"
       },
       "ResponseBody": {
         "modelSettings": {
           "name": "testModel",
           "timeSeriesIdProperties": [
             {
-              "name": "building",
+              "name": "Building",
               "type": "String"
             },
             {
-              "name": "floor",
+              "name": "Floor",
               "type": "String"
             },
             {
-              "name": "room",
+              "name": "Room",
               "type": "String"
             }
           ],
@@ -100,7 +100,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "2052630005",
+    "RandomSeed": "134609761",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestException.json
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestException.json
@@ -9,10 +9,10 @@
         "Content-Length": "26",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "2dd7bbe9ec06257892d6efbaa2e20d4e",
+        "x-ms-client-request-id": "a5563c95a402fd23a2908e68db6937ef",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -23,12 +23,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "7f328ea8-042b-45d2-84ee-bbfa59939894"
+        "x-ms-request-id": "430701a8-8c48-4493-8085-b43f32601b56"
       },
       "ResponseBody": {
         "error": {
@@ -42,7 +42,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1230734841",
+    "RandomSeed": "1123008219",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestExceptionAsync.json
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestExceptionAsync.json
@@ -9,10 +9,10 @@
         "Content-Length": "26",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "4e0e7396c4e7ce4ae21c559376835229",
+        "x-ms-client-request-id": "a5563c95a402fd23a2908e68db6937ef",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -23,12 +23,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "adcff1e2-a548-452c-b6a9-e13b2d4d588d"
+        "x-ms-request-id": "e3ae0ff5-d1d7-4ac8-9fc8-66f0d3191f80"
       },
       "ResponseBody": {
         "error": {
@@ -42,7 +42,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "879362950",
+    "RandomSeed": "1123008219",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3Keys.json
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3Keys.json
@@ -9,10 +9,10 @@
         "Content-Length": "97",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "726ff2397d2941a18771f4bfda14a747",
+        "x-ms-client-request-id": "68b27672e57b986add7ab98984c8fd29",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -20,9 +20,9 @@
         "put": [
           {
             "timeSeriesId": [
-              "ATJOd",
+              "ZxGat",
               null,
-              "Wph8A"
+              "cYjVW"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
           }
@@ -33,12 +33,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "43ea4774-e429-4a2f-b64f-7183807cbaaf"
+        "x-ms-request-id": "41814f26-6def-4faf-99a0-2d70f3e9032f"
       },
       "ResponseBody": {
         "put": [
@@ -55,10 +55,10 @@
         "Content-Length": "50",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "71d9c14bc9fa107d543b152d3267684e",
+        "x-ms-client-request-id": "cfa441efcc6a1ee015ab93f1f3064ba6",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -66,9 +66,9 @@
         "get": {
           "timeSeriesIds": [
             [
-              "ATJOd",
+              "ZxGat",
               null,
-              "Wph8A"
+              "cYjVW"
             ]
           ]
         }
@@ -78,12 +78,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "2f1286e8-d631-4ae5-9d2a-9032d8a1ab98"
+        "x-ms-request-id": "700dc103-2e05-4c48-91f1-ee2e318dc6c1"
       },
       "ResponseBody": {
         "get": [
@@ -91,9 +91,9 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "ATJOd",
+                "ZxGat",
                 null,
-                "Wph8A"
+                "cYjVW"
               ]
             }
           }
@@ -109,10 +109,10 @@
         "Content-Length": "53",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "df6880bb7b70d765bd21daa2cf4eeecf",
+        "x-ms-client-request-id": "c045fa4ef8fbdbd4b7fb33d8a4dfa010",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -120,9 +120,9 @@
         "delete": {
           "timeSeriesIds": [
             [
-              "ATJOd",
+              "ZxGat",
               null,
-              "Wph8A"
+              "cYjVW"
             ]
           ]
         }
@@ -132,12 +132,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "90e1532c-46bd-4bd7-9509-561b3088b137"
+        "x-ms-request-id": "1d7a4f63-f6a7-4a63-8e3a-da84dcf63da0"
       },
       "ResponseBody": {
         "delete": [
@@ -147,7 +147,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "2052630005",
+    "RandomSeed": "134609761",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3KeysAsync.json
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3KeysAsync.json
@@ -9,10 +9,10 @@
         "Content-Length": "97",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "726ff2397d2941a18771f4bfda14a747",
+        "x-ms-client-request-id": "68b27672e57b986add7ab98984c8fd29",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -20,9 +20,9 @@
         "put": [
           {
             "timeSeriesId": [
-              "ATJOd",
+              "ZxGat",
               null,
-              "Wph8A"
+              "cYjVW"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
           }
@@ -33,12 +33,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "b16429e6-374f-4abe-9cc5-c6f8d15daa1d"
+        "x-ms-request-id": "cfee9c69-134b-4807-9e6d-dbf60029d50b"
       },
       "ResponseBody": {
         "put": [
@@ -55,10 +55,10 @@
         "Content-Length": "50",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "71d9c14bc9fa107d543b152d3267684e",
+        "x-ms-client-request-id": "cfa441efcc6a1ee015ab93f1f3064ba6",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -66,9 +66,9 @@
         "get": {
           "timeSeriesIds": [
             [
-              "ATJOd",
+              "ZxGat",
               null,
-              "Wph8A"
+              "cYjVW"
             ]
           ]
         }
@@ -78,12 +78,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "5554af06-7ae3-4542-b667-66316671cd3f"
+        "x-ms-request-id": "1689d52a-9928-46ea-8f84-750b9093fd8e"
       },
       "ResponseBody": {
         "get": [
@@ -91,9 +91,9 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "ATJOd",
+                "ZxGat",
                 null,
-                "Wph8A"
+                "cYjVW"
               ]
             }
           }
@@ -109,10 +109,10 @@
         "Content-Length": "53",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "df6880bb7b70d765bd21daa2cf4eeecf",
+        "x-ms-client-request-id": "c045fa4ef8fbdbd4b7fb33d8a4dfa010",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -120,9 +120,9 @@
         "delete": {
           "timeSeriesIds": [
             [
-              "ATJOd",
+              "ZxGat",
               null,
-              "Wph8A"
+              "cYjVW"
             ]
           ]
         }
@@ -132,12 +132,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "181c73eb-aedc-4ccd-9eb5-d0379bef5a17"
+        "x-ms-request-id": "bac42359-e956-4c99-8cd3-0626f9d2884d"
       },
       "ResponseBody": {
         "delete": [
@@ -147,7 +147,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "2052630005",
+    "RandomSeed": "134609761",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_Lifecycle.json
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_Lifecycle.json
@@ -6,13 +6,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "62",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "bff4718714da47a74bc1d971fac97d10",
+        "x-ms-client-request-id": "89b97addc88429fdef41a4cf6acce01e",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -20,9 +20,9 @@
         "get": {
           "timeSeriesIds": [
             [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "ZxGatc2A",
+              "cYjVW5hm",
+              "zO49NECW"
             ]
           ]
         }
@@ -32,19 +32,19 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "ab1ca5b4-5492-4eba-8876-2cb3cb4931fd"
+        "x-ms-request-id": "1c63270b-80d9-46a3-8535-2ad4ba1a70e0"
       },
       "ResponseBody": {
         "get": [
           {
             "error": {
               "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022ATJOd\u0022,\u0022Wph8A\u0022,\u0022Gw6BV\u0022]\u0027 is not found.",
+              "message": "Time series instance with time series ID \u0027[\u0022ZxGatc2A\u0022,\u0022cYjVW5hm\u0022,\u0022zO49NECW\u0022]\u0027 is not found.",
               "innerError": {
                 "code": "InstanceNotFound"
               }
@@ -59,13 +59,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "62",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "e3413e3a84166f34755f1ded67730e20",
+        "x-ms-client-request-id": "5d1f644a0865a60a959453d05178a4d7",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -73,9 +73,9 @@
         "get": {
           "timeSeriesIds": [
             [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "QFdW0I0y",
+              "9pLI0aRV",
+              "vuD2OzEV"
             ]
           ]
         }
@@ -85,19 +85,19 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "9c5709e0-ed32-495f-b351-03f45d1d491b"
+        "x-ms-request-id": "c0f463b2-00d1-4a17-845b-e6adaf0511f0"
       },
       "ResponseBody": {
         "get": [
           {
             "error": {
               "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022H29oO\u0022,\u0022BAWLL\u0022,\u0022EFY7A\u0022]\u0027 is not found.",
+              "message": "Time series instance with time series ID \u0027[\u0022QFdW0I0y\u0022,\u00229pLI0aRV\u0022,\u0022vuD2OzEV\u0022]\u0027 is not found.",
               "innerError": {
                 "code": "InstanceNotFound"
               }
@@ -112,13 +112,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "191",
+        "Content-Length": "209",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "5a04a608c8accfd65b02b3d9efda4105",
+        "x-ms-client-request-id": "8a3a122e3d82f62d6dc9186e99077a35",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -126,17 +126,17 @@
         "put": [
           {
             "timeSeriesId": [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "ZxGatc2A",
+              "cYjVW5hm",
+              "zO49NECW"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
           },
           {
             "timeSeriesId": [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "QFdW0I0y",
+              "9pLI0aRV",
+              "vuD2OzEV"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
           }
@@ -147,12 +147,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "5d92303d-8811-4eeb-92e2-23a3251a6824"
+        "x-ms-request-id": "15e3578f-5db6-4b83-8ebd-3a26607c3bf7"
       },
       "ResponseBody": {
         "put": [
@@ -167,13 +167,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "79",
+        "Content-Length": "97",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "f3f2464d842636374bf869105e776f49",
+        "x-ms-client-request-id": "8fa6830beee74641f09e2a67a404893f",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -181,14 +181,14 @@
         "get": {
           "timeSeriesIds": [
             [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "ZxGatc2A",
+              "cYjVW5hm",
+              "zO49NECW"
             ],
             [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "QFdW0I0y",
+              "9pLI0aRV",
+              "vuD2OzEV"
             ]
           ]
         }
@@ -198,12 +198,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a5d05bcf-976c-4141-87f3-46b9087410cf"
+        "x-ms-request-id": "c18d3803-e46a-486b-a123-3b1fbf165fad"
       },
       "ResponseBody": {
         "get": [
@@ -211,9 +211,9 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "ATJOd",
-                "Wph8A",
-                "Gw6BV"
+                "ZxGatc2A",
+                "cYjVW5hm",
+                "zO49NECW"
               ]
             }
           },
@@ -221,9 +221,9 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "H29oO",
-                "BAWLL",
-                "EFY7A"
+                "QFdW0I0y",
+                "9pLI0aRV",
+                "vuD2OzEV"
               ]
             }
           }
@@ -236,13 +236,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "246",
+        "Content-Length": "264",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "21a0181e1b8084fa6fcd0eb35fc671e3",
+        "x-ms-client-request-id": "cec51e1915d140f0d0f39ae412c65269",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -250,21 +250,21 @@
         "update": [
           {
             "timeSeriesId": [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "ZxGatc2A",
+              "cYjVW5hm",
+              "zO49NECW"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instanceQGIaJ3JK"
+            "name": "instanceOz3yvzaB"
           },
           {
             "timeSeriesId": [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "QFdW0I0y",
+              "9pLI0aRV",
+              "vuD2OzEV"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instancenxV1Lmhk"
+            "name": "instancewIY0oDHW"
           }
         ]
       },
@@ -273,12 +273,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "51f396c7-128b-4933-a8d1-960f29c463be"
+        "x-ms-request-id": "ea5cb79f-b3c9-4bfc-a59d-a1ffbfed6825"
       },
       "ResponseBody": {
         "update": [
@@ -296,18 +296,18 @@
         "Content-Length": "57",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "34c76a92183fb9bb23808cb4fc2266f1",
+        "x-ms-client-request-id": "3d17d83fe85ef58ff59958befda55554",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
           "names": [
-            "instanceQGIaJ3JK",
-            "instancenxV1Lmhk"
+            "instanceOz3yvzaB",
+            "instancewIY0oDHW"
           ]
         }
       },
@@ -316,12 +316,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "10e9dba0-8395-4834-9045-253a81734914"
+        "x-ms-request-id": "6f425e97-b4c1-4545-8fb8-deba5c7462fc"
       },
       "ResponseBody": {
         "get": [
@@ -329,22 +329,22 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "ATJOd",
-                "Wph8A",
-                "Gw6BV"
+                "ZxGatc2A",
+                "cYjVW5hm",
+                "zO49NECW"
               ],
-              "name": "instanceQGIaJ3JK"
+              "name": "instanceOz3yvzaB"
             }
           },
           {
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "H29oO",
-                "BAWLL",
-                "EFY7A"
+                "QFdW0I0y",
+                "9pLI0aRV",
+                "vuD2OzEV"
               ],
-              "name": "instancenxV1Lmhk"
+              "name": "instancewIY0oDHW"
             }
           }
         ]
@@ -357,10 +357,10 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "46f1cd784ed7f7c8bf16b97c846f12a1",
+        "x-ms-client-request-id": "864d9d91bb3f416d6b69c1b17ba9fa70",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -370,651 +370,219 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "02b05590-a0ad-4716-84e5-0edbe981f3d0"
+        "x-ms-request-id": "fccd88b0-5561-4ffd-b685-9197a87cf9cd"
       },
       "ResponseBody": {
         "instances": [
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "0VBLZ",
-              "DOZCQ",
-              "I1kMo"
+              "4wzf4b92",
+              "JuySZgMR",
+              "9SNC9aLM"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "2JofZ",
-              "ty3iF",
-              "pVaUF"
+              "5DhMbTV4",
+              "x7CeLsyT",
+              "VmOgzQZO"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "3idCj",
-              "YpLj0",
-              "f4IrO"
+              "a3U5WXvQ",
+              "cMH5lXkK",
+              "gbxaO2h5"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "5LI7S",
-              "rwTX5",
-              "MGWrK"
+              "am5ideo7",
+              "gSwtPghT",
+              "faJyAXL2"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "5Z12Y",
-              "sm8SC",
-              "9ty18"
+              "avTPsvaL",
+              "0UT0LqMp",
+              "8cHcUBeo"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "6eGyV",
-              "uJ3G1",
-              "bOz70"
+              "ccu9mszE",
+              "CzMRhQlU",
+              "n6822fch"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "890jQ",
-              null,
-              "EgbFw"
+              "cnaw5QVW",
+              "KrepBMJK",
+              "ru3EVicc"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "8tCfe",
-              "znHXP",
-              "u05EA"
+              "D3RjBoCN",
+              "BI8HVM6P",
+              "XKhGGZTt"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "8wO4G",
-              "UKR3v",
-              "0BcWk"
+              "E73SiJpV",
+              "9coPcncf",
+              "lPb3kvBP"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "9lgRY",
-              "WNUMf",
-              "HMW9N"
+              "F1yjoY3U",
+              "fqNoHtJJ",
+              "S3H3wwXV"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "9q9oX",
-              "q4BwA",
-              "FV6BZ"
+              "gimnTQDr",
+              "kb9mzYFv",
+              "XDIHJsyG"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "HkinV12B",
+              "7D4Eamrn",
+              "0vJnYkat"
+            ]
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "lbwuxBqV",
+              "FHJt2N0L",
+              "mcEL6Fw0"
+            ]
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "m16u2Vsc",
+              "3gpyBQMk",
+              "p42LUhZA"
+            ]
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "OYRj6FtK",
+              "rh9ep92Y",
+              "0W429uxB"
+            ]
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "PECHvfyo",
+              "6S9OXXTw",
+              "19kM6Ll0"
+            ]
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "QFdW0I0y",
+              "9pLI0aRV",
+              "vuD2OzEV"
             ],
-            "name": "instanceQGIaJ3JK"
+            "name": "instancewIY0oDHW"
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "AxC60",
-              "3mdL3",
-              "L9sqd"
+              "SedqHEXL",
+              "ypeQhLTD",
+              "2R4Ha50k"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "biTUE",
-              "NUvUj",
-              "YAhbV"
+              "tmWffVoP",
+              "BLEC2KQ3",
+              "s2gFV3OO"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "BTWOM",
-              "rOtjM",
-              "3xF9b"
+              "URxe0512",
+              "kzGdILcS",
+              "5n2yiWW5"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "DGu7z",
-              "1T7r6",
-              "Ib7nQ"
+              "vwYDGQLi",
+              "a69Fx2zJ",
+              "NOba2ubz"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "dkhWI",
-              "lDcPz",
-              "Ce7yD"
+              "wfzexoFW",
+              "ffJKxeYa",
+              "PUAV2QeF"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "dTER8",
-              "ioMkQ",
-              "aX8hG"
+              "wwL9qCfu",
+              "EbfFa4Ru",
+              "8PaboQFk"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "DZ1Z0",
-              "0EL57",
-              "BG7kZ"
+              "xaKu2zRv",
+              "VFAOrdm8",
+              "vDiUalv1"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "EEnuU",
-              "XmSpe",
-              "GhCJn"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "eu68I",
-              "7uSH5",
-              "Lk4I5"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "euxPu",
-              "j44oA",
-              "a08F7"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "FaZbW",
-              "aM57l",
-              "Y24MV"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "fLlaE",
-              "XN4vD",
-              "rXcgy"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "fQfco",
-              "B8kYo",
-              "7Ef7i"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "FRNUE",
-              "TVeW5",
-              "3Xhvs"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "g3146",
-              "t6gA2",
-              "TlLCn"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "g3rFS",
-              "kJ4xx",
-              "yT8dT"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "gmITz",
-              "vQ5rd",
-              "SC1gb"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "gprPf",
-              "m8OmO",
-              "FI9Fz"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "GZtsI",
-              "rksLE",
-              "u5Xxv"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "ZxGatc2A",
+              "cYjVW5hm",
+              "zO49NECW"
             ],
-            "name": "instancenxV1Lmhk"
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "hBgp5",
-              "ant5K",
-              "4GEO7"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "HsBvG",
-              "gGAZK",
-              "84Ue6"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "InipO",
-              "t2QBK",
-              "abVWq"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "JWB03",
-              "kHWIG",
-              "96RGs"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "jzWxk",
-              "SVhDy",
-              "D2Q1S"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "Ka30a",
-              "26jwg",
-              "NLyFw"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "kDy6V",
-              "B1Ca3",
-              "pvZ7m"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "KFVs0",
-              "8OU7g",
-              "fRBqZ"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "kG04H",
-              "FFWNV",
-              "tVV8g"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "knlKm",
-              null,
-              "doFl4"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "l7UAM",
-              "6MIcn",
-              "JYNh2"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "L8fvu",
-              "6POhd",
-              "adesG"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "LzLOE",
-              "7ybpK",
-              "y7OMp"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "MFDln",
-              "aNYFJ",
-              "4Fica"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "mmWG1",
-              "rgGpf",
-              "ppkjx"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "Msxvy",
-              "kUkTa",
-              "THY87"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "n39rK",
-              "NVRzr",
-              "QemwW"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "NA2zc",
-              "gm2al",
-              "XXZRx"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "o6thh",
-              "9VAWy",
-              "cxLoA"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "OleAp",
-              "W92bR",
-              "mqLan"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "OSriZ",
-              "t2imm",
-              "YIjf6"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "oZbvK",
-              null,
-              "UokjR"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "pKZEw",
-              "ADTjI",
-              "ndcFB"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "PT35K",
-              "INd8V",
-              "qPTii"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "PvEAo",
-              "OS9pe",
-              "pf7is"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "Q2Wnr",
-              "n7uIj",
-              "0rn8s"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "Qnyab",
-              "QXMnt",
-              "7DhqU"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "ROpWL",
-              "H9BJ2",
-              "G6cFs"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "RvL6C",
-              "PCYGw",
-              "psRXY"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "rYpTK",
-              "moMWz",
-              "XpwNW"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "SajgA",
-              "HHqmu",
-              "L38IR"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "sbHIv",
-              "v778H",
-              "SWbn7"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "SIAsg",
-              "vYHMM",
-              "t5kDe"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "sptmc",
-              "JEEfs",
-              "4YbEs"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "tcZwq",
-              "B14W4",
-              "vcXHJ"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "TpUy5",
-              "GDjLP",
-              "MhELv"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "ttmEa",
-              "QcX3g",
-              "5rHJL"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "ULFmz",
-              "NlmoU",
-              "KhpDi"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "v9ws4",
-              "CNTPr",
-              "tzbfW"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "VeisK",
-              "i8vIu",
-              "mBlo6"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "wvUZJ",
-              "bfmNd",
-              "EyMJr"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "xo0CG",
-              "x3jso",
-              "v5lOU"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "YFqSF",
-              "9PCm4",
-              "KrFRt"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "yty86",
-              "lOy0X",
-              "jET7P"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "z605y",
-              "8uAq0",
-              "yBSDa"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "z8AvX",
-              "FzOr9",
-              "Dqbz7"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "zIWMB",
-              null,
-              "sCYyD"
-            ]
+            "name": "instanceOz3yvzaB"
           }
         ],
-        "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiNTRjYzQ4MjMtZjI5Zi00MzNjLTkxOWYtNTBiOTBjMjBlYTc4In0="
+        "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiN2RhNWU1NjQtMTI3NS00YjQwLWI1ZWMtZGZmZjBmMGExMWFhIn0="
       }
     },
     {
@@ -1024,12 +592,12 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "6582a4004b93065b5ce7fd008e45874c",
+        "x-ms-client-request-id": "175c87d5cf84312f8ecfd838bd31432b",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-continuation": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiNTRjYzQ4MjMtZjI5Zi00MzNjLTkxOWYtNTBiOTBjMjBlYTc4In0=",
+        "x-ms-continuation": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiN2RhNWU1NjQtMTI3NS00YjQwLWI1ZWMtZGZmZjBmMGExMWFhIn0=",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1038,12 +606,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e2f3196f-c742-4cd9-b48f-b6ccd4b7126a"
+        "x-ms-request-id": "db6ce509-9502-4513-9a8c-bbe9666cd404"
       },
       "ResponseBody": {
         "instances": []
@@ -1058,33 +626,33 @@
         "Content-Length": "22",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "913b1d662bd5430ca1cf75295f3e34b3",
+        "x-ms-client-request-id": "7552459ecb78842a6bd5d1f527dd794c",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "searchString": "ATJ"
+        "searchString": "ZxG"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "6f1c7c04-c70a-410b-8266-65b95f0b8f0e"
+        "x-ms-request-id": "68864025-812e-46fe-be22-fbadbbf7e0ba"
       },
       "ResponseBody": {
         "suggestions": [
           {
-            "searchString": "ATJOd",
-            "highlightedSearchString": "\u003Chit\u003EATJ\u003C/hit\u003EOd"
+            "searchString": "ZxGatc2A",
+            "highlightedSearchString": "\u003Chit\u003EZxG\u003C/hit\u003Eatc2A"
           }
         ]
       }
@@ -1095,13 +663,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "82",
+        "Content-Length": "100",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "57b4eb6d009f2c5d72eae9f050c8687a",
+        "x-ms-client-request-id": "76e9e79f3d49c1cf6e1cf76fe234843a",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -1109,14 +677,14 @@
         "delete": {
           "timeSeriesIds": [
             [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "ZxGatc2A",
+              "cYjVW5hm",
+              "zO49NECW"
             ],
             [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "QFdW0I0y",
+              "9pLI0aRV",
+              "vuD2OzEV"
             ]
           ]
         }
@@ -1126,12 +694,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "487ff732-794d-48b8-8dfe-684e3d05cb31"
+        "x-ms-request-id": "8337d41f-2a90-4404-aa55-6228bc17cef0"
       },
       "ResponseBody": {
         "delete": [
@@ -1142,7 +710,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "2052630005",
+    "RandomSeed": "134609761",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_LifecycleAsync.json
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_LifecycleAsync.json
@@ -6,13 +6,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "62",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "bff4718714da47a74bc1d971fac97d10",
+        "x-ms-client-request-id": "f3927c7261e8fee9f7877806974f32cd",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -20,9 +20,9 @@
         "get": {
           "timeSeriesIds": [
             [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "E73SiJpV",
+              "9coPcncf",
+              "lPb3kvBP"
             ]
           ]
         }
@@ -32,19 +32,19 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f411be09-1bd4-4b71-bca7-7537d55ab106"
+        "x-ms-request-id": "af4a07b7-e376-4148-a0d8-ec79d2580c1c"
       },
       "ResponseBody": {
         "get": [
           {
             "error": {
               "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022ATJOd\u0022,\u0022Wph8A\u0022,\u0022Gw6BV\u0022]\u0027 is not found.",
+              "message": "Time series instance with time series ID \u0027[\u0022E73SiJpV\u0022,\u00229coPcncf\u0022,\u0022lPb3kvBP\u0022]\u0027 is not found.",
               "innerError": {
                 "code": "InstanceNotFound"
               }
@@ -59,13 +59,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "62",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "e3413e3a84166f34755f1ded67730e20",
+        "x-ms-client-request-id": "53d928c61c82f1dd15a4eda29e483f02",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -73,9 +73,9 @@
         "get": {
           "timeSeriesIds": [
             [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "URxe0512",
+              "kzGdILcS",
+              "5n2yiWW5"
             ]
           ]
         }
@@ -85,19 +85,19 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "07179f70-e758-47ac-8035-c5dcaf1dd184"
+        "x-ms-request-id": "a461903a-8f00-4320-9310-e714fdc592d5"
       },
       "ResponseBody": {
         "get": [
           {
             "error": {
               "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022H29oO\u0022,\u0022BAWLL\u0022,\u0022EFY7A\u0022]\u0027 is not found.",
+              "message": "Time series instance with time series ID \u0027[\u0022URxe0512\u0022,\u0022kzGdILcS\u0022,\u00225n2yiWW5\u0022]\u0027 is not found.",
               "innerError": {
                 "code": "InstanceNotFound"
               }
@@ -112,13 +112,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "191",
+        "Content-Length": "209",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "5a04a608c8accfd65b02b3d9efda4105",
+        "x-ms-client-request-id": "52a117b874cdc1bb11fd66a685ef245f",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -126,17 +126,17 @@
         "put": [
           {
             "timeSeriesId": [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "E73SiJpV",
+              "9coPcncf",
+              "lPb3kvBP"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
           },
           {
             "timeSeriesId": [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "URxe0512",
+              "kzGdILcS",
+              "5n2yiWW5"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
           }
@@ -147,12 +147,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "26bd85fe-133d-459a-b614-cf03db48c74c"
+        "x-ms-request-id": "ce240a65-83f3-46d8-b98e-5080e25dd114"
       },
       "ResponseBody": {
         "put": [
@@ -167,13 +167,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "79",
+        "Content-Length": "97",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "f3f2464d842636374bf869105e776f49",
+        "x-ms-client-request-id": "d8fd0c2d709635f8b9a15e9d47d4db57",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -181,14 +181,14 @@
         "get": {
           "timeSeriesIds": [
             [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "E73SiJpV",
+              "9coPcncf",
+              "lPb3kvBP"
             ],
             [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "URxe0512",
+              "kzGdILcS",
+              "5n2yiWW5"
             ]
           ]
         }
@@ -198,12 +198,79 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:33 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "1bd5e503-0b6e-4b25-b268-5ae1e4933b02"
+        "x-ms-request-id": "3bda56c7-062b-48d0-88d1-58f3d76f5fe8"
+      },
+      "ResponseBody": {
+        "get": [
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series instance with time series ID \u0027[\u0022E73SiJpV\u0022,\u00229coPcncf\u0022,\u0022lPb3kvBP\u0022]\u0027 is not found.",
+              "innerError": {
+                "code": "InstanceNotFound"
+              }
+            }
+          },
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series instance with time series ID \u0027[\u0022URxe0512\u0022,\u0022kzGdILcS\u0022,\u00225n2yiWW5\u0022]\u0027 is not found.",
+              "innerError": {
+                "code": "InstanceNotFound"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "97",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "9089c7b1fac6518e6c174284b6366b26",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "get": {
+          "timeSeriesIds": [
+            [
+              "E73SiJpV",
+              "9coPcncf",
+              "lPb3kvBP"
+            ],
+            [
+              "URxe0512",
+              "kzGdILcS",
+              "5n2yiWW5"
+            ]
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Tue, 23 Mar 2021 09:36:42 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "af033d96-ae6c-48e2-8c3d-274a984eaa3f"
       },
       "ResponseBody": {
         "get": [
@@ -211,9 +278,9 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "ATJOd",
-                "Wph8A",
-                "Gw6BV"
+                "E73SiJpV",
+                "9coPcncf",
+                "lPb3kvBP"
               ]
             }
           },
@@ -221,9 +288,9 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "H29oO",
-                "BAWLL",
-                "EFY7A"
+                "URxe0512",
+                "kzGdILcS",
+                "5n2yiWW5"
               ]
             }
           }
@@ -236,13 +303,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "246",
+        "Content-Length": "264",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "21a0181e1b8084fa6fcd0eb35fc671e3",
+        "x-ms-client-request-id": "bef50e22936533997dab6b7f2d737e82",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -250,21 +317,21 @@
         "update": [
           {
             "timeSeriesId": [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "E73SiJpV",
+              "9coPcncf",
+              "lPb3kvBP"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instanceQGIaJ3JK"
+            "name": "instancezlWGdMs2"
           },
           {
             "timeSeriesId": [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "URxe0512",
+              "kzGdILcS",
+              "5n2yiWW5"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instancenxV1Lmhk"
+            "name": "instanceUgqKxGU9"
           }
         ]
       },
@@ -273,12 +340,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e55a2978-dd74-48d7-8b2d-e07cec2ea27c"
+        "x-ms-request-id": "454fb852-ef8a-40ca-a319-18f2708cdcc9"
       },
       "ResponseBody": {
         "update": [
@@ -296,18 +363,18 @@
         "Content-Length": "57",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "34c76a92183fb9bb23808cb4fc2266f1",
+        "x-ms-client-request-id": "ba1d3835495f4a0b5b41715a61623c4e",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
           "names": [
-            "instanceQGIaJ3JK",
-            "instancenxV1Lmhk"
+            "instancezlWGdMs2",
+            "instanceUgqKxGU9"
           ]
         }
       },
@@ -316,12 +383,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "5955e040-954b-46cf-8cd9-8b4ebfdd88c2"
+        "x-ms-request-id": "8fb2e55d-8e2b-41e8-a850-0c00118a7586"
       },
       "ResponseBody": {
         "get": [
@@ -329,22 +396,22 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "ATJOd",
-                "Wph8A",
-                "Gw6BV"
+                "E73SiJpV",
+                "9coPcncf",
+                "lPb3kvBP"
               ],
-              "name": "instanceQGIaJ3JK"
+              "name": "instancezlWGdMs2"
             }
           },
           {
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "H29oO",
-                "BAWLL",
-                "EFY7A"
+                "URxe0512",
+                "kzGdILcS",
+                "5n2yiWW5"
               ],
-              "name": "instancenxV1Lmhk"
+              "name": "instanceUgqKxGU9"
             }
           }
         ]
@@ -357,10 +424,10 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "46f1cd784ed7f7c8bf16b97c846f12a1",
+        "x-ms-client-request-id": "a762059cad41ecc0f44014a0fbec1bab",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -370,651 +437,203 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "c9fcb851-b10e-4e98-a479-14f1ad2bee6d"
+        "x-ms-request-id": "bd2c3ec1-232d-4d7f-b91d-3983429fac13"
       },
       "ResponseBody": {
         "instances": [
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "0VBLZ",
-              "DOZCQ",
-              "I1kMo"
+              "4wzf4b92",
+              "JuySZgMR",
+              "9SNC9aLM"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "2JofZ",
-              "ty3iF",
-              "pVaUF"
+              "5DhMbTV4",
+              "x7CeLsyT",
+              "VmOgzQZO"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "3idCj",
-              "YpLj0",
-              "f4IrO"
+              "a3U5WXvQ",
+              "cMH5lXkK",
+              "gbxaO2h5"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "5LI7S",
-              "rwTX5",
-              "MGWrK"
+              "am5ideo7",
+              "gSwtPghT",
+              "faJyAXL2"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "5Z12Y",
-              "sm8SC",
-              "9ty18"
+              "avTPsvaL",
+              "0UT0LqMp",
+              "8cHcUBeo"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "6eGyV",
-              "uJ3G1",
-              "bOz70"
+              "ccu9mszE",
+              "CzMRhQlU",
+              "n6822fch"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "890jQ",
-              null,
-              "EgbFw"
+              "cnaw5QVW",
+              "KrepBMJK",
+              "ru3EVicc"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "8tCfe",
-              "znHXP",
-              "u05EA"
+              "D3RjBoCN",
+              "BI8HVM6P",
+              "XKhGGZTt"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "8wO4G",
-              "UKR3v",
-              "0BcWk"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "9lgRY",
-              "WNUMf",
-              "HMW9N"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "9q9oX",
-              "q4BwA",
-              "FV6BZ"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "E73SiJpV",
+              "9coPcncf",
+              "lPb3kvBP"
             ],
-            "name": "instanceQGIaJ3JK"
+            "name": "instancezlWGdMs2"
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "AxC60",
-              "3mdL3",
-              "L9sqd"
+              "F1yjoY3U",
+              "fqNoHtJJ",
+              "S3H3wwXV"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "biTUE",
-              "NUvUj",
-              "YAhbV"
+              "gimnTQDr",
+              "kb9mzYFv",
+              "XDIHJsyG"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "BTWOM",
-              "rOtjM",
-              "3xF9b"
+              "HkinV12B",
+              "7D4Eamrn",
+              "0vJnYkat"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "DGu7z",
-              "1T7r6",
-              "Ib7nQ"
+              "lbwuxBqV",
+              "FHJt2N0L",
+              "mcEL6Fw0"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "dkhWI",
-              "lDcPz",
-              "Ce7yD"
+              "m16u2Vsc",
+              "3gpyBQMk",
+              "p42LUhZA"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "dTER8",
-              "ioMkQ",
-              "aX8hG"
+              "OYRj6FtK",
+              "rh9ep92Y",
+              "0W429uxB"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "DZ1Z0",
-              "0EL57",
-              "BG7kZ"
+              "PECHvfyo",
+              "6S9OXXTw",
+              "19kM6Ll0"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "EEnuU",
-              "XmSpe",
-              "GhCJn"
+              "SedqHEXL",
+              "ypeQhLTD",
+              "2R4Ha50k"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "eu68I",
-              "7uSH5",
-              "Lk4I5"
+              "tmWffVoP",
+              "BLEC2KQ3",
+              "s2gFV3OO"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "euxPu",
-              "j44oA",
-              "a08F7"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "FaZbW",
-              "aM57l",
-              "Y24MV"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "fLlaE",
-              "XN4vD",
-              "rXcgy"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "fQfco",
-              "B8kYo",
-              "7Ef7i"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "FRNUE",
-              "TVeW5",
-              "3Xhvs"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "g3146",
-              "t6gA2",
-              "TlLCn"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "g3rFS",
-              "kJ4xx",
-              "yT8dT"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "gmITz",
-              "vQ5rd",
-              "SC1gb"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "gprPf",
-              "m8OmO",
-              "FI9Fz"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "GZtsI",
-              "rksLE",
-              "u5Xxv"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "URxe0512",
+              "kzGdILcS",
+              "5n2yiWW5"
             ],
-            "name": "instancenxV1Lmhk"
+            "name": "instanceUgqKxGU9"
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "hBgp5",
-              "ant5K",
-              "4GEO7"
+              "vwYDGQLi",
+              "a69Fx2zJ",
+              "NOba2ubz"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "HsBvG",
-              "gGAZK",
-              "84Ue6"
+              "wfzexoFW",
+              "ffJKxeYa",
+              "PUAV2QeF"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "InipO",
-              "t2QBK",
-              "abVWq"
+              "wwL9qCfu",
+              "EbfFa4Ru",
+              "8PaboQFk"
             ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "JWB03",
-              "kHWIG",
-              "96RGs"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "jzWxk",
-              "SVhDy",
-              "D2Q1S"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "Ka30a",
-              "26jwg",
-              "NLyFw"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "kDy6V",
-              "B1Ca3",
-              "pvZ7m"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "KFVs0",
-              "8OU7g",
-              "fRBqZ"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "kG04H",
-              "FFWNV",
-              "tVV8g"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "knlKm",
-              null,
-              "doFl4"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "l7UAM",
-              "6MIcn",
-              "JYNh2"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "L8fvu",
-              "6POhd",
-              "adesG"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "LzLOE",
-              "7ybpK",
-              "y7OMp"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "MFDln",
-              "aNYFJ",
-              "4Fica"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "mmWG1",
-              "rgGpf",
-              "ppkjx"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "Msxvy",
-              "kUkTa",
-              "THY87"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "n39rK",
-              "NVRzr",
-              "QemwW"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "NA2zc",
-              "gm2al",
-              "XXZRx"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "o6thh",
-              "9VAWy",
-              "cxLoA"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "OleAp",
-              "W92bR",
-              "mqLan"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "OSriZ",
-              "t2imm",
-              "YIjf6"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "oZbvK",
-              null,
-              "UokjR"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "pKZEw",
-              "ADTjI",
-              "ndcFB"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "PT35K",
-              "INd8V",
-              "qPTii"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "PvEAo",
-              "OS9pe",
-              "pf7is"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "Q2Wnr",
-              "n7uIj",
-              "0rn8s"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "Qnyab",
-              "QXMnt",
-              "7DhqU"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "ROpWL",
-              "H9BJ2",
-              "G6cFs"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "RvL6C",
-              "PCYGw",
-              "psRXY"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "rYpTK",
-              "moMWz",
-              "XpwNW"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "SajgA",
-              "HHqmu",
-              "L38IR"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "sbHIv",
-              "v778H",
-              "SWbn7"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "SIAsg",
-              "vYHMM",
-              "t5kDe"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "sptmc",
-              "JEEfs",
-              "4YbEs"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "tcZwq",
-              "B14W4",
-              "vcXHJ"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "TpUy5",
-              "GDjLP",
-              "MhELv"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "ttmEa",
-              "QcX3g",
-              "5rHJL"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "ULFmz",
-              "NlmoU",
-              "KhpDi"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "v9ws4",
-              "CNTPr",
-              "tzbfW"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "VeisK",
-              "i8vIu",
-              "mBlo6"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "wvUZJ",
-              "bfmNd",
-              "EyMJr"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "xo0CG",
-              "x3jso",
-              "v5lOU"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "YFqSF",
-              "9PCm4",
-              "KrFRt"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "yty86",
-              "lOy0X",
-              "jET7P"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "z605y",
-              "8uAq0",
-              "yBSDa"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "z8AvX",
-              "FzOr9",
-              "Dqbz7"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "zIWMB",
-              null,
-              "sCYyD"
+              "xaKu2zRv",
+              "VFAOrdm8",
+              "vDiUalv1"
             ]
           }
         ],
-        "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiNTRjYzQ4MjMtZjI5Zi00MzNjLTkxOWYtNTBiOTBjMjBlYTc4In0="
+        "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiN2RhNWU1NjQtMTI3NS00YjQwLWI1ZWMtZGZmZjBmMGExMWFhIn0="
       }
     },
     {
@@ -1024,12 +643,12 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "6582a4004b93065b5ce7fd008e45874c",
+        "x-ms-client-request-id": "ddf616edc000d9dd02ab6224223fd21b",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-continuation": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiNTRjYzQ4MjMtZjI5Zi00MzNjLTkxOWYtNTBiOTBjMjBlYTc4In0=",
+        "x-ms-continuation": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiN2RhNWU1NjQtMTI3NS00YjQwLWI1ZWMtZGZmZjBmMGExMWFhIn0=",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1038,12 +657,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e4233440-ce36-4633-912e-1b07e8805f86"
+        "x-ms-request-id": "4c08efd5-eda0-4819-8194-dbf5a6b88eda"
       },
       "ResponseBody": {
         "instances": []
@@ -1058,33 +677,33 @@
         "Content-Length": "22",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "913b1d662bd5430ca1cf75295f3e34b3",
+        "x-ms-client-request-id": "27e21c6fd71188407831c51f356b4e6f",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "searchString": "ATJ"
+        "searchString": "E73"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "c3b4e9bc-78dc-48d0-9eb9-23d160733acb"
+        "x-ms-request-id": "52abd816-3da7-4752-a636-9992356000f3"
       },
       "ResponseBody": {
         "suggestions": [
           {
-            "searchString": "ATJOd",
-            "highlightedSearchString": "\u003Chit\u003EATJ\u003C/hit\u003EOd"
+            "searchString": "E73SiJpV",
+            "highlightedSearchString": "\u003Chit\u003EE73\u003C/hit\u003ESiJpV"
           }
         ]
       }
@@ -1095,13 +714,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "82",
+        "Content-Length": "100",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210322.1",
+          "azsdk-net-Iot.TimeSeriesInsights/1.0.0-alpha.20210323.1",
           "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "57b4eb6d009f2c5d72eae9f050c8687a",
+        "x-ms-client-request-id": "4b6cc5255e6cdc4e2888a4964b9bc9b5",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -1109,14 +728,14 @@
         "delete": {
           "timeSeriesIds": [
             [
-              "ATJOd",
-              "Wph8A",
-              "Gw6BV"
+              "E73SiJpV",
+              "9coPcncf",
+              "lPb3kvBP"
             ],
             [
-              "H29oO",
-              "BAWLL",
-              "EFY7A"
+              "URxe0512",
+              "kzGdILcS",
+              "5n2yiWW5"
             ]
           ]
         }
@@ -1126,12 +745,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Mon, 22 Mar 2021 18:47:50 GMT",
+        "Date": "Tue, 23 Mar 2021 09:36:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "3a1f16d7-674e-4be1-b81f-7eeb091ce50a"
+        "x-ms-request-id": "501e906a-f430-4a50-a6e5-7da2e00674ba"
       },
       "ResponseBody": {
         "delete": [
@@ -1142,7 +761,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "2052630005",
+    "RandomSeed": "1228320732",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/TimeSeriesInsightsQueryTests.cs
+++ b/sdk/timeseriesinsights/Azure.Iot.TimeSeriesInsights/tests/TimeSeriesInsightsQueryTests.cs
@@ -14,7 +14,7 @@ using NUnit.Framework;
 
 namespace Azure.Iot.TimeSeriesInsights.Tests
 {
-    [Parallelizable(ParallelScope.None)]
+    [LiveOnly]
     public class TimeSeriesInsightsQueryTests : E2eTestBase
     {
         private static readonly TimeSpan s_retryDelay = TimeSpan.FromSeconds(10);
@@ -29,12 +29,11 @@ namespace Azure.Iot.TimeSeriesInsights.Tests
         }
 
         [Test]
-        [Ignore("This test is flakey when running on the net-core pipeline. Ignoring and investigating for now as net-core wants to ship.")]
         public async Task TimeSeriesInsightsQuery_GetEventsLifecycle()
         {
             // Arrange
             TimeSeriesInsightsClient tsiClient = GetClient();
-            DeviceClient deviceClient = GetDeviceClient();
+            DeviceClient deviceClient = await GetDeviceClient().ConfigureAwait(false);
 
             // Figure out what the Time Series Id is composed of
             TimeSeriesModelSettings modelSettings = await tsiClient.GetModelSettingsAsync().ConfigureAwait(false);

--- a/sdk/timeseriesinsights/test-resources.json
+++ b/sdk/timeseriesinsights/test-resources.json
@@ -94,10 +94,7 @@
     "rbacOwnerRoleDefinitionId": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635', subscription().subscriptionId)]",
     "storageAccountName": "[concat('tsi', uniqueString(resourceGroup().id))]",
     "eventSourceResourceId": "[resourceId(parameters('resourceGroup'), 'Microsoft.Devices/IotHubs', parameters('iotHubName'))]",
-    "userIdentityName": "userIdentity",
-    "roleAssignmentName": "[guid(resourceGroup().name)]",
-    "ownerRoleDefinitionId": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
-    "deviceName": "device1"
+    "hubKeysId": "[resourceId('Microsoft.Devices/IotHubs/Iothubkeys', parameters('iotHubName'), 'iothubowner')]"
   },
   "resources": [
     {
@@ -129,48 +126,6 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.Devices/IotHubs', parameters('iotHubName'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
-      "apiVersion": "2018-11-30",
-      "name": "[variables('userIdentityName')]",
-      "location": "[resourceGroup().location]"
-    },
-    {
-      "type": "Microsoft.Authorization/roleAssignments",
-      "apiVersion": "2018-09-01-preview",
-      "name": "[variables('roleAssignmentName')]",
-      "properties": {
-        "roleDefinitionId": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/{1}', subscription().subscriptionId, variables('ownerRoleDefinitionId'))]",
-        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userIdentityName')), '2018-11-30').principalId]",
-        "principalType": "ServicePrincipal"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userIdentityName'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Resources/deploymentScripts",
-      "apiVersion": "2020-10-01",
-      "name": "createIotHubDevice",
-      "kind": "AzureCLI",
-      "location": "[resourceGroup().location]",
-      "identity": {
-        "type": "UserAssigned",
-        "userAssignedIdentities": {
-          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userIdentityName'))]": {}
-        }
-      },
-      "properties": {
-        "azCliVersion": "2.9.1",
-        "retentionInterval": "P1D",
-        "arguments": "[format('{0} {1}', parameters('iotHubName'), variables('deviceName'))]",
-        "scriptContent": "      az extension add --name azure-iot -y\r\n  \r\n      az iot hub device-identity create --hub-name $1 --device-id $2\r\n      connectionstring=$(az iot hub device-identity connection-string show --hub-name $1 --device-id $2 -o tsv)\r\n      \r\n      result=\"{\\\"device-connection-string\\\":\"\\\"\"$connectionstring\"\\\"\"}\"\r\n      echo $result | jq -c > $AZ_SCRIPTS_OUTPUT_PATH    \r\n      "
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userIdentityName'))]",
-        "[resourceId('Microsoft.Authorization/roleAssignments', variables('roleAssignmentName'))]"
       ]
     },
     {
@@ -247,14 +202,14 @@
     },
     "IOTHUB_CONNECTION_STRING": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deploymentScripts', 'createIotHubDevice')).outputs['device-connection-string']]"
+      "value": "[format('HostName={0}.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey={1}', parameters('iotHubName'), listkeys(variables('hubKeysId'), '2019-11-04').primaryKey)]"
     }
   },
   "metadata": {
     "_generator": {
       "name": "bicep",
       "version": "0.3.1.62928",
-      "templateHash": "2613984384433687728"
+      "templateHash": "62977174382774977"
     }
   }
 }


### PR DESCRIPTION
Changes:
1. Change Query/getEvents to be LiveOnly. Reason being is the DeviceClient requests that are going out are not being recorded. The reason why they are not being recorded is because they are not being instrumented to be recorded during test setup. They are not being instrumented because the client is track1 client and not track2. So changing to LiveOnly. Pavel made the suggestion that we'll have to do this.
2. Do not rely on a single device for the whole E2E suite. Create a new device using RegistryManager at every test run. This way, there are not conflicts and test transient failures when running in parallel.