### PR TITLE
[TSI] Additional e2e tests for Types

### DIFF
--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTest.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTest.json
@@ -6,8 +6,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "cca7660cb671219d9f4d9e91ae9f09d3",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "2262d60156078163a5f13b0ee607629e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,12 +16,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a5a61d2f-5383-456b-99af-917f47782798"
+        "x-ms-request-id": "afffa7ea-9e88-4d42-b87f-bcd790511e0e"
       },
       "ResponseBody": {
         "modelSettings": {
@@ -52,8 +52,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "20",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "c8393bbac85eb7f4b723a57ea173eb3e",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "a011e72c767bc8042f043dc4bb0995ff",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -64,12 +64,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:57 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "6bdcef59-2b11-47a4-8aee-b9c0bbc3d12e"
+        "x-ms-request-id": "950930ad-a665-46c0-b557-34f9aef27973"
       },
       "ResponseBody": {
         "modelSettings": {
@@ -94,7 +94,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1188087842",
+    "RandomSeed": "1233880478",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTest.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTest.json
@@ -16,12 +16,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "afffa7ea-9e88-4d42-b87f-bcd790511e0e"
+        "x-ms-request-id": "1bed56ce-01a7-44db-89d7-d3c7eab5ee90"
       },
       "ResponseBody": {
         "modelSettings": {
@@ -64,12 +64,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:57 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "950930ad-a665-46c0-b557-34f9aef27973"
+        "x-ms-request-id": "1167a070-d1f3-41f2-ba0a-fc66519e3ce9"
       },
       "ResponseBody": {
         "modelSettings": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTest.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTest.json
@@ -16,12 +16,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e64a60d2-d419-4f38-ae7a-fc64df6dd7d8"
+        "x-ms-request-id": "02929327-843f-4d07-a427-d7bac5d422df"
       },
       "ResponseBody": {
         "modelSettings": {
@@ -64,12 +64,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "7958a06c-7227-4dcb-ad2b-60f638666cd2"
+        "x-ms-request-id": "c598a539-accf-43f8-a19b-39d51e5fde79"
       },
       "ResponseBody": {
         "modelSettings": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTest.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTest.json
@@ -16,12 +16,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "1bed56ce-01a7-44db-89d7-d3c7eab5ee90"
+        "x-ms-request-id": "e64a60d2-d419-4f38-ae7a-fc64df6dd7d8"
       },
       "ResponseBody": {
         "modelSettings": {
@@ -64,12 +64,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "1167a070-d1f3-41f2-ba0a-fc66519e3ce9"
+        "x-ms-request-id": "7958a06c-7227-4dcb-ad2b-60f638666cd2"
       },
       "ResponseBody": {
         "modelSettings": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTestAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTestAsync.json
@@ -16,12 +16,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "191b4310-8a83-441c-892a-9696d577ba2f"
+        "x-ms-request-id": "6fc4ae41-41b4-4476-b1f4-9a7a752baaa3"
       },
       "ResponseBody": {
         "modelSettings": {
@@ -64,12 +64,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "1ce80044-4df7-4970-9d35-a50e638fa8bc"
+        "x-ms-request-id": "6a60af83-eef0-47db-a829-38c0ed10b849"
       },
       "ResponseBody": {
         "modelSettings": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTestAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTestAsync.json
@@ -16,12 +16,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:57 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "6a718c23-1684-4824-a391-1239619e89bd"
+        "x-ms-request-id": "1402d96e-71ad-42d8-ba81-a93c3d657325"
       },
       "ResponseBody": {
         "modelSettings": {
@@ -64,12 +64,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "7f2f0406-32bd-40ce-a8e1-436623a3a2cd"
+        "x-ms-request-id": "f2939e9d-98e8-4be7-abb2-bebc33a06c63"
       },
       "ResponseBody": {
         "modelSettings": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTestAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTestAsync.json
@@ -16,12 +16,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "1402d96e-71ad-42d8-ba81-a93c3d657325"
+        "x-ms-request-id": "191b4310-8a83-441c-892a-9696d577ba2f"
       },
       "ResponseBody": {
         "modelSettings": {
@@ -64,12 +64,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f2939e9d-98e8-4be7-abb2-bebc33a06c63"
+        "x-ms-request-id": "1ce80044-4df7-4970-9d35-a50e638fa8bc"
       },
       "ResponseBody": {
         "modelSettings": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTestAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/TimeSeriesInsightsClient_ModelSettingsTestAsync.json
@@ -6,8 +6,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "cca7660cb671219d9f4d9e91ae9f09d3",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "678064e05eda1ffaa73dbdd18e58a320",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,12 +16,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:57 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "51a956e2-4e3a-4c22-9fbf-39d7c8ffbda8"
+        "x-ms-request-id": "6a718c23-1684-4824-a391-1239619e89bd"
       },
       "ResponseBody": {
         "modelSettings": {
@@ -52,8 +52,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "20",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "c8393bbac85eb7f4b723a57ea173eb3e",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "5fd47605d5816767366e2536e61eb2f5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -64,12 +64,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "4729302b-7358-4538-93fa-9ce7b875972e"
+        "x-ms-request-id": "7f2f0406-32bd-40ce-a8e1-436623a3a2cd"
       },
       "ResponseBody": {
         "modelSettings": {
@@ -94,7 +94,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1188087842",
+    "RandomSeed": "1169486807",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestException.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestException.json
@@ -20,12 +20,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:32 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "7e1c984c-33f7-4a47-a241-b30281ea800f"
+        "x-ms-request-id": "dd98ed81-de7c-488c-8225-9aed3fc5d3d4"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestException.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestException.json
@@ -8,8 +8,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "26",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "89baa0257ccc4ae701540eec455870c4",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "57dc257e5fba4f23b25647988b1cb17f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -20,12 +20,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "cb1de73e-a519-413d-80fe-91f03be2ae66"
+        "x-ms-request-id": "2239aa30-571d-4091-a55e-eeedd0020fcb"
       },
       "ResponseBody": {
         "error": {
@@ -39,7 +39,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1900157601",
+    "RandomSeed": "996400433",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestException.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestException.json
@@ -20,12 +20,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "2239aa30-571d-4091-a55e-eeedd0020fcb"
+        "x-ms-request-id": "7e1c984c-33f7-4a47-a241-b30281ea800f"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestException.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestException.json
@@ -20,12 +20,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:32 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "dd98ed81-de7c-488c-8225-9aed3fc5d3d4"
+        "x-ms-request-id": "b9f952ec-9c3d-4a16-b2db-d945b919549c"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestExceptionAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestExceptionAsync.json
@@ -8,8 +8,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "26",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "89baa0257ccc4ae701540eec455870c4",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "95f62ac4428362e8baf9f14573a32e55",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -20,12 +20,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:52 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "8a11206b-ee7c-4fb7-b7f1-0731d99a5f92"
+        "x-ms-request-id": "ea6e3fc3-8767-44e7-921a-e9a31744a5a7"
       },
       "ResponseBody": {
         "error": {
@@ -39,7 +39,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1900157601",
+    "RandomSeed": "1202577774",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestExceptionAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestExceptionAsync.json
@@ -20,12 +20,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:32 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "036b6178-7d7b-4b07-b04e-7514d35b58e2"
+        "x-ms-request-id": "70dc09c3-ec4c-438e-b84a-c8c0b2f58da0"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestExceptionAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestExceptionAsync.json
@@ -20,12 +20,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:32 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f929805d-e794-460a-ae4c-cbc33a4bba5a"
+        "x-ms-request-id": "036b6178-7d7b-4b07-b04e-7514d35b58e2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestExceptionAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/ModelSettingsTests/UpdateModelSettingsWithInvalidType_ThrowsBadRequestExceptionAsync.json
@@ -20,12 +20,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "ea6e3fc3-8767-44e7-921a-e9a31744a5a7"
+        "x-ms-request-id": "f929805d-e794-460a-ae4c-cbc33a4bba5a"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3Keys.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3Keys.json
@@ -30,12 +30,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "fdd406d2-e115-4017-a2d2-6f0bb9d6bc4d"
+        "x-ms-request-id": "bd4c6a34-5c5e-4eec-97b2-d74019763db8"
       },
       "ResponseBody": {
         "put": [
@@ -72,12 +72,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:57 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "07809a87-d53c-453e-a939-6db8b047e515"
+        "x-ms-request-id": "25e708ca-2bc6-43fe-9982-27fe9ea200d6"
       },
       "ResponseBody": {
         "get": [
@@ -122,12 +122,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:07 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:11 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a6efa959-78e2-4318-a4d7-297cb38013ff"
+        "x-ms-request-id": "6884e2bb-c55f-4033-98e4-3d356edb23dd"
       },
       "ResponseBody": {
         "get": [
@@ -173,12 +173,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:07 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:11 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "6265dd0c-5d1f-4f55-8d58-81d51313b260"
+        "x-ms-request-id": "676a6db8-3ea2-476c-80b6-dd654fbeb3a8"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3Keys.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3Keys.json
@@ -30,12 +30,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e6c0fb6e-103c-4754-9c84-6d387e7df620"
+        "x-ms-request-id": "80f8ce15-986c-4305-b97e-222108c9e41a"
       },
       "ResponseBody": {
         "put": [
@@ -72,12 +72,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a21c5858-203d-4c5a-a545-e2d81b1b7656"
+        "x-ms-request-id": "dba21f80-cb13-4ffb-9d3f-30d2c24442f7"
       },
       "ResponseBody": {
         "get": [
@@ -123,12 +123,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "2dc19913-99e5-4f32-bfea-9ab4167de1a9"
+        "x-ms-request-id": "f9639aed-0071-47ac-a97d-142d60d68b60"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3KeysAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3KeysAsync.json
@@ -30,12 +30,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a5fe2939-48c5-4f0d-abe4-05e9dff0fcc6"
+        "x-ms-request-id": "5e7c6fbf-c0f4-4efe-beab-514f5593e9a8"
       },
       "ResponseBody": {
         "put": [
@@ -72,12 +72,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e051d62a-b239-405e-bdeb-e984f534af1e"
+        "x-ms-request-id": "f6d567e4-0bc5-4776-b982-4aeb312ed052"
       },
       "ResponseBody": {
         "get": [
@@ -123,12 +123,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "28cfc221-d970-4d71-97cf-d5f94c9cdfff"
+        "x-ms-request-id": "ac59255b-5ee6-45a8-a369-5bac8a17bab7"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3KeysAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3KeysAsync.json
@@ -30,12 +30,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "424990f8-f14b-412e-97b7-6ac9e07c7ab3"
+        "x-ms-request-id": "cfb05fcd-5627-4557-b145-5f4ad243520c"
       },
       "ResponseBody": {
         "put": [
@@ -72,62 +72,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "61e2ac11-ffd6-4973-a6d1-bf2d2c0fdb4e"
-      },
-      "ResponseBody": {
-        "get": [
-          {
-            "error": {
-              "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022bEUMP\u0022,null,\u0022fAZXF\u0022]\u0027 is not found.",
-              "innerError": {
-                "code": "InstanceNotFound"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "50",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "5b79c683fb7f15a0032e90823c83e201",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "bEUMP",
-              null,
-              "fAZXF"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:08 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e8519c26-f3d6-42f6-b537-b2d3bb66d618"
+        "x-ms-request-id": "806ebb5d-6159-4124-b3d8-06cbba0363d7"
       },
       "ResponseBody": {
         "get": [
@@ -153,7 +103,7 @@
         "Content-Length": "53",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "3d51db0bf1048426f2a5d60650038254",
+        "x-ms-client-request-id": "5b79c683fb7f15a0032e90823c83e201",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -173,12 +123,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:08 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "c9569163-5d0b-429e-b3ac-dd16e62e7466"
+        "x-ms-request-id": "1e2cb3a9-d5c6-406b-8b1b-aea34a4208d6"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3KeysAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3KeysAsync.json
@@ -30,12 +30,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "cfb05fcd-5627-4557-b145-5f4ad243520c"
+        "x-ms-request-id": "a5fe2939-48c5-4f0d-abe4-05e9dff0fcc6"
       },
       "ResponseBody": {
         "put": [
@@ -72,12 +72,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "806ebb5d-6159-4124-b3d8-06cbba0363d7"
+        "x-ms-request-id": "e051d62a-b239-405e-bdeb-e984f534af1e"
       },
       "ResponseBody": {
         "get": [
@@ -123,12 +123,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "1e2cb3a9-d5c6-406b-8b1b-aea34a4208d6"
+        "x-ms-request-id": "28cfc221-d970-4d71-97cf-d5f94c9cdfff"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3KeysAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesIdTests/TimeSeriesId_CreateInstanceWith3KeysAsync.json
@@ -8,8 +8,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "97",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "c8393bbac85eb7f4b723a57ea173eb3e",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "64ce60acd0c87d1bbd6c09402ade870e",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -17,9 +17,9 @@
         "put": [
           {
             "timeSeriesId": [
-              "197Vc",
+              "bEUMP",
               null,
-              "kGW1m"
+              "fAZXF"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
           }
@@ -30,12 +30,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "8ad8551f-b5d2-4f3a-be25-468949919e7e"
+        "x-ms-request-id": "424990f8-f14b-412e-97b7-6ac9e07c7ab3"
       },
       "ResponseBody": {
         "put": [
@@ -51,8 +51,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "50",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "5436bbb17e5e32973b5af8d65d121cfc",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "9c72e04328e8286e8dc18018fa681afc",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -60,9 +60,9 @@
         "get": {
           "timeSeriesIds": [
             [
-              "197Vc",
+              "bEUMP",
               null,
-              "kGW1m"
+              "fAZXF"
             ]
           ]
         }
@@ -72,12 +72,62 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "d3db0813-3a5d-4319-8d99-80018055e1bb"
+        "x-ms-request-id": "61e2ac11-ffd6-4973-a6d1-bf2d2c0fdb4e"
+      },
+      "ResponseBody": {
+        "get": [
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series instance with time series ID \u0027[\u0022bEUMP\u0022,null,\u0022fAZXF\u0022]\u0027 is not found.",
+              "innerError": {
+                "code": "InstanceNotFound"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "50",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "5b79c683fb7f15a0032e90823c83e201",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "get": {
+          "timeSeriesIds": [
+            [
+              "bEUMP",
+              null,
+              "fAZXF"
+            ]
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 19:00:08 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "e8519c26-f3d6-42f6-b537-b2d3bb66d618"
       },
       "ResponseBody": {
         "get": [
@@ -85,9 +135,9 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "197Vc",
+                "bEUMP",
                 null,
-                "kGW1m"
+                "fAZXF"
               ]
             }
           }
@@ -102,8 +152,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "53",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "d857e5efc256441672f0154e111f802c",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "3d51db0bf1048426f2a5d60650038254",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -111,9 +161,9 @@
         "delete": {
           "timeSeriesIds": [
             [
-              "197Vc",
+              "bEUMP",
               null,
-              "kGW1m"
+              "fAZXF"
             ]
           ]
         }
@@ -123,12 +173,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 19:00:08 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "ad63418b-e1bc-44dc-8268-ad4c6c11fa47"
+        "x-ms-request-id": "c9569163-5d0b-429e-b3ac-dd16e62e7466"
       },
       "ResponseBody": {
         "delete": [
@@ -138,7 +188,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1188087842",
+    "RandomSeed": "587153701",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_Lifecycle.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_Lifecycle.json
@@ -29,12 +29,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "d1d22b77-3dbf-48d4-8d35-02032d4b5041"
+        "x-ms-request-id": "66f3cf4c-a428-43fc-bcc5-b834f8ebdd73"
       },
       "ResponseBody": {
         "get": [
@@ -79,12 +79,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "75ced40c-42cc-4170-a4f5-ded7e0434312"
+        "x-ms-request-id": "4ecfe259-624d-4d50-aa6b-e6915355f8eb"
       },
       "ResponseBody": {
         "get": [
@@ -138,12 +138,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "70b0ceec-ea4f-40de-aac0-7fcf07eca860"
+        "x-ms-request-id": "b16bcf40-069c-4e1e-985c-82833776578f"
       },
       "ResponseBody": {
         "put": [
@@ -186,12 +186,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "0bfcaa56-b673-4505-9b59-976da336616b"
+        "x-ms-request-id": "5e170dd0-f8c5-42f9-825a-2397b7bebba3"
       },
       "ResponseBody": {
         "get": [
@@ -258,12 +258,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "636ca5b1-f7d8-40f8-be9b-f24d72500b5e"
+        "x-ms-request-id": "fd99f820-47d2-4f61-99c3-a4cde84e8faa"
       },
       "ResponseBody": {
         "update": [
@@ -298,12 +298,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e81b400a-ff06-44d7-a496-6a5922c38953"
+        "x-ms-request-id": "1041012d-aa1e-490e-98e4-9600c7c6ed8c"
       },
       "ResponseBody": {
         "get": [
@@ -349,12 +349,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "cc3017d0-b0d1-47fb-8c71-859df7121647"
+        "x-ms-request-id": "99cfe50d-d03c-4338-b32d-d403e09d1979"
       },
       "ResponseBody": {
         "instances": [
@@ -554,15 +554,6 @@
               "3RVQDYYd",
               "qXZqkRzA",
               "gepQ7d1i"
-            ],
-            "name": "instance0jX7Shog"
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "bEUMP",
-              null,
-              "fAZXF"
             ]
           },
           {
@@ -587,8 +578,7 @@
               "jcPrllTM",
               "13u6R1ta",
               "axmDkaDx"
-            ],
-            "name": "instanceS6a2xvIl"
+            ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
@@ -630,12 +620,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a1a93fae-91bb-4a5f-93c6-61ec6098223f"
+        "x-ms-request-id": "c7dd7c7c-71ae-48cb-a0ec-24e3ee7aae38"
       },
       "ResponseBody": {
         "instances": []
@@ -662,12 +652,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "09a7fb27-d4f8-4397-8a1c-7eb1c2a830f7"
+        "x-ms-request-id": "8333137d-2244-4113-83a1-d29293a657b8"
       },
       "ResponseBody": {
         "suggestions": [
@@ -712,12 +702,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "22092d73-638e-4263-a051-86ce5c0964e8"
+        "x-ms-request-id": "82c1d098-0407-4320-8954-20d64f598d2a"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_Lifecycle.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_Lifecycle.json
@@ -29,12 +29,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "069500c7-f49b-486f-b49e-d50f802496cf"
+        "x-ms-request-id": "008a53d6-cf5f-469c-8081-a4db455d9c1f"
       },
       "ResponseBody": {
         "get": [
@@ -79,12 +79,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "85c46448-d767-4a7f-ab73-ce24a72b4687"
+        "x-ms-request-id": "d3d9a93e-9379-4b7a-a85d-a5e824385636"
       },
       "ResponseBody": {
         "get": [
@@ -138,12 +138,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "682a808a-8e2c-42f5-ae9d-e49204d83ef3"
+        "x-ms-request-id": "b7329c49-0a93-4872-9dbb-9a5832f9e98e"
       },
       "ResponseBody": {
         "put": [
@@ -186,12 +186,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "9e46e18c-fb93-43f7-b685-17f7063e93c7"
+        "x-ms-request-id": "d2376d10-55d6-4649-85aa-06ba6e892f3a"
       },
       "ResponseBody": {
         "get": [
@@ -258,12 +258,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "7079206a-ea10-49ac-838a-44eab75fb385"
+        "x-ms-request-id": "4a68255a-9003-4bed-a4ad-ce860d57cdc7"
       },
       "ResponseBody": {
         "update": [
@@ -298,12 +298,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "0953a532-a140-4709-af5b-f614634eeea3"
+        "x-ms-request-id": "8cf7c233-6212-469b-ba67-d8c9ceb4954f"
       },
       "ResponseBody": {
         "get": [
@@ -349,12 +349,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e508cc5b-e10b-4790-b943-8b2a2466acf5"
+        "x-ms-request-id": "7edc73b3-4c40-4e52-806b-9775adb9e3fb"
       },
       "ResponseBody": {
         "instances": [
@@ -551,9 +551,25 @@
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
+              "3RVQDYYd",
+              "qXZqkRzA",
+              "gepQ7d1i"
+            ]
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
               "gOjeQNrW",
               "N1AmVbS5",
               "T3UOUYw1"
+            ]
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "jcPrllTM",
+              "13u6R1ta",
+              "axmDkaDx"
             ]
           },
           {
@@ -596,12 +612,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "6d31071e-3fa7-48e3-af00-3a05fd2240fb"
+        "x-ms-request-id": "96bd385a-ea95-4274-8223-ca42320a4d75"
       },
       "ResponseBody": {
         "instances": []
@@ -628,12 +644,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "1ec1dbb5-08ec-4fd5-85e8-b18a295300c8"
+        "x-ms-request-id": "d8880bcd-5f81-4bb3-be67-4737e4059256"
       },
       "ResponseBody": {
         "suggestions": [
@@ -678,12 +694,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "bf1ccc9c-ed12-4fb7-a8c8-3202b17e17e0"
+        "x-ms-request-id": "cd131208-82da-47da-a31b-e036a47d2e5e"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_Lifecycle.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_Lifecycle.json
@@ -8,8 +8,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "62",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "7ea523b773a13eebb1bb36545e7e9732",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7991110d0184a11f1fddfd2603093029",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -17,9 +17,9 @@
         "get": {
           "timeSeriesIds": [
             [
-              "197Vczz6",
-              "kGW1mmY9",
-              "XgjczZC4"
+              "YMx4QOn9",
+              "faKHzWsO",
+              "Rg7RCsP1"
             ]
           ]
         }
@@ -29,123 +29,19 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:50 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "61b6c6af-1a10-4769-b3d6-b48f2a5a3ddc"
-      },
-      "ResponseBody": {
-        "get": [
-          {
-            "instance": {
-              "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-              "timeSeriesId": [
-                "197Vczz6",
-                "kGW1mmY9",
-                "XgjczZC4"
-              ],
-              "name": "instance354sVNgp"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "62",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "f2e06061b4683c75a4078c04cf1d5aa5",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "xYlruOUo",
-              "UEZqatbc",
-              "7CBBbaDV"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "6d5b8f94-5ce8-4fcf-a3fc-8b6a2d0cac98"
-      },
-      "ResponseBody": {
-        "get": [
-          {
-            "instance": {
-              "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-              "timeSeriesId": [
-                "xYlruOUo",
-                "UEZqatbc",
-                "7CBBbaDV"
-              ],
-              "name": "instanceL9IFgxu6"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "62",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "4f341b6f11365574956f466890c3104e",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "af9a1d52-7bcc-4058-b108-4bf374426d7a"
+        "x-ms-request-id": "d1d22b77-3dbf-48d4-8d35-02032d4b5041"
       },
       "ResponseBody": {
         "get": [
           {
             "error": {
               "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022GtEzy22E\u0022,\u0022ggcjSR0X\u0022,\u0022VPJrLpCW\u0022]\u0027 is not found.",
+              "message": "Time series instance with time series ID \u0027[\u0022YMx4QOn9\u0022,\u0022faKHzWsO\u0022,\u0022Rg7RCsP1\u0022]\u0027 is not found.",
               "innerError": {
                 "code": "InstanceNotFound"
               }
@@ -162,8 +58,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "62",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "f9d88b7db802178cbb268541dc1d6668",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "707e7172b0b8fb38de915e56b511a00a",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -171,9 +67,9 @@
         "get": {
           "timeSeriesIds": [
             [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
+              "SFIN2CZR",
+              "t1xpifTp",
+              "76oYQ1aw"
             ]
           ]
         }
@@ -183,19 +79,19 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "67f8181d-fb18-4d5a-82dc-64c7b69c0526"
+        "x-ms-request-id": "75ced40c-42cc-4170-a4f5-ded7e0434312"
       },
       "ResponseBody": {
         "get": [
           {
             "error": {
               "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022L9IFgxu6\u0022,\u0022bRGhLc4a\u0022,\u0022qsIbZt9g\u0022]\u0027 is not found.",
+              "message": "Time series instance with time series ID \u0027[\u0022SFIN2CZR\u0022,\u0022t1xpifTp\u0022,\u002276oYQ1aw\u0022]\u0027 is not found.",
               "innerError": {
                 "code": "InstanceNotFound"
               }
@@ -212,8 +108,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "209",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "c568d94871e739adfd69543b761070df",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "67dce2ba0ab5857dc2d9d7e45045f21d",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -221,17 +117,17 @@
         "put": [
           {
             "timeSeriesId": [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
+              "YMx4QOn9",
+              "faKHzWsO",
+              "Rg7RCsP1"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
           },
           {
             "timeSeriesId": [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
+              "SFIN2CZR",
+              "t1xpifTp",
+              "76oYQ1aw"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
           }
@@ -242,12 +138,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "1eea9b22-5c3d-4af9-b89f-2772bac5fa51"
+        "x-ms-request-id": "70b0ceec-ea4f-40de-aac0-7fcf07eca860"
       },
       "ResponseBody": {
         "put": [
@@ -264,8 +160,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "97",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "47f8b938d92e2e58e4124781d63100f6",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "f3cbb52ce684edf6e45036923ac36f3d",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -273,14 +169,14 @@
         "get": {
           "timeSeriesIds": [
             [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
+              "YMx4QOn9",
+              "faKHzWsO",
+              "Rg7RCsP1"
             ],
             [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
+              "SFIN2CZR",
+              "t1xpifTp",
+              "76oYQ1aw"
             ]
           ]
         }
@@ -290,12 +186,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a407168e-8822-4d22-a2b3-bb35f38d3205"
+        "x-ms-request-id": "0bfcaa56-b673-4505-9b59-976da336616b"
       },
       "ResponseBody": {
         "get": [
@@ -303,9 +199,9 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "GtEzy22E",
-                "ggcjSR0X",
-                "VPJrLpCW"
+                "YMx4QOn9",
+                "faKHzWsO",
+                "Rg7RCsP1"
               ]
             }
           },
@@ -313,9 +209,9 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "L9IFgxu6",
-                "bRGhLc4a",
-                "qsIbZt9g"
+                "SFIN2CZR",
+                "t1xpifTp",
+                "76oYQ1aw"
               ]
             }
           }
@@ -330,8 +226,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "264",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "2209a6b61f256f3a803ae1d4292b62cb",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "002a419fad45d385ecee8365d3eb4bff",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -339,21 +235,21 @@
         "update": [
           {
             "timeSeriesId": [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
+              "YMx4QOn9",
+              "faKHzWsO",
+              "Rg7RCsP1"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instance3Oy3CMmu"
+            "name": "instance7a5kzs1R"
           },
           {
             "timeSeriesId": [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
+              "SFIN2CZR",
+              "t1xpifTp",
+              "76oYQ1aw"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instanceYQV2HYBn"
+            "name": "instancegv0o35iq"
           }
         ]
       },
@@ -362,12 +258,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "efc0c737-68a7-4028-82fb-8581948522b7"
+        "x-ms-request-id": "636ca5b1-f7d8-40f8-be9b-f24d72500b5e"
       },
       "ResponseBody": {
         "update": [
@@ -384,16 +280,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "57",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "914d5d686b5844af0deb698eddbfca93",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "a26699699d14bc0e3563008b38161490",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
           "names": [
-            "instance3Oy3CMmu",
-            "instanceYQV2HYBn"
+            "instance7a5kzs1R",
+            "instancegv0o35iq"
           ]
         }
       },
@@ -402,12 +298,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "eca91c6d-1fa3-413f-8910-cb0acf50f6cd"
+        "x-ms-request-id": "e81b400a-ff06-44d7-a496-6a5922c38953"
       },
       "ResponseBody": {
         "get": [
@@ -415,22 +311,22 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "GtEzy22E",
-                "ggcjSR0X",
-                "VPJrLpCW"
+                "YMx4QOn9",
+                "faKHzWsO",
+                "Rg7RCsP1"
               ],
-              "name": "instance3Oy3CMmu"
+              "name": "instance7a5kzs1R"
             }
           },
           {
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "L9IFgxu6",
-                "bRGhLc4a",
-                "qsIbZt9g"
+                "SFIN2CZR",
+                "t1xpifTp",
+                "76oYQ1aw"
               ],
-              "name": "instanceYQV2HYBn"
+              "name": "instancegv0o35iq"
             }
           }
         ]
@@ -442,8 +338,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "30cb9c71dd28ced1a94883f511d6e3b2",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "f8f39da66e99d0f8285d6820ec1a9408",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -453,12 +349,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "bfbfcd65-7b1f-46c0-9252-f24a2c0f4d05"
+        "x-ms-request-id": "cc3017d0-b0d1-47fb-8c71-859df7121647"
       },
       "ResponseBody": {
         "instances": [
@@ -655,38 +551,62 @@
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "197Vczz6",
-              "kGW1mmY9",
-              "XgjczZC4"
+              "3RVQDYYd",
+              "qXZqkRzA",
+              "gepQ7d1i"
             ],
-            "name": "instance354sVNgp"
+            "name": "instance0jX7Shog"
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
-            ],
-            "name": "instance3Oy3CMmu"
+              "bEUMP",
+              null,
+              "fAZXF"
+            ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
-            ],
-            "name": "instanceYQV2HYBn"
+              "gOjeQNrW",
+              "N1AmVbS5",
+              "T3UOUYw1"
+            ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "xYlruOUo",
-              "UEZqatbc",
-              "7CBBbaDV"
+              "iojyD",
+              null,
+              "aam4n"
+            ]
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "jcPrllTM",
+              "13u6R1ta",
+              "axmDkaDx"
             ],
-            "name": "instanceL9IFgxu6"
+            "name": "instanceS6a2xvIl"
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "SFIN2CZR",
+              "t1xpifTp",
+              "76oYQ1aw"
+            ],
+            "name": "instancegv0o35iq"
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "YMx4QOn9",
+              "faKHzWsO",
+              "Rg7RCsP1"
+            ],
+            "name": "instance7a5kzs1R"
           }
         ],
         "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiZTYyMTY4NGEtZmMwNi00M2RiLTg1YTQtMjkxNjBjMjZmMmQ1In0="
@@ -698,8 +618,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "0630313c0f024a53f6c4143ab5ab92c1",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "3f75aead08ed0185326dcae1acfa9ad5",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-continuation": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiZTYyMTY4NGEtZmMwNi00M2RiLTg1YTQtMjkxNjBjMjZmMmQ1In0=",
         "x-ms-return-client-request-id": "true"
@@ -710,12 +630,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "0477cd15-98ad-4dbf-95bb-f55405df0b00"
+        "x-ms-request-id": "a1a93fae-91bb-4a5f-93c6-61ec6098223f"
       },
       "ResponseBody": {
         "instances": []
@@ -729,31 +649,31 @@
         "Authorization": "Sanitized",
         "Content-Length": "22",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "8d624d7031608aa28c7ee80fe7b93337",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "36bff3da52f8fb66a09579b735eed01a",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "searchString": "GtE"
+        "searchString": "YMx"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f395eb88-a121-4219-bcab-6a6a9289c316"
+        "x-ms-request-id": "09a7fb27-d4f8-4397-8a1c-7eb1c2a830f7"
       },
       "ResponseBody": {
         "suggestions": [
           {
-            "searchString": "GtEzy22E",
-            "highlightedSearchString": "\u003Chit\u003EGtE\u003C/hit\u003Ezy22E"
+            "searchString": "YMx4QOn9",
+            "highlightedSearchString": "\u003Chit\u003EYMx\u003C/hit\u003E4QOn9"
           }
         ]
       }
@@ -766,8 +686,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "100",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "ab52b608c38f629148803a64c99618fd",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "8adef8ced5a19da317f1c62ba416232e",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -775,14 +695,14 @@
         "delete": {
           "timeSeriesIds": [
             [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
+              "YMx4QOn9",
+              "faKHzWsO",
+              "Rg7RCsP1"
             ],
             [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
+              "SFIN2CZR",
+              "t1xpifTp",
+              "76oYQ1aw"
             ]
           ]
         }
@@ -792,12 +712,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:52 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "0f411f45-5cdf-4a54-9864-8e36f8a79f57"
+        "x-ms-request-id": "22092d73-638e-4263-a051-86ce5c0964e8"
       },
       "ResponseBody": {
         "delete": [
@@ -808,7 +728,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1188087842",
+    "RandomSeed": "893115967",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_Lifecycle.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_Lifecycle.json
@@ -29,12 +29,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "66f3cf4c-a428-43fc-bcc5-b834f8ebdd73"
+        "x-ms-request-id": "069500c7-f49b-486f-b49e-d50f802496cf"
       },
       "ResponseBody": {
         "get": [
@@ -79,12 +79,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "4ecfe259-624d-4d50-aa6b-e6915355f8eb"
+        "x-ms-request-id": "85c46448-d767-4a7f-ab73-ce24a72b4687"
       },
       "ResponseBody": {
         "get": [
@@ -138,12 +138,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "b16bcf40-069c-4e1e-985c-82833776578f"
+        "x-ms-request-id": "682a808a-8e2c-42f5-ae9d-e49204d83ef3"
       },
       "ResponseBody": {
         "put": [
@@ -186,12 +186,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "5e170dd0-f8c5-42f9-825a-2397b7bebba3"
+        "x-ms-request-id": "9e46e18c-fb93-43f7-b685-17f7063e93c7"
       },
       "ResponseBody": {
         "get": [
@@ -258,12 +258,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "fd99f820-47d2-4f61-99c3-a4cde84e8faa"
+        "x-ms-request-id": "7079206a-ea10-49ac-838a-44eab75fb385"
       },
       "ResponseBody": {
         "update": [
@@ -298,12 +298,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "1041012d-aa1e-490e-98e4-9600c7c6ed8c"
+        "x-ms-request-id": "0953a532-a140-4709-af5b-f614634eeea3"
       },
       "ResponseBody": {
         "get": [
@@ -349,12 +349,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "99cfe50d-d03c-4338-b32d-d403e09d1979"
+        "x-ms-request-id": "e508cc5b-e10b-4790-b943-8b2a2466acf5"
       },
       "ResponseBody": {
         "instances": [
@@ -551,33 +551,9 @@
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "3RVQDYYd",
-              "qXZqkRzA",
-              "gepQ7d1i"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
               "gOjeQNrW",
               "N1AmVbS5",
               "T3UOUYw1"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "jcPrllTM",
-              "13u6R1ta",
-              "axmDkaDx"
             ]
           },
           {
@@ -620,12 +596,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "c7dd7c7c-71ae-48cb-a0ec-24e3ee7aae38"
+        "x-ms-request-id": "6d31071e-3fa7-48e3-af00-3a05fd2240fb"
       },
       "ResponseBody": {
         "instances": []
@@ -652,12 +628,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "8333137d-2244-4113-83a1-d29293a657b8"
+        "x-ms-request-id": "1ec1dbb5-08ec-4fd5-85e8-b18a295300c8"
       },
       "ResponseBody": {
         "suggestions": [
@@ -702,12 +678,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "82c1d098-0407-4320-8954-20d64f598d2a"
+        "x-ms-request-id": "bf1ccc9c-ed12-4fb7-a8c8-3202b17e17e0"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_LifecycleAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_LifecycleAsync.json
@@ -29,12 +29,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "d114a535-22f1-421d-8ed6-9b5903322c2f"
+        "x-ms-request-id": "519108f6-e554-4198-8506-798ca7d8a9f0"
       },
       "ResponseBody": {
         "get": [
@@ -79,12 +79,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "55720023-64f3-4ce9-95d1-07c9a80dbc10"
+        "x-ms-request-id": "495f6a1d-da5f-4e10-a8c5-e9b7846f5060"
       },
       "ResponseBody": {
         "get": [
@@ -138,12 +138,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "c42a228d-9c3b-42aa-a248-8bd49c6defa1"
+        "x-ms-request-id": "b677f53d-83b0-4098-9ab1-cfe0b224c7d8"
       },
       "ResponseBody": {
         "put": [
@@ -186,76 +186,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "58a54027-8aa5-4f5a-ae30-31af1ff1528e"
-      },
-      "ResponseBody": {
-        "get": [
-          {
-            "error": {
-              "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u00223RVQDYYd\u0022,\u0022qXZqkRzA\u0022,\u0022gepQ7d1i\u0022]\u0027 is not found.",
-              "innerError": {
-                "code": "InstanceNotFound"
-              }
-            }
-          },
-          {
-            "error": {
-              "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022jcPrllTM\u0022,\u002213u6R1ta\u0022,\u0022axmDkaDx\u0022]\u0027 is not found.",
-              "innerError": {
-                "code": "InstanceNotFound"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "97",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "bf1a0ac10d00660baaab998766c39904",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "3RVQDYYd",
-              "qXZqkRzA",
-              "gepQ7d1i"
-            ],
-            [
-              "jcPrllTM",
-              "13u6R1ta",
-              "axmDkaDx"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f25d5ec9-6fc9-41c3-9742-2218889adce5"
+        "x-ms-request-id": "920e21c5-1cd8-47f3-aa54-13da9a7b0271"
       },
       "ResponseBody": {
         "get": [
@@ -291,7 +227,7 @@
         "Content-Length": "264",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "fa5db5be1027766a2e1207f5c232abab",
+        "x-ms-client-request-id": "ffa6c7dd72174f3890cdd7a5d3f5277d",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -304,7 +240,7 @@
               "gepQ7d1i"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instanceYiGv6jUf"
+            "name": "instance0jX7Shog"
           },
           {
             "timeSeriesId": [
@@ -313,7 +249,7 @@
               "axmDkaDx"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instancewWl3hXwd"
+            "name": "instanceS6a2xvIl"
           }
         ]
       },
@@ -322,12 +258,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "82f813c5-674d-4dd7-957d-205b7dbf0e24"
+        "x-ms-request-id": "23a3be0c-0d6c-4368-8481-5b3214033524"
       },
       "ResponseBody": {
         "update": [
@@ -345,15 +281,15 @@
         "Content-Length": "57",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "e4f5cb9c3b8a4fc8d2ca2f32356592b4",
+        "x-ms-client-request-id": "fa5db5be1027766a2e1207f5c232abab",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
           "names": [
-            "instanceYiGv6jUf",
-            "instancewWl3hXwd"
+            "instance0jX7Shog",
+            "instanceS6a2xvIl"
           ]
         }
       },
@@ -362,12 +298,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "6cf5f74f-ee25-4324-bf32-60a65c4ae29e"
+        "x-ms-request-id": "5b495b5d-7970-446e-a5a1-a2516c9218c9"
       },
       "ResponseBody": {
         "get": [
@@ -379,7 +315,7 @@
                 "qXZqkRzA",
                 "gepQ7d1i"
               ],
-              "name": "instanceYiGv6jUf"
+              "name": "instance0jX7Shog"
             }
           },
           {
@@ -390,7 +326,7 @@
                 "13u6R1ta",
                 "axmDkaDx"
               ],
-              "name": "instancewWl3hXwd"
+              "name": "instanceS6a2xvIl"
             }
           }
         ]
@@ -403,7 +339,7 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "b1c91b849e66cddd5c2fd0056b428c5d",
+        "x-ms-client-request-id": "e4f5cb9c3b8a4fc8d2ca2f32356592b4",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -413,12 +349,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e71933ed-a128-45f7-961b-b4225a35a586"
+        "x-ms-request-id": "d43b32ca-9551-4da9-8f3e-a4cb2ef18f12"
       },
       "ResponseBody": {
         "instances": [
@@ -619,7 +555,7 @@
               "qXZqkRzA",
               "gepQ7d1i"
             ],
-            "name": "instanceYiGv6jUf"
+            "name": "instance0jX7Shog"
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
@@ -636,7 +572,25 @@
               "13u6R1ta",
               "axmDkaDx"
             ],
-            "name": "instancewWl3hXwd"
+            "name": "instanceS6a2xvIl"
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "SFIN2CZR",
+              "t1xpifTp",
+              "76oYQ1aw"
+            ],
+            "name": "instancegv0o35iq"
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "YMx4QOn9",
+              "faKHzWsO",
+              "Rg7RCsP1"
+            ],
+            "name": "instance7a5kzs1R"
           }
         ],
         "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiZTYyMTY4NGEtZmMwNi00M2RiLTg1YTQtMjkxNjBjMjZmMmQ1In0="
@@ -649,7 +603,7 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "07092c21430082f3ec0e285ce13740c9",
+        "x-ms-client-request-id": "b1c91b849e66cddd5c2fd0056b428c5d",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-continuation": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiZTYyMTY4NGEtZmMwNi00M2RiLTg1YTQtMjkxNjBjMjZmMmQ1In0=",
         "x-ms-return-client-request-id": "true"
@@ -660,12 +614,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "dfac61e0-5eeb-499a-a54f-21b4e64f7291"
+        "x-ms-request-id": "27a72dbc-10e5-4ba2-a7bf-5fa6ac65242e"
       },
       "ResponseBody": {
         "instances": []
@@ -680,7 +634,7 @@
         "Content-Length": "22",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "a671527ffa69fd44ee28875a6ac3e38f",
+        "x-ms-client-request-id": "07092c21430082f3ec0e285ce13740c9",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -692,12 +646,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "b1739ca1-8e3d-4fc5-b8f2-ee7758af0833"
+        "x-ms-request-id": "b14bc9f5-ca06-4310-be77-2f7ac9b517d9"
       },
       "ResponseBody": {
         "suggestions": [
@@ -717,7 +671,7 @@
         "Content-Length": "100",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "0911d13e8b5b40b42846c5587580eb24",
+        "x-ms-client-request-id": "a671527ffa69fd44ee28875a6ac3e38f",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -742,12 +696,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "473249ec-4165-4d79-9b08-66cbf8892076"
+        "x-ms-request-id": "b4afa6fb-a131-40bf-9f2a-4e915e0b6c1f"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_LifecycleAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_LifecycleAsync.json
@@ -29,12 +29,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "62700567-85ee-41e0-8701-8069f0a2f3ce"
+        "x-ms-request-id": "d114a535-22f1-421d-8ed6-9b5903322c2f"
       },
       "ResponseBody": {
         "get": [
@@ -79,12 +79,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "b4cda475-58fd-4b76-abcd-8d4800bd0424"
+        "x-ms-request-id": "55720023-64f3-4ce9-95d1-07c9a80dbc10"
       },
       "ResponseBody": {
         "get": [
@@ -138,12 +138,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "cd670e6a-081f-49cf-b3e2-b24af9b3148f"
+        "x-ms-request-id": "c42a228d-9c3b-42aa-a248-8bd49c6defa1"
       },
       "ResponseBody": {
         "put": [
@@ -186,12 +186,76 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "95cf9785-108f-46cf-9400-1599067a756c"
+        "x-ms-request-id": "58a54027-8aa5-4f5a-ae30-31af1ff1528e"
+      },
+      "ResponseBody": {
+        "get": [
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series instance with time series ID \u0027[\u00223RVQDYYd\u0022,\u0022qXZqkRzA\u0022,\u0022gepQ7d1i\u0022]\u0027 is not found.",
+              "innerError": {
+                "code": "InstanceNotFound"
+              }
+            }
+          },
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series instance with time series ID \u0027[\u0022jcPrllTM\u0022,\u002213u6R1ta\u0022,\u0022axmDkaDx\u0022]\u0027 is not found.",
+              "innerError": {
+                "code": "InstanceNotFound"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "97",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "bf1a0ac10d00660baaab998766c39904",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "get": {
+          "timeSeriesIds": [
+            [
+              "3RVQDYYd",
+              "qXZqkRzA",
+              "gepQ7d1i"
+            ],
+            [
+              "jcPrllTM",
+              "13u6R1ta",
+              "axmDkaDx"
+            ]
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "f25d5ec9-6fc9-41c3-9742-2218889adce5"
       },
       "ResponseBody": {
         "get": [
@@ -227,7 +291,7 @@
         "Content-Length": "264",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "ffa6c7dd72174f3890cdd7a5d3f5277d",
+        "x-ms-client-request-id": "fa5db5be1027766a2e1207f5c232abab",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -240,7 +304,7 @@
               "gepQ7d1i"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instance0jX7Shog"
+            "name": "instanceYiGv6jUf"
           },
           {
             "timeSeriesId": [
@@ -249,7 +313,7 @@
               "axmDkaDx"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instanceS6a2xvIl"
+            "name": "instancewWl3hXwd"
           }
         ]
       },
@@ -258,12 +322,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "9f9ed210-295a-4a77-a791-1639009278c4"
+        "x-ms-request-id": "82f813c5-674d-4dd7-957d-205b7dbf0e24"
       },
       "ResponseBody": {
         "update": [
@@ -281,15 +345,15 @@
         "Content-Length": "57",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "fa5db5be1027766a2e1207f5c232abab",
+        "x-ms-client-request-id": "e4f5cb9c3b8a4fc8d2ca2f32356592b4",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
           "names": [
-            "instance0jX7Shog",
-            "instanceS6a2xvIl"
+            "instanceYiGv6jUf",
+            "instancewWl3hXwd"
           ]
         }
       },
@@ -298,12 +362,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "7dca2274-a09b-4ad4-aaf8-43178bc0cc20"
+        "x-ms-request-id": "6cf5f74f-ee25-4324-bf32-60a65c4ae29e"
       },
       "ResponseBody": {
         "get": [
@@ -315,7 +379,7 @@
                 "qXZqkRzA",
                 "gepQ7d1i"
               ],
-              "name": "instance0jX7Shog"
+              "name": "instanceYiGv6jUf"
             }
           },
           {
@@ -326,7 +390,7 @@
                 "13u6R1ta",
                 "axmDkaDx"
               ],
-              "name": "instanceS6a2xvIl"
+              "name": "instancewWl3hXwd"
             }
           }
         ]
@@ -339,7 +403,7 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "e4f5cb9c3b8a4fc8d2ca2f32356592b4",
+        "x-ms-client-request-id": "b1c91b849e66cddd5c2fd0056b428c5d",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -349,12 +413,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "684a6f10-e1ea-4176-a08f-9bc8682c2665"
+        "x-ms-request-id": "e71933ed-a128-45f7-961b-b4225a35a586"
       },
       "ResponseBody": {
         "instances": [
@@ -555,7 +619,7 @@
               "qXZqkRzA",
               "gepQ7d1i"
             ],
-            "name": "instance0jX7Shog"
+            "name": "instanceYiGv6jUf"
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
@@ -568,37 +632,11 @@
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
               "jcPrllTM",
               "13u6R1ta",
               "axmDkaDx"
             ],
-            "name": "instanceS6a2xvIl"
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "SFIN2CZR",
-              "t1xpifTp",
-              "76oYQ1aw"
-            ],
-            "name": "instancegv0o35iq"
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
-              "YMx4QOn9",
-              "faKHzWsO",
-              "Rg7RCsP1"
-            ],
-            "name": "instance7a5kzs1R"
+            "name": "instancewWl3hXwd"
           }
         ],
         "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiZTYyMTY4NGEtZmMwNi00M2RiLTg1YTQtMjkxNjBjMjZmMmQ1In0="
@@ -611,7 +649,7 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "b1c91b849e66cddd5c2fd0056b428c5d",
+        "x-ms-client-request-id": "07092c21430082f3ec0e285ce13740c9",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-continuation": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiZTYyMTY4NGEtZmMwNi00M2RiLTg1YTQtMjkxNjBjMjZmMmQ1In0=",
         "x-ms-return-client-request-id": "true"
@@ -622,12 +660,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "639259bc-71fe-4092-82b3-5037b53b46df"
+        "x-ms-request-id": "dfac61e0-5eeb-499a-a54f-21b4e64f7291"
       },
       "ResponseBody": {
         "instances": []
@@ -642,7 +680,7 @@
         "Content-Length": "22",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "07092c21430082f3ec0e285ce13740c9",
+        "x-ms-client-request-id": "a671527ffa69fd44ee28875a6ac3e38f",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -654,12 +692,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "4a171965-dbe0-4d03-813a-28382e9cd5b0"
+        "x-ms-request-id": "b1739ca1-8e3d-4fc5-b8f2-ee7758af0833"
       },
       "ResponseBody": {
         "suggestions": [
@@ -679,7 +717,7 @@
         "Content-Length": "100",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "a671527ffa69fd44ee28875a6ac3e38f",
+        "x-ms-client-request-id": "0911d13e8b5b40b42846c5587580eb24",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -704,12 +742,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "30439ea2-016d-471c-b6a5-6558650b021a"
+        "x-ms-request-id": "473249ec-4165-4d79-9b08-66cbf8892076"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_LifecycleAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_LifecycleAsync.json
@@ -8,8 +8,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "62",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "7ea523b773a13eebb1bb36545e7e9732",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "ee874efbae9848bab2086e0605ea07db",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -17,9 +17,9 @@
         "get": {
           "timeSeriesIds": [
             [
-              "197Vczz6",
-              "kGW1mmY9",
-              "XgjczZC4"
+              "3RVQDYYd",
+              "qXZqkRzA",
+              "gepQ7d1i"
             ]
           ]
         }
@@ -29,123 +29,19 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:57 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "3846b78f-0fcb-4c47-9bf3-468be60c6035"
-      },
-      "ResponseBody": {
-        "get": [
-          {
-            "instance": {
-              "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-              "timeSeriesId": [
-                "197Vczz6",
-                "kGW1mmY9",
-                "XgjczZC4"
-              ],
-              "name": "instance354sVNgp"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "62",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "f2e06061b4683c75a4078c04cf1d5aa5",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "xYlruOUo",
-              "UEZqatbc",
-              "7CBBbaDV"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:50 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "63185703-ae42-4339-aed2-386962507644"
-      },
-      "ResponseBody": {
-        "get": [
-          {
-            "instance": {
-              "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-              "timeSeriesId": [
-                "xYlruOUo",
-                "UEZqatbc",
-                "7CBBbaDV"
-              ],
-              "name": "instanceL9IFgxu6"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "62",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "4f341b6f11365574956f466890c3104e",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "bb0eec83-02c9-4343-bbd1-05043d4b4aeb"
+        "x-ms-request-id": "13115728-6682-4aeb-916c-440c6183beea"
       },
       "ResponseBody": {
         "get": [
           {
             "error": {
               "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022GtEzy22E\u0022,\u0022ggcjSR0X\u0022,\u0022VPJrLpCW\u0022]\u0027 is not found.",
+              "message": "Time series instance with time series ID \u0027[\u00223RVQDYYd\u0022,\u0022qXZqkRzA\u0022,\u0022gepQ7d1i\u0022]\u0027 is not found.",
               "innerError": {
                 "code": "InstanceNotFound"
               }
@@ -162,8 +58,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "62",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "f9d88b7db802178cbb268541dc1d6668",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "477f720afc819ee246ad322a3a9123da",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -171,9 +67,9 @@
         "get": {
           "timeSeriesIds": [
             [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
+              "jcPrllTM",
+              "13u6R1ta",
+              "axmDkaDx"
             ]
           ]
         }
@@ -183,19 +79,19 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "fa954998-b019-4d3a-a3a2-73c3cb821dc7"
+        "x-ms-request-id": "4ed1ca5d-6477-4b75-8792-d4f20aa0de78"
       },
       "ResponseBody": {
         "get": [
           {
             "error": {
               "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022L9IFgxu6\u0022,\u0022bRGhLc4a\u0022,\u0022qsIbZt9g\u0022]\u0027 is not found.",
+              "message": "Time series instance with time series ID \u0027[\u0022jcPrllTM\u0022,\u002213u6R1ta\u0022,\u0022axmDkaDx\u0022]\u0027 is not found.",
               "innerError": {
                 "code": "InstanceNotFound"
               }
@@ -212,8 +108,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "209",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "c568d94871e739adfd69543b761070df",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "46e04baba3dbd3c7adf9951f0541d06b",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -221,17 +117,17 @@
         "put": [
           {
             "timeSeriesId": [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
+              "3RVQDYYd",
+              "qXZqkRzA",
+              "gepQ7d1i"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
           },
           {
             "timeSeriesId": [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
+              "jcPrllTM",
+              "13u6R1ta",
+              "axmDkaDx"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
           }
@@ -242,12 +138,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "08d8073c-026f-4033-a0ab-371899e51fd9"
+        "x-ms-request-id": "73703403-2c16-40e6-8b41-ca03f18258b7"
       },
       "ResponseBody": {
         "put": [
@@ -264,8 +160,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "97",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "47f8b938d92e2e58e4124781d63100f6",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "b1793a845ca112ba6e35d0d2ac303be0",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -273,14 +169,14 @@
         "get": {
           "timeSeriesIds": [
             [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
+              "3RVQDYYd",
+              "qXZqkRzA",
+              "gepQ7d1i"
             ],
             [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
+              "jcPrllTM",
+              "13u6R1ta",
+              "axmDkaDx"
             ]
           ]
         }
@@ -290,12 +186,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "ec747b12-9999-45d2-a035-8d6bd886c421"
+        "x-ms-request-id": "4d82f211-dbeb-437d-b957-0c1c25951420"
       },
       "ResponseBody": {
         "get": [
@@ -303,9 +199,9 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "GtEzy22E",
-                "ggcjSR0X",
-                "VPJrLpCW"
+                "3RVQDYYd",
+                "qXZqkRzA",
+                "gepQ7d1i"
               ]
             }
           },
@@ -313,9 +209,9 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "L9IFgxu6",
-                "bRGhLc4a",
-                "qsIbZt9g"
+                "jcPrllTM",
+                "13u6R1ta",
+                "axmDkaDx"
               ]
             }
           }
@@ -330,8 +226,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "264",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "2209a6b61f256f3a803ae1d4292b62cb",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "ffa6c7dd72174f3890cdd7a5d3f5277d",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -339,21 +235,21 @@
         "update": [
           {
             "timeSeriesId": [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
+              "3RVQDYYd",
+              "qXZqkRzA",
+              "gepQ7d1i"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instance3Oy3CMmu"
+            "name": "instance0jX7Shog"
           },
           {
             "timeSeriesId": [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
+              "jcPrllTM",
+              "13u6R1ta",
+              "axmDkaDx"
             ],
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "name": "instanceYQV2HYBn"
+            "name": "instanceS6a2xvIl"
           }
         ]
       },
@@ -362,12 +258,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "73044138-0028-4d08-b755-0327c091947c"
+        "x-ms-request-id": "0fbf66db-8ee1-402b-a9d1-16d91d43aa8c"
       },
       "ResponseBody": {
         "update": [
@@ -384,16 +280,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "57",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "914d5d686b5844af0deb698eddbfca93",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "fa5db5be1027766a2e1207f5c232abab",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
           "names": [
-            "instance3Oy3CMmu",
-            "instanceYQV2HYBn"
+            "instance0jX7Shog",
+            "instanceS6a2xvIl"
           ]
         }
       },
@@ -402,12 +298,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "2f286537-4475-47f3-a285-264860f6ea0b"
+        "x-ms-request-id": "9469cc89-720c-4906-af61-ba4752d14887"
       },
       "ResponseBody": {
         "get": [
@@ -415,22 +311,22 @@
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "GtEzy22E",
-                "ggcjSR0X",
-                "VPJrLpCW"
+                "3RVQDYYd",
+                "qXZqkRzA",
+                "gepQ7d1i"
               ],
-              "name": "instance3Oy3CMmu"
+              "name": "instance0jX7Shog"
             }
           },
           {
             "instance": {
               "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
               "timeSeriesId": [
-                "L9IFgxu6",
-                "bRGhLc4a",
-                "qsIbZt9g"
+                "jcPrllTM",
+                "13u6R1ta",
+                "axmDkaDx"
               ],
-              "name": "instanceYQV2HYBn"
+              "name": "instanceS6a2xvIl"
             }
           }
         ]
@@ -442,8 +338,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "30cb9c71dd28ced1a94883f511d6e3b2",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "e4f5cb9c3b8a4fc8d2ca2f32356592b4",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -453,12 +349,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "461ccaeb-6758-46a9-b347-9e6223353c97"
+        "x-ms-request-id": "53a8b090-0c11-4bb7-aba2-db897f64a9e2"
       },
       "ResponseBody": {
         "instances": [
@@ -655,38 +551,62 @@
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "197Vczz6",
-              "kGW1mmY9",
-              "XgjczZC4"
+              "3RVQDYYd",
+              "qXZqkRzA",
+              "gepQ7d1i"
             ],
-            "name": "instance354sVNgp"
+            "name": "instance0jX7Shog"
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
-            ],
-            "name": "instance3Oy3CMmu"
+              "bEUMP",
+              null,
+              "fAZXF"
+            ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
-            ],
-            "name": "instanceYQV2HYBn"
+              "gOjeQNrW",
+              "N1AmVbS5",
+              "T3UOUYw1"
+            ]
           },
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "xYlruOUo",
-              "UEZqatbc",
-              "7CBBbaDV"
+              "iojyD",
+              null,
+              "aam4n"
+            ]
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "jcPrllTM",
+              "13u6R1ta",
+              "axmDkaDx"
             ],
-            "name": "instanceL9IFgxu6"
+            "name": "instanceS6a2xvIl"
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "SFIN2CZR",
+              "t1xpifTp",
+              "76oYQ1aw"
+            ],
+            "name": "instancegv0o35iq"
+          },
+          {
+            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "timeSeriesId": [
+              "YMx4QOn9",
+              "faKHzWsO",
+              "Rg7RCsP1"
+            ],
+            "name": "instance7a5kzs1R"
           }
         ],
         "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiZTYyMTY4NGEtZmMwNi00M2RiLTg1YTQtMjkxNjBjMjZmMmQ1In0="
@@ -698,8 +618,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "0630313c0f024a53f6c4143ab5ab92c1",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "b1c91b849e66cddd5c2fd0056b428c5d",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-continuation": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMCwicmVxdWVzdEhhc2hDb2RlIjoxOTQ3MjUzNzgyLCJlbnZpcm9ubWVudElkIjoiZTYyMTY4NGEtZmMwNi00M2RiLTg1YTQtMjkxNjBjMjZmMmQ1In0=",
         "x-ms-return-client-request-id": "true"
@@ -710,12 +630,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a5ebc20b-4b42-4a72-bb29-315e55e61693"
+        "x-ms-request-id": "42b756d5-7433-494e-8b57-f96dbcc59f0e"
       },
       "ResponseBody": {
         "instances": []
@@ -729,31 +649,31 @@
         "Authorization": "Sanitized",
         "Content-Length": "22",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "8d624d7031608aa28c7ee80fe7b93337",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "07092c21430082f3ec0e285ce13740c9",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "searchString": "GtE"
+        "searchString": "3RV"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "93d16028-a3a2-49e9-a826-6e8fb8b321c2"
+        "x-ms-request-id": "81cbad43-82e1-4f02-983a-a8c2cdd02791"
       },
       "ResponseBody": {
         "suggestions": [
           {
-            "searchString": "GtEzy22E",
-            "highlightedSearchString": "\u003Chit\u003EGtE\u003C/hit\u003Ezy22E"
+            "searchString": "3RVQDYYd",
+            "highlightedSearchString": "\u003Chit\u003E3RV\u003C/hit\u003EQDYYd"
           }
         ]
       }
@@ -766,8 +686,8 @@
         "Authorization": "Sanitized",
         "Content-Length": "100",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "ab52b608c38f629148803a64c99618fd",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "a671527ffa69fd44ee28875a6ac3e38f",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -775,14 +695,14 @@
         "delete": {
           "timeSeriesIds": [
             [
-              "GtEzy22E",
-              "ggcjSR0X",
-              "VPJrLpCW"
+              "3RVQDYYd",
+              "qXZqkRzA",
+              "gepQ7d1i"
             ],
             [
-              "L9IFgxu6",
-              "bRGhLc4a",
-              "qsIbZt9g"
+              "jcPrllTM",
+              "13u6R1ta",
+              "axmDkaDx"
             ]
           ]
         }
@@ -792,12 +712,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "8a0cb6d0-ac67-4348-94f0-10f4f3f74794"
+        "x-ms-request-id": "25931991-f7cb-44f6-af2a-c44e2ce4a13f"
       },
       "ResponseBody": {
         "delete": [
@@ -808,7 +728,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1188087842",
+    "RandomSeed": "474035975",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_LifecycleAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsInstancesTests/TimeSeriesInsightsInstances_LifecycleAsync.json
@@ -29,12 +29,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:57 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "13115728-6682-4aeb-916c-440c6183beea"
+        "x-ms-request-id": "62700567-85ee-41e0-8701-8069f0a2f3ce"
       },
       "ResponseBody": {
         "get": [
@@ -79,12 +79,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "4ed1ca5d-6477-4b75-8792-d4f20aa0de78"
+        "x-ms-request-id": "b4cda475-58fd-4b76-abcd-8d4800bd0424"
       },
       "ResponseBody": {
         "get": [
@@ -138,12 +138,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "73703403-2c16-40e6-8b41-ca03f18258b7"
+        "x-ms-request-id": "cd670e6a-081f-49cf-b3e2-b24af9b3148f"
       },
       "ResponseBody": {
         "put": [
@@ -186,12 +186,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "4d82f211-dbeb-437d-b957-0c1c25951420"
+        "x-ms-request-id": "95cf9785-108f-46cf-9400-1599067a756c"
       },
       "ResponseBody": {
         "get": [
@@ -258,12 +258,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "0fbf66db-8ee1-402b-a9d1-16d91d43aa8c"
+        "x-ms-request-id": "9f9ed210-295a-4a77-a791-1639009278c4"
       },
       "ResponseBody": {
         "update": [
@@ -298,12 +298,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "9469cc89-720c-4906-af61-ba4752d14887"
+        "x-ms-request-id": "7dca2274-a09b-4ad4-aaf8-43178bc0cc20"
       },
       "ResponseBody": {
         "get": [
@@ -349,12 +349,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "53a8b090-0c11-4bb7-aba2-db897f64a9e2"
+        "x-ms-request-id": "684a6f10-e1ea-4176-a08f-9bc8682c2665"
       },
       "ResponseBody": {
         "instances": [
@@ -560,14 +560,6 @@
           {
             "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
             "timeSeriesId": [
-              "bEUMP",
-              null,
-              "fAZXF"
-            ]
-          },
-          {
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-            "timeSeriesId": [
               "gOjeQNrW",
               "N1AmVbS5",
               "T3UOUYw1"
@@ -630,12 +622,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "42b756d5-7433-494e-8b57-f96dbcc59f0e"
+        "x-ms-request-id": "639259bc-71fe-4092-82b3-5037b53b46df"
       },
       "ResponseBody": {
         "instances": []
@@ -662,12 +654,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "81cbad43-82e1-4f02-983a-a8c2cdd02791"
+        "x-ms-request-id": "4a171965-dbe0-4d03-813a-28382e9cd5b0"
       },
       "ResponseBody": {
         "suggestions": [
@@ -712,12 +704,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "25931991-f7cb-44f6-af2a-c44e2ce4a13f"
+        "x-ms-request-id": "30439ea2-016d-471c-b6a5-6558650b021a"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsCategoricalTypes_ExpectsError.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsCategoricalTypes_ExpectsError.json
@@ -37,12 +37,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "1c07ddb5-dee1-46bc-a963-a41b5d1fd064"
+        "x-ms-request-id": "b42c43d3-5115-485f-9e37-5655ae456d56"
       },
       "ResponseBody": {
         "put": [
@@ -97,12 +97,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:57 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "d6621c9e-218b-42f8-a6a4-6cf6ae2c4cae"
+        "x-ms-request-id": "518c9508-5366-46d4-b7e9-034f1cab4958"
       },
       "ResponseBody": {
         "get": [
@@ -143,12 +143,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:57 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "85e0df03-83ec-47d7-916c-404350921ac7"
+        "x-ms-request-id": "045fc6bd-fb79-499b-a79a-20fa0a6a5b33"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsCategoricalTypes_ExpectsError.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsCategoricalTypes_ExpectsError.json
@@ -1,27 +1,34 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "97",
+        "Content-Length": "183",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "d08d800c5de4c76657330d1c0c6ed2b1",
+        "x-ms-client-request-id": "e296b9ffcc3617faa93ab1efee7cdfb6",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "put": [
           {
-            "timeSeriesId": [
-              "iojyD",
-              null,
-              "aam4n"
-            ],
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
+            "id": "1162292174",
+            "name": "typeftwXLWQo",
+            "variables": {
+              "categoricalVariableNameh7BCutNP": {
+                "value": {
+                  "tsx": "$event"
+                },
+                "defaultCategory": {
+                  "label": "label"
+                },
+                "kind": "categorical"
+              }
+            }
           }
         ]
       },
@@ -35,35 +42,53 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "fdd406d2-e115-4017-a2d2-6f0bb9d6bc4d"
+        "x-ms-request-id": "1c07ddb5-dee1-46bc-a963-a41b5d1fd064"
       },
       "ResponseBody": {
         "put": [
-          {}
+          {
+            "error": {
+              "code": "InvalidInput",
+              "message": "Unable to parse \u0027value\u0027 time series expression (TSX) in variable \u0027categoricalVariableNameh7BCutNP\u0027.",
+              "target": "variables.categoricalVariableNameh7BCutNP.value",
+              "innerError": {
+                "parseErrorDetails": [
+                  {
+                    "pos": [
+                      6,
+                      6
+                    ],
+                    "line": 1,
+                    "col": 6,
+                    "msg": "no viable alternative at input \u0027$event\u0027",
+                    "code": "SyntaxError",
+                    "target": "\u003CEOF\u003E"
+                  }
+                ],
+                "code": "TsxParseError"
+              }
+            }
+          }
         ]
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "50",
+        "Content-Length": "34",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "0be158ed95b3a0f03f2485d3077682db",
+        "x-ms-client-request-id": "4ea575b1da2b2961400e7278cf496f5c",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
+          "names": [
+            "typeftwXLWQo"
           ]
         }
       },
@@ -77,16 +102,16 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "07809a87-d53c-453e-a939-6db8b047e515"
+        "x-ms-request-id": "d6621c9e-218b-42f8-a6a4-6cf6ae2c4cae"
       },
       "ResponseBody": {
         "get": [
           {
             "error": {
               "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022iojyD\u0022,null,\u0022aam4n\u0022]\u0027 is not found.",
+              "message": "Time series type with name \u0027typeftwXLWQo\u0027 is not found.",
               "innerError": {
-                "code": "InstanceNotFound"
+                "code": "TypeNotFound"
               }
             }
           }
@@ -94,77 +119,22 @@
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "50",
+        "Content-Length": "37",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "566467ec18c407361d16cb462ff8c9de",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:07 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a6efa959-78e2-4318-a4d7-297cb38013ff"
-      },
-      "ResponseBody": {
-        "get": [
-          {
-            "instance": {
-              "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-              "timeSeriesId": [
-                "iojyD",
-                null,
-                "aam4n"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "53",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "a44b34fea84676e990ed90c0d792c0e0",
+        "x-ms-client-request-id": "53a8ae7a22166482d175c1b59fcbdf9b",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "delete": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
+          "names": [
+            "typeftwXLWQo"
           ]
         }
       },
@@ -173,12 +143,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:07 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:57 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "6265dd0c-5d1f-4f55-8d58-81d51313b260"
+        "x-ms-request-id": "85e0df03-83ec-47d7-916c-404350921ac7"
       },
       "ResponseBody": {
         "delete": [
@@ -188,7 +158,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "142571774",
+    "RandomSeed": "595439050",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsCategoricalTypes_ExpectsErrorAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsCategoricalTypes_ExpectsErrorAsync.json
@@ -1,27 +1,34 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "97",
+        "Content-Length": "183",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "d08d800c5de4c76657330d1c0c6ed2b1",
+        "x-ms-client-request-id": "03f4b4eecdd1617f8a78187cdb2758a9",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "put": [
           {
-            "timeSeriesId": [
-              "iojyD",
-              null,
-              "aam4n"
-            ],
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
+            "id": "1192705670",
+            "name": "typeJgCie5MG",
+            "variables": {
+              "categoricalVariableNameVr6PZLb5": {
+                "value": {
+                  "tsx": "$event"
+                },
+                "defaultCategory": {
+                  "label": "label"
+                },
+                "kind": "categorical"
+              }
+            }
           }
         ]
       },
@@ -35,58 +42,30 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "fdd406d2-e115-4017-a2d2-6f0bb9d6bc4d"
+        "x-ms-request-id": "a81abd42-1870-4e50-aeb6-e6f4cdd43a28"
       },
       "ResponseBody": {
         "put": [
-          {}
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "50",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "0be158ed95b3a0f03f2485d3077682db",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:57 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "07809a87-d53c-453e-a939-6db8b047e515"
-      },
-      "ResponseBody": {
-        "get": [
           {
             "error": {
-              "code": "ResourceNotFound",
-              "message": "Time series instance with time series ID \u0027[\u0022iojyD\u0022,null,\u0022aam4n\u0022]\u0027 is not found.",
+              "code": "InvalidInput",
+              "message": "Unable to parse \u0027value\u0027 time series expression (TSX) in variable \u0027categoricalVariableNameVr6PZLb5\u0027.",
+              "target": "variables.categoricalVariableNameVr6PZLb5.value",
               "innerError": {
-                "code": "InstanceNotFound"
+                "parseErrorDetails": [
+                  {
+                    "pos": [
+                      6,
+                      6
+                    ],
+                    "line": 1,
+                    "col": 6,
+                    "msg": "no viable alternative at input \u0027$event\u0027",
+                    "code": "SyntaxError",
+                    "target": "\u003CEOF\u003E"
+                  }
+                ],
+                "code": "TsxParseError"
               }
             }
           }
@@ -94,26 +73,22 @@
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "50",
+        "Content-Length": "34",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "566467ec18c407361d16cb462ff8c9de",
+        "x-ms-client-request-id": "f46b71895b96aa48028b5e69a53e94d2",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
+          "names": [
+            "typeJgCie5MG"
           ]
         }
       },
@@ -122,49 +97,44 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:07 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a6efa959-78e2-4318-a4d7-297cb38013ff"
+        "x-ms-request-id": "5160fa2d-9ff5-4b2e-a3e4-fec416215d07"
       },
       "ResponseBody": {
         "get": [
           {
-            "instance": {
-              "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-              "timeSeriesId": [
-                "iojyD",
-                null,
-                "aam4n"
-              ]
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series type with name \u0027typeJgCie5MG\u0027 is not found.",
+              "innerError": {
+                "code": "TypeNotFound"
+              }
             }
           }
         ]
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "37",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "a44b34fea84676e990ed90c0d792c0e0",
+        "x-ms-client-request-id": "8367f6e32291745714d9e4585522ab54",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "delete": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
+          "names": [
+            "typeJgCie5MG"
           ]
         }
       },
@@ -173,12 +143,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:07 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "6265dd0c-5d1f-4f55-8d58-81d51313b260"
+        "x-ms-request-id": "66f61720-9b9a-41d7-9143-04b7f8c04f5c"
       },
       "ResponseBody": {
         "delete": [
@@ -188,7 +158,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "142571774",
+    "RandomSeed": "1782484053",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsCategoricalTypes_ExpectsErrorAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsCategoricalTypes_ExpectsErrorAsync.json
@@ -37,12 +37,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a81abd42-1870-4e50-aeb6-e6f4cdd43a28"
+        "x-ms-request-id": "a97f519a-30d6-4955-b075-efc5bf64eb27"
       },
       "ResponseBody": {
         "put": [
@@ -97,12 +97,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "5160fa2d-9ff5-4b2e-a3e4-fec416215d07"
+        "x-ms-request-id": "0d4e4459-6012-49c4-aa54-249b8ac6cd5b"
       },
       "ResponseBody": {
         "get": [
@@ -143,12 +143,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:58 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "66f61720-9b9a-41d7-9143-04b7f8c04f5c"
+        "x-ms-request-id": "4fd759fd-8c25-4f4c-b73f-01f5e3f60718"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsNumericTypes_ExpectsError.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsNumericTypes_ExpectsError.json
@@ -37,12 +37,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "95819ce5-0cd3-4e60-85f2-c6af5d820d92"
+        "x-ms-request-id": "578e41f6-e802-4251-901f-d81dcbc4d82c"
       },
       "ResponseBody": {
         "put": [
@@ -97,12 +97,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a1d52772-590a-4af1-86fd-7e5d641862db"
+        "x-ms-request-id": "edea016f-69bc-4bc1-bae3-ca0a83cb6381"
       },
       "ResponseBody": {
         "get": [
@@ -143,12 +143,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "30a554b4-b50f-484d-812f-470d89404b02"
+        "x-ms-request-id": "5aff59bf-eccb-46f9-9f47-8f6621eecbd6"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsNumericTypes_ExpectsError.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsNumericTypes_ExpectsError.json
@@ -1,0 +1,164 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "175",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "3f8bde4105fb40aa4f57a10baac59e98",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "put": [
+          {
+            "id": "1316208383",
+            "name": "typervwgShZA",
+            "variables": {
+              "numericVariableNamedql3ahEO": {
+                "value": {
+                  "tsx": "$event"
+                },
+                "aggregation": {
+                  "tsx": "avg($value)"
+                },
+                "kind": "numeric"
+              }
+            }
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "95819ce5-0cd3-4e60-85f2-c6af5d820d92"
+      },
+      "ResponseBody": {
+        "put": [
+          {
+            "error": {
+              "code": "InvalidInput",
+              "message": "Unable to parse \u0027value\u0027 time series expression (TSX) in variable \u0027numericVariableNamedql3ahEO\u0027.",
+              "target": "variables.numericVariableNamedql3ahEO.value",
+              "innerError": {
+                "parseErrorDetails": [
+                  {
+                    "pos": [
+                      6,
+                      6
+                    ],
+                    "line": 1,
+                    "col": 6,
+                    "msg": "no viable alternative at input \u0027$event\u0027",
+                    "code": "SyntaxError",
+                    "target": "\u003CEOF\u003E"
+                  }
+                ],
+                "code": "TsxParseError"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "34",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "900ae9c946ac43820cd3d19880dd4196",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "get": {
+          "names": [
+            "typervwgShZA"
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "a1d52772-590a-4af1-86fd-7e5d641862db"
+      },
+      "ResponseBody": {
+        "get": [
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series type with name \u0027typervwgShZA\u0027 is not found.",
+              "innerError": {
+                "code": "TypeNotFound"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "37",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "632e7fd6cd5419515abde4917a86544a",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "delete": {
+          "names": [
+            "typervwgShZA"
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "30a554b4-b50f-484d-812f-470d89404b02"
+      },
+      "ResponseBody": {
+        "delete": [
+          null
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "895610037",
+    "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
+  }
+}

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsNumericTypes_ExpectsErrorAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsNumericTypes_ExpectsErrorAsync.json
@@ -1,0 +1,164 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "174",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "0ddf940ef7fb4f5022a2f04a05234921",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "put": [
+          {
+            "id": "172286470",
+            "name": "typevsQNrKD3",
+            "variables": {
+              "numericVariableNamevJOyk4ro": {
+                "value": {
+                  "tsx": "$event"
+                },
+                "aggregation": {
+                  "tsx": "avg($value)"
+                },
+                "kind": "numeric"
+              }
+            }
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "39498ca1-1788-4fc9-8efd-2f4102d60e9d"
+      },
+      "ResponseBody": {
+        "put": [
+          {
+            "error": {
+              "code": "InvalidInput",
+              "message": "Unable to parse \u0027value\u0027 time series expression (TSX) in variable \u0027numericVariableNamevJOyk4ro\u0027.",
+              "target": "variables.numericVariableNamevJOyk4ro.value",
+              "innerError": {
+                "parseErrorDetails": [
+                  {
+                    "pos": [
+                      6,
+                      6
+                    ],
+                    "line": 1,
+                    "col": 6,
+                    "msg": "no viable alternative at input \u0027$event\u0027",
+                    "code": "SyntaxError",
+                    "target": "\u003CEOF\u003E"
+                  }
+                ],
+                "code": "TsxParseError"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "34",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "a0e700d37e2cece66e2ba55c0df71a27",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "get": {
+          "names": [
+            "typevsQNrKD3"
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "ac91d32a-3286-4fed-ba45-ae7e9f97863b"
+      },
+      "ResponseBody": {
+        "get": [
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series type with name \u0027typevsQNrKD3\u0027 is not found.",
+              "innerError": {
+                "code": "TypeNotFound"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "37",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "2ac47e8199051e9b0d51c2f757990061",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "delete": {
+          "names": [
+            "typevsQNrKD3"
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "f78e2789-1cfd-43b1-ada5-ddcec844a6d3"
+      },
+      "ResponseBody": {
+        "delete": [
+          null
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1532083910",
+    "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
+  }
+}

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsNumericTypes_ExpectsErrorAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsNumericTypes_ExpectsErrorAsync.json
@@ -37,12 +37,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "39498ca1-1788-4fc9-8efd-2f4102d60e9d"
+        "x-ms-request-id": "6d4ae0fe-fcd9-4305-bf53-0e435135708d"
       },
       "ResponseBody": {
         "put": [
@@ -97,12 +97,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "ac91d32a-3286-4fed-ba45-ae7e9f97863b"
+        "x-ms-request-id": "496c4797-9c53-4da3-a2f7-e855b77e1535"
       },
       "ResponseBody": {
         "get": [
@@ -143,12 +143,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f78e2789-1cfd-43b1-ada5-ddcec844a6d3"
+        "x-ms-request-id": "a65d19ea-6735-41eb-95d3-8877d4c2400f"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithCategoricalVariable_ExpectsError.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithCategoricalVariable_ExpectsError.json
@@ -37,12 +37,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:30 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f5d370db-bbd2-4daa-b749-01866f735aae"
+        "x-ms-request-id": "325e508b-8d97-4c58-a54f-05ac1fb6c1f0"
       },
       "ResponseBody": {
         "put": [
@@ -97,12 +97,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:30 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a6affdb1-2d8a-42df-a5e4-808b5b29f2e1"
+        "x-ms-request-id": "3e66277f-45e0-4599-89cc-1ab7bacd2f70"
       },
       "ResponseBody": {
         "get": [
@@ -143,12 +143,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:30 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e3960d9c-8500-41de-88f0-9334b93e0b89"
+        "x-ms-request-id": "7574b161-69db-4cef-888a-ba0de58babf7"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithCategoricalVariable_ExpectsError.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithCategoricalVariable_ExpectsError.json
@@ -1,27 +1,34 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "97",
+        "Content-Length": "182",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "d08d800c5de4c76657330d1c0c6ed2b1",
+        "x-ms-client-request-id": "6c7fc4d3b97358fea1d30918a9bb622c",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "put": [
           {
-            "timeSeriesId": [
-              "iojyD",
-              null,
-              "aam4n"
-            ],
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
+            "id": "192996723",
+            "name": "typeXGcNET0E",
+            "variables": {
+              "categoricalVariableNameVpxgorI8": {
+                "value": {
+                  "tsx": "$event"
+                },
+                "defaultCategory": {
+                  "label": "label"
+                },
+                "kind": "categorical"
+              }
+            }
           }
         ]
       },
@@ -30,91 +37,58 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e6c0fb6e-103c-4754-9c84-6d387e7df620"
+        "x-ms-request-id": "f5d370db-bbd2-4daa-b749-01866f735aae"
       },
       "ResponseBody": {
         "put": [
-          {}
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "50",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "0be158ed95b3a0f03f2485d3077682db",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a21c5858-203d-4c5a-a545-e2d81b1b7656"
-      },
-      "ResponseBody": {
-        "get": [
           {
-            "instance": {
-              "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-              "timeSeriesId": [
-                "iojyD",
-                null,
-                "aam4n"
-              ]
+            "error": {
+              "code": "InvalidInput",
+              "message": "Unable to parse \u0027value\u0027 time series expression (TSX) in variable \u0027categoricalVariableNameVpxgorI8\u0027.",
+              "target": "variables.categoricalVariableNameVpxgorI8.value",
+              "innerError": {
+                "parseErrorDetails": [
+                  {
+                    "pos": [
+                      6,
+                      6
+                    ],
+                    "line": 1,
+                    "col": 6,
+                    "msg": "no viable alternative at input \u0027$event\u0027",
+                    "code": "SyntaxError",
+                    "target": "\u003CEOF\u003E"
+                  }
+                ],
+                "code": "TsxParseError"
+              }
             }
           }
         ]
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "34",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "566467ec18c407361d16cb462ff8c9de",
+        "x-ms-client-request-id": "c3604dba0775525b662b31c3e0934be3",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "delete": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
+        "get": {
+          "names": [
+            "typeXGcNET0E"
           ]
         }
       },
@@ -123,12 +97,58 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "2dc19913-99e5-4f32-bfea-9ab4167de1a9"
+        "x-ms-request-id": "a6affdb1-2d8a-42df-a5e4-808b5b29f2e1"
+      },
+      "ResponseBody": {
+        "get": [
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series type with name \u0027typeXGcNET0E\u0027 is not found.",
+              "innerError": {
+                "code": "TypeNotFound"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "37",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "b391d9c08b4ea21cdef715368998ca39",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "delete": {
+          "names": [
+            "typeXGcNET0E"
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "e3960d9c-8500-41de-88f0-9334b93e0b89"
       },
       "ResponseBody": {
         "delete": [
@@ -138,7 +158,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "142571774",
+    "RandomSeed": "526037252",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithCategoricalVariable_ExpectsErrorAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithCategoricalVariable_ExpectsErrorAsync.json
@@ -1,27 +1,34 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "97",
+        "Content-Length": "183",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "d08d800c5de4c76657330d1c0c6ed2b1",
+        "x-ms-client-request-id": "24ba4b0b3e0711aa856514d04425b444",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "put": [
           {
-            "timeSeriesId": [
-              "iojyD",
-              null,
-              "aam4n"
-            ],
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
+            "id": "1936309184",
+            "name": "typezh3Qk1NQ",
+            "variables": {
+              "categoricalVariableNameMZ2KLDg5": {
+                "value": {
+                  "tsx": "$event"
+                },
+                "defaultCategory": {
+                  "label": "label"
+                },
+                "kind": "categorical"
+              }
+            }
           }
         ]
       },
@@ -30,91 +37,58 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e6c0fb6e-103c-4754-9c84-6d387e7df620"
+        "x-ms-request-id": "7aed2836-a8e9-4735-af9c-95f4d1836e11"
       },
       "ResponseBody": {
         "put": [
-          {}
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "50",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "0be158ed95b3a0f03f2485d3077682db",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a21c5858-203d-4c5a-a545-e2d81b1b7656"
-      },
-      "ResponseBody": {
-        "get": [
           {
-            "instance": {
-              "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-              "timeSeriesId": [
-                "iojyD",
-                null,
-                "aam4n"
-              ]
+            "error": {
+              "code": "InvalidInput",
+              "message": "Unable to parse \u0027value\u0027 time series expression (TSX) in variable \u0027categoricalVariableNameMZ2KLDg5\u0027.",
+              "target": "variables.categoricalVariableNameMZ2KLDg5.value",
+              "innerError": {
+                "parseErrorDetails": [
+                  {
+                    "pos": [
+                      6,
+                      6
+                    ],
+                    "line": 1,
+                    "col": 6,
+                    "msg": "no viable alternative at input \u0027$event\u0027",
+                    "code": "SyntaxError",
+                    "target": "\u003CEOF\u003E"
+                  }
+                ],
+                "code": "TsxParseError"
+              }
             }
           }
         ]
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "34",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "566467ec18c407361d16cb462ff8c9de",
+        "x-ms-client-request-id": "d2b8683c2b5986ea2c2196c34a1df207",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "delete": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
+        "get": {
+          "names": [
+            "typezh3Qk1NQ"
           ]
         }
       },
@@ -123,12 +97,58 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "2dc19913-99e5-4f32-bfea-9ab4167de1a9"
+        "x-ms-request-id": "4f6d45b5-3417-4098-9f04-90b60e054166"
+      },
+      "ResponseBody": {
+        "get": [
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series type with name \u0027typezh3Qk1NQ\u0027 is not found.",
+              "innerError": {
+                "code": "TypeNotFound"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "37",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "06bd163f00cfa5e49bc8d29ea8927cb7",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "delete": {
+          "names": [
+            "typezh3Qk1NQ"
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "45fe9460-42ff-475a-9a78-21d8061a4e1c"
       },
       "ResponseBody": {
         "delete": [
@@ -138,7 +158,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "142571774",
+    "RandomSeed": "720101398",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithCategoricalVariable_ExpectsErrorAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithCategoricalVariable_ExpectsErrorAsync.json
@@ -37,12 +37,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:30 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "7aed2836-a8e9-4735-af9c-95f4d1836e11"
+        "x-ms-request-id": "670146b6-69e3-43f5-87d9-715de6b1f8a3"
       },
       "ResponseBody": {
         "put": [
@@ -97,12 +97,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:30 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "4f6d45b5-3417-4098-9f04-90b60e054166"
+        "x-ms-request-id": "05f96eb7-5406-4091-aadd-80612ff5f01c"
       },
       "ResponseBody": {
         "get": [
@@ -143,12 +143,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:30 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "45fe9460-42ff-475a-9a78-21d8061a4e1c"
+        "x-ms-request-id": "d93af969-396f-4dc7-8123-7436fbb383e0"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithNumericVariable_ExpectsError.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithNumericVariable_ExpectsError.json
@@ -37,12 +37,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:30 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "4257785b-ec2e-42da-aee8-ba79389b23d3"
+        "x-ms-request-id": "e6f6c1ce-3741-4140-a285-e4bbbabefc1c"
       },
       "ResponseBody": {
         "put": [
@@ -97,12 +97,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:30 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "ae44f09e-2a5b-4772-a95a-e492222d9200"
+        "x-ms-request-id": "0c21ff28-f07a-488f-911e-8f0af7299469"
       },
       "ResponseBody": {
         "get": [
@@ -143,12 +143,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:30 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "77654a0b-632f-47c8-a348-be2a29a86f66"
+        "x-ms-request-id": "9496e40f-fb0e-4c7a-8e7c-874b166ac9e2"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithNumericVariable_ExpectsError.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithNumericVariable_ExpectsError.json
@@ -1,27 +1,34 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "97",
+        "Content-Length": "175",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "d08d800c5de4c76657330d1c0c6ed2b1",
+        "x-ms-client-request-id": "3c34f3ea400c36bd705c18a058da2c6f",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "put": [
           {
-            "timeSeriesId": [
-              "iojyD",
-              null,
-              "aam4n"
-            ],
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
+            "id": "2012784359",
+            "name": "type262fOsfi",
+            "variables": {
+              "numericVariableNamep89KbDwR": {
+                "value": {
+                  "tsx": "$event"
+                },
+                "aggregation": {
+                  "tsx": "avg($value)"
+                },
+                "kind": "numeric"
+              }
+            }
           }
         ]
       },
@@ -30,91 +37,58 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e6c0fb6e-103c-4754-9c84-6d387e7df620"
+        "x-ms-request-id": "4257785b-ec2e-42da-aee8-ba79389b23d3"
       },
       "ResponseBody": {
         "put": [
-          {}
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "50",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "0be158ed95b3a0f03f2485d3077682db",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a21c5858-203d-4c5a-a545-e2d81b1b7656"
-      },
-      "ResponseBody": {
-        "get": [
           {
-            "instance": {
-              "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-              "timeSeriesId": [
-                "iojyD",
-                null,
-                "aam4n"
-              ]
+            "error": {
+              "code": "InvalidInput",
+              "message": "Unable to parse \u0027value\u0027 time series expression (TSX) in variable \u0027numericVariableNamep89KbDwR\u0027.",
+              "target": "variables.numericVariableNamep89KbDwR.value",
+              "innerError": {
+                "parseErrorDetails": [
+                  {
+                    "pos": [
+                      6,
+                      6
+                    ],
+                    "line": 1,
+                    "col": 6,
+                    "msg": "no viable alternative at input \u0027$event\u0027",
+                    "code": "SyntaxError",
+                    "target": "\u003CEOF\u003E"
+                  }
+                ],
+                "code": "TsxParseError"
+              }
             }
           }
         ]
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "34",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "566467ec18c407361d16cb462ff8c9de",
+        "x-ms-client-request-id": "2d8d14ce3e109617859f9b22edb7bf89",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "delete": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
+        "get": {
+          "names": [
+            "type262fOsfi"
           ]
         }
       },
@@ -123,12 +97,58 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "2dc19913-99e5-4f32-bfea-9ab4167de1a9"
+        "x-ms-request-id": "ae44f09e-2a5b-4772-a95a-e492222d9200"
+      },
+      "ResponseBody": {
+        "get": [
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series type with name \u0027type262fOsfi\u0027 is not found.",
+              "innerError": {
+                "code": "TypeNotFound"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "37",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "79ba44c589f53a7dfa03ab8830628f4c",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "delete": {
+          "names": [
+            "type262fOsfi"
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "77654a0b-632f-47c8-a348-be2a29a86f66"
       },
       "ResponseBody": {
         "delete": [
@@ -138,7 +158,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "142571774",
+    "RandomSeed": "1190360230",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithNumericVariable_ExpectsErrorAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithNumericVariable_ExpectsErrorAsync.json
@@ -1,27 +1,34 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "97",
+        "Content-Length": "175",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "d08d800c5de4c76657330d1c0c6ed2b1",
+        "x-ms-client-request-id": "a3a0161c4cb738be041192cd110bccb4",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "put": [
           {
-            "timeSeriesId": [
-              "iojyD",
-              null,
-              "aam4n"
-            ],
-            "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393"
+            "id": "1946263745",
+            "name": "typeioRB22eI",
+            "variables": {
+              "numericVariableNamePsjedBj8": {
+                "value": {
+                  "tsx": "$event"
+                },
+                "aggregation": {
+                  "tsx": "avg($value)"
+                },
+                "kind": "numeric"
+              }
+            }
           }
         ]
       },
@@ -30,91 +37,58 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e6c0fb6e-103c-4754-9c84-6d387e7df620"
+        "x-ms-request-id": "38ed2363-2855-4eb5-83c7-a66b347eed7c"
       },
       "ResponseBody": {
         "put": [
-          {}
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "50",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "0be158ed95b3a0f03f2485d3077682db",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a21c5858-203d-4c5a-a545-e2d81b1b7656"
-      },
-      "ResponseBody": {
-        "get": [
           {
-            "instance": {
-              "typeId": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
-              "timeSeriesId": [
-                "iojyD",
-                null,
-                "aam4n"
-              ]
+            "error": {
+              "code": "InvalidInput",
+              "message": "Unable to parse \u0027value\u0027 time series expression (TSX) in variable \u0027numericVariableNamePsjedBj8\u0027.",
+              "target": "variables.numericVariableNamePsjedBj8.value",
+              "innerError": {
+                "parseErrorDetails": [
+                  {
+                    "pos": [
+                      6,
+                      6
+                    ],
+                    "line": 1,
+                    "col": 6,
+                    "msg": "no viable alternative at input \u0027$event\u0027",
+                    "code": "SyntaxError",
+                    "target": "\u003CEOF\u003E"
+                  }
+                ],
+                "code": "TsxParseError"
+              }
             }
           }
         ]
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/instances/$batch?api-version=2020-07-31",
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "34",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "566467ec18c407361d16cb462ff8c9de",
+        "x-ms-client-request-id": "e102a2f29e625612d03e123b6ad97dbc",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "delete": {
-          "timeSeriesIds": [
-            [
-              "iojyD",
-              null,
-              "aam4n"
-            ]
+        "get": {
+          "names": [
+            "typeioRB22eI"
           ]
         }
       },
@@ -123,12 +97,58 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "2dc19913-99e5-4f32-bfea-9ab4167de1a9"
+        "x-ms-request-id": "64d209e5-fe97-45ae-912b-ab1188af5946"
+      },
+      "ResponseBody": {
+        "get": [
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series type with name \u0027typeioRB22eI\u0027 is not found.",
+              "innerError": {
+                "code": "TypeNotFound"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "37",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "c995dd62f22df54f617b3abf0f29b046",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "delete": {
+          "names": [
+            "typeioRB22eI"
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "cda478bc-d191-497d-bfd9-937d8f31deb9"
       },
       "ResponseBody": {
         "delete": [
@@ -138,7 +158,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "142571774",
+    "RandomSeed": "1942835269",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithNumericVariable_ExpectsErrorAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypeWithNumericVariable_ExpectsErrorAsync.json
@@ -37,12 +37,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "38ed2363-2855-4eb5-83c7-a66b347eed7c"
+        "x-ms-request-id": "2b42dd4a-6c94-47a8-900e-e389f04a04ff"
       },
       "ResponseBody": {
         "put": [
@@ -97,12 +97,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "64d209e5-fe97-45ae-912b-ab1188af5946"
+        "x-ms-request-id": "67854cf6-5e02-4ee6-bf62-4dc40888ae02"
       },
       "ResponseBody": {
         "get": [
@@ -143,12 +143,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:43 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "cda478bc-d191-497d-bfd9-937d8f31deb9"
+        "x-ms-request-id": "c8e81a34-3da0-4b01-9756-1efcf7d158b5"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_Lifecycle.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_Lifecycle.json
@@ -6,8 +6,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "73a17ea53eebbbb136545e7e97323b5a",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "940421f1f02c19b2b4a385dd8c9edf88",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -17,12 +17,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "429349a3-bcca-4dd2-8a44-661ff2ff1f40"
+        "x-ms-request-id": "578bb7d1-b08a-4dab-9760-2315349f1e0f"
       },
       "ResponseBody": {
         "types": [
@@ -87,6 +87,46 @@
                 "aggregation": {
                   "tsx": "median($value)"
                 }
+              },
+              "aggregateVar": {
+                "kind": "aggregate",
+                "aggregation": {
+                  "tsx": "avg($event[\u0027Temperature\u0027].Double)"
+                }
+              }
+            }
+          },
+          {
+            "id": "5107825e-4b61-4d03-b84d-1df93999b0a8",
+            "name": "ddd",
+            "variables": {
+              "aaaa": {
+                "kind": "categorical",
+                "value": {
+                  "tsx": "$event.building.String"
+                },
+                "filter": {
+                  "tsx": "($event.building.String) != null"
+                },
+                "interpolation": {
+                  "kind": "step",
+                  "boundary": {
+                    "span": "PT5M"
+                  }
+                },
+                "categories": [
+                  {
+                    "label": "dddd",
+                    "values": [
+                      "asdada"
+                    ],
+                    "annotations": {}
+                  }
+                ],
+                "defaultCategory": {
+                  "label": "aa",
+                  "annotations": {}
+                }
               }
             }
           }
@@ -99,20 +139,20 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "255",
+        "Content-Length": "253",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "125dd6f8fc1ce5ef57d856c2164472f0",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "8888aa77c4e054a4d91219112a3c0131",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "put": [
           {
-            "id": "1270999455",
-            "name": "type197Vczz6",
+            "id": "37976889",
+            "name": "typea0mOMnD6",
             "variables": {
-              "varjczZC4Ub": {
+              "varLvv3jph8": {
                 "aggregation": {
                   "tsx": "count()"
                 },
@@ -121,10 +161,10 @@
             }
           },
           {
-            "id": "1109560891",
-            "name": "typeGW1mmY9X",
+            "id": "1079623250",
+            "name": "typezlAgsedX",
             "variables": {
-              "varjczZC4Ub": {
+              "varLvv3jph8": {
                 "aggregation": {
                   "tsx": "count()"
                 },
@@ -139,21 +179,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "99bcef46-36dc-4ac2-b8f0-18e8817e2c04"
+        "x-ms-request-id": "6e763f37-548d-4e65-8ba3-4b6fbddc8265"
       },
       "ResponseBody": {
         "put": [
           {
             "timeSeriesType": {
-              "id": "1270999455",
-              "name": "type197Vczz6",
+              "id": "37976889",
+              "name": "typea0mOMnD6",
               "variables": {
-                "varjczZC4Ub": {
+                "varLvv3jph8": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -164,10 +204,10 @@
           },
           {
             "timeSeriesType": {
-              "id": "1109560891",
-              "name": "typeGW1mmY9X",
+              "id": "1079623250",
+              "name": "typezlAgsedX",
               "variables": {
-                "varjczZC4Ub": {
+                "varLvv3jph8": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -187,16 +227,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "49",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "1f114e152c806061e0f268b4753ca407",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "112db9b4a4656e422abf1fa9de0bc577",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
           "names": [
-            "type197Vczz6",
-            "typeGW1mmY9X"
+            "typea0mOMnD6",
+            "typezlAgsedX"
           ]
         }
       },
@@ -205,21 +245,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "7dc615a5-5d72-443c-a3f9-973547a7fdc4"
+        "x-ms-request-id": "aed764d7-a353-46bb-8ce2-8a97ce1040ad"
       },
       "ResponseBody": {
         "get": [
           {
             "timeSeriesType": {
-              "id": "1270999455",
-              "name": "type197Vczz6",
+              "id": "37976889",
+              "name": "typea0mOMnD6",
               "variables": {
-                "varjczZC4Ub": {
+                "varLvv3jph8": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -230,10 +270,10 @@
           },
           {
             "timeSeriesType": {
-              "id": "1109560891",
-              "name": "typeGW1mmY9X",
+              "id": "1079623250",
+              "name": "typezlAgsedX",
               "variables": {
-                "varjczZC4Ub": {
+                "varLvv3jph8": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -251,21 +291,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "311",
+        "Content-Length": "309",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "1dcf048ca55aa8078fbc1b12e7efa5f2",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "d4cbc2ed9b3c2d487cb0bb1ad6a1ee78",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "put": [
           {
-            "id": "1270999455",
-            "name": "type197Vczz6",
+            "id": "37976889",
+            "name": "typea0mOMnD6",
             "description": "Description",
             "variables": {
-              "varjczZC4Ub": {
+              "varLvv3jph8": {
                 "aggregation": {
                   "tsx": "count()"
                 },
@@ -274,11 +314,11 @@
             }
           },
           {
-            "id": "1109560891",
-            "name": "typeGW1mmY9X",
+            "id": "1079623250",
+            "name": "typezlAgsedX",
             "description": "Description",
             "variables": {
-              "varjczZC4Ub": {
+              "varLvv3jph8": {
                 "aggregation": {
                   "tsx": "count()"
                 },
@@ -293,22 +333,22 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a409a9a4-8239-43d8-9474-527709e49c26"
+        "x-ms-request-id": "cd5e640f-5ab1-4b4c-9659-86c627287abf"
       },
       "ResponseBody": {
         "put": [
           {
             "timeSeriesType": {
-              "id": "1270999455",
-              "name": "type197Vczz6",
+              "id": "37976889",
+              "name": "typea0mOMnD6",
               "description": "Description",
               "variables": {
-                "varjczZC4Ub": {
+                "varLvv3jph8": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -319,11 +359,11 @@
           },
           {
             "timeSeriesType": {
-              "id": "1109560891",
-              "name": "typeGW1mmY9X",
+              "id": "1079623250",
+              "name": "typezlAgsedX",
               "description": "Description",
               "variables": {
-                "varjczZC4Ub": {
+                "varLvv3jph8": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -341,18 +381,18 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "47",
+        "Content-Length": "45",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "49696ee11c20ccda75fd3229943a6f1b",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "d32953a1ce70d323671a5e20a4fa76ce",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
           "typeIds": [
-            "1270999455",
-            "1109560891"
+            "37976889",
+            "1079623250"
           ]
         }
       },
@@ -361,22 +401,22 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "4fbac152-bfe1-4012-874e-0bd17c45a30f"
+        "x-ms-request-id": "8763a5c4-98b1-4c75-91fe-e1ae97d6972f"
       },
       "ResponseBody": {
         "get": [
           {
             "timeSeriesType": {
-              "id": "1270999455",
-              "name": "type197Vczz6",
+              "id": "37976889",
+              "name": "typea0mOMnD6",
               "description": "Description",
               "variables": {
-                "varjczZC4Ub": {
+                "varLvv3jph8": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -387,11 +427,11 @@
           },
           {
             "timeSeriesType": {
-              "id": "1109560891",
-              "name": "typeGW1mmY9X",
+              "id": "1079623250",
+              "name": "typezlAgsedX",
               "description": "Description",
               "variables": {
-                "varjczZC4Ub": {
+                "varLvv3jph8": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -409,18 +449,18 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "50",
+        "Content-Length": "48",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "11364f3455746f95466890c3104e78f0",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "6724a14c2d7119f4700094b5e9289788",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "delete": {
           "typeIds": [
-            "1270999455",
-            "1109560891"
+            "37976889",
+            "1079623250"
           ]
         }
       },
@@ -429,12 +469,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "66a92db0-31e5-498e-95dc-73695c35c80f"
+        "x-ms-request-id": "7816d255-d6f6-4af9-a94a-b06843bd84a6"
       },
       "ResponseBody": {
         "delete": [
@@ -445,7 +485,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1188087842",
+    "RandomSeed": "1997356551",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_Lifecycle.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_Lifecycle.json
@@ -17,12 +17,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e751ce9a-d7c8-4bc9-9494-446e66da70d8"
+        "x-ms-request-id": "20086a81-4654-449c-b0b6-f3a7961830a8"
       },
       "ResponseBody": {
         "types": [
@@ -179,12 +179,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "d6420ad1-dcd4-44ce-977a-4126f579821a"
+        "x-ms-request-id": "cef7d47a-7908-43a1-ad42-b17c26021784"
       },
       "ResponseBody": {
         "put": [
@@ -245,68 +245,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "5ffdfefe-3457-466e-9279-292c8f1dae69"
-      },
-      "ResponseBody": {
-        "get": [
-          {
-            "error": {
-              "code": "ResourceNotFound",
-              "message": "Time series type with name \u0027typea0mOMnD6\u0027 is not found.",
-              "innerError": {
-                "code": "TypeNotFound"
-              }
-            }
-          },
-          {
-            "error": {
-              "code": "ResourceNotFound",
-              "message": "Time series type with name \u0027typezlAgsedX\u0027 is not found.",
-              "innerError": {
-                "code": "TypeNotFound"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "49",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "d4cbc2ed9b3c2d487cb0bb1ad6a1ee78",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "names": [
-            "typea0mOMnD6",
-            "typezlAgsedX"
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "7d968fc1-3553-48ba-8a96-d29c1ad8fb58"
+        "x-ms-request-id": "ce73f60d-2902-46f8-9fe3-385ca3dce768"
       },
       "ResponseBody": {
         "get": [
@@ -350,7 +294,7 @@
         "Content-Length": "309",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "d32953a1ce70d323671a5e20a4fa76ce",
+        "x-ms-client-request-id": "d4cbc2ed9b3c2d487cb0bb1ad6a1ee78",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -389,12 +333,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "d304534f-2154-4fdc-9eb2-7fc43f01b4b2"
+        "x-ms-request-id": "96ef24c9-e27b-40cb-a21d-c1eff68130a3"
       },
       "ResponseBody": {
         "put": [
@@ -440,7 +384,7 @@
         "Content-Length": "45",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "6724a14c2d7119f4700094b5e9289788",
+        "x-ms-client-request-id": "d32953a1ce70d323671a5e20a4fa76ce",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -457,12 +401,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "11818c82-2dee-43e7-9297-c7422e447ccd"
+        "x-ms-request-id": "33e50d28-a94d-4008-ae28-f0530670509c"
       },
       "ResponseBody": {
         "get": [
@@ -508,7 +452,7 @@
         "Content-Length": "48",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "8a07a7d0f2e21e069ff76c223c278981",
+        "x-ms-client-request-id": "6724a14c2d7119f4700094b5e9289788",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -525,12 +469,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "fd47358d-b30c-4f04-8f56-3483c3b8e8a7"
+        "x-ms-request-id": "5c7e8652-109f-4183-9573-7ca015c5cb2a"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_Lifecycle.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_Lifecycle.json
@@ -17,12 +17,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "3dfc518a-e7aa-4e89-9871-2eda59ba5139"
+        "x-ms-request-id": "e751ce9a-d7c8-4bc9-9494-446e66da70d8"
       },
       "ResponseBody": {
         "types": [
@@ -179,12 +179,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "621c9ca0-a4c3-4ca3-b710-de8f274b7c21"
+        "x-ms-request-id": "d6420ad1-dcd4-44ce-977a-4126f579821a"
       },
       "ResponseBody": {
         "put": [
@@ -245,12 +245,68 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "facd0fe5-2ab6-4ffe-9802-ec9ddc8794c5"
+        "x-ms-request-id": "5ffdfefe-3457-466e-9279-292c8f1dae69"
+      },
+      "ResponseBody": {
+        "get": [
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series type with name \u0027typea0mOMnD6\u0027 is not found.",
+              "innerError": {
+                "code": "TypeNotFound"
+              }
+            }
+          },
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series type with name \u0027typezlAgsedX\u0027 is not found.",
+              "innerError": {
+                "code": "TypeNotFound"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "49",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "d4cbc2ed9b3c2d487cb0bb1ad6a1ee78",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "get": {
+          "names": [
+            "typea0mOMnD6",
+            "typezlAgsedX"
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "7d968fc1-3553-48ba-8a96-d29c1ad8fb58"
       },
       "ResponseBody": {
         "get": [
@@ -294,7 +350,7 @@
         "Content-Length": "309",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "d4cbc2ed9b3c2d487cb0bb1ad6a1ee78",
+        "x-ms-client-request-id": "d32953a1ce70d323671a5e20a4fa76ce",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -333,12 +389,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "5c974988-8222-4816-bb4b-e1b66bbac5ce"
+        "x-ms-request-id": "d304534f-2154-4fdc-9eb2-7fc43f01b4b2"
       },
       "ResponseBody": {
         "put": [
@@ -384,7 +440,7 @@
         "Content-Length": "45",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "d32953a1ce70d323671a5e20a4fa76ce",
+        "x-ms-client-request-id": "6724a14c2d7119f4700094b5e9289788",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -401,12 +457,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "83d5eda4-70a6-47c2-9a70-6dd4487b68dc"
+        "x-ms-request-id": "11818c82-2dee-43e7-9297-c7422e447ccd"
       },
       "ResponseBody": {
         "get": [
@@ -452,7 +508,7 @@
         "Content-Length": "48",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "6724a14c2d7119f4700094b5e9289788",
+        "x-ms-client-request-id": "8a07a7d0f2e21e069ff76c223c278981",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -469,12 +525,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "0713362a-fed7-43b9-92f0-dc76c9dc88bf"
+        "x-ms-request-id": "fd47358d-b30c-4f04-8f56-3483c3b8e8a7"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_Lifecycle.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_Lifecycle.json
@@ -17,12 +17,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:01 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "578bb7d1-b08a-4dab-9760-2315349f1e0f"
+        "x-ms-request-id": "3dfc518a-e7aa-4e89-9871-2eda59ba5139"
       },
       "ResponseBody": {
         "types": [
@@ -179,12 +179,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "6e763f37-548d-4e65-8ba3-4b6fbddc8265"
+        "x-ms-request-id": "621c9ca0-a4c3-4ca3-b710-de8f274b7c21"
       },
       "ResponseBody": {
         "put": [
@@ -245,12 +245,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "aed764d7-a353-46bb-8ce2-8a97ce1040ad"
+        "x-ms-request-id": "facd0fe5-2ab6-4ffe-9802-ec9ddc8794c5"
       },
       "ResponseBody": {
         "get": [
@@ -333,12 +333,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "cd5e640f-5ab1-4b4c-9659-86c627287abf"
+        "x-ms-request-id": "5c974988-8222-4816-bb4b-e1b66bbac5ce"
       },
       "ResponseBody": {
         "put": [
@@ -401,12 +401,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "8763a5c4-98b1-4c75-91fe-e1ae97d6972f"
+        "x-ms-request-id": "83d5eda4-70a6-47c2-9a70-6dd4487b68dc"
       },
       "ResponseBody": {
         "get": [
@@ -469,12 +469,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "7816d255-d6f6-4af9-a94a-b06843bd84a6"
+        "x-ms-request-id": "0713362a-fed7-43b9-92f0-dc76c9dc88bf"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_LifecycleAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_LifecycleAsync.json
@@ -6,8 +6,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "73a17ea53eebbbb136545e7e97323b5a",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "eddbfbbb3a242b282fd669a3e6b466c3",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -17,12 +17,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:50 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "3c0bc54e-aa78-4bf5-8590-3ceb6f7c78b8"
+        "x-ms-request-id": "668afe4f-1d12-4cac-9b5a-ea187c04a66e"
       },
       "ResponseBody": {
         "types": [
@@ -87,6 +87,46 @@
                 "aggregation": {
                   "tsx": "median($value)"
                 }
+              },
+              "aggregateVar": {
+                "kind": "aggregate",
+                "aggregation": {
+                  "tsx": "avg($event[\u0027Temperature\u0027].Double)"
+                }
+              }
+            }
+          },
+          {
+            "id": "5107825e-4b61-4d03-b84d-1df93999b0a8",
+            "name": "ddd",
+            "variables": {
+              "aaaa": {
+                "kind": "categorical",
+                "value": {
+                  "tsx": "$event.building.String"
+                },
+                "filter": {
+                  "tsx": "($event.building.String) != null"
+                },
+                "interpolation": {
+                  "kind": "step",
+                  "boundary": {
+                    "span": "PT5M"
+                  }
+                },
+                "categories": [
+                  {
+                    "label": "dddd",
+                    "values": [
+                      "asdada"
+                    ],
+                    "annotations": {}
+                  }
+                ],
+                "defaultCategory": {
+                  "label": "aa",
+                  "annotations": {}
+                }
               }
             }
           }
@@ -101,18 +141,18 @@
         "Authorization": "Sanitized",
         "Content-Length": "255",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "125dd6f8fc1ce5ef57d856c2164472f0",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1a1666a7347215b5704d2c3013947b1e",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "put": [
           {
-            "id": "1270999455",
-            "name": "type197Vczz6",
+            "id": "1141002836",
+            "name": "typen6ZDuE3F",
             "variables": {
-              "varjczZC4Ub": {
+              "varxWpruYEk": {
                 "aggregation": {
                   "tsx": "count()"
                 },
@@ -121,10 +161,10 @@
             }
           },
           {
-            "id": "1109560891",
-            "name": "typeGW1mmY9X",
+            "id": "1546230302",
+            "name": "typewNX0JO1y",
             "variables": {
-              "varjczZC4Ub": {
+              "varxWpruYEk": {
                 "aggregation": {
                   "tsx": "count()"
                 },
@@ -139,21 +179,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "27c42474-6517-4676-a871-be58b448b25f"
+        "x-ms-request-id": "3a5cd142-b546-4ae0-9a62-e337af4487fb"
       },
       "ResponseBody": {
         "put": [
           {
             "timeSeriesType": {
-              "id": "1270999455",
-              "name": "type197Vczz6",
+              "id": "1141002836",
+              "name": "typen6ZDuE3F",
               "variables": {
-                "varjczZC4Ub": {
+                "varxWpruYEk": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -164,10 +204,10 @@
           },
           {
             "timeSeriesType": {
-              "id": "1109560891",
-              "name": "typeGW1mmY9X",
+              "id": "1546230302",
+              "name": "typewNX0JO1y",
               "variables": {
-                "varjczZC4Ub": {
+                "varxWpruYEk": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -187,16 +227,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "49",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "1f114e152c806061e0f268b4753ca407",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "5313d34b6769a42beaee38758cb63763",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
           "names": [
-            "type197Vczz6",
-            "typeGW1mmY9X"
+            "typen6ZDuE3F",
+            "typewNX0JO1y"
           ]
         }
       },
@@ -205,21 +245,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "9e97b547-b473-443f-8244-3d3191cc4562"
+        "x-ms-request-id": "5e853e6c-e551-41e5-9505-ea18a57c5086"
       },
       "ResponseBody": {
         "get": [
           {
             "timeSeriesType": {
-              "id": "1270999455",
-              "name": "type197Vczz6",
+              "id": "1141002836",
+              "name": "typen6ZDuE3F",
               "variables": {
-                "varjczZC4Ub": {
+                "varxWpruYEk": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -230,10 +270,10 @@
           },
           {
             "timeSeriesType": {
-              "id": "1109560891",
-              "name": "typeGW1mmY9X",
+              "id": "1546230302",
+              "name": "typewNX0JO1y",
               "variables": {
-                "varjczZC4Ub": {
+                "varxWpruYEk": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -253,19 +293,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "311",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "1dcf048ca55aa8078fbc1b12e7efa5f2",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "8952673a2089869045c57cd60ef8189a",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "put": [
           {
-            "id": "1270999455",
-            "name": "type197Vczz6",
+            "id": "1141002836",
+            "name": "typen6ZDuE3F",
             "description": "Description",
             "variables": {
-              "varjczZC4Ub": {
+              "varxWpruYEk": {
                 "aggregation": {
                   "tsx": "count()"
                 },
@@ -274,11 +314,11 @@
             }
           },
           {
-            "id": "1109560891",
-            "name": "typeGW1mmY9X",
+            "id": "1546230302",
+            "name": "typewNX0JO1y",
             "description": "Description",
             "variables": {
-              "varjczZC4Ub": {
+              "varxWpruYEk": {
                 "aggregation": {
                   "tsx": "count()"
                 },
@@ -293,22 +333,22 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "cf774f78-a772-4078-95ce-dac2813788e7"
+        "x-ms-request-id": "e7928be4-de01-43f2-8ad7-462760594571"
       },
       "ResponseBody": {
         "put": [
           {
             "timeSeriesType": {
-              "id": "1270999455",
-              "name": "type197Vczz6",
+              "id": "1141002836",
+              "name": "typen6ZDuE3F",
               "description": "Description",
               "variables": {
-                "varjczZC4Ub": {
+                "varxWpruYEk": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -319,11 +359,11 @@
           },
           {
             "timeSeriesType": {
-              "id": "1109560891",
-              "name": "typeGW1mmY9X",
+              "id": "1546230302",
+              "name": "typewNX0JO1y",
               "description": "Description",
               "variables": {
-                "varjczZC4Ub": {
+                "varxWpruYEk": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -343,16 +383,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "47",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "49696ee11c20ccda75fd3229943a6f1b",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "13574b5b12a040593a712f83fb3f88b9",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "get": {
           "typeIds": [
-            "1270999455",
-            "1109560891"
+            "1141002836",
+            "1546230302"
           ]
         }
       },
@@ -361,22 +401,22 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e5bbf9b4-f024-43e0-a98b-0aaeb2e86285"
+        "x-ms-request-id": "fffc0b2b-c93f-47cb-acfc-6df77e297cdd"
       },
       "ResponseBody": {
         "get": [
           {
             "timeSeriesType": {
-              "id": "1270999455",
-              "name": "type197Vczz6",
+              "id": "1141002836",
+              "name": "typen6ZDuE3F",
               "description": "Description",
               "variables": {
-                "varjczZC4Ub": {
+                "varxWpruYEk": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -387,11 +427,11 @@
           },
           {
             "timeSeriesType": {
-              "id": "1109560891",
-              "name": "typeGW1mmY9X",
+              "id": "1546230302",
+              "name": "typewNX0JO1y",
               "description": "Description",
               "variables": {
-                "varjczZC4Ub": {
+                "varxWpruYEk": {
                   "kind": "aggregate",
                   "aggregation": {
                     "tsx": "count()"
@@ -411,16 +451,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "50",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210324.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "11364f3455746f95466890c3104e78f0",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "abf5c815f2422b94428d0da4ea5495f1",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "delete": {
           "typeIds": [
-            "1270999455",
-            "1109560891"
+            "1141002836",
+            "1546230302"
           ]
         }
       },
@@ -429,12 +469,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Wed, 24 Mar 2021 20:18:51 GMT",
+        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e72114ca-e9ab-4ede-837e-548d4f28910d"
+        "x-ms-request-id": "508da5e7-4a10-4280-baee-4b25736cf200"
       },
       "ResponseBody": {
         "delete": [
@@ -445,7 +485,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1188087842",
+    "RandomSeed": "2126553769",
     "TIMESERIESINSIGHTS_URL": "fakeHost.api.wus2.timeseriesinsights.azure.com"
   }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_LifecycleAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_LifecycleAsync.json
@@ -17,12 +17,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "fe3d6623-fc5c-4faf-b863-d5d03eb30cb9"
+        "x-ms-request-id": "d5847d2a-0925-4097-8bb3-586c298bff3c"
       },
       "ResponseBody": {
         "types": [
@@ -179,12 +179,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "2c588c83-7b9b-44c8-b981-210753ce5f9d"
+        "x-ms-request-id": "df2b9d6e-1a6d-4016-a2fc-f7fbb23db394"
       },
       "ResponseBody": {
         "put": [
@@ -245,68 +245,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:28 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "af57e33d-9b67-4bde-ab4a-c1f79595d379"
-      },
-      "ResponseBody": {
-        "get": [
-          {
-            "error": {
-              "code": "ResourceNotFound",
-              "message": "Time series type with name \u0027typen6ZDuE3F\u0027 is not found.",
-              "innerError": {
-                "code": "TypeNotFound"
-              }
-            }
-          },
-          {
-            "error": {
-              "code": "ResourceNotFound",
-              "message": "Time series type with name \u0027typewNX0JO1y\u0027 is not found.",
-              "innerError": {
-                "code": "TypeNotFound"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "49",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "8952673a2089869045c57cd60ef8189a",
-        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "get": {
-          "names": [
-            "typen6ZDuE3F",
-            "typewNX0JO1y"
-          ]
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
-        "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
-        "Server": "Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "b92932e8-56be-4774-af96-3dc92400af79"
+        "x-ms-request-id": "1a790040-e9a6-441e-ad5a-4daa4c9141b1"
       },
       "ResponseBody": {
         "get": [
@@ -350,7 +294,7 @@
         "Content-Length": "311",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "13574b5b12a040593a712f83fb3f88b9",
+        "x-ms-client-request-id": "8952673a2089869045c57cd60ef8189a",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -389,12 +333,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "c8ad9c28-97d0-4ea4-ac25-9fe9f726be45"
+        "x-ms-request-id": "5c3fb610-2146-4466-bdbe-de16e6a1248f"
       },
       "ResponseBody": {
         "put": [
@@ -440,7 +384,7 @@
         "Content-Length": "47",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "abf5c815f2422b94428d0da4ea5495f1",
+        "x-ms-client-request-id": "13574b5b12a040593a712f83fb3f88b9",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -457,12 +401,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "c22738e3-98da-4ef9-9df0-352311450e1e"
+        "x-ms-request-id": "4f1f361d-cf7b-4bea-b767-63079e40854a"
       },
       "ResponseBody": {
         "get": [
@@ -508,7 +452,7 @@
         "Content-Length": "50",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "411a9dd6245f27c30e124e17f00c8b06",
+        "x-ms-client-request-id": "abf5c815f2422b94428d0da4ea5495f1",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -525,12 +469,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Date": "Fri, 26 Mar 2021 20:08:29 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "2799de70-d996-48fa-a9be-76095cc60375"
+        "x-ms-request-id": "02edbcc9-67bb-48cd-bce3-27aecdb96ff4"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_LifecycleAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_LifecycleAsync.json
@@ -17,12 +17,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "12362b21-8b34-4deb-98e7-f1875780e43a"
+        "x-ms-request-id": "fe3d6623-fc5c-4faf-b863-d5d03eb30cb9"
       },
       "ResponseBody": {
         "types": [
@@ -179,12 +179,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "850d460a-97f2-4d24-a7bc-022ee1b9ec2a"
+        "x-ms-request-id": "2c588c83-7b9b-44c8-b981-210753ce5f9d"
       },
       "ResponseBody": {
         "put": [
@@ -245,12 +245,68 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:31 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "58f58e4c-bb24-49f1-99cd-672760267ca7"
+        "x-ms-request-id": "af57e33d-9b67-4bde-ab4a-c1f79595d379"
+      },
+      "ResponseBody": {
+        "get": [
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series type with name \u0027typen6ZDuE3F\u0027 is not found.",
+              "innerError": {
+                "code": "TypeNotFound"
+              }
+            }
+          },
+          {
+            "error": {
+              "code": "ResourceNotFound",
+              "message": "Time series type with name \u0027typewNX0JO1y\u0027 is not found.",
+              "innerError": {
+                "code": "TypeNotFound"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.timeseriesinsights.azure.com/timeseries/types/$batch?api-version=2020-07-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "49",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "8952673a2089869045c57cd60ef8189a",
+        "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "get": {
+          "names": [
+            "typen6ZDuE3F",
+            "typewNX0JO1y"
+          ]
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
+        "Content-Type": "application/json",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-request-id": "b92932e8-56be-4774-af96-3dc92400af79"
       },
       "ResponseBody": {
         "get": [
@@ -294,7 +350,7 @@
         "Content-Length": "311",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "8952673a2089869045c57cd60ef8189a",
+        "x-ms-client-request-id": "13574b5b12a040593a712f83fb3f88b9",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -333,12 +389,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "6c70fe77-ea3d-4daf-a9e7-a0f49b51dabe"
+        "x-ms-request-id": "c8ad9c28-97d0-4ea4-ac25-9fe9f726be45"
       },
       "ResponseBody": {
         "put": [
@@ -384,7 +440,7 @@
         "Content-Length": "47",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "13574b5b12a040593a712f83fb3f88b9",
+        "x-ms-client-request-id": "abf5c815f2422b94428d0da4ea5495f1",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -401,12 +457,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "ee1177d9-8a24-4857-a8fa-74f27713aac9"
+        "x-ms-request-id": "c22738e3-98da-4ef9-9df0-352311450e1e"
       },
       "ResponseBody": {
         "get": [
@@ -452,7 +508,7 @@
         "Content-Length": "50",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-IoT.TimeSeriesInsights/1.0.0-alpha.20210326.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "abf5c815f2422b94428d0da4ea5495f1",
+        "x-ms-client-request-id": "411a9dd6245f27c30e124e17f00c8b06",
         "x-ms-client-session-id": "00000000-0000-0000-0000-000000000000",
         "x-ms-return-client-request-id": "true"
       },
@@ -469,12 +525,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
+        "Date": "Fri, 26 Mar 2021 19:32:42 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "a5943376-8366-452b-9e9c-8cd95002d7fe"
+        "x-ms-request-id": "2799de70-d996-48fa-a9be-76095cc60375"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_LifecycleAsync.json
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/SessionRecords/TimeSeriesInsightsTypesTests/TimeSeriesInsightsTypes_LifecycleAsync.json
@@ -17,12 +17,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "668afe4f-1d12-4cac-9b5a-ea187c04a66e"
+        "x-ms-request-id": "12362b21-8b34-4deb-98e7-f1875780e43a"
       },
       "ResponseBody": {
         "types": [
@@ -179,12 +179,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 18:59:59 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "3a5cd142-b546-4ae0-9a62-e337af4487fb"
+        "x-ms-request-id": "850d460a-97f2-4d24-a7bc-022ee1b9ec2a"
       },
       "ResponseBody": {
         "put": [
@@ -245,12 +245,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "5e853e6c-e551-41e5-9505-ea18a57c5086"
+        "x-ms-request-id": "58f58e4c-bb24-49f1-99cd-672760267ca7"
       },
       "ResponseBody": {
         "get": [
@@ -333,12 +333,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "e7928be4-de01-43f2-8ad7-462760594571"
+        "x-ms-request-id": "6c70fe77-ea3d-4daf-a9e7-a0f49b51dabe"
       },
       "ResponseBody": {
         "put": [
@@ -401,12 +401,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "fffc0b2b-c93f-47cb-acfc-6df77e297cdd"
+        "x-ms-request-id": "ee1177d9-8a24-4857-a8fa-74f27713aac9"
       },
       "ResponseBody": {
         "get": [
@@ -469,12 +469,12 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-continuation",
         "Content-Type": "application/json",
-        "Date": "Fri, 26 Mar 2021 19:00:00 GMT",
+        "Date": "Fri, 26 Mar 2021 19:11:02 GMT",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "508da5e7-4a10-4280-baee-4b25736cf200"
+        "x-ms-request-id": "a5943376-8366-452b-9e9c-8cd95002d7fe"
       },
       "ResponseBody": {
         "delete": [

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsTypesTests.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsTypesTests.cs
@@ -44,28 +44,8 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             type.Id = timeSeriesTypeId;
             timeSeriesTypes.Add(type);
 
-            // create numeric type and expect failure due to invalid input expression
-            Response<TimeSeriesOperationError[]> createTypesResult = await client
-                .CreateOrReplaceTimeSeriesTypesAsync(timeSeriesTypes)
-                .ConfigureAwait(false);
-
-            // Assert that the result error array does not contain an error
-            createTypesResult.Value.Should().OnlyContain((errorResult) => errorResult != null);
-
-            // Get the type by name and expect error
-            var getTypesByNamesResult = await client
-                .GetTimeSeriesTypesByNamesAsync(new string[] { timeSeriesTypesName })
-                .ConfigureAwait(false);
-            getTypesByNamesResult.Value.Should().OnlyContain((errorResult) => errorResult.Error != null);
-
-            // Delete the type by name and expect error
-            Response<TimeSeriesOperationError[]> deleteTypesResponse = await client
-                       .DeleteTimeSeriesTypesByNamesAsync(new string[] { timeSeriesTypesName })
-                       .ConfigureAwait(false);
-
-            // Assert that the response array does not have any error object set
-            // Response is null even when type does not exist, conversation is started with Tsi team to confirm this behavior.
-            deleteTypesResponse.Value.Should().OnlyContain((errorResult) => errorResult == null);
+            // Act and Assert
+            await TypeUnhappyPathTests(client, timeSeriesTypes, timeSeriesTypesName).ConfigureAwait(false);
         }
 
         [Test]
@@ -91,28 +71,8 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             type.Id = timeSeriesTypeId;
             timeSeriesTypes.Add(type);
 
-            // create numeric type and expect failure due to invalid input expression
-            Response<TimeSeriesOperationError[]> createTypesResult = await client
-                .CreateOrReplaceTimeSeriesTypesAsync(timeSeriesTypes)
-                .ConfigureAwait(false);
-
-            // Assert that the result error array does not contain an error
-            createTypesResult.Value.Should().OnlyContain((errorResult) => errorResult != null);
-
-            // Get the type by name and expect error
-            var getTypesByNamesResult = await client
-                .GetTimeSeriesTypesByNamesAsync(new string[] { timeSeriesTypesName })
-                .ConfigureAwait(false);
-            getTypesByNamesResult.Value.Should().OnlyContain((errorResult) => errorResult.Error != null);
-
-            // Delete the type by name and expect error
-            Response<TimeSeriesOperationError[]> deleteTypesResponse = await client
-                       .DeleteTimeSeriesTypesByNamesAsync(new string[] { timeSeriesTypesName })
-                       .ConfigureAwait(false);
-
-            // Assert that the response array does not have any error object set
-            // Response is null even when type does not exist, conversation is started with Tsi team to confirm this behavior.
-            deleteTypesResponse.Value.Should().OnlyContain((errorResult) => errorResult == null);
+            // Act and Assert
+            await TypeUnhappyPathTests(client, timeSeriesTypes, timeSeriesTypesName).ConfigureAwait(false);
         }
 
         [Test]
@@ -236,6 +196,31 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
                     throw;
                 }
             }
+        }
+
+        private static async Task TypeUnhappyPathTests(TimeSeriesInsightsClient client, List<TimeSeriesType> timeSeriesTypes, string timeSeriesTypesName)
+        {
+            // create numeric type and expect failure due to invalid input expression
+            Response<TimeSeriesOperationError[]> createTypesResult = await client
+                .CreateOrReplaceTimeSeriesTypesAsync(timeSeriesTypes)
+                .ConfigureAwait(false);
+
+            // Assert that the result error array does not contain an error
+            createTypesResult.Value.Should().OnlyContain((errorResult) => errorResult != null);
+
+            // Get the type by name and expect error
+            var getTypesByNamesResult = await client
+                .GetTimeSeriesTypesByNamesAsync(new string[] { timeSeriesTypesName })
+                .ConfigureAwait(false);
+            getTypesByNamesResult.Value.Should().OnlyContain((errorResult) => errorResult.Error != null);
+
+            // Delete the type by name and expect error
+            Response<TimeSeriesOperationError[]> deleteTypesResponse = await client
+                       .DeleteTimeSeriesTypesByNamesAsync(new string[] { timeSeriesTypesName })
+                       .ConfigureAwait(false);
+
+            // Response is null even when type does not exist.
+            deleteTypesResponse.Value.Should().OnlyContain((errorResult) => errorResult == null);
         }
     }
 }

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsTypesTests.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsTypesTests.cs
@@ -29,7 +29,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             var timeSeriesTypes = new List<TimeSeriesType>();
             var tsiTypeNamePrefix = "type";
             var timeSeriesTypesName = Recording.GenerateAlphaNumericId(tsiTypeNamePrefix);
-            var timeSeriesTypeId = Recording.GenerateId();
+            string timeSeriesTypeId = Recording.GenerateId();
 
             // Build Numeric variable
             // Below is an invalid expression
@@ -45,7 +45,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             timeSeriesTypes.Add(type);
 
             // Act and Assert
-            await TestTypeUnhappyPath(client, timeSeriesTypes, timeSeriesTypesName).ConfigureAwait(false);
+            await TestTimeSeriesTypeWhereErrorIsExpected(client, timeSeriesTypes, timeSeriesTypesName).ConfigureAwait(false);
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             var timeSeriesTypes = new List<TimeSeriesType>();
             var tsiTypeNamePrefix = "type";
             var timeSeriesTypesName = Recording.GenerateAlphaNumericId(tsiTypeNamePrefix);
-            var timeSeriesTypeId = Recording.GenerateId();
+            string timeSeriesTypeId = Recording.GenerateId();
 
             // Build Numeric variable
             // Below is an invalid expression
@@ -72,7 +72,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             timeSeriesTypes.Add(type);
 
             // Act and Assert
-            await TestTypeUnhappyPath(client, timeSeriesTypes, timeSeriesTypesName).ConfigureAwait(false);
+            await TestTimeSeriesTypeWhereErrorIsExpected(client, timeSeriesTypes, timeSeriesTypesName).ConfigureAwait(false);
         }
 
         [Test]
@@ -198,7 +198,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             }
         }
 
-        private static async Task TestTypeUnhappyPath(TimeSeriesInsightsClient client, List<TimeSeriesType> timeSeriesTypes, string timeSeriesTypesName)
+        private static async Task TestTimeSeriesTypeWhereErrorIsExpected(TimeSeriesInsightsClient client, List<TimeSeriesType> timeSeriesTypes, string timeSeriesTypesName)
         {
             // create numeric type and expect failure due to invalid input expression
             Response<TimeSeriesOperationError[]> createTypesResult = await client

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsTypesTests.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsTypesTests.cs
@@ -22,7 +22,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
         }
 
         [Test]
-        public async Task TimeSeriesInsightsNumericTypes_ExpectsError()
+        public async Task TimeSeriesInsightsTypeWithNumericVariable_ExpectsError()
         {
             // Arrange
             TimeSeriesInsightsClient client = GetClient();
@@ -31,7 +31,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             var timeSeriesTypesName = Recording.GenerateAlphaNumericId(tsiTypeNamePrefix);
             var timeSeriesTypeId = Recording.GenerateId();
 
-            // Build Numeric type
+            // Build Numeric variable
             // Below is an invalid expression
             var numExpression = new TimeSeriesExpression("$event");
             var aggregation = new TimeSeriesExpression("avg($value)");
@@ -45,11 +45,11 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             timeSeriesTypes.Add(type);
 
             // Act and Assert
-            await TypeUnhappyPathTests(client, timeSeriesTypes, timeSeriesTypesName).ConfigureAwait(false);
+            await TestTypeUnhappyPath(client, timeSeriesTypes, timeSeriesTypesName).ConfigureAwait(false);
         }
 
         [Test]
-        public async Task TimeSeriesInsightsCategoricalTypes_ExpectsError()
+        public async Task TimeSeriesInsightsTypeWithCategoricalVariable_ExpectsError()
         {
             // Arrange
             TimeSeriesInsightsClient client = GetClient();
@@ -58,7 +58,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             var timeSeriesTypesName = Recording.GenerateAlphaNumericId(tsiTypeNamePrefix);
             var timeSeriesTypeId = Recording.GenerateId();
 
-            // Build Numeric type
+            // Build Numeric variable
             // Below is an invalid expression
             var categoricalValue = new TimeSeriesExpression("$event");
             var category = new TimeSeriesDefaultCategory("label");
@@ -72,7 +72,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             timeSeriesTypes.Add(type);
 
             // Act and Assert
-            await TypeUnhappyPathTests(client, timeSeriesTypes, timeSeriesTypesName).ConfigureAwait(false);
+            await TestTypeUnhappyPath(client, timeSeriesTypes, timeSeriesTypesName).ConfigureAwait(false);
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
                 { Recording.GenerateAlphaNumericId(tsiTypeNamePrefix), Recording.GenerateId()}
             };
 
-            // Build aggregate type
+            // Build aggregate variable
             var countExpression = new TimeSeriesExpression("count()");
             var aggValue = new AggregateVariable(countExpression);
             var variables = new Dictionary<string, TimeSeriesVariable>();
@@ -198,7 +198,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             }
         }
 
-        private static async Task TypeUnhappyPathTests(TimeSeriesInsightsClient client, List<TimeSeriesType> timeSeriesTypes, string timeSeriesTypesName)
+        private static async Task TestTypeUnhappyPath(TimeSeriesInsightsClient client, List<TimeSeriesType> timeSeriesTypes, string timeSeriesTypesName)
         {
             // create numeric type and expect failure due to invalid input expression
             Response<TimeSeriesOperationError[]> createTypesResult = await client

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsTypesTests.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsTypesTests.cs
@@ -22,6 +22,100 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
         }
 
         [Test]
+        public async Task TimeSeriesInsightsNumericTypes_ExpectsError()
+        {
+            // Arrange
+            TimeSeriesInsightsClient client = GetClient();
+            var timeSeriesTypes = new List<TimeSeriesType>();
+            var tsiTypeNamePrefix = "type";
+            var timeSeriesTypesName = Recording.GenerateAlphaNumericId(tsiTypeNamePrefix);
+            var timeSeriesTypeId = Recording.GenerateId();
+
+            // Build Numeric type
+            // Below is an invalid expression
+            var numExpression = new TimeSeriesExpression("$event");
+            var aggregation = new TimeSeriesExpression("avg($value)");
+            var numericVariable = new NumericVariable(numExpression, aggregation);
+            var variables = new Dictionary<string, TimeSeriesVariable>();
+            var variableNamePrefix = "numericVariableName";
+            variables.Add(Recording.GenerateAlphaNumericId(variableNamePrefix), numericVariable);
+
+            var type = new TimeSeriesType(timeSeriesTypesName, variables);
+            type.Id = timeSeriesTypeId;
+            timeSeriesTypes.Add(type);
+
+            // create numeric type and expect failure due to invalid input expression
+            Response<TimeSeriesOperationError[]> createTypesResult = await client
+                .CreateOrReplaceTimeSeriesTypesAsync(timeSeriesTypes)
+                .ConfigureAwait(false);
+
+            // Assert that the result error array does not contain an error
+            createTypesResult.Value.Should().OnlyContain((errorResult) => errorResult != null);
+
+            // Get the type by name and expect error
+            var getTypesByNamesResult = await client
+                .GetTimeSeriesTypesByNamesAsync(new string[] { timeSeriesTypesName })
+                .ConfigureAwait(false);
+            getTypesByNamesResult.Value.Should().OnlyContain((errorResult) => errorResult.Error != null);
+
+            // Delete the type by name and expect error
+            Response<TimeSeriesOperationError[]> deleteTypesResponse = await client
+                       .DeleteTimeSeriesTypesByNamesAsync(new string[] { timeSeriesTypesName })
+                       .ConfigureAwait(false);
+
+            // Assert that the response array does not have any error object set
+            // Response is null even when type does not exist, conversation is started with Tsi team to confirm this behavior.
+            deleteTypesResponse.Value.Should().OnlyContain((errorResult) => errorResult == null);
+        }
+
+        [Test]
+        public async Task TimeSeriesInsightsCategoricalTypes_ExpectsError()
+        {
+            // Arrange
+            TimeSeriesInsightsClient client = GetClient();
+            var timeSeriesTypes = new List<TimeSeriesType>();
+            var tsiTypeNamePrefix = "type";
+            var timeSeriesTypesName = Recording.GenerateAlphaNumericId(tsiTypeNamePrefix);
+            var timeSeriesTypeId = Recording.GenerateId();
+
+            // Build Numeric type
+            // Below is an invalid expression
+            var categoricalValue = new TimeSeriesExpression("$event");
+            var category = new TimeSeriesDefaultCategory("label");
+            var categoricalVariable = new CategoricalVariable(categoricalValue, category);
+            var variables = new Dictionary<string, TimeSeriesVariable>();
+            var variableNamePrefix = "categoricalVariableName";
+            variables.Add(Recording.GenerateAlphaNumericId(variableNamePrefix), categoricalVariable);
+
+            var type = new TimeSeriesType(timeSeriesTypesName, variables);
+            type.Id = timeSeriesTypeId;
+            timeSeriesTypes.Add(type);
+
+            // create numeric type and expect failure due to invalid input expression
+            Response<TimeSeriesOperationError[]> createTypesResult = await client
+                .CreateOrReplaceTimeSeriesTypesAsync(timeSeriesTypes)
+                .ConfigureAwait(false);
+
+            // Assert that the result error array does not contain an error
+            createTypesResult.Value.Should().OnlyContain((errorResult) => errorResult != null);
+
+            // Get the type by name and expect error
+            var getTypesByNamesResult = await client
+                .GetTimeSeriesTypesByNamesAsync(new string[] { timeSeriesTypesName })
+                .ConfigureAwait(false);
+            getTypesByNamesResult.Value.Should().OnlyContain((errorResult) => errorResult.Error != null);
+
+            // Delete the type by name and expect error
+            Response<TimeSeriesOperationError[]> deleteTypesResponse = await client
+                       .DeleteTimeSeriesTypesByNamesAsync(new string[] { timeSeriesTypesName })
+                       .ConfigureAwait(false);
+
+            // Assert that the response array does not have any error object set
+            // Response is null even when type does not exist, conversation is started with Tsi team to confirm this behavior.
+            deleteTypesResponse.Value.Should().OnlyContain((errorResult) => errorResult == null);
+        }
+
+        [Test]
         public async Task TimeSeriesInsightsTypes_Lifecycle()
         {
             // Arrange


### PR DESCRIPTION
Adding tests to cover different kind of variables used with Time Series Types (learn more [here](https://docs.microsoft.com/en-us/azure/time-series-insights/concepts-variables))

- Categorical Types
- Numeric Types

These tests are written such that we do not need to know about what are existing properties (for example shown below) on the TSI environment. Hence we are testing unhappy/negative path here with an invalid expression for a type variable and expecting an error object trying to create/get this type.

> {"properties":[{"name":"building","type":"String"},{"name":"floor","type":"String"},{"name":"room","type":"String"},{"name":"temperature","type":"Double"},{"name":"humidity","type":"Double"},{"name":"room","type":"Long"},{"name":"isConference","type":"Bool"},{"name":"isConferenceRoom","type":"Bool"}]}