### PR TITLE
Stop requiring use PackageDirName argument in Update-PkgVersion.ps1

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -215,7 +215,7 @@ stages:
                     steps:
                       - checkout: self
                       - pwsh: |
-                          eng/scripts/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -PackageDirName '${{artifact.directoryName}}'
+                          eng/scripts/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}'
                         displayName: Increment package version
                       - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
                         parameters:

--- a/eng/scripts/Update-PkgVersion.ps1
+++ b/eng/scripts/Update-PkgVersion.ps1
@@ -14,9 +14,6 @@ The Name of the Service Directory
 .PARAMETER PackageName
 The Name of the Package
 
-.PARAMETER PackageDirName
-Used in the case where the package directory name is different from the package name. e.g in cognitiveservice packages
-
 .PARAMETER NewVersionString
 Use this to overide version incement logic and set a version specified by this parameter
 
@@ -31,9 +28,6 @@ Update-PkgVersion.ps1 -ServiceDirectory core -PackageName Azure.Core -NewVersion
 Updating package version for Azure.Core with a specified verion and release date
 Update-PkgVersion.ps1 -ServiceDirectory core -PackageName Azure.Core -NewVersionString 2.0.5 -ReleaseDate "2020-05-01"
 
-Updating package version for Microsoft.Azure.CognitiveServices.AnomalyDetector
-Update-PkgVersion.ps1 -ServiceDirectory cognitiveservices -PackageName Microsoft.Azure.CognitiveServices.AnomalyDetector -PackageDirName AnomalyDetector
-
 #>
 
 [CmdletBinding()]
@@ -44,16 +38,14 @@ Param (
   [string] $ServiceDirectory,
   [Parameter(Mandatory=$True)]
   [string] $PackageName,
-  [string] $PackageDirName,
   [string] $NewVersionString,
   [string] $ReleaseDate
 )
 
-. ${PSScriptRoot}\..\common\scripts\SemVer.ps1
-# Obtain Current Package Version
-if ([System.String]::IsNullOrEmpty($PackageDirName)) { $PackageDirName = $PackageName }
-$changelogPath = Join-Path $RepoRoot "sdk" $ServiceDirectory $PackageDirName "CHANGELOG.md"
-$csprojPath = Join-Path $RepoRoot "sdk" $ServiceDirectory $PackageDirName "src" "${PackageName}.csproj"
+. (Join-Path $PSScriptRoot ".." common scripts common.ps1)
+
+$pkgProperties = Get-PkgProperties -PackageName $PackageName -ServiceDirectory $ServiceDirectory
+$csprojPath = Join-Path $pkgProperties.DirectoryPath src "${PackageName}.csproj"
 $csproj = new-object xml
 $csproj.PreserveWhitespace = $true
 $csproj.Load($csprojPath)

--- a/eng/scripts/Update-PkgVersion.ps1
+++ b/eng/scripts/Update-PkgVersion.ps1
@@ -60,13 +60,13 @@ if ([System.String]::IsNullOrEmpty($NewVersionString)) {
   $packageSemVer.IncrementAndSetToPrerelease()
 
   & "${PSScriptRoot}/../common/scripts/Update-ChangeLog.ps1" -Version $packageSemVer.ToString() `
-  -ServiceDirectory $ServiceDirectory -PackageName $PackageName -Unreleased $True
+  -ChangelogPath $pkgProperties.ChangeLogPath -Unreleased $True
 }
 else {
   $packageSemVer = [AzureEngSemanticVersion]::new($NewVersionString)
 
   & "${PSScriptRoot}/../common/scripts/Update-ChangeLog.ps1" -Version $packageSemVer.ToString() `
-  -ServiceDirectory $ServiceDirectory -PackageName $PackageName -Unreleased $False `
+  -ChangelogPath $pkgProperties.ChangeLogPath -Unreleased $False `
   -ReplaceLatestEntryTitle $True -ReleaseDate $ReleaseDate
 }
 


### PR DESCRIPTION
- We used `PackageDirName` for packages where were the packagename is not the same as the package directory name.
-  Since we can get all the package properties we no longer need to do that.