### PR TITLE
We always want customers to have access to "MS-CV".

### DIFF
--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/CHANGELOG.md
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 1.1.0-beta.1 (Unreleased)
-
+- Ensure the MS-CV header is not redacted in logs. If you are logging an issue, it can be useful to quote this value.
 
 ## 1.0.0 (2021-03-02)
 - Release client.

--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/RemoteRenderingClientOptions.cs
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/RemoteRenderingClientOptions.cs
@@ -26,6 +26,8 @@ namespace Azure.MixedReality.RemoteRendering
         /// <param name="version">The version.</param>
         public RemoteRenderingClientOptions(ServiceVersion version = ServiceVersion.V2021_01_01)
         {
+            Diagnostics.LoggedHeaderNames.Add("MS-CV");
+
             Version = version switch
             {
                 ServiceVersion.V2021_01_01 => "2021-01-01",


### PR DESCRIPTION
This adds "MS-CV" to the set of headers which are _not_ redacted by logging. (It's useful for customers to quote this value when logging bugs).