### PR TITLE
Fix Azure.Core version

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 1.11.0-beta.1 (Unreleased)
+
 ## 1.11.0 (2021-03-22)
 
 ### Added

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.11.0-beta.1 (Unreleased)
+## 1.12.0-beta.1 (Unreleased)
 
 ## 1.11.0 (2021-03-22)
 

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.11.0</Version>
+    <Version>1.12.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.10.0</ApiCompatVersion>
     <!-- TODO: remove when we have a released package with the netcoreapp2.1 target -->

--- a/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
+++ b/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
@@ -90,7 +90,6 @@ namespace Azure.Core
                 {
                     // Since we are already allocating a list, cache it
                     values = new List<string> { objValue as string };
-                    _headers[name] = values;
                 }
 
                 return true;

--- a/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
+++ b/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
@@ -80,16 +80,22 @@ namespace Azure.Core
         /// <returns><c>true</c> if the specified header is stored in the collection, otherwise <c>false</c>.</returns>
         public bool TryGetHeaderValues(string name, out IEnumerable<string> values)
         {
-            var result = _headers.TryGetValue(name, out object objValue);
-            if (objValue is List<string> valuesList)
+            if (_headers.TryGetValue(name, out object objValue))
             {
-                values = valuesList;
+                if (objValue is List<string> valuesList)
+                {
+                    values = valuesList;
+                }
+                else
+                {
+                    values = new List<string> { objValue as string };
+                }
+
+                return true;
             }
-            else
-            {
-                values = new List<string> { objValue as string };
-            }
-            return result;
+
+            values = null;
+            return false;
         }
 
         /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
+++ b/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
@@ -88,7 +88,6 @@ namespace Azure.Core
                 }
                 else
                 {
-                    // Since we are already allocating a list, cache it
                     values = new List<string> { objValue as string };
                 }
 

--- a/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
+++ b/sdk/core/Azure.Core/src/Shared/DictionaryHeaders.cs
@@ -88,7 +88,9 @@ namespace Azure.Core
                 }
                 else
                 {
+                    // Since we are already allocating a list, cache it
                     values = new List<string> { objValue as string };
+                    _headers[name] = values;
                 }
 
                 return true;

--- a/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
+++ b/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
@@ -27,7 +27,6 @@
     <Compile Include="..\src\Shared\AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\BearerTokenChallengeAuthenticationPolicy.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\ConnectionString.cs" LinkBase="Shared" />
-    <Compile Include="..\src\Shared\DictionaryHeaders.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\ForwardsClientCallsAttribute.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\HttpPipelineMessageHandler.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\NoBodyResponseOfT.cs" LinkBase="Shared" />


### PR DESCRIPTION
NuGet doesn't prefer the ProjectReference over the PackageReference it actually compares versions and we failed to update the version the last time during the release. 