### PR TITLE
[Translation] Add more live tests

### DIFF
--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/src/ClientDiagnostics.cs
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/src/ClientDiagnostics.cs
@@ -45,8 +45,8 @@ namespace Azure.Core.Pipeline
                     if (doc.RootElement.TryGetProperty("error", out JsonElement errorElement))
                     {
                         DocumentTranslationError error = DocumentTranslationError.DeserializeDocumentTranslationError(errorElement);
-                        message ??= error?.Message;
-                        errorCode ??= error?.ErrorCode.ToString();
+                        message = error.Message;
+                        errorCode = error.ErrorCode.ToString();
                     }
                 }
                 catch (JsonException)

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/src/ClientDiagnostics.cs
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/src/ClientDiagnostics.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json;
+using Azure.AI.DocumentTranslation;
+
+#nullable enable
+
+namespace Azure.Core.Pipeline
+{
+    /// <summary>
+    /// Extend ClientDiagnostics to customize the exceptions thrown by the
+    /// generated code.
+    /// </summary>
+    internal sealed partial class ClientDiagnostics
+    {
+        /// <summary>
+        /// Customize the exception messages we throw from the protocol layer by
+        /// attempting to parse them as <see cref="DocumentTranslationError"/>s.
+        /// </summary>
+        /// <param name="content">The error content.</param>
+        /// <param name="responseHeaders">The response headers.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="errorCode">The error code.</param>
+        /// <param name="additionalInfo">Additional error details.</param>
+#pragma warning disable CA1822 // Member can be static
+#pragma warning disable CA1801 // Remove unused parameter
+        partial void ExtractFailureContent(
+            string? content,
+            ResponseHeaders responseHeaders,
+            ref string? message,
+            ref string? errorCode,
+            ref IDictionary<string, string>? additionalInfo)
+#pragma warning restore CA1801 // Remove unused parameter
+#pragma warning restore CA1822 // Member can be static
+        {
+            if (!string.IsNullOrEmpty(content))
+            {
+                try
+                {
+                    // Try to parse the failure content and use that as the
+                    // default value for the message, error code, etc.
+                    using JsonDocument doc = JsonDocument.Parse(content);
+                    if (doc.RootElement.TryGetProperty("error", out JsonElement errorElement))
+                    {
+                        DocumentTranslationError error = DocumentTranslationError.DeserializeDocumentTranslationError(errorElement);
+                        message ??= error?.Message;
+                        errorCode ??= error?.ErrorCode.ToString();
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore any failures - unexpected content will be
+                    // included verbatim in the detailed error message
+                }
+            }
+        }
+    }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/DocumentTranslationClientLiveTests.cs
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/DocumentTranslationClientLiveTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -23,16 +25,61 @@ namespace Azure.AI.DocumentTranslation.Tests
         {
             var client = GetClient(credential: new AzureKeyCredential("fakeKey"));
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await client.GetDocumentFormatsAsync());
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.GetDocumentFormatsAsync());
+
+            Assert.AreEqual("401", ex.ErrorCode);
         }
 
         [RecordedTest]
-        public async Task GetDocumentFormatsTestAsync()
+        public async Task GetDocumentFormatsTest()
         {
             var client = GetClient();
 
             var documentFormats = await client.GetDocumentFormatsAsync();
             Assert.GreaterOrEqual(documentFormats.Value.Count, 0);
+        }
+
+        [RecordedTest]
+        public async Task GetGlossaryFormatsTest()
+        {
+            var client = GetClient();
+
+            var glossaryFormats = await client.GetGlossaryFormatsAsync();
+            Assert.GreaterOrEqual(glossaryFormats.Value.Count, 0);
+        }
+
+        [RecordedTest]
+        public async Task GetTranslationsTest()
+        {
+            Uri source = await CreateSourceContainerAsync(OneDocumentList);
+            Uri target = await CreateTargetContainerAsync();
+
+            var client = GetClient();
+
+            var input = new DocumentTranslationInput(source, target, "fr");
+            await client.StartTranslationAsync(input);
+
+            List<TranslationStatusResult> translations = await client.GetTranslationsAsync().ToEnumerableAsync();
+
+            Assert.GreaterOrEqual(translations.Count, 1);
+            TranslationStatusResult oneTranslation = translations[0];
+            Assert.AreNotEqual(new DateTimeOffset(), oneTranslation.CreatedOn);
+            Assert.AreNotEqual(new DateTimeOffset(), oneTranslation.LastModified);
+            Assert.GreaterOrEqual(oneTranslation.DocumentsCancelled, 0);
+            Assert.GreaterOrEqual(oneTranslation.DocumentsFailed, 0);
+            Assert.GreaterOrEqual(oneTranslation.DocumentsInProgress, 0);
+            Assert.GreaterOrEqual(oneTranslation.DocumentsNotStarted, 0);
+            Assert.GreaterOrEqual(oneTranslation.DocumentsSucceeded, 0);
+            Assert.GreaterOrEqual(oneTranslation.DocumentsTotal, 0);
+
+            if (oneTranslation.Error == null && oneTranslation.HasCompleted)
+            {
+                Assert.Greater(oneTranslation.TotalCharactersCharged, 0);
+            }
+            else
+            {
+                Assert.AreEqual(0, oneTranslation.TotalCharactersCharged);
+            }
         }
     }
 }

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/DocumentTranslationClientLiveTests.cs
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/DocumentTranslationClientLiveTests.cs
@@ -51,7 +51,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task GetTranslationsTest()
         {
-            Uri source = await CreateSourceContainerAsync(OneDocumentList);
+            Uri source = await CreateSourceContainerAsync(oneTestDocuments);
             Uri target = await CreateTargetContainerAsync();
 
             var client = GetClient();

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/Infrastructure/DocumentTranslationLiveTestBase.cs
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/Infrastructure/DocumentTranslationLiveTestBase.cs
@@ -23,6 +23,20 @@ namespace Azure.AI.DocumentTranslation.Tests
             Sanitizer = new DocumentTranslationRecordedTestSanitizer();
         }
 
+        private static readonly List<TestDocument> oneTestDocuments = new()
+        {
+            new TestDocument("Document1.txt", "First english test document"),
+        };
+
+        private static readonly List<TestDocument> twoTestDocuments = new()
+        {
+            new TestDocument("Document1.txt", "First english test document"),
+            new TestDocument("File2.txt", "Second english test file"),
+        };
+
+        protected List<TestDocument> OneDocumentList = oneTestDocuments;
+        protected List<TestDocument> TwoDocumentList = twoTestDocuments;
+
         public DocumentTranslationClient GetClient(
             AzureKeyCredential credential = default,
             DocumentTranslationClientOptions options = default)
@@ -53,7 +67,7 @@ namespace Azure.AI.DocumentTranslation.Tests
                 await containerClient.UploadBlobAsync(documents[i].Name, stream);
             }
 
-            var expiresOn = DateTimeOffset.Now.AddHours(1);
+            var expiresOn = DateTimeOffset.UtcNow.AddHours(1);
             return containerClient.GenerateSasUri(BlobContainerSasPermissions.List | BlobContainerSasPermissions.Read, expiresOn);
         }
 
@@ -64,7 +78,7 @@ namespace Azure.AI.DocumentTranslation.Tests
             var containerClient = GetBlobContainerClient(containerName);
             await containerClient.CreateAsync(PublicAccessType.BlobContainer).ConfigureAwait(false);
 
-            var expiresOn = DateTimeOffset.Now.AddHours(1);
+            var expiresOn = DateTimeOffset.UtcNow.AddHours(1);
             return containerClient.GenerateSasUri(BlobContainerSasPermissions.List | BlobContainerSasPermissions.Write, expiresOn);
         }
     }

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/Infrastructure/DocumentTranslationLiveTestBase.cs
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/Infrastructure/DocumentTranslationLiveTestBase.cs
@@ -23,19 +23,16 @@ namespace Azure.AI.DocumentTranslation.Tests
             Sanitizer = new DocumentTranslationRecordedTestSanitizer();
         }
 
-        private static readonly List<TestDocument> oneTestDocuments = new()
+        protected static readonly List<TestDocument> oneTestDocuments = new()
         {
             new TestDocument("Document1.txt", "First english test document"),
         };
 
-        private static readonly List<TestDocument> twoTestDocuments = new()
+        protected static readonly List<TestDocument> twoTestDocuments = new()
         {
             new TestDocument("Document1.txt", "First english test document"),
             new TestDocument("File2.txt", "Second english test file"),
         };
-
-        protected List<TestDocument> OneDocumentList = oneTestDocuments;
-        protected List<TestDocument> TwoDocumentList = twoTestDocuments;
 
         public DocumentTranslationClient GetClient(
             AzureKeyCredential credential = default,

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentFormatsTest.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentFormatsTest.json
@@ -1,32 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://python-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/documents/formats",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/documents/formats",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-37cf8a045faeb54eadfa71870bbb3c07-ffd6b680ce8fa848-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210316.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "701de2170cc2d39d01e76b6112fe8a7d",
+        "traceparent": "00-87572ae64ca8314b8b665ee28e685e26-a364c35dabcef54e-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "a8e73b5683b0ddaa8ba6727fb67c7ea4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a6f13eb-adb3-442e-aace-276ea17469a8",
+        "apim-request-id": "7de1259d-da73-44c2-a55d-e539b9f3cfbc",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 16 Mar 2021 23:44:13 GMT",
-        "ETag": "\u00229286211A60DF4B26245EA35A361E28C65AD4EC6AA36FD35FDD84FC606B95BEB6\u0022",
+        "Date": "Mon, 29 Mar 2021 22:09:36 GMT",
+        "ETag": "\u0022F50180F3F7A3DA2AD0976187D2FFC4ACD76EE3CF8049CD8DC1CB04DC7EE88660\u0022",
+        "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6a6f13eb-adb3-442e-aace-276ea17469a8"
+        "X-RequestId": "7de1259d-da73-44c2-a55d-e539b9f3cfbc"
       },
       "ResponseBody": {
         "value": [
@@ -132,7 +137,7 @@
   ],
   "Variables": {
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://python-doctranslation.cognitiveservices.azure.com",
-    "RandomSeed": "11358514"
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "1622717040"
   }
 }

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentFormatsTestAsync.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentFormatsTestAsync.json
@@ -1,23 +1,28 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://python-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/documents/formats",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/documents/formats",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bc4b7e483fbb844197da34dcb437933b-2d09358f097bee45-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210316.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "76bd242b36f37da0de837ecad9d879b3",
+        "traceparent": "00-823031427c63b34880c027079a4915f5-b27336e8410b8244-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1b6d256ced018bc79c6c514db058b487",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1ffd3d78-33d1-4287-8aa3-1db2419692a0",
+        "apim-request-id": "483d9b91-97cb-40c5-bad4-2bdf99dbb52c",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 16 Mar 2021 23:44:13 GMT",
-        "ETag": "\u00229286211A60DF4B26245EA35A361E28C65AD4EC6AA36FD35FDD84FC606B95BEB6\u0022",
+        "Date": "Mon, 29 Mar 2021 22:09:37 GMT",
+        "ETag": "\u0022F50180F3F7A3DA2AD0976187D2FFC4ACD76EE3CF8049CD8DC1CB04DC7EE88660\u0022",
+        "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
           "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
@@ -26,7 +31,7 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "1ffd3d78-33d1-4287-8aa3-1db2419692a0"
+        "X-RequestId": "483d9b91-97cb-40c5-bad4-2bdf99dbb52c"
       },
       "ResponseBody": {
         "value": [
@@ -132,7 +137,7 @@
   ],
   "Variables": {
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://python-doctranslation.cognitiveservices.azure.com",
-    "RandomSeed": "1634212269"
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "224656635"
   }
 }

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetGlossaryFormatsTest.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetGlossaryFormatsTest.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/glossaries/formats",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3991c8c3d297f14c800a8387a5fd5fb6-af514713ce724d4e-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7eb7899bb3d318d9e29cd0ea9f4b66a6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "20fcba91-f481-4931-9f8c-16efbfba6560",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:09:36 GMT",
+        "ETag": "\u0022E45B28E0479C2E4442005F96664ED8DE0001CBFEE34F87F4E4C6D25064CECB2F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "20fcba91-f481-4931-9f8c-16efbfba6560"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "format": "XLIFF",
+            "fileExtensions": [
+              ".xlf"
+            ],
+            "contentTypes": [
+              "application/xliff\u002Bxml"
+            ],
+            "defaultVersion": "1.2",
+            "versions": [
+              "1.0",
+              "1.1",
+              "1.2"
+            ]
+          },
+          {
+            "format": "TSV",
+            "fileExtensions": [
+              ".tsv",
+              ".tab"
+            ],
+            "contentTypes": [
+              "text/tab-separated-values"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "1376819004"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetGlossaryFormatsTestAsync.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetGlossaryFormatsTestAsync.json
@@ -1,0 +1,73 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/glossaries/formats",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-347d2daa12f73f44995663250c89f08f-c016ef24c9bc3148-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "4110c7dfe312faf50d86e60d2f0bbd9c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Age": "0",
+        "apim-request-id": "19c4cb5e-fed0-45da-8f97-6ba3d5abe09d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Length": "246",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:09:37 GMT",
+        "ETag": "\u0022E45B28E0479C2E4442005F96664ED8DE0001CBFEE34F87F4E4C6D25064CECB2F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "20fcba91-f481-4931-9f8c-16efbfba6560"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "format": "XLIFF",
+            "fileExtensions": [
+              ".xlf"
+            ],
+            "contentTypes": [
+              "application/xliff\u002Bxml"
+            ],
+            "defaultVersion": "1.2",
+            "versions": [
+              "1.0",
+              "1.1",
+              "1.2"
+            ]
+          },
+          {
+            "format": "TSV",
+            "fileExtensions": [
+              ".tsv",
+              ".tab"
+            ],
+            "contentTypes": [
+              "text/tab-separated-values"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "1032706159"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationsTest.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationsTest.json
@@ -1,0 +1,209 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1798463133?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8922c817d7682a44bd92b401323180d7-13bc6cbcec2c5442-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "335229b0ef2c606e7d8e1e2e4d0980cb",
+        "x-ms-date": "Mon, 29 Mar 2021 22:23:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:23:43 GMT",
+        "ETag": "\u00220x8D8F3014FDCD6E6\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:23:43 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "335229b0ef2c606e7d8e1e2e4d0980cb",
+        "x-ms-request-id": "212e7b5b-401e-0039-2dea-24134e000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1798463133/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-3d64f049f4ac274f93ab207771ceca5e-27d40d230972754e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5f6f1a2cc30a600048c72ebafbcf3871",
+        "x-ms-date": "Mon, 29 Mar 2021 22:23:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Mon, 29 Mar 2021 22:23:43 GMT",
+        "ETag": "\u00220x8D8F3014FFCD8A2\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:23:43 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "5f6f1a2cc30a600048c72ebafbcf3871",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "212e7b89-401e-0039-57ea-24134e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target189097895?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d662c2522bf08c4f8d6d074b5180346a-913d2dcd0c6f4c48-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d57c6a228c77ff6bd23d683747eff524",
+        "x-ms-date": "Mon, 29 Mar 2021 22:23:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:23:43 GMT",
+        "ETag": "\u00220x8D8F3015007BF43\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:23:43 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "d57c6a228c77ff6bd23d683747eff524",
+        "x-ms-request-id": "212e7ba4-401e-0039-6dea-24134e000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1cd53d5a93931b4895afa7f27104a1d2-a02f5a7ed4f5304c-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "57f11995933a28edf1eb65c1b364ae56",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "4d41b891-7582-47d4-b162-885a461a8a6f",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:23:43 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/a91f4c40-6ed5-4f3d-92ae-682a443bee77",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "4d41b891-7582-47d4-b162-885a461a8a6f"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7afeefa62498444abf3d8b5120bb68d4-b596d91bcfd26d44-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "9e2b87acf5048db5045f3886982800d7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "df8e6b2c-ca22-458a-a06c-3a2cfd16780e",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:23:44 GMT",
+        "ETag": "\u0022ABC0BA2C4DA3628627CC465EA3A63B74417FB05EE3A6F6EA657FF8FE52DB1808\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "df8e6b2c-ca22-458a-a06c-3a2cfd16780e"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "a91f4c40-6ed5-4f3d-92ae-682a443bee77",
+            "createdDateTimeUtc": "2021-03-29T22:23:44.2743379Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:23:44.2743437Z",
+            "status": "NotStarted",
+            "summary": {
+              "total": 0,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 0,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c72e0b77-6fd7-4a61-bde6-73c2d7e04f6b",
+            "createdDateTimeUtc": "2021-03-29T22:05:33.3806701Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:05:37.325113Z",
+            "status": "Failed",
+            "summary": {
+              "total": 1,
+              "failed": 1,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 0,
+              "totalCharacterCharged": 0
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "67905854"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationsTestAsync.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationsTestAsync.json
@@ -1,0 +1,209 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1312721669?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ccaf0aeaf419d54abf72ed1605d21930-99a607a07f107248-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "ca68dfd9e83b86265f6619afc3500ddd",
+        "x-ms-date": "Mon, 29 Mar 2021 22:23:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:23:45 GMT",
+        "ETag": "\u00220x8D8F30151640CAD\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:23:45 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "ca68dfd9e83b86265f6619afc3500ddd",
+        "x-ms-request-id": "212e7eff-401e-0039-0cea-24134e000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1312721669/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-37cc4a979086f142aeb53e3f60a889dd-9e159c899e986849-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "faf368151ce9f4c8b439b15af57ad5e3",
+        "x-ms-date": "Mon, 29 Mar 2021 22:23:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Mon, 29 Mar 2021 22:23:46 GMT",
+        "ETag": "\u00220x8D8F30151D9428C\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:23:46 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "faf368151ce9f4c8b439b15af57ad5e3",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "212e7f99-401e-0039-19ea-24134e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1274407801?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-9eadb1f914a6e44497645f9c7967c016-57d048f86da94f45-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "55ecd9d7f837d341f7f60b6078e38d8d",
+        "x-ms-date": "Mon, 29 Mar 2021 22:23:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:23:47 GMT",
+        "ETag": "\u00220x8D8F301521AFAEF\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:23:47 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "55ecd9d7f837d341f7f60b6078e38d8d",
+        "x-ms-request-id": "212e8023-401e-0039-13ea-24134e000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7855da4b16b24048abdba349570ed07d-3fa190cca37e6e40-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1364467e1c1716bd74160237cc91e591",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "5e6a1ed7-2e45-4135-9469-d62613d52e6f",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:23:47 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/f631951a-8e96-4514-bb00-8023ed6583be",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "5e6a1ed7-2e45-4135-9469-d62613d52e6f"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-defc1b404e286545bae627abc09f736c-10df9e89fc238448-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "77ec353588216fddb227f125bc933c56",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1767d456-5cc2-4b7f-b26c-67e5e4dceec2",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:23:47 GMT",
+        "ETag": "\u002202750F0CF4582147BBE026531CF65BF0F173DA54CD77A50067CF9EA9C2F5384A\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "1767d456-5cc2-4b7f-b26c-67e5e4dceec2"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "f631951a-8e96-4514-bb00-8023ed6583be",
+            "createdDateTimeUtc": "2021-03-29T22:23:47.7348057Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:23:47.9031732Z",
+            "status": "NotStarted",
+            "summary": {
+              "total": 1,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 1,
+              "cancelled": 0,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "a91f4c40-6ed5-4f3d-92ae-682a443bee77",
+            "createdDateTimeUtc": "2021-03-29T22:23:44.2743379Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:23:44.5524428Z",
+            "status": "NotStarted",
+            "summary": {
+              "total": 1,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 1,
+              "cancelled": 0,
+              "totalCharacterCharged": 0
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "271762631"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/ContainerWithSupportedAndUnsupportedFiles.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/ContainerWithSupportedAndUnsupportedFiles.json
@@ -1,0 +1,317 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source998250298?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-18a1809f9f19ef46be2ee0ea0fdf6d14-83e3156608c6264d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "02fd1e25eeca2dc077ac74f5fd2c6514",
+        "x-ms-date": "Mon, 29 Mar 2021 22:04:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:04:56 GMT",
+        "ETag": "\u00220x8D8F2FEB071467A\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:04:56 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "02fd1e25eeca2dc077ac74f5fd2c6514",
+        "x-ms-request-id": "07f4b77c-501e-0035-71e7-248446000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source998250298/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-ac7f1b6b232eea4b9ad528081635b501-efd9db94c47c3541-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "71efb60c43090ede86e1f8cc182dc4df",
+        "x-ms-date": "Mon, 29 Mar 2021 22:04:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Mon, 29 Mar 2021 22:04:56 GMT",
+        "ETag": "\u00220x8D8F2FEB08C8B2F\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:04:57 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "71efb60c43090ede86e1f8cc182dc4df",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "07f4b7d8-501e-0035-36e7-248446000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source998250298/File2.jpg",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "3",
+        "If-None-Match": "*",
+        "traceparent": "00-9efd8728234aa844866783d4874170fe-d33ab7dd61b38f44-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fce706d8b2ed1012096cc78a02081b9a",
+        "x-ms-date": "Mon, 29 Mar 2021 22:04:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "anBn",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "w2u9JYt\u002B5pTrmHIhsrGXsA==",
+        "Date": "Mon, 29 Mar 2021 22:04:56 GMT",
+        "ETag": "\u00220x8D8F2FEB095DBB6\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:04:57 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "fce706d8b2ed1012096cc78a02081b9a",
+        "x-ms-content-crc64": "NngqzE\u002Bv31M=",
+        "x-ms-request-id": "07f4b7fa-501e-0035-51e7-248446000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target864101064?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-09d4f9c679042048bd643db9d2ef0045-d906763a151a724d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5500cc12304e3fe2ee7ce8f5f41449e8",
+        "x-ms-date": "Mon, 29 Mar 2021 22:04:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:04:56 GMT",
+        "ETag": "\u00220x8D8F2FEB09EA038\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:04:57 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "5500cc12304e3fe2ee7ce8f5f41449e8",
+        "x-ms-request-id": "07f4b81a-501e-0035-6ae7-248446000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d4942cf772825d4b85fb466dd1b9bc55-259ab2536efde648-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "45f71c952768a45ade679c7c540b7dc6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "c0909cfa-5fdf-4eaa-a566-608cfa4df839",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:04:57 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/30e189e4-8a22-43e9-9000-9d6f6b0cab12",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c0909cfa-5fdf-4eaa-a566-608cfa4df839"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/30e189e4-8a22-43e9-9000-9d6f6b0cab12",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "6006045e8ac3d58905bcfe35291a1558",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8707ce56-d0ae-4942-a589-882060dbd805",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:04:57 GMT",
+        "ETag": "\u0022F23B84EA71673C77B0E3F2B8D8E4F079E96506D1BD69B4A4501D8222363DD4E7\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "8707ce56-d0ae-4942-a589-882060dbd805"
+      },
+      "ResponseBody": {
+        "id": "30e189e4-8a22-43e9-9000-9d6f6b0cab12",
+        "createdDateTimeUtc": "2021-03-29T22:04:57.6051067Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:04:57.6051114Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/30e189e4-8a22-43e9-9000-9d6f6b0cab12",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "ec6da17d5424eb5f715c76e79465ebe3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a52a9735-34cd-4ec5-b442-096a5681c84d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:05:27 GMT",
+        "ETag": "\u00229122D69161D963299CD2C11D0399CA504D0A6A045DF7CF63AD7FB0D1DE28AD32\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "a52a9735-34cd-4ec5-b442-096a5681c84d"
+      },
+      "ResponseBody": {
+        "id": "30e189e4-8a22-43e9-9000-9d6f6b0cab12",
+        "createdDateTimeUtc": "2021-03-29T22:04:57.6051067Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:05:14.369017Z",
+        "status": "Succeeded",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 1,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 27
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/30e189e4-8a22-43e9-9000-9d6f6b0cab12/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "f09622ffe90e0a25932240ab29247ac4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0bf2943c-cffe-4132-834b-a5c93f0b3c9a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:05:27 GMT",
+        "ETag": "\u002272053E40078A5FE5E260DDFDB8342F2DB1533D8D1FDB61ED04B6D374F360FB52\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "0bf2943c-cffe-4132-834b-a5c93f0b3c9a"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target864101064/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source998250298/Document1.txt",
+            "createdDateTimeUtc": "2021-03-29T22:05:02.2581765Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:05:15.0138857Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "00003ce9-0000-0000-0000-000000000000",
+            "characterCharged": 27
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "2009961794"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/ContainerWithSupportedAndUnsupportedFilesAsync.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/ContainerWithSupportedAndUnsupportedFilesAsync.json
@@ -1,0 +1,317 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source749851757?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-11ac37590895324dba78aebfeb9a1266-76722a090f82394e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5457f4b25f01b624757e554494c8fa47",
+        "x-ms-date": "Mon, 29 Mar 2021 22:02:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:03:00 GMT",
+        "ETag": "\u00220x8D8F2FE6AFC1FAA\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:03:00 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "5457f4b25f01b624757e554494c8fa47",
+        "x-ms-request-id": "edb6aeba-f01e-002c-04e7-2404fd000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source749851757/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-8f9b3d6172ed3c40a65ee1d99cf82a9d-91e877a2774d814a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7723e3bff4d5ad9b62076b91725fba1b",
+        "x-ms-date": "Mon, 29 Mar 2021 22:03:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Mon, 29 Mar 2021 22:03:00 GMT",
+        "ETag": "\u00220x8D8F2FE6B1AAD0E\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:03:00 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "7723e3bff4d5ad9b62076b91725fba1b",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "edb6af20-f01e-002c-5ae7-2404fd000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source749851757/File2.jpg",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "3",
+        "If-None-Match": "*",
+        "traceparent": "00-6c535af41dd19c4d908da8fdb6b18eea-4b35358f8fc6fc4b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "26aa7b62ba1c8bfb507140892c9c216f",
+        "x-ms-date": "Mon, 29 Mar 2021 22:03:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "anBn",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "w2u9JYt\u002B5pTrmHIhsrGXsA==",
+        "Date": "Mon, 29 Mar 2021 22:03:00 GMT",
+        "ETag": "\u00220x8D8F2FE6B224F96\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:03:00 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "26aa7b62ba1c8bfb507140892c9c216f",
+        "x-ms-content-crc64": "NngqzE\u002Bv31M=",
+        "x-ms-request-id": "edb6af39-f01e-002c-6ee7-2404fd000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1734279778?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e3b9f21e865a0e41b926a14c0c75c938-6c18e65a6ac82c4a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "04730d5b97a659bea9f1faf4924316c4",
+        "x-ms-date": "Mon, 29 Mar 2021 22:03:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:03:00 GMT",
+        "ETag": "\u00220x8D8F2FE6B2C1201\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:03:00 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "04730d5b97a659bea9f1faf4924316c4",
+        "x-ms-request-id": "edb6af64-f01e-002c-15e7-2404fd000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-db1b9dfcca35f6439fd0201f5cb277c4-5e30578dab5e4f4d-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1e18e23a2bd4e705982663b31180c5e5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "38f1721c-fe7a-47f6-9552-7ef7e2465419",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:03:01 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/936c38bb-edaf-4c73-91d3-15a9e4c80d0c",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "38f1721c-fe7a-47f6-9552-7ef7e2465419"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/936c38bb-edaf-4c73-91d3-15a9e4c80d0c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "51172efc1747e4bbebcd72c80197be2d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "14f990ca-7318-426b-8a2b-ea1f38303b2d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:03:01 GMT",
+        "ETag": "\u00224B4A7A690DB8955EECC286F4EA39399A4D93C603F18E8BC205C1B30F3E9F04A0\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "14f990ca-7318-426b-8a2b-ea1f38303b2d"
+      },
+      "ResponseBody": {
+        "id": "936c38bb-edaf-4c73-91d3-15a9e4c80d0c",
+        "createdDateTimeUtc": "2021-03-29T22:03:01.1117088Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:03:01.1117154Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/936c38bb-edaf-4c73-91d3-15a9e4c80d0c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "baf2c5295009308e078b6c7f330a4729",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c127e53f-4e8d-4583-8808-0eb436d627aa",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:03:30 GMT",
+        "ETag": "\u00222B6238F92F71FF5F25844C9190CFE48AB24C2EA9E1A181FFE1C88B8C62AECA9F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c127e53f-4e8d-4583-8808-0eb436d627aa"
+      },
+      "ResponseBody": {
+        "id": "936c38bb-edaf-4c73-91d3-15a9e4c80d0c",
+        "createdDateTimeUtc": "2021-03-29T22:03:01.1117088Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:03:08.3435867Z",
+        "status": "Succeeded",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 1,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 27
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/936c38bb-edaf-4c73-91d3-15a9e4c80d0c/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "63f8142cc52b227c26333306b83de600",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "66b6a7d0-534b-4603-aab5-5d9f47e56470",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:03:30 GMT",
+        "ETag": "\u00220FC60761A2C6711C8C17133B8F5B01D0ACCC6134611E01B948876489FC9EA990\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "66b6a7d0-534b-4603-aab5-5d9f47e56470"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target1734279778/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source749851757/Document1.txt",
+            "createdDateTimeUtc": "2021-03-29T22:03:02.0729509Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:03:08.8883988Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "00003ce7-0000-0000-0000-000000000000",
+            "characterCharged": 27
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "1249928045"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/GetDocumentStatusTest.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/GetDocumentStatusTest.json
@@ -1,0 +1,377 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1895674641?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-c8b77ed8f3a9674eaa8473e589133867-bb3df636795ab34d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "323e8020b1d73d71d6cce0157ef7eb4a",
+        "x-ms-date": "Mon, 29 Mar 2021 22:35:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:35:25 GMT",
+        "ETag": "\u00220x8D8F302F31DD60A\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:35:26 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "323e8020b1d73d71d6cce0157ef7eb4a",
+        "x-ms-request-id": "68c9bef0-901e-0058-41eb-24300d000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1895674641/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-a3a81a717ca3084ebbd3768d4f8d1e05-6e15b1cb14368642-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6c86da921ec809dfd7a0f3ebe45b69fa",
+        "x-ms-date": "Mon, 29 Mar 2021 22:35:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Mon, 29 Mar 2021 22:35:26 GMT",
+        "ETag": "\u00220x8D8F302F33C0033\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:35:26 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "6c86da921ec809dfd7a0f3ebe45b69fa",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "68c9bf58-901e-0058-24eb-24300d000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target512773566?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-b59c99a7c57614428c22be443c5ba7c4-3d499a9e6b4b6946-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "0979ac824e1f6575228cac73796cf82d",
+        "x-ms-date": "Mon, 29 Mar 2021 22:35:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:35:26 GMT",
+        "ETag": "\u00220x8D8F302F346E931\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:35:26 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "0979ac824e1f6575228cac73796cf82d",
+        "x-ms-request-id": "68c9bf7d-901e-0058-44eb-24300d000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d6cdb233a7495c4fb58dd323edd91132-31c3e1a02f1fd042-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "5659560b49b3a102355a36be85587a63",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "8e618325-a4f0-495d-b89f-e028c541b890",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:35:27 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/1c0b7d71-ba47-47a7-8b23-f45657db175c",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "8e618325-a4f0-495d-b89f-e028c541b890"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/1c0b7d71-ba47-47a7-8b23-f45657db175c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "4afc57e640718c721106a59232955d33",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e1c9d4ef-fce0-4b43-aeb5-88ce7a696373",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:35:27 GMT",
+        "ETag": "\u00225F39E4E7ED23A8CBF68221CD678FECAF20F37ECB46603E485CDAE9DD712DA08B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e1c9d4ef-fce0-4b43-aeb5-88ce7a696373"
+      },
+      "ResponseBody": {
+        "id": "1c0b7d71-ba47-47a7-8b23-f45657db175c",
+        "createdDateTimeUtc": "2021-03-29T22:35:27.6002189Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:35:27.6002252Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/1c0b7d71-ba47-47a7-8b23-f45657db175c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "04d8bdfaa40f390aaad8d4c417b7dfca",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cc3a2e13-2bbe-49b4-b18d-20ff66718752",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:35:57 GMT",
+        "ETag": "\u00226D68C5C3A0A5610064C6D867988593060BCC0A993983E787E1D1973CFA73BC69\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "cc3a2e13-2bbe-49b4-b18d-20ff66718752"
+      },
+      "ResponseBody": {
+        "id": "1c0b7d71-ba47-47a7-8b23-f45657db175c",
+        "createdDateTimeUtc": "2021-03-29T22:35:27.6002189Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:35:38.5079405Z",
+        "status": "Succeeded",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 1,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 27
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/1c0b7d71-ba47-47a7-8b23-f45657db175c/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "228c4811ad70cbbce3cd44aca3706e9f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a388c725-1bc6-485c-a668-9b79f67333f8",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:35:57 GMT",
+        "ETag": "\u00228A196CF2B4226D961CF9D5ABAA5B5FFAFCC3922B82AFFBCB8A42EB61CCCFC9F1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "a388c725-1bc6-485c-a668-9b79f67333f8"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target512773566/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source1895674641/Document1.txt",
+            "createdDateTimeUtc": "2021-03-29T22:35:29.3222162Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:35:39.1656249Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "00003ced-0000-0000-0000-000000000000",
+            "characterCharged": 27
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/1c0b7d71-ba47-47a7-8b23-f45657db175c/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "c7c302fc767f42534dc2a0996cae7459",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d21fa1ef-1db5-4129-bdb6-5a5466f37f22",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:35:57 GMT",
+        "ETag": "\u00228A196CF2B4226D961CF9D5ABAA5B5FFAFCC3922B82AFFBCB8A42EB61CCCFC9F1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d21fa1ef-1db5-4129-bdb6-5a5466f37f22"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target512773566/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source1895674641/Document1.txt",
+            "createdDateTimeUtc": "2021-03-29T22:35:29.3222162Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:35:39.1656249Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "00003ced-0000-0000-0000-000000000000",
+            "characterCharged": 27
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/1c0b7d71-ba47-47a7-8b23-f45657db175c/documents/00003ced-0000-0000-0000-000000000000",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "ea80db273b084cc3010d20425f5d9539",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fc4c3384-1bf4-4829-8194-6fc41810b5d7",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:35:58 GMT",
+        "ETag": "\u00229F208F442AABA10FD5C8DB16C187FA7483AF16D80F8BFC159A31224A09314D48\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "fc4c3384-1bf4-4829-8194-6fc41810b5d7"
+      },
+      "ResponseBody": {
+        "path": "https://mariaridoctrans29prim.blob.core.windows.net/target512773566/Document1.txt",
+        "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source1895674641/Document1.txt",
+        "createdDateTimeUtc": "2021-03-29T22:35:29.3222162Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:35:39.1656249Z",
+        "status": "Succeeded",
+        "to": "fr",
+        "progress": 1,
+        "id": "00003ced-0000-0000-0000-000000000000",
+        "characterCharged": 27
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "1518137243"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/GetDocumentStatusTestAsync.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/GetDocumentStatusTestAsync.json
@@ -1,0 +1,377 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1280618530?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-979f69f9bc47cd4eafa2686cb95a5f37-0f5d1009e352e548-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "be505279e516a3c195eb14b1c3e7559d",
+        "x-ms-date": "Mon, 29 Mar 2021 22:35:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:35:58 GMT",
+        "ETag": "\u00220x8D8F3030687BD52\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:35:59 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "be505279e516a3c195eb14b1c3e7559d",
+        "x-ms-request-id": "68ca196c-901e-0058-03eb-24300d000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1280618530/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-84fa81134998604298d5be69af424a0c-56e1621abb848040-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "92a5c468537fd65b89839db1b88310af",
+        "x-ms-date": "Mon, 29 Mar 2021 22:35:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Mon, 29 Mar 2021 22:35:59 GMT",
+        "ETag": "\u00220x8D8F30306FD780E\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:36:00 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "92a5c468537fd65b89839db1b88310af",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "68ca1a41-901e-0058-3beb-24300d000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target139518720?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-b3e6545273c4904b93cef73bac1ed1df-c27e57aa88842143-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "ffbe1f61166aa2ea17a5e5baf53dbc58",
+        "x-ms-date": "Mon, 29 Mar 2021 22:36:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:35:59 GMT",
+        "ETag": "\u00220x8D8F30307400AC0\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:36:00 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "ffbe1f61166aa2ea17a5e5baf53dbc58",
+        "x-ms-request-id": "68ca1c25-901e-0058-71eb-24300d000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-cd8c18cc1189a2428d49ff646416ff7b-3707db7743184846-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1fd24d42a3c5f7257934924710ea11db",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "4bbdf364-420f-467d-a761-0f42707372f3",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:36:01 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/c1f57f3c-3490-43dd-a87a-666ae2bdfb0e",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "4bbdf364-420f-467d-a761-0f42707372f3"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/c1f57f3c-3490-43dd-a87a-666ae2bdfb0e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "c862b1649e97aefebbef67ae751c9446",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8f311b2d-2f1e-4402-b791-166b5050c5f1",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:36:01 GMT",
+        "ETag": "\u002247B0592023BC1FA7F99B61299CA76B6EF75F6DA12B877F4880C6002B5E23309D\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "8f311b2d-2f1e-4402-b791-166b5050c5f1"
+      },
+      "ResponseBody": {
+        "id": "c1f57f3c-3490-43dd-a87a-666ae2bdfb0e",
+        "createdDateTimeUtc": "2021-03-29T22:36:01.369204Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:36:01.5643219Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/c1f57f3c-3490-43dd-a87a-666ae2bdfb0e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "357659e18f3dbe3af9c6863583a3922c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0f5c6da5-e49d-4983-a946-02ea6dd8aa43",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:36:31 GMT",
+        "ETag": "\u0022A3D73D2DBEC08CF60A153DE3393DCF8209F92669DCC0D4FB96A4F839B0AFDCD8\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "0f5c6da5-e49d-4983-a946-02ea6dd8aa43"
+      },
+      "ResponseBody": {
+        "id": "c1f57f3c-3490-43dd-a87a-666ae2bdfb0e",
+        "createdDateTimeUtc": "2021-03-29T22:36:01.369204Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:36:14.5270643Z",
+        "status": "Succeeded",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 1,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 27
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/c1f57f3c-3490-43dd-a87a-666ae2bdfb0e/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "44550a93f4dba4c04f2464d53b77825d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d2eb4817-b2e9-4ff2-935d-4b5779eaa78e",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:36:31 GMT",
+        "ETag": "\u0022612AB45500B0A5D3D3EFEE29487727A057A11CC1022FAE49480A01BF5B0DC733\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d2eb4817-b2e9-4ff2-935d-4b5779eaa78e"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target139518720/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source1280618530/Document1.txt",
+            "createdDateTimeUtc": "2021-03-29T22:36:04.028374Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:36:15.2304804Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "00003cee-0000-0000-0000-000000000000",
+            "characterCharged": 27
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/c1f57f3c-3490-43dd-a87a-666ae2bdfb0e/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "b6654ca0dc74d59d76a4ced017c82a17",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "644accec-9ee7-41b8-919b-e96ada3999ee",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:36:31 GMT",
+        "ETag": "\u0022612AB45500B0A5D3D3EFEE29487727A057A11CC1022FAE49480A01BF5B0DC733\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "644accec-9ee7-41b8-919b-e96ada3999ee"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target139518720/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source1280618530/Document1.txt",
+            "createdDateTimeUtc": "2021-03-29T22:36:04.028374Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:36:15.2304804Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "00003cee-0000-0000-0000-000000000000",
+            "characterCharged": 27
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/c1f57f3c-3490-43dd-a87a-666ae2bdfb0e/documents/00003cee-0000-0000-0000-000000000000",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "6b1b3a5c50c6ec6a98d2e5192b658282",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "161eb8b3-f99b-4dca-a31f-5bb22e06f85e",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:36:31 GMT",
+        "ETag": "\u002227E98E0F8DC90EED915C9937D533A780C7C2F378B8CE108F1180A84D36088346\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "161eb8b3-f99b-4dca-a31f-5bb22e06f85e"
+      },
+      "ResponseBody": {
+        "path": "https://mariaridoctrans29prim.blob.core.windows.net/target139518720/Document1.txt",
+        "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source1280618530/Document1.txt",
+        "createdDateTimeUtc": "2021-03-29T22:36:04.028374Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:36:15.2304804Z",
+        "status": "Succeeded",
+        "to": "fr",
+        "progress": 1,
+        "id": "00003cee-0000-0000-0000-000000000000",
+        "characterCharged": 27
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "1092967914"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTarget.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTarget.json
@@ -1,0 +1,171 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source698049479?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-eb10404cd7faca4bbff43c1cb5b01a17-164cac8981089746-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "251d52a14369df430fc579df7ccffe74",
+        "x-ms-date": "Mon, 29 Mar 2021 22:05:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:05:28 GMT",
+        "ETag": "\u00220x8D8F2FEC38F50C4\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:05:28 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "251d52a14369df430fc579df7ccffe74",
+        "x-ms-request-id": "07f4ed91-501e-0035-2be7-248446000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source698049479/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-4be022584c123f4eb230f2bd4288aec3-e8b7b1765ed25746-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ea41cd2ed3cabcea600064179df2d013",
+        "x-ms-date": "Mon, 29 Mar 2021 22:05:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Mon, 29 Mar 2021 22:05:28 GMT",
+        "ETag": "\u00220x8D8F2FEC3DBF27C\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:05:29 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "ea41cd2ed3cabcea600064179df2d013",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "07f4edf9-501e-0035-06e7-248446000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d829add4f1de5744a033d6184cc3b1ad-e13be3aae1dc184b-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "fceeecd3913cdc5e25d62bdb6421cc62",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "aab09a36-deb3-4aac-b6b6-7ae2aa7eb57a",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:05:29 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/f4bee4d9-1607-4d25-b930-d0cb95c363a6",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "aab09a36-deb3-4aac-b6b6-7ae2aa7eb57a"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/f4bee4d9-1607-4d25-b930-d0cb95c363a6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "c18e721e6127cefd6760c568df2c421c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "115739aa-158e-49f5-9f64-2d4e77045476",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:05:30 GMT",
+        "ETag": "\u0022249CE59B2C5F40050766B1F37F6A5A8B127F3EA66A951DC9D1762AA3E970BAD1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "115739aa-158e-49f5-9f64-2d4e77045476"
+      },
+      "ResponseBody": {
+        "id": "f4bee4d9-1607-4d25-b930-d0cb95c363a6",
+        "createdDateTimeUtc": "2021-03-29T22:05:29.9357334Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:05:30.1071124Z",
+        "status": "ValidationFailed",
+        "error": {
+          "code": "InvalidRequest",
+          "message": "Cannot access source document location with the current permissions.",
+          "target": "Operation",
+          "innerError": {
+            "code": "InvalidDocumentAccessLevel",
+            "message": "Cannot access source document location with the current permissions."
+          }
+        },
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "50827542"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTargetAsync.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTargetAsync.json
@@ -1,0 +1,171 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source18224896?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f3a6f6ef0c104a438b2439d00250a773-d6f090e267e17c44-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "3f10d19745857fc61c122af6c3d72724",
+        "x-ms-date": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "ETag": "\u00220x8D8F2FE7E222549\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "3f10d19745857fc61c122af6c3d72724",
+        "x-ms-request-id": "edb702e0-f01e-002c-49e7-2404fd000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source18224896/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-024be1d22e24a6408e44f64cf72ac5d4-c881574e9730eb42-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "28c5fa18444d725ba99cbba42b4d8792",
+        "x-ms-date": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "ETag": "\u00220x8D8F2FE7E585DC6\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "28c5fa18444d725ba99cbba42b4d8792",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "edb70314-f01e-002c-77e7-2404fd000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c28db55da4b91445bad5e446cab15fc4-c3da274c414ccb4b-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "9e0739f09d606a72731fd80ea4475968",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "1ab77998-6570-4d29-adc9-2f751df5ea41",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/9bee1b87-044a-4945-a9df-2e875e2e3fe1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "1ab77998-6570-4d29-adc9-2f751df5ea41"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/9bee1b87-044a-4945-a9df-2e875e2e3fe1",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7e9d14f44a0e52b2769d96e8892254ce",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "18e380b0-258b-4331-af5f-9e5b8c740fec",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:03:33 GMT",
+        "ETag": "\u002263A575F29138241B6067A5A0552DCE7593A83CDB926B6B5C2252BA4E15C72314\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "18e380b0-258b-4331-af5f-9e5b8c740fec"
+      },
+      "ResponseBody": {
+        "id": "9bee1b87-044a-4945-a9df-2e875e2e3fe1",
+        "createdDateTimeUtc": "2021-03-29T22:03:33.3975576Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:03:33.5123233Z",
+        "status": "ValidationFailed",
+        "error": {
+          "code": "InvalidRequest",
+          "message": "Cannot access source document location with the current permissions.",
+          "target": "Operation",
+          "innerError": {
+            "code": "InvalidDocumentAccessLevel",
+            "message": "Cannot access source document location with the current permissions."
+          }
+        },
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "248593475"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/WrongDocumentEncoding.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/WrongDocumentEncoding.json
@@ -1,0 +1,293 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1024656640?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ad8fceedc7f077478f50494bd005e333-d3fac62a82313b4a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "e9d0c4662baec06eab1dd755fe646b4f",
+        "x-ms-date": "Mon, 29 Mar 2021 22:05:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:05:32 GMT",
+        "ETag": "\u00220x8D8F2FEC5FE28E5\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:05:33 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "e9d0c4662baec06eab1dd755fe646b4f",
+        "x-ms-request-id": "07f4f508-501e-0035-1ee7-248446000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1024656640/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-133cf0141ace3445a2e3c94d353d4cba-4db4924994c32f4c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f8e05791a6072e3fea7b8f7efc8556cd",
+        "x-ms-date": "Mon, 29 Mar 2021 22:05:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": [],
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Mon, 29 Mar 2021 22:05:32 GMT",
+        "ETag": "\u00220x8D8F2FEC6109EA5\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:05:33 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "f8e05791a6072e3fea7b8f7efc8556cd",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "07f4f567-501e-0035-6fe7-248446000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1485570010?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d549928e050bc94185907f98fdf6b03f-e0583194cb528843-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a047abc3de7b3a8cd47841942d1057bc",
+        "x-ms-date": "Mon, 29 Mar 2021 22:05:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:05:32 GMT",
+        "ETag": "\u00220x8D8F2FEC61A8FA7\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:05:33 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "a047abc3de7b3a8cd47841942d1057bc",
+        "x-ms-request-id": "07f4f588-501e-0035-0ee7-248446000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-80ebdf42c010d249a1048e011d2f9828-0ea29f1b72a81f4b-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7b5da5ecf8de84bfa2ff329cf0c425c7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "38f8541c-0e59-4ebd-812b-34c66ed8d255",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:05:33 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/c72e0b77-6fd7-4a61-bde6-73c2d7e04f6b",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "38f8541c-0e59-4ebd-812b-34c66ed8d255"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/c72e0b77-6fd7-4a61-bde6-73c2d7e04f6b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "b93b7b0aaf24781654bd332efd9abc6b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0743ff64-3051-41e7-8fbb-cb329ff60dab",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:05:33 GMT",
+        "ETag": "\u0022C17DA6F6C2FCFB2416DA7DBD6B8510828A7EB60D96997E4C5D55FD5EFF956245\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "0743ff64-3051-41e7-8fbb-cb329ff60dab"
+      },
+      "ResponseBody": {
+        "id": "c72e0b77-6fd7-4a61-bde6-73c2d7e04f6b",
+        "createdDateTimeUtc": "2021-03-29T22:05:33.3806701Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:05:33.3806732Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/c72e0b77-6fd7-4a61-bde6-73c2d7e04f6b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "df0fc13751f9cafcebc2fd7babef4a0f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f5725379-d997-4275-9e8f-3ed500f9298a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:06:03 GMT",
+        "ETag": "\u0022F8178D34410DD7FD0D097D6D92A704DCDEA20BC2DD8F1F67F396278957A4F605\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "f5725379-d997-4275-9e8f-3ed500f9298a"
+      },
+      "ResponseBody": {
+        "id": "c72e0b77-6fd7-4a61-bde6-73c2d7e04f6b",
+        "createdDateTimeUtc": "2021-03-29T22:05:33.3806701Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:05:37.325113Z",
+        "status": "Failed",
+        "summary": {
+          "total": 1,
+          "failed": 1,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/c72e0b77-6fd7-4a61-bde6-73c2d7e04f6b/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "b2897a529dd53d978fe42721c5908608",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e8a91a38-a44f-41dd-9845-6ad060d1585b",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:06:03 GMT",
+        "ETag": "\u0022CAC04404B377D09628395EC4667A216613441884DF87DBCA59E890F9923334DF\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e8a91a38-a44f-41dd-9845-6ad060d1585b"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source1024656640/Document1.txt",
+            "createdDateTimeUtc": "2021-03-29T22:05:37.2892554Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:05:37.2892554Z",
+            "status": "Failed",
+            "to": "fr",
+            "error": {
+              "code": "InvalidRequest",
+              "message": "Document has wrong encoding or is binary file.",
+              "target": "Document",
+              "innerError": {
+                "code": "WrongDocumentEncoding",
+                "message": "Document has wrong encoding or is binary file."
+              }
+            },
+            "progress": 0,
+            "id": "00003cea-0000-0000-0000-000000000000",
+            "characterCharged": 0
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "1250005597"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/WrongDocumentEncodingAsync.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/WrongDocumentEncodingAsync.json
@@ -1,0 +1,293 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source344832057?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-401ff06c66431349a68aa5ae62a33159-85d4fda4f42a7447-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "03c3435b2dca60f1b86a886c466c95ff",
+        "x-ms-date": "Mon, 29 Mar 2021 22:03:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:03:36 GMT",
+        "ETag": "\u00220x8D8F2FE809E20B1\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:03:36 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "03c3435b2dca60f1b86a886c466c95ff",
+        "x-ms-request-id": "edb70eb8-f01e-002c-01e7-2404fd000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source344832057/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-fe9c2b4eddfa7749a507197a79af399a-dec5fe4bd50bb841-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3664837b188ae4b03317e60b89e10d4c",
+        "x-ms-date": "Mon, 29 Mar 2021 22:03:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": [],
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Mon, 29 Mar 2021 22:03:36 GMT",
+        "ETag": "\u00220x8D8F2FE80BED178\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:03:36 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "3664837b188ae4b03317e60b89e10d4c",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "edb70f65-f01e-002c-06e7-2404fd000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target2019492087?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7d73068d9f15d543be2a538d532e2130-6ab0e7ef542fab43-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c4e9c40ff186891a1d2574d4539e5e92",
+        "x-ms-date": "Mon, 29 Mar 2021 22:03:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:03:36 GMT",
+        "ETag": "\u00220x8D8F2FE80CB5371\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:03:36 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "c4e9c40ff186891a1d2574d4539e5e92",
+        "x-ms-request-id": "edb70f82-f01e-002c-1ce7-2404fd000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-16a736f49fda8b40ab533398cc0febfa-267b3805a4701b4a-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "6219b48faec79243dfcfb247e6d6d75d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "02d8232b-d638-4f72-986b-20776567a8e9",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:03:36 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/d05bd3b2-6a68-413d-9080-e816742b245e",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "02d8232b-d638-4f72-986b-20776567a8e9"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/d05bd3b2-6a68-413d-9080-e816742b245e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "a836743b3bac91f44aad6df23b0fe079",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5838164b-e4c3-4195-9e7f-4cb462435900",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:03:36 GMT",
+        "ETag": "\u0022D7EDABB54ABFEE14E07DEA9ED9068216FDA8573AA73EFE0A39B7EE90F3CC0251\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "5838164b-e4c3-4195-9e7f-4cb462435900"
+      },
+      "ResponseBody": {
+        "id": "d05bd3b2-6a68-413d-9080-e816742b245e",
+        "createdDateTimeUtc": "2021-03-29T22:03:37.0197194Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:03:37.0197241Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/d05bd3b2-6a68-413d-9080-e816742b245e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "2cfa7888e9f361308156e5b63fd3a246",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "67ad1827-b488-434e-a791-4fe6232091a0",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:04:07 GMT",
+        "ETag": "\u002255E353D9EA0179DB763B040455D20D4051FC43D5FFE59449EB8371CCB5E5B31B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "67ad1827-b488-434e-a791-4fe6232091a0"
+      },
+      "ResponseBody": {
+        "id": "d05bd3b2-6a68-413d-9080-e816742b245e",
+        "createdDateTimeUtc": "2021-03-29T22:03:37.0197194Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:03:47.160309Z",
+        "status": "Failed",
+        "summary": {
+          "total": 1,
+          "failed": 1,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/d05bd3b2-6a68-413d-9080-e816742b245e/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "de98174eb56754e6c088181a405057cf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5bb3f584-58bc-452d-9616-288c4972abb9",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:04:07 GMT",
+        "ETag": "\u00228F1D293E041592A1BAED8A693D8D96CB06A268F1D6CB5A1E0FA36C02B9920B67\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "5bb3f584-58bc-452d-9616-288c4972abb9"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source344832057/Document1.txt",
+            "createdDateTimeUtc": "2021-03-29T22:03:47.1225436Z",
+            "lastActionDateTimeUtc": "2021-03-29T22:03:47.1225436Z",
+            "status": "Failed",
+            "to": "fr",
+            "error": {
+              "code": "InvalidRequest",
+              "message": "Document has wrong encoding or is binary file.",
+              "target": "Document",
+              "innerError": {
+                "code": "WrongDocumentEncoding",
+                "message": "Document has wrong encoding or is binary file."
+              }
+            },
+            "progress": 0,
+            "id": "00003ce8-0000-0000-0000-000000000000",
+            "characterCharged": 0
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "1447771530"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTarget.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTarget.json
@@ -1,0 +1,139 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1975097330?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8fdaac7f320bec4cabb24c00bfe95ce1-ea9b7014b4144740-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "39813578d6bc9900ae5eeaa526bb6c41",
+        "x-ms-date": "Mon, 29 Mar 2021 20:02:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 20:02:37 GMT",
+        "ETag": "\u00220x8D8F2ED9A29DBE7\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 20:02:38 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "39813578d6bc9900ae5eeaa526bb6c41",
+        "x-ms-request-id": "963bd64b-701e-009b-74d6-242957000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e2acc8f745078845977852b480d8ccbc-c62fa90c51bc7b45-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "8e55a27be348b38b411bf91a17ebe28b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "35c0b636-033c-41ae-971e-b91ab83f22f7",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 20:02:38 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/5fae77cb-59cd-4021-bae7-5fcc4fb6cd2c",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "35c0b636-033c-41ae-971e-b91ab83f22f7"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/5fae77cb-59cd-4021-bae7-5fcc4fb6cd2c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "495abe4052c5dbe59a303ed4e45da222",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "53971b6a-d8d4-411e-ae00-8ca19014c2ed",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 20:02:38 GMT",
+        "ETag": "\u00221896FC34685EE237390A421959D24389AF788E84405256DFBB9BA149CAFC8E40\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "53971b6a-d8d4-411e-ae00-8ca19014c2ed"
+      },
+      "ResponseBody": {
+        "id": "5fae77cb-59cd-4021-bae7-5fcc4fb6cd2c",
+        "createdDateTimeUtc": "2021-03-29T20:02:38.6637111",
+        "lastActionDateTimeUtc": "2021-03-29T20:02:38.8240231",
+        "status": "ValidationFailed",
+        "error": {
+          "code": "InvalidRequest",
+          "message": "Cannot access source document location with the current permissions.",
+          "target": "Operation",
+          "innerError": {
+            "code": "InvalidDocumentAccessLevel",
+            "message": "Cannot access source document location with the current permissions."
+          }
+        },
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "1304523582"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTargetAsync.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTargetAsync.json
@@ -1,0 +1,139 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1191210950?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a2cb45d0a5e7b84aa8aae7da508d72b3-e18eac37575b8d4a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "f5d48f90a78e5b44a791fc59ae8a9b77",
+        "x-ms-date": "Mon, 29 Mar 2021 22:04:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:04:07 GMT",
+        "ETag": "\u00220x8D8F2FE92F16DAC\u0022",
+        "Last-Modified": "Mon, 29 Mar 2021 22:04:07 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "f5d48f90a78e5b44a791fc59ae8a9b77",
+        "x-ms-request-id": "edb75c2f-f01e-002c-04e7-2404fd000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9ef8394e8a59e24894651e885d4231bd-7af6e745a8352f4b-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "278b37e4c1330177a6d9cc86e292a3c2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "386b9e79-779e-4fc1-8289-d4d320ba37f9",
+        "Content-Length": "0",
+        "Date": "Mon, 29 Mar 2021 22:04:07 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/e23a6b30-7872-4e7d-9375-b925b7f56a93",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "386b9e79-779e-4fc1-8289-d4d320ba37f9"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/e23a6b30-7872-4e7d-9375-b925b7f56a93",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "c89cd07360e4d120015f5965b1179f2e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e7151610-a5c3-400c-bbdd-43a796e6eba8",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 29 Mar 2021 22:04:08 GMT",
+        "ETag": "\u00220BF9587DDA3BEF711909560197A9B84EC427FBA2A5A1558629A6302C182D2953\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e7151610-a5c3-400c-bbdd-43a796e6eba8"
+      },
+      "ResponseBody": {
+        "id": "e23a6b30-7872-4e7d-9375-b925b7f56a93",
+        "createdDateTimeUtc": "2021-03-29T22:04:07.7752119Z",
+        "lastActionDateTimeUtc": "2021-03-29T22:04:08.0995268Z",
+        "status": "ValidationFailed",
+        "error": {
+          "code": "InvalidRequest",
+          "message": "Cannot access source document location with the current permissions.",
+          "target": "Operation",
+          "innerError": {
+            "code": "InvalidDocumentAccessLevel",
+            "message": "Cannot access source document location with the current permissions."
+          }
+        },
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "422929117"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/TranslationOperationLiveTests.cs
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/TranslationOperationLiveTests.cs
@@ -20,21 +20,10 @@ namespace Azure.AI.DocumentTranslation.Tests
         {
         }
 
-        private List<TestDocument> oneDocumentList = new List<TestDocument>
-        {
-            new TestDocument("Document1.txt", "First english test document"),
-        };
-
-        private List<TestDocument> twoDocumentsList = new List<TestDocument>
-        {
-            new TestDocument("Document1.txt", "First english test document"),
-            new TestDocument("File2.txt", "Second english test file"),
-        };
-
         [RecordedTest]
         public async Task SingleSourceSingleTargetTest()
         {
-            Uri source = await CreateSourceContainerAsync(oneDocumentList);
+            Uri source = await CreateSourceContainerAsync(OneDocumentList);
             Uri target = await CreateTargetContainerAsync();
 
             var client = GetClient();
@@ -62,7 +51,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task SingleSourceMultipleTargetsTest()
         {
-            Uri source = await CreateSourceContainerAsync(oneDocumentList);
+            Uri source = await CreateSourceContainerAsync(OneDocumentList);
             Uri targetFrench = await CreateTargetContainerAsync();
             Uri targetSpanish = await CreateTargetContainerAsync();
             Uri targetArabic = await CreateTargetContainerAsync();
@@ -94,8 +83,8 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task MultipleSourcesSingleTarget()
         {
-            Uri source1 = await CreateSourceContainerAsync(oneDocumentList);
-            Uri source2 = await CreateSourceContainerAsync(oneDocumentList);
+            Uri source1 = await CreateSourceContainerAsync(OneDocumentList);
+            Uri source2 = await CreateSourceContainerAsync(OneDocumentList);
             Uri target1 = await CreateTargetContainerAsync();
             Uri target2 = await CreateTargetContainerAsync();
 
@@ -129,7 +118,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task SingleSourceSingleTargetWithPrefixTest()
         {
-            Uri sourceUri = await CreateSourceContainerAsync(twoDocumentsList);
+            Uri sourceUri = await CreateSourceContainerAsync(TwoDocumentList);
             Uri targetUri = await CreateTargetContainerAsync();
 
             var client = GetClient();
@@ -166,7 +155,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task SingleSourceSingleTargetWithSuffixTest()
         {
-            Uri sourceUri = await CreateSourceContainerAsync(twoDocumentsList);
+            Uri sourceUri = await CreateSourceContainerAsync(TwoDocumentList);
             Uri targetUri = await CreateTargetContainerAsync();
 
             var client = GetClient();
@@ -203,7 +192,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task SingleSourceSingleTargetListDocumentsTest()
         {
-            Uri sourceUri = await CreateSourceContainerAsync(oneDocumentList);
+            Uri sourceUri = await CreateSourceContainerAsync(OneDocumentList);
             Uri targetUri = await CreateTargetContainerAsync();
 
             var client = GetClient();
@@ -235,6 +224,142 @@ namespace Azure.AI.DocumentTranslation.Tests
                 Assert.AreEqual("fr", document.TranslateTo);
                 Assert.NotNull(document.TranslatedDocumentUri);
             }
+        }
+
+        [RecordedTest]
+        public async Task GetDocumentStatusTest()
+        {
+            Uri sourceUri = await CreateSourceContainerAsync(OneDocumentList);
+            Uri targetUri = await CreateTargetContainerAsync();
+
+            var client = GetClient();
+
+            var input = new DocumentTranslationInput(sourceUri, targetUri, "fr");
+            var operation = await client.StartTranslationAsync(input);
+
+            await operation.WaitForCompletionAsync(PollingInterval);
+            var documents = operation.GetAllDocumentStatusesAsync();
+
+            List<DocumentStatusResult> documentsList = await documents.ToEnumerableAsync();
+
+            Assert.AreEqual(1, documentsList.Count);
+
+            DocumentStatusResult document = await operation.GetDocumentStatusAsync(documentsList[0].DocumentId);
+
+            Assert.AreEqual(TranslationStatus.Succeeded, document.Status);
+            Assert.IsTrue(document.HasCompleted);
+            Assert.AreEqual(100f, document.TranslationProgressPercentage);
+            Assert.AreEqual("fr", document.TranslateTo);
+            Assert.NotNull(document.TranslatedDocumentUri);
+        }
+
+        [RecordedTest]
+        public async Task WrongSourceRightTarget()
+        {
+            Uri source = new("https://idont.ex.ist");
+            Uri target = await CreateTargetContainerAsync();
+
+            var client = GetClient();
+
+            var input = new DocumentTranslationInput(source, target, "fr");
+            var operation = await client.StartTranslationAsync(input);
+
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.UpdateStatusAsync());
+
+            Assert.AreEqual("InvalidDocumentAccessLevel", ex.ErrorCode);
+
+            Assert.IsTrue(operation.HasCompleted);
+            Assert.IsFalse(operation.HasValue);
+            Assert.AreEqual(TranslationStatus.ValidationFailed, operation.Status);
+        }
+
+        [RecordedTest]
+        public async Task RightSourceWrongTarget()
+        {
+            Uri source = await CreateSourceContainerAsync(OneDocumentList);
+            Uri target = new("https://idont.ex.ist");
+
+            var client = GetClient();
+
+            var input = new DocumentTranslationInput(source, target, "fr");
+            var operation = await client.StartTranslationAsync(input);
+
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.UpdateStatusAsync());
+
+            Assert.AreEqual("InvalidDocumentAccessLevel", ex.ErrorCode);
+
+            Assert.IsTrue(operation.HasCompleted);
+            Assert.IsFalse(operation.HasValue);
+            Assert.AreEqual(TranslationStatus.ValidationFailed, operation.Status);
+        }
+
+        [RecordedTest]
+        public async Task ContainerWithSupportedAndUnsupportedFiles()
+        {
+            var documentsList = new List<TestDocument>
+            {
+                new TestDocument("Document1.txt", "First english test document"),
+                new TestDocument("File2.jpg", "jpg"),
+            };
+
+            Uri source = await CreateSourceContainerAsync(documentsList);
+            Uri target = await CreateTargetContainerAsync();
+
+            var client = GetClient();
+
+            var input = new DocumentTranslationInput(source, target, "fr");
+            var operation = await client.StartTranslationAsync(input);
+
+            await operation.WaitForCompletionAsync(PollingInterval);
+
+            if (operation.DocumentsSucceeded < 1)
+            {
+                await PrintNotSucceededDocumentsAsync(operation);
+            }
+
+            Assert.IsTrue(operation.HasCompleted);
+            Assert.IsTrue(operation.HasValue);
+            Assert.AreEqual(1, operation.DocumentsTotal);
+            Assert.AreEqual(1, operation.DocumentsSucceeded);
+            Assert.AreEqual(0, operation.DocumentsFailed);
+            Assert.AreEqual(0, operation.DocumentsCancelled);
+            Assert.AreEqual(0, operation.DocumentsInProgress);
+            Assert.AreEqual(0, operation.DocumentsNotStarted);
+        }
+
+        [RecordedTest]
+        public async Task WrongDocumentEncoding()
+        {
+            var document = new List<TestDocument>
+            {
+                new TestDocument("Document1.txt", string.Empty),
+            };
+
+            Uri source = await CreateSourceContainerAsync(document);
+            Uri target = await CreateTargetContainerAsync();
+
+            var client = GetClient();
+
+            var input = new DocumentTranslationInput(source, target, "fr");
+            var operation = await client.StartTranslationAsync(input);
+
+            AsyncPageable<DocumentStatusResult> documents = await operation.WaitForCompletionAsync(PollingInterval);
+
+            Assert.IsTrue(operation.HasCompleted);
+            Assert.IsTrue(operation.HasValue);
+            Assert.AreEqual(TranslationStatus.Failed, operation.Status);
+
+            Assert.AreEqual(1, operation.DocumentsTotal);
+            Assert.AreEqual(0, operation.DocumentsSucceeded);
+            Assert.AreEqual(1, operation.DocumentsFailed);
+            Assert.AreEqual(0, operation.DocumentsCancelled);
+            Assert.AreEqual(0, operation.DocumentsInProgress);
+            Assert.AreEqual(0, operation.DocumentsNotStarted);
+
+            List<DocumentStatusResult> documentsList = await documents.ToEnumerableAsync();
+            Assert.AreEqual(1, documentsList.Count);
+            Assert.AreEqual(TranslationStatus.Failed, documentsList[0].Status);
+            Assert.AreEqual(new DocumentTranslationErrorCode("WrongDocumentEncoding"), documentsList[0].Error.ErrorCode);
         }
 
         private async Task PrintNotSucceededDocumentsAsync(DocumentTranslationOperation operation)

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/TranslationOperationLiveTests.cs
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/TranslationOperationLiveTests.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task SingleSourceSingleTargetTest()
         {
-            Uri source = await CreateSourceContainerAsync(OneDocumentList);
+            Uri source = await CreateSourceContainerAsync(oneTestDocuments);
             Uri target = await CreateTargetContainerAsync();
 
             var client = GetClient();
@@ -51,7 +51,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task SingleSourceMultipleTargetsTest()
         {
-            Uri source = await CreateSourceContainerAsync(OneDocumentList);
+            Uri source = await CreateSourceContainerAsync(oneTestDocuments);
             Uri targetFrench = await CreateTargetContainerAsync();
             Uri targetSpanish = await CreateTargetContainerAsync();
             Uri targetArabic = await CreateTargetContainerAsync();
@@ -83,8 +83,8 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task MultipleSourcesSingleTarget()
         {
-            Uri source1 = await CreateSourceContainerAsync(OneDocumentList);
-            Uri source2 = await CreateSourceContainerAsync(OneDocumentList);
+            Uri source1 = await CreateSourceContainerAsync(oneTestDocuments);
+            Uri source2 = await CreateSourceContainerAsync(oneTestDocuments);
             Uri target1 = await CreateTargetContainerAsync();
             Uri target2 = await CreateTargetContainerAsync();
 
@@ -118,7 +118,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task SingleSourceSingleTargetWithPrefixTest()
         {
-            Uri sourceUri = await CreateSourceContainerAsync(TwoDocumentList);
+            Uri sourceUri = await CreateSourceContainerAsync(twoTestDocuments);
             Uri targetUri = await CreateTargetContainerAsync();
 
             var client = GetClient();
@@ -155,7 +155,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task SingleSourceSingleTargetWithSuffixTest()
         {
-            Uri sourceUri = await CreateSourceContainerAsync(TwoDocumentList);
+            Uri sourceUri = await CreateSourceContainerAsync(twoTestDocuments);
             Uri targetUri = await CreateTargetContainerAsync();
 
             var client = GetClient();
@@ -192,7 +192,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task SingleSourceSingleTargetListDocumentsTest()
         {
-            Uri sourceUri = await CreateSourceContainerAsync(OneDocumentList);
+            Uri sourceUri = await CreateSourceContainerAsync(oneTestDocuments);
             Uri targetUri = await CreateTargetContainerAsync();
 
             var client = GetClient();
@@ -229,7 +229,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task GetDocumentStatusTest()
         {
-            Uri sourceUri = await CreateSourceContainerAsync(OneDocumentList);
+            Uri sourceUri = await CreateSourceContainerAsync(oneTestDocuments);
             Uri targetUri = await CreateTargetContainerAsync();
 
             var client = GetClient();
@@ -276,7 +276,7 @@ namespace Azure.AI.DocumentTranslation.Tests
         [RecordedTest]
         public async Task RightSourceWrongTarget()
         {
-            Uri source = await CreateSourceContainerAsync(OneDocumentList);
+            Uri source = await CreateSourceContainerAsync(oneTestDocuments);
             Uri target = new("https://idont.ex.ist");
 
             var client = GetClient();


### PR DESCRIPTION
- Adds more tests especially to verify error behavior (Fixes https://github.com/Azure/azure-sdk-for-net/issues/19560)
- Uses `UtcNow` instead of `Now` so it doesn't use the local computer time when setting the expiration date of the SAS tokens.
- Adds `ClientDiagnostics` implementation so when a method (outside of LRO context) throws, we can encapsulate the information in a `DocumentTranslationError`.
- Refactoring of the tests to avoid creating input documents in multiple places
