### PR TITLE
Make AzureKeyVaultConfigurationProvider public

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.1.0-beta.1 (Unreleased)
 
+### Added
+
+- The `AzureKeyVaultConfigurationProvider` was made public.
+- The `KeyVaultSecretManager.GetData` method was added to allow customizing the way secrets are turned into configuration values.
 
 ## 1.0.2 (2020-11-10)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
@@ -6,6 +6,13 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         public Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager Manager { get { throw null; } set { } }
         public System.TimeSpan? ReloadInterval { get { throw null; } set { } }
     }
+    public partial class AzureKeyVaultConfigurationProvider : Microsoft.Extensions.Configuration.ConfigurationProvider, System.IDisposable
+    {
+        public AzureKeyVaultConfigurationProvider(Azure.Security.KeyVault.Secrets.SecretClient client, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options = null) { }
+        public override void Load() { }
+        protected virtual void SetData(System.Collections.Generic.IEnumerable<Azure.Security.KeyVault.Secrets.KeyVaultSecret> secrets) { }
+        void System.IDisposable.Dispose() { }
+    }
     public partial class KeyVaultSecretManager
     {
         public KeyVaultSecretManager() { }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
@@ -10,12 +10,12 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
     {
         public AzureKeyVaultConfigurationProvider(Azure.Security.KeyVault.Secrets.SecretClient client, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options = null) { }
         public override void Load() { }
-        protected virtual void SetData(System.Collections.Generic.IEnumerable<Azure.Security.KeyVault.Secrets.KeyVaultSecret> secrets) { }
         void System.IDisposable.Dispose() { }
     }
     public partial class KeyVaultSecretManager
     {
         public KeyVaultSecretManager() { }
+        public virtual System.Collections.Generic.Dictionary<string, string> GetData(System.Collections.Generic.IEnumerable<Azure.Security.KeyVault.Secrets.KeyVaultSecret> secrets) { throw null; }
         public virtual string GetKey(Azure.Security.KeyVault.Secrets.KeyVaultSecret secret) { throw null; }
         public virtual bool Load(Azure.Security.KeyVault.Secrets.SecretProperties secret) { throw null; }
     }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
@@ -9,8 +9,9 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
     public partial class AzureKeyVaultConfigurationProvider : Microsoft.Extensions.Configuration.ConfigurationProvider, System.IDisposable
     {
         public AzureKeyVaultConfigurationProvider(Azure.Security.KeyVault.Secrets.SecretClient client, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options = null) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
         public override void Load() { }
-        void System.IDisposable.Dispose() { }
     }
     public partial class KeyVaultSecretManager
     {

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
@@ -44,9 +44,8 @@ namespace Microsoft.Extensions.Configuration
             TokenCredential credential,
             KeyVaultSecretManager manager)
         {
-            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions
+            return AddAzureKeyVault(configurationBuilder, new SecretClient(vaultUri, credential), new AzureKeyVaultConfigurationOptions
             {
-                Client = new SecretClient(vaultUri, credential),
                 Manager = manager
             });
         }
@@ -63,11 +62,10 @@ namespace Microsoft.Extensions.Configuration
             SecretClient client,
             KeyVaultSecretManager manager)
         {
-            return configurationBuilder.Add(new AzureKeyVaultConfigurationSource(new AzureKeyVaultConfigurationOptions()
+            return AddAzureKeyVault(configurationBuilder, client, new AzureKeyVaultConfigurationOptions()
             {
-                Client = client,
                 Manager = manager
-            }));
+            });
         }
 
         /// <summary>
@@ -99,24 +97,12 @@ namespace Microsoft.Extensions.Configuration
             SecretClient client,
             AzureKeyVaultConfigurationOptions options)
         {
-            options.Client = client;
-            return configurationBuilder.AddAzureKeyVault(options);
-        }
-
-        /// <summary>
-        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
-        /// </summary>
-        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
-        /// <param name="options">The <see cref="AzureKeyVaultConfigurationOptions"/> to use.</param>
-        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-        internal static IConfigurationBuilder AddAzureKeyVault(this IConfigurationBuilder configurationBuilder, AzureKeyVaultConfigurationOptions options)
-        {
             Argument.AssertNotNull(configurationBuilder, nameof(configurationBuilder));
             Argument.AssertNotNull(options, nameof(configurationBuilder));
-            Argument.AssertNotNull(options.Client, $"{nameof(options)}.{nameof(options.Client)}");
+            Argument.AssertNotNull(client, nameof(client));
             Argument.AssertNotNull(options.Manager, $"{nameof(options)}.{nameof(options.Manager)}");
 
-            configurationBuilder.Add(new AzureKeyVaultConfigurationSource(options));
+            configurationBuilder.Add(new AzureKeyVaultConfigurationSource(client, options));
 
             return configurationBuilder;
         }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationOptions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationOptions.cs
@@ -21,11 +21,6 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="SecretClient"/> to use for retrieving values.
-        /// </summary>
-        internal SecretClient Client { get; set; }
-
-        /// <summary>
         /// Gets or sets the <see cref="KeyVaultSecretManager"/> instance used to control secret loading.
         /// </summary>
         public KeyVaultSecretManager Manager { get; set; }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
@@ -29,6 +29,8 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         /// </summary>
         /// <param name="client">The <see cref="SecretClient"/> to use for retrieving values.</param>
         /// <param name="options">The <see cref="AzureKeyVaultConfigurationOptions"/> to configure provider behaviors.</param>
+        /// <exception cref="ArgumentNullException">When either <paramref name="client"/> or <see cref="AzureKeyVaultConfigurationOptions.Manager"/> is <code>null</code>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">When either <see cref="AzureKeyVaultConfigurationOptions.ReloadInterval"/> is not positive or <code>null</code>.</exception>
         public AzureKeyVaultConfigurationProvider(SecretClient client, AzureKeyVaultConfigurationOptions options = null)
         {
             options ??= new AzureKeyVaultConfigurationOptions();
@@ -129,12 +131,26 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
             }
         }
 
-        /// <inheritdoc/>
-        void IDisposable.Dispose()
+        /// <summary>
+        /// Frees resources held by the <see cref="AzureKeyVaultConfigurationProvider"/> object.
+        /// </summary>
+        public void Dispose()
         {
+            Dispose(true);
             GC.SuppressFinalize(this);
-            _cancellationToken.Cancel();
-            _cancellationToken.Dispose();
+        }
+
+        /// <summary>
+        /// Frees resources held by the <see cref="AzureKeyVaultConfigurationProvider"/> object.
+        /// </summary>
+        /// <param name="disposing">true if called from <see cref="Dispose()"/>, otherwise false.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _cancellationToken.Cancel();
+                _cancellationToken.Dispose();
+            }
         }
 
         private static bool IsUpToDate(KeyVaultSecret current, SecretProperties updated)

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationSource.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationSource.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Configuration;
 
 namespace Azure.Extensions.AspNetCore.Configuration.Secrets
@@ -11,16 +12,18 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
     internal class AzureKeyVaultConfigurationSource : IConfigurationSource
     {
         private readonly AzureKeyVaultConfigurationOptions _options;
+        private readonly SecretClient _client;
 
-        public AzureKeyVaultConfigurationSource(AzureKeyVaultConfigurationOptions options)
+        public AzureKeyVaultConfigurationSource(SecretClient client, AzureKeyVaultConfigurationOptions options)
         {
             _options = options;
+            _client = client;
         }
 
         /// <inheritdoc />
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new AzureKeyVaultConfigurationProvider(_options.Client, _options.Manager, _options.ReloadInterval);
+            return new AzureKeyVaultConfigurationProvider(_client, _options);
         }
     }
 }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Configuration;
 
@@ -22,6 +25,39 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         public virtual string GetKey(KeyVaultSecret secret)
         {
             return secret.Name.Replace("--", ConfigurationPath.KeyDelimiter);
+        }
+
+        /// <summary>
+        /// Converts a loaded list of secrets into a corresponding set of configuration key-value pairs.
+        /// </summary>
+        /// <param name="secrets">A set of secrets retrieved during <see cref="AzureKeyVaultConfigurationProvider.Load"/> call.</param>
+        /// <returns>The dictionary of configuration key-value pairs that would be assigned to the <see cref="ConfigurationProvider.Data"/>
+        /// and exposed from the <see cref="IConfiguration"/>.</returns>
+        public virtual Dictionary<string, string> GetData(IEnumerable<KeyVaultSecret> secrets)
+        {
+            var data = new Dictionary<string, KeyVaultSecret>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var secret in secrets)
+            {
+                string key = GetKey(secret);
+
+                // It is possible that multiple
+                // LoadedSecrets objects uses the same configuration key. This loop
+                // takes the latest updated value for each key.
+                if (data.TryGetValue(key, out KeyVaultSecret currentSecret))
+                {
+                    if (secret.Properties.UpdatedOn > currentSecret.Properties.UpdatedOn)
+                    {
+                        data[key] = secret;
+                    }
+                }
+                else
+                {
+                    data.Add(key, secret);
+                }
+            }
+
+            return data.ToDictionary(d => d.Key, v => v.Value.Value);
         }
 
         /// <summary>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Azure.Core;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Configuration;
 
@@ -33,8 +34,11 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         /// <param name="secrets">A set of secrets retrieved during <see cref="AzureKeyVaultConfigurationProvider.Load"/> call.</param>
         /// <returns>The dictionary of configuration key-value pairs that would be assigned to the <see cref="ConfigurationProvider.Data"/>
         /// and exposed from the <see cref="IConfiguration"/>.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="secrets"/> is <code>null</code>.</exception>
         public virtual Dictionary<string, string> GetData(IEnumerable<KeyVaultSecret> secrets)
         {
+            Argument.AssertNotNull(secrets, nameof(secrets));
+
             var data = new Dictionary<string, KeyVaultSecret>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var secret in secrets)

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
@@ -84,7 +84,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
                 );
 
             // Act
-            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object,  new KeyVaultSecretManager()))
+            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object, new AzureKeyVaultConfigurationOptions() { Manager = new KeyVaultSecretManager() }))
             {
                 provider.Load();
 
@@ -121,7 +121,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
             );
 
             // Act
-            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object, new EndsWithOneKeyVaultSecretManager()))
+            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object,  new AzureKeyVaultConfigurationOptions() { Manager = new EndsWithOneKeyVaultSecretManager() }))
             {
                 provider.Load();
 
@@ -149,7 +149,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
             );
 
             // Act
-            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object, new KeyVaultSecretManager()))
+            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object, new AzureKeyVaultConfigurationOptions() { Manager = new KeyVaultSecretManager() }))
             {
                 provider.Load();
 
@@ -176,7 +176,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
             );
 
             // Act & Assert
-            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object, new KeyVaultSecretManager()))
+            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object, new AzureKeyVaultConfigurationOptions() { Manager = new KeyVaultSecretManager() }))
             {
                 provider.Load();
 
@@ -429,7 +429,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
             );
 
             // Act
-            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object, new KeyVaultSecretManager()))
+            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object,  new AzureKeyVaultConfigurationOptions() { Manager = new KeyVaultSecretManager() }))
             {
                 provider.Load();
 
@@ -454,7 +454,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
             );
 
             // Act
-            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object, new KeyVaultSecretManagerMultiDash()))
+            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object,  new AzureKeyVaultConfigurationOptions() { Manager = new KeyVaultSecretManagerMultiDash() }))
             {
                 provider.Load();
 
@@ -483,7 +483,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
             );
 
             // Act
-            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object, new KeyVaultSecretManagerMultiDash()))
+            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object,  new AzureKeyVaultConfigurationOptions() { Manager = new KeyVaultSecretManagerMultiDash() }))
             {
                 provider.Load();
 
@@ -517,7 +517,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
             );
 
             // Act
-            var provider = new AzureKeyVaultConfigurationProvider(client.Object, new KeyVaultSecretManager());
+            var provider = new AzureKeyVaultConfigurationProvider(client.Object,  new AzureKeyVaultConfigurationOptions() { Manager = new KeyVaultSecretManager() });
             provider.Load();
             await tcs.Task;
 
@@ -553,7 +553,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
             );
 
             // Act
-            var provider = new AzureKeyVaultConfigurationProvider(client.Object, new KeyVaultSecretManager());
+            var provider = new AzureKeyVaultConfigurationProvider(client.Object,  new AzureKeyVaultConfigurationOptions() { Manager = new KeyVaultSecretManager() });
             provider.Load();
 
             // Assert
@@ -574,13 +574,13 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
         [Test]
         public void ConstructorThrowsForZeroRefreshPeriodValue()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new AzureKeyVaultConfigurationProvider(Mock.Of<SecretClient>(), new KeyVaultSecretManager(), TimeSpan.Zero));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new AzureKeyVaultConfigurationProvider(Mock.Of<SecretClient>(),  new AzureKeyVaultConfigurationOptions() { ReloadInterval = TimeSpan.Zero }));
         }
 
         [Test]
         public void ConstructorThrowsForNegativeRefreshPeriodValue()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new AzureKeyVaultConfigurationProvider(Mock.Of<SecretClient>(), new KeyVaultSecretManager(), TimeSpan.FromMilliseconds(-1)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new AzureKeyVaultConfigurationProvider(Mock.Of<SecretClient>(),  new AzureKeyVaultConfigurationOptions() { ReloadInterval = TimeSpan.FromMilliseconds(-1) }));
         }
 
         private class EndsWithOneKeyVaultSecretManager : KeyVaultSecretManager
@@ -596,11 +596,12 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
             private TaskCompletionSource<object> _releaseTaskCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             private TaskCompletionSource<object> _signalTaskCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            public ReloadControlKeyVaultProvider(SecretClient client, KeyVaultSecretManager manager, TimeSpan? reloadPollDelay = null) : base(client, manager, reloadPollDelay)
+            public ReloadControlKeyVaultProvider(SecretClient client, KeyVaultSecretManager manager, TimeSpan? reloadPollDelay = null)
+                : base(client, new AzureKeyVaultConfigurationOptions() { Manager =  manager, ReloadInterval = reloadPollDelay})
             {
             }
 
-            protected override async Task WaitForReload()
+            internal override async Task WaitForReload()
             {
                 _signalTaskCompletionSource.SetResult(null);
                 await _releaseTaskCompletionSource.Task.TimeoutAfter(TimeSpan.FromSeconds(10));


### PR DESCRIPTION
We had a few request from people wrapping the AzureKeyVaultConfigurationProvider and needing it to be public and others who wanted advanced transformation of secrets they've received (parse single JSON value into multiple configuration keys, etc.).

This PRs does both. 

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/19638
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/15459