### PR TITLE
Optimize Request.SetHeader

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
+++ b/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
@@ -14,9 +14,10 @@
   </ItemGroup>
   <!-- Import Azure.Core shared source -->
   <ItemGroup>
-    <Compile Include="$(AzureCoreSharedSources)EventSourceEventFormatting.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
-    <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
-    <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
-    <Compile Include="$(AzureCoreSharedSources)Argument.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)DictionaryHeaders.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)EventSourceEventFormatting.cs" LinkBase="Shared" />
   </ItemGroup>
 </Project>

--- a/sdk/core/Azure.Core.TestFramework/src/MockRequest.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/MockRequest.cs
@@ -27,6 +27,19 @@ namespace Azure.Core.TestFramework
             }
         }
 
+        protected override void SetHeader(string name, string value)
+        {
+            if (!_headers.TryGetValue(name, out List<string> values))
+            {
+                _headers[name] = _ = new List<string>() { value };
+            }
+            else
+            {
+                values.Clear();
+                values.Add(value);
+            }
+        }
+
         protected override void AddHeader(string name, string value)
         {
             if (!_headers.TryGetValue(name, out List<string> values))

--- a/sdk/core/Azure.Core.TestFramework/src/MockRequest.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/MockRequest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Azure.Core.TestFramework
 {
@@ -14,8 +13,7 @@ namespace Azure.Core.TestFramework
             ClientRequestId = Guid.NewGuid().ToString();
         }
 
-        private readonly Dictionary<string, List<string>> _headers = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-
+        private readonly DictionaryHeaders _headers = new();
         public bool IsDisposed { get; private set; }
 
         public override RequestContent Content
@@ -27,64 +25,19 @@ namespace Azure.Core.TestFramework
             }
         }
 
-        protected override void SetHeader(string name, string value)
-        {
-            if (!_headers.TryGetValue(name, out List<string> values))
-            {
-                _headers[name] = _ = new List<string>() { value };
-            }
-            else
-            {
-                values.Clear();
-                values.Add(value);
-            }
-        }
+        protected override void SetHeader(string name, string value) => _headers.SetHeader(name, value);
 
-        protected override void AddHeader(string name, string value)
-        {
-            if (!_headers.TryGetValue(name, out List<string> values))
-            {
-                _headers[name] = values = new List<string>();
-            }
+        protected override void AddHeader(string name, string value) => _headers.AddHeader(name, value);
 
-            values.Add(value);
-        }
+        protected override bool TryGetHeader(string name, out string value) => _headers.TryGetHeader(name, out value);
 
-        protected override bool TryGetHeader(string name, out string value)
-        {
-            if (_headers.TryGetValue(name, out List<string> values))
-            {
-                value = JoinHeaderValue(values);
-                return true;
-            }
+        protected override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => _headers.TryGetHeaderValues(name, out values);
 
-            value = null;
-            return false;
-        }
+        protected override bool ContainsHeader(string name) => _headers.TryGetHeaderValues(name, out _);
 
-        protected override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
-        {
-            var result = _headers.TryGetValue(name, out List<string> valuesList);
-            values = valuesList;
-            return result;
-        }
+        protected override bool RemoveHeader(string name) => _headers.RemoveHeader(name);
 
-        protected override bool ContainsHeader(string name)
-        {
-            return TryGetHeaderValues(name, out _);
-        }
-
-        protected override bool RemoveHeader(string name)
-        {
-            return _headers.Remove(name);
-        }
-
-        protected override IEnumerable<HttpHeader> EnumerateHeaders() => _headers.Select(h => new HttpHeader(h.Key, JoinHeaderValue(h.Value)));
-
-        private static string JoinHeaderValue(IEnumerable<string> values)
-        {
-            return string.Join(",", values);
-        }
+        protected override IEnumerable<HttpHeader> EnumerateHeaders() => _headers.EnumerateHeaders();
 
         public override string ClientRequestId { get; set; }
 

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -33,14 +33,15 @@
     <Compile Include="Shared\AzureKeyCredentialPolicy.cs" />
     <Compile Include="Shared\AzureSasCredentialSynchronousPolicy.cs" />
     <Compile Include="Shared\Base64Url.cs" />
+    <Compile Include="Shared\ClientDiagnostics.cs" />
+    <Compile Include="Shared\ContentTypeUtilities.cs" />
+    <Compile Include="Shared\DiagnosticScope.cs" />
+    <Compile Include="Shared\DiagnosticScopeFactory.cs" />
+    <Compile Include="Shared\DictionaryHeaders.cs" />
     <Compile Include="Shared\EventSourceEventFormatting.cs" />
     <Compile Include="Shared\HashCodeBuilder.cs" />
-    <Compile Include="Shared\ClientDiagnostics.cs" />
     <Compile Include="Shared\HttpMessageSanitizer.cs" />
     <Compile Include="Shared\NullableAttributes.cs" />
-    <Compile Include="Shared\ContentTypeUtilities.cs" />
-    <Compile Include="Shared\DiagnosticScopeFactory.cs" />
-    <Compile Include="Shared\DiagnosticScope.cs" />
     <Compile Include="Shared\TaskExtensions.cs" />
   </ItemGroup>
 

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -262,6 +262,7 @@ namespace Azure.Core.Pipeline
 
             protected internal override void SetHeader(string name, string value)
             {
+                // Authorization is special cased because it is in the hot path for auth polices that set this header on each request and retry.
                 if (name.Equals(HttpHeader.Names.Authorization) && AuthenticationHeaderValue.TryParse(value, out var authHeader))
                 {
                     _requestMessage.Headers.Authorization = authHeader;

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -260,7 +260,7 @@ namespace Azure.Core.Pipeline
                 }
             }
 
-            // The HttpClient implementation overwrites non-list header values rather than appending them as lists in all cases.
+            // TryAddWithoutValidation overwrites non-list header values rather than appending them as lists in all cases.
             // So a Remove call is not required when setting a header value.
             protected internal override void SetHeader(string name, string value) =>
                 AddHeader(name, value);

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -264,6 +264,7 @@ namespace Azure.Core.Pipeline
             // So a Remove call is not required when setting a header value.
             protected internal override void SetHeader(string name, string value) =>
                 AddHeader(name, value);
+
             protected internal override void AddHeader(string name, string value)
             {
                 if (_requestMessage.Headers.TryAddWithoutValidation(name, value))

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -260,6 +260,10 @@ namespace Azure.Core.Pipeline
                 }
             }
 
+            // The HttpClient implementation overwrites non-list header values rather than appending them as lists in all cases.
+            // So a Remove call is not required when setting a header value.
+            protected internal override void SetHeader(string name, string value) =>
+                AddHeader(name, value);
             protected internal override void AddHeader(string name, string value)
             {
                 if (_requestMessage.Headers.TryAddWithoutValidation(name, value))

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -260,10 +260,17 @@ namespace Azure.Core.Pipeline
                 }
             }
 
-            // TryAddWithoutValidation overwrites non-list header values rather than appending them as lists in all cases.
-            // So a Remove call is not required when setting a header value.
-            protected internal override void SetHeader(string name, string value) =>
-                AddHeader(name, value);
+            protected internal override void SetHeader(string name, string value)
+            {
+                if (name.Equals(HttpHeader.Names.Authorization) && AuthenticationHeaderValue.TryParse(value, out var authHeader))
+                {
+                    _requestMessage.Headers.Authorization = authHeader;
+                }
+                else
+                {
+                    base.SetHeader(name, value);
+                }
+            }
 
             protected internal override void AddHeader(string name, string value)
             {

--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -27,7 +27,7 @@ namespace Azure.Core.Pipeline
         /// <summary>
         /// Creates a new instance of <see cref="HttpWebRequestTransport"/>
         /// </summary>
-        public HttpWebRequestTransport(): this (_ => { })
+        public HttpWebRequestTransport() : this(_ => { })
         {
         }
 
@@ -58,7 +58,7 @@ namespace Azure.Core.Pipeline
 
             ServicePointHelpers.SetLimits(request.ServicePoint);
 
-            using var registration = message.CancellationToken.Register(state => ((HttpWebRequest) state).Abort(), request);
+            using var registration = message.CancellationToken.Register(state => ((HttpWebRequest)state).Abort(), request);
             try
             {
                 if (message.Request.Content != null)
@@ -90,7 +90,7 @@ namespace Azure.Core.Pipeline
                     webResponse = exception.Response;
                 }
 
-                message.Response = new HttpWebResponseImplementation(message.Request.ClientRequestId, (HttpWebResponse) webResponse);
+                message.Response = new HttpWebResponseImplementation(message.Request.ClientRequestId, (HttpWebResponse)webResponse);
             }
             // ObjectDisposedException might be thrown if the request is aborted during the content upload via SSL
             catch (ObjectDisposedException) when (message.CancellationToken.IsCancellationRequested)
@@ -239,7 +239,7 @@ namespace Azure.Core.Pipeline
             return new HttpWebRequestImplementation();
         }
 
-        private sealed class HttpWebResponseImplementation: Response
+        private sealed class HttpWebResponseImplementation : Response
         {
             private readonly HttpWebResponse _webResponse;
             private Stream? _contentStream;
@@ -253,7 +253,7 @@ namespace Azure.Core.Pipeline
                 ClientRequestId = clientRequestId;
             }
 
-            public override int Status => (int) _webResponse.StatusCode;
+            public override int Status => (int)_webResponse.StatusCode;
 
             public override string ReasonPhrase => _webResponse.StatusDescription;
 
@@ -302,7 +302,7 @@ namespace Azure.Core.Pipeline
             }
         }
 
-        private sealed class HttpWebRequestImplementation: Request
+        private sealed class HttpWebRequestImplementation : Request
         {
             public HttpWebRequestImplementation()
             {
@@ -311,6 +311,19 @@ namespace Azure.Core.Pipeline
 
             private string? _clientRequestId;
             private readonly Dictionary<string, List<string>> _headers = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+            protected internal override void SetHeader(string name, string value)
+            {
+                if (!_headers.TryGetValue(name, out List<string> values))
+                {
+                    _headers[name] = values = new List<string>() { value };
+                }
+                else
+                {
+                    values.Clear();
+                    values.Add(value);
+                }
+            }
 
             protected internal override void AddHeader(string name, string value)
             {

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -83,6 +83,7 @@ namespace Azure.Core
             RemoveHeader(name);
             AddHeader(name, value);
         }
+
         /// <summary>
         /// Removes the header from the collection.
         /// </summary>
@@ -103,7 +104,7 @@ namespace Azure.Core
         /// <summary>
         /// Gets the response HTTP headers.
         /// </summary>
-        public RequestHeaders Headers => new RequestHeaders(this);
+        public RequestHeaders Headers => new(this);
 
         /// <summary>
         /// Frees resources held by this <see cref="Response"/> instance.

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -80,11 +80,7 @@ namespace Azure.Core
         /// <param name="value">The header value.</param>
         protected internal virtual void SetHeader(string name, string value)
         {
-#if NETFRAMEWORK
-            // RemoveHeader is only required for the WebRequest.Headers.Add behavior implemented by HttpWebRequest
-            // The HttpClient implementation overwrites non-list header values rather than appending them as lists in all cases.
             RemoveHeader(name);
-#endif
             AddHeader(name, value);
         }
         /// <summary>

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -80,7 +80,11 @@ namespace Azure.Core
         /// <param name="value">The header value.</param>
         protected internal virtual void SetHeader(string name, string value)
         {
+#if NETFRAMEWORK
+            // RemoveHeader is only required for the WebRequest.Headers.Add behavior implemented by HttpWebRequest
+            // The HttpClient implementation overwrites non-list header values rather than appending them as lists in all cases.
             RemoveHeader(name);
+#endif
             AddHeader(name, value);
         }
         /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
+++ b/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable disable
+
+namespace Azure.Core
+{
+    /// <summary>
+    /// An implementation for manipulating headers on <see cref="Request"/>.
+    /// </summary>
+    public class DictionaryHeaders
+    {
+        private readonly Dictionary<string, object> _headers = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Initializes an instance of <see cref="DictionaryHeaders"/>
+        /// </summary>
+        public DictionaryHeaders()
+        { }
+
+        /// <summary>
+        /// Adds a header value to the header collection.
+        /// </summary>
+        /// <param name="name">The header name.</param>
+        /// <param name="value">The header value.</param>
+        public void AddHeader(string name, string value)
+        {
+            if (!_headers.TryGetValue(name, out object objValue))
+            {
+                _headers[name] = value;
+            }
+            else
+            {
+                if (objValue is not List<string> values)
+                {
+                    _headers[name] = values = new List<string> { objValue as string, value };
+                }
+                else
+                {
+                    values.Add(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns header value if the header is stored in the collection. If the header has multiple values they are going to be joined with a comma.
+        /// </summary>
+        /// <param name="name">The header name.</param>
+        /// <param name="value">The reference to populate with value.</param>
+        /// <returns><c>true</c> if the specified header is stored in the collection, otherwise <c>false</c>.</returns>
+        public bool TryGetHeader(string name, out string value)
+        {
+            if (_headers.TryGetValue(name, out object objValue))
+            {
+                if (objValue is List<string> values)
+                {
+                    value = JoinHeaderValue(values);
+                }
+                else
+                {
+                    value = objValue as string;
+                }
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Returns header values if the header is stored in the collection.
+        /// </summary>
+        /// <param name="name">The header name.</param>
+        /// <param name="values">The reference to populate with values.</param>
+        /// <returns><c>true</c> if the specified header is stored in the collection, otherwise <c>false</c>.</returns>
+        public bool TryGetHeaderValues(string name, out IEnumerable<string> values)
+        {
+            var result = _headers.TryGetValue(name, out object objValue);
+            if (objValue is List<string> valuesList)
+            {
+                values = valuesList;
+            }
+            else
+            {
+                values = new List<string> { objValue as string };
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the header is stored in the collection.
+        /// </summary>
+        /// <param name="name">The header name.</param>
+        /// <returns><c>true</c> if the specified header is stored in the collection, otherwise <c>false</c>.</returns>
+        public bool ContainsHeader(string name)
+        {
+            return TryGetHeaderValues(name, out _);
+        }
+
+        /// <summary>
+        /// Sets a header value the header collection.
+        /// </summary>
+        /// <param name="name">The header name.</param>
+        /// <param name="value">The header value.</param>
+        public void SetHeader(string name, string value)
+        {
+            _headers[name] = value;
+        }
+
+        /// <summary>
+        /// Removes the header from the collection.
+        /// </summary>
+        /// <param name="name">The header name.</param>
+        public bool RemoveHeader(string name)
+        {
+            return _headers.Remove(name);
+        }
+
+        /// <summary>
+        /// Returns an iterator enumerating <see cref="HttpHeader"/> in the request.
+        /// </summary>
+        /// <returns>The <see cref="IEnumerable{T}"/> enumerating <see cref="HttpHeader"/> in the response.</returns>
+        public IEnumerable<HttpHeader> EnumerateHeaders() => _headers.Select(h => new HttpHeader(h.Key, (h.Value is List<string> values) ? JoinHeaderValue(values) : h.Value as string));
+
+        private static string JoinHeaderValue(IEnumerable<string> values)
+        {
+            return string.Join(",", values);
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
+++ b/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
@@ -35,13 +35,14 @@ namespace Azure.Core
             }
             else
             {
-                if (objValue is not List<string> values)
+                if (objValue is List<string> values)
                 {
-                    _headers[name] = values = new List<string> { objValue as string, value };
+                    values.Add(value);
                 }
                 else
                 {
-                    values.Add(value);
+                    // upgrade to a List
+                    _headers[name] = new List<string> { objValue as string, value };
                 }
             }
         }

--- a/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
+++ b/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
@@ -12,7 +12,7 @@ namespace Azure.Core
     /// <summary>
     /// An implementation for manipulating headers on <see cref="Request"/>.
     /// </summary>
-    public class DictionaryHeaders
+    internal class DictionaryHeaders
     {
         private readonly Dictionary<string, object> _headers = new(StringComparer.OrdinalIgnoreCase);
 
@@ -98,7 +98,7 @@ namespace Azure.Core
         /// <returns><c>true</c> if the specified header is stored in the collection, otherwise <c>false</c>.</returns>
         public bool ContainsHeader(string name)
         {
-            return TryGetHeaderValues(name, out _);
+            return _headers.ContainsKey(name);
         }
 
         /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/Multipart/MemoryRequest.cs
+++ b/sdk/core/Azure.Core/src/Shared/Multipart/MemoryRequest.cs
@@ -28,6 +28,24 @@ namespace Azure.Core
 #if HAS_INTERNALS_VISIBLE_CORE
         internal
 #endif
+
+       protected override void SetHeader(string name, string value)
+        {
+            if (!_headers.TryGetValue(name, out List<string> values))
+            {
+                _headers[name] = _ = new List<string>() { value };
+            }
+            else
+            {
+                values.Clear();
+                values.Add(value);
+            }
+        }
+
+#if HAS_INTERNALS_VISIBLE_CORE
+        internal
+#endif
+
         protected override void AddHeader(string name, string value)
         {
             if (!_headers.TryGetValue(name, out List<string> values))

--- a/sdk/core/Azure.Core/src/Shared/Multipart/MemoryRequest.cs
+++ b/sdk/core/Azure.Core/src/Shared/Multipart/MemoryRequest.cs
@@ -14,7 +14,7 @@ namespace Azure.Core
             ClientRequestId = Guid.NewGuid().ToString();
         }
 
-        private readonly Dictionary<string, List<string>> _headers = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        private readonly DictionaryHeaders _headers = new();
 
         public override RequestContent Content
         {
@@ -29,83 +29,43 @@ namespace Azure.Core
         internal
 #endif
 
-       protected override void SetHeader(string name, string value)
-        {
-            if (!_headers.TryGetValue(name, out List<string> values))
-            {
-                _headers[name] = _ = new List<string>() { value };
-            }
-            else
-            {
-                values.Clear();
-                values.Add(value);
-            }
-        }
+       protected override void SetHeader(string name, string value) => _headers.SetHeader(name, value);
 
 #if HAS_INTERNALS_VISIBLE_CORE
         internal
 #endif
 
-        protected override void AddHeader(string name, string value)
-        {
-            if (!_headers.TryGetValue(name, out List<string> values))
-            {
-                _headers[name] = values = new List<string>();
-            }
-
-            values.Add(value);
-        }
+        protected override void AddHeader(string name, string value) => _headers.AddHeader(name, value);
 
 #if HAS_INTERNALS_VISIBLE_CORE
         internal
 #endif
-        protected override bool TryGetHeader(string name, out string value)
-        {
-            if (_headers.TryGetValue(name, out List<string> values))
-            {
-                value = JoinHeaderValue(values);
-                return true;
-            }
 
-            value = null;
-            return false;
-        }
+        protected override bool TryGetHeader(string name, out string value) => _headers.TryGetHeader(name, out value);
 
 #if HAS_INTERNALS_VISIBLE_CORE
         internal
 #endif
-        protected override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
-        {
-            var result = _headers.TryGetValue(name, out List<string> valuesList);
-            values = valuesList;
-            return result;
-        }
+
+        protected override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => _headers.TryGetHeaderValues(name, out values);
 
 #if HAS_INTERNALS_VISIBLE_CORE
         internal
 #endif
-        protected override bool ContainsHeader(string name)
-        {
-            return TryGetHeaderValues(name, out _);
-        }
+
+        protected override bool ContainsHeader(string name) => _headers.TryGetHeaderValues(name, out _);
 
 #if HAS_INTERNALS_VISIBLE_CORE
         internal
 #endif
-        protected override bool RemoveHeader(string name)
-        {
-            return _headers.Remove(name);
-        }
+
+        protected override bool RemoveHeader(string name) => _headers.RemoveHeader(name);
 
 #if HAS_INTERNALS_VISIBLE_CORE
         internal
 #endif
-        protected override IEnumerable<HttpHeader> EnumerateHeaders() => _headers.Select(h => new HttpHeader(h.Key, JoinHeaderValue(h.Value)));
 
-        private static string JoinHeaderValue(IEnumerable<string> values)
-        {
-            return string.Join(",", values);
-        }
+        protected override IEnumerable<HttpHeader> EnumerateHeaders() => _headers.EnumerateHeaders();
 
         public override string ClientRequestId { get; set; }
 

--- a/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
+++ b/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="..\src\Shared\AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\BearerTokenChallengeAuthenticationPolicy.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\ConnectionString.cs" LinkBase="Shared" />
+    <Compile Include="..\src\Shared\DictionaryHeaders.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\ForwardsClientCallsAttribute.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\HttpPipelineMessageHandler.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\NoBodyResponseOfT.cs" LinkBase="Shared" />

--- a/sdk/tables/Azure.Data.Tables/src/Azure.Data.Tables.csproj
+++ b/sdk/tables/Azure.Data.Tables/src/Azure.Data.Tables.csproj
@@ -29,6 +29,7 @@
     <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" Link="Shared\Core\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" Link="Shared\Core\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" Link="Shared\Core\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="$(AzureCoreSharedSources)DictionaryHeaders.cs" LinkBase="Shared\Core" />
     <Compile Include="$(AzureCoreSharedSources)HashCodeBuilder.cs" Link="Shared\Core\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" Link="Shared\Core\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureCoreSharedSources)OperationHelpers.cs" Link="Shared\Core\%(RecursiveDir)\%(Filename)%(Extension)" />


### PR DESCRIPTION
fixes #19750

Note that for `HttpClientTransport` `Headers.SetValue` for headers other than `Authorization`, the perf is essentially the same. However, in the hot path of setting the `Authorization` header, we see a 2x improvement.

For `HttpWebRequestTransport` (including `MockRequest` and `MemoryRequest`) we see a nearly 4x improvement.

```
|                          Method |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|     HttpClientTsp_SetHeader_Old | 442.31 ns | 4.483 ns | 4.193 ns | 20.62 |    0.20 | 0.0324 |     - |     - |     272 B |
|     HttpClientTsp_SetHeader_New | 452.10 ns | 7.264 ns | 6.795 ns | 21.08 |    0.41 | 0.0324 |     - |     - |     272 B |
| HttpClientTsp_SetAuthHeader_New | 219.25 ns | 2.130 ns | 1.888 ns | 10.22 |    0.14 | 0.0153 |     - |     - |     128 B |
| HttpWebRequestTsp_SetHeader_Old |  83.51 ns | 1.244 ns | 1.164 ns |  3.89 |    0.05 | 0.0105 |     - |     - |      88 B |
| HttpWebRequestTsp_SetHeader_New |  21.45 ns | 0.188 ns | 0.167 ns |  1.00 |    0.00 |      - |     - |     - |         - |
```