### PR TITLE
[Event Hubs Client] Hide Obsolete Event Data Mocking Constructor

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -3,6 +3,7 @@ namespace Azure.Messaging.EventHubs
     public partial class EventData
     {
         public EventData(System.BinaryData eventBody) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected EventData(System.BinaryData eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = (long)-9223372036854775808, long offset = (long)-9223372036854775808, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset), string partitionKey = null) { }
         public EventData(System.ReadOnlyMemory<byte> eventBody) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -383,6 +383,16 @@ namespace Azure.Messaging.EventHubs
         /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
         /// <param name="partitionKey">The partition hashing key associated with the event when it was published.</param>
         ///
+        /// <remarks>
+        ///   <para>This constructor has been superseded by the <see cref="EventHubsModelFactory.EventData" /> factory method.
+        ///   It is strongly recommended that the model factory be preferred over use of this constructor.</para>
+        ///
+        ///   <para>This overload was previously intended for mocking in support of testing efforts.  It is recommended that
+        ///   it not be used in production scenarios, as it allows setting of data that is broker-owned and is only
+        ///   meaningful on events that have been read from the Event Hubs service.</para>
+        /// </remarks>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected EventData(BinaryData eventBody,
                             IDictionary<string, object> properties = null,
                             IReadOnlyDictionary<string, object> systemProperties = null,
@@ -404,6 +414,15 @@ namespace Azure.Messaging.EventHubs
         /// <param name="offset">The offset of the event when it was received from the associated Event Hub partition.</param>
         /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
         /// <param name="partitionKey">The partition hashing key associated with the event when it was published.</param>
+        ///
+        /// <remarks>
+        ///   <para>This constructor has been superseded by the <see cref="EventHubsModelFactory.EventData" /> factory method.
+        ///   It is strongly recommended that the model factory be preferred over use of this constructor.</para>
+        ///
+        ///   <para>This overload was previously intended for mocking in support of testing efforts.  It is recommended that
+        ///   it not be used in production scenarios, as it allows setting of data that is broker-owned and is only
+        ///   meaningful on events that have been read from the Event Hubs service.</para>
+        /// </remarks>
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected EventData(ReadOnlyMemory<byte> eventBody,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
@@ -105,10 +105,10 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <param name="ownerLevel">The owner level associated with the partition.</param>
         /// <param name="lastPublishedSequenceNumber">The sequence number assigned to the event that was last successfully published to the partition.</param>
         ///
-        protected internal PartitionPublishingProperties(bool isIdempotentPublishingEnabled,
-                                                         long? producerGroupId,
-                                                         short? ownerLevel,
-                                                         int? lastPublishedSequenceNumber) =>
+        internal PartitionPublishingProperties(bool isIdempotentPublishingEnabled,
+                                               long? producerGroupId,
+                                               short? ownerLevel,
+                                               int? lastPublishedSequenceNumber) =>
             (IsIdempotentPublishingEnabled, ProducerGroupId, OwnerLevel, LastPublishedSequenceNumber) = (isIdempotentPublishingEnabled, producerGroupId, ownerLevel, lastPublishedSequenceNumber);
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to hide a constructor for `EventData` that was originally intended to support mocking scenarios before the model factory pattern was adopted.

# Last Upstream Rebase

Friday, March 265, 4pm (EST)