### PR TITLE
[Event Hubs Client] Lazy `EventData` Properties Dictionaries

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventDataExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventDataExtensions.cs
@@ -60,6 +60,17 @@ namespace Azure.Messaging.EventHubs.Tests
                 return false;
             }
 
+            // Verify that the stand-alone system properties are equivalent.
+
+            if ((considerSystemProperties)
+                && ((instance.Offset != other.Offset)
+                    || (instance.EnqueuedTime != other.EnqueuedTime)
+                    || (instance.PartitionKey != other.PartitionKey)
+                    || (instance.SequenceNumber != other.SequenceNumber)))
+            {
+                return false;
+            }
+
             // Verify the system properties are equivalent, unless they're the same reference.
 
             if ((considerSystemProperties) && (!Object.ReferenceEquals(instance.SystemProperties, other.SystemProperties)))
@@ -70,14 +81,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 }
 
                 if (instance.SystemProperties.Count != other.SystemProperties.Count)
-                {
-                    return false;
-                }
-
-                if ((instance.Offset != other.Offset)
-                    || (instance.EnqueuedTime != other.EnqueuedTime)
-                    || (instance.PartitionKey != other.PartitionKey)
-                    || (instance.SequenceNumber != other.SequenceNumber))
                 {
                     return false;
                 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using Azure.Core.Serialization;
@@ -17,6 +18,12 @@ namespace Azure.Messaging.EventHubs
     ///
     public class EventData
     {
+        /// <summary>An empty default set for the <see cref="SystemProperties" /> member, intended to used when no actual property set is available.</summary>
+        private static readonly IReadOnlyDictionary<string, object> EmptySystemProperties = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>(0));
+
+        /// <summary>The backing store for the <see cref="Properties" /> member, intended to be lazily allocated.</summary>
+        private IDictionary<string, object> _properties;
+
         /// <summary>
         ///   The data associated with the event, in <see cref="BinaryData" /> form, providing support
         ///   for a variety of data transformations and <see cref="ObjectSerializer" /> integration.
@@ -50,7 +57,10 @@ namespace Azure.Messaging.EventHubs
         ///   </code>
         /// </example>
         ///
-        public IDictionary<string, object> Properties { get; }
+        public IDictionary<string, object> Properties
+        {
+            get => _properties ??= new Dictionary<string, object>();
+        }
 
         /// <summary>
         ///   The set of free-form event properties which were provided by the Event Hubs service to pass metadata associated with the
@@ -161,6 +171,15 @@ namespace Azure.Messaging.EventHubs
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Stream BodyAsStream => EventBody.ToStream();
+
+        /// <summary>
+        ///   Indicates whether this instance has a populated set of <see cref="Properties" />
+        ///   or not, to avoid triggering lazy allocation by checking the property itself.
+        /// </summary>
+        ///
+        /// <value><c>true</c> if this instance has properties; otherwise, <c>false</c>.</value>
+        ///
+        internal bool HasProperties => (_properties != null);
 
         /// <summary>
         ///   The sequence number of the event that was last enqueued into the Event Hub partition from which this
@@ -355,12 +374,11 @@ namespace Azure.Messaging.EventHubs
                            short? pendingOwnerLevel = null)
         {
             EventBody = eventBody;
-            Properties = properties ?? new Dictionary<string, object>();
-            SystemProperties = systemProperties ?? new Dictionary<string, object>();
             SequenceNumber = sequenceNumber;
             Offset = offset;
             EnqueuedTime = enqueuedTime;
             PartitionKey = partitionKey;
+            SystemProperties = systemProperties ?? EmptySystemProperties;
             LastPartitionSequenceNumber = lastPartitionSequenceNumber;
             LastPartitionOffset = lastPartitionOffset;
             LastPartitionEnqueuedTime = lastPartitionEnqueuedTime;
@@ -369,6 +387,8 @@ namespace Azure.Messaging.EventHubs
             PendingPublishSequenceNumber = pendingPublishSequenceNumber;
             PendingProducerGroupId = pendingProducerGroupId;
             PendingProducerOwnerLevel = pendingOwnerLevel;
+
+            _properties = properties;
         }
 
         /// <summary>
@@ -476,7 +496,7 @@ namespace Azure.Messaging.EventHubs
             new EventData
             (
                 EventBody,
-                new Dictionary<string, object>(Properties),
+                (_properties == null) ? null : new Dictionary<string, object>(_properties),
                 SystemProperties,
                 SequenceNumber,
                 Offset,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Tests
@@ -16,6 +17,53 @@ namespace Azure.Messaging.EventHubs.Tests
     [TestFixture]
     public class EventDataTests
     {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData" /> constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorDoesNotCreatePropertiesyDefault()
+        {
+            var eventData = new EventData(Array.Empty<byte>());
+
+            Assert.That(GetPropertiesBackingStore(eventData), Is.Null, "The user properties should be created lazily.");
+            Assert.That(eventData.SystemProperties, Is.SameAs(GetEmptySystemProperties()), "The system properties should be the static empty set.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData" /> constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorHonorsPropertiesWhenPassed()
+        {
+            var properties = new Dictionary<string, object>();
+            var systemProperties = (IReadOnlyDictionary<string, object>)new Dictionary<string, object>();
+
+            var eventData = new EventData(
+                eventBody: Array.Empty<byte>(),
+                properties: properties,
+                systemProperties: systemProperties);
+
+            Assert.That(GetPropertiesBackingStore(eventData), Is.SameAs(properties), "The passed properties dictionary should have been used.");
+            Assert.That(eventData.SystemProperties, Is.SameAs(systemProperties), "The system properties dictionary should have been used.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData.Properties "/>
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void ApplicationPropertiesDictionaryIsLazilyCreated()
+        {
+            var eventData = new EventData(Array.Empty<byte>());
+            eventData.Properties.Add("test", "value");
+
+            Assert.That(GetPropertiesBackingStore(eventData), Is.Not.Null, "The properties dictionary should have been crated on demand.");
+            Assert.That(eventData.Properties.Count, Is.EqualTo(1), "The property that triggered creation should have been included in the set.");
+        }
+
         /// <summary>
         ///   Verifies functionality of the <see cref="EventData.BodyAsStream "/>
         ///   property.
@@ -83,7 +131,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void CloneProducesACopy()
+        public void CloneProducesACopyWhenPropertyDictionariesAreSet()
         {
             var sourceEvent = new EventData(
                 new byte[] { 0x21, 0x22 },
@@ -105,6 +153,37 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(clone.IsEquivalentTo(sourceEvent, true), Is.True, "The clone should be equivalent to the source event.");
             Assert.That(clone, Is.Not.SameAs(sourceEvent), "The clone should be a distinct reference.");
             Assert.That(object.ReferenceEquals(clone.Properties, sourceEvent.Properties), Is.False, "The clone's property bag should be a distinct reference.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloneProducesACopyWhenPropertyDictionariesAreNotSet()
+        {
+            var sourceEvent = new EventData(
+                new byte[] { 0x21, 0x22 },
+                null,
+                null,
+                33334444,
+                666777,
+                DateTimeOffset.Parse("2015-10-27T00:00:00Z"),
+                "TestKey",
+                111222,
+                999888,
+                DateTimeOffset.Parse("2012-03-04T09:00:00Z"),
+                DateTimeOffset.Parse("2003-09-27T15:00:00Z"),
+                787878,
+                987654);
+
+            var clone = sourceEvent.Clone();
+            Assert.That(clone, Is.Not.Null, "The clone should not be null.");
+            Assert.That(GetPropertiesBackingStore(clone), Is.Null, "The user properties should be created lazily.");
+            Assert.That(clone.SystemProperties, Is.SameAs(GetEmptySystemProperties()), "The system properties should be the static empty set.");
+            Assert.That(clone.IsEquivalentTo(sourceEvent, false), Is.True, "The clone should be equivalent to the source event.");
+            Assert.That(clone, Is.Not.SameAs(sourceEvent), "The clone should be a distinct reference.");
         }
 
         /// <summary>
@@ -138,5 +217,33 @@ namespace Azure.Messaging.EventHubs.Tests
             sourceEvent.Properties.Add("New", "thing");
             Assert.That(clone.IsEquivalentTo(sourceEvent, true), Is.False, "The clone should no longer be equivalent to the source event; user properties were changed.");
         }
+
+        /// <summary>
+        ///   Retrieves the empty system properties dictionary from the Event Data
+        ///   type, using its private field.
+        /// </summary>
+        ///
+        /// <returns>The empty dictionary used as the default for the <see cref="EventData.SystemProperties" /> set.</returns>
+        ///
+        private static IReadOnlyDictionary<string, object> GetEmptySystemProperties() =>
+            (IReadOnlyDictionary<string, object>)
+                typeof(EventData)
+                    .GetField("EmptySystemProperties", BindingFlags.Static | BindingFlags.NonPublic)
+                    .GetValue(null);
+
+        /// <summary>
+        ///   Retrieves the backing store for the Properties dictionary from the Event Data
+        ///   type, using its private field.
+        /// </summary>
+        ///
+        /// <param name="eventData">The instance to read the field from.</param>
+        ///
+        /// <returns>The backing store for the <see cref="EventData.Properties" /> set.</returns>
+        ///
+        private static IReadOnlyDictionary<string, object> GetPropertiesBackingStore(EventData eventData) =>
+            (IReadOnlyDictionary<string, object>)
+                typeof(EventData)
+                    .GetField("_properties", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(eventData);
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to move to a lazy lazily initializing the property dictionaries used for `EventData`.  

# Last Upstream Rebase

Monday, March 29, 1:30pm (EST)