### PR TITLE
[Event Hubs Client] AMQP Converter Enhancements

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -50,8 +50,8 @@
 
   <!-- Import Azure.Core shared source -->
   <ItemGroup>
-    <Compile Include="$(AzureCoreSharedSources)Argument.cs" Link="SharedSource\Azure.Core\Argument.cs" />
-    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" Link="SharedSource\Azure.Core\TaskExtensions.cs" />
+    <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="SharedSource\Azure.Core" />
   </ItemGroup>
 
   <!--Embed the shared resources -->

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
@@ -43,7 +43,7 @@
 
   <!-- Import Azure.Core shared source -->
   <ItemGroup>
-    <Compile Include="$(AzureCoreSharedSources)Argument.cs" Link="SharedSource\Azure.Core\Argument.cs" />
+    <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="SharedSource\Azure.Core" />
   </ItemGroup>
 
   <!--Embed the shared resources -->

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using Azure.Core;
 using Azure.Messaging.EventHubs.Diagnostics;
@@ -260,6 +261,11 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         /// <returns>The batch <see cref="AmqpMessage" /> containing the source messages.</returns>
         ///
+        /// <remarks>
+        ///   The caller is assumed to hold ownership over the message once it has been created, including
+        ///   ensuring proper disposal.
+        /// </remarks>
+        ///
         private static AmqpMessage BuildAmqpBatchFromMessages(IEnumerable<AmqpMessage> source,
                                                               string partitionKey)
         {
@@ -301,12 +307,20 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         /// <returns>The <see cref="AmqpMessage" /> constructed from the source event.</returns>
         ///
+        /// <remarks>
+        ///   The caller is assumed to hold ownership over the message once it has been created, including
+        ///   ensuring proper disposal.
+        /// </remarks>
+        ///
         private static AmqpMessage BuildAmqpMessageFromEvent(EventData source,
                                                              string partitionKey)
         {
-            var bodyBytes = source.EventBody.ToMemory();
-            var body = new ArraySegment<byte>((bodyBytes.IsEmpty) ? Array.Empty<byte>() : bodyBytes.ToArray());
-            var message = AmqpMessage.Create(new Data { Value = body });
+            if (!MemoryMarshal.TryGetArray(source.EventBody.ToMemory(), out var bodySegment))
+            {
+                bodySegment = new ArraySegment<byte>(source.EventBody.ToArray());
+            }
+
+            var message = AmqpMessage.Create(new Data { Value = bodySegment });
 
             if ((source.HasProperties) && (source.Properties.Count > 0))
             {
@@ -354,9 +368,9 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         private static EventData BuildEventFromAmqpMessage(AmqpMessage source)
         {
-            ReadOnlyMemory<byte> body = (source.BodyType.HasFlag(SectionFlag.Data))
-                ? ReadStreamToMemory(source.BodyStream)
-                : ReadOnlyMemory<byte>.Empty;
+            var body = (source.BodyType.HasFlag(SectionFlag.Data))
+                ? ReadAmqpDataBody(source.DataBody)
+                : new BinaryData(ReadOnlyMemory<byte>.Empty);
 
             ParsedAnnotations systemAnnotations = ParseSystemAnnotations(source);
 
@@ -752,31 +766,72 @@ namespace Azure.Messaging.EventHubs.Amqp
                 return new ArraySegment<byte>();
             }
 
-            using var memStream = new MemoryStream(StreamBufferSizeInBytes);
-            stream.CopyTo(memStream, StreamBufferSizeInBytes);
+            switch (stream)
+            {
+                case BufferListStream bufferListStream:
+                    return bufferListStream.ReadBytes((int)stream.Length);
 
-            return new ArraySegment<byte>(memStream.ToArray());
+                default:
+                {
+                    using var memStream = new MemoryStream(StreamBufferSizeInBytes);
+                    stream.CopyTo(memStream, StreamBufferSizeInBytes);
+                    return new ArraySegment<byte>(memStream.ToArray());
+                }
+            }
         }
 
         /// <summary>
-        ///   Converts a stream to a set of memory bytes.
+        ///   Reads the data body of an AMQP message, transforming it for use
+        ///   as the body of an <see cref="EventData" /> instance.
         /// </summary>
         ///
-        /// <param name="stream">The stream to read and capture in memory.</param>
+        /// <param name="body">The body data set of an AMQP message.</param>
         ///
-        /// <returns>The set of memory bytes containing the stream data.</returns>
+        /// <returns>A <see cref="BinaryData" /> representation of the <paramref name="body"/>.</returns>
         ///
-        private static ReadOnlyMemory<byte> ReadStreamToMemory(Stream stream)
+        private static BinaryData ReadAmqpDataBody(IEnumerable<Data> body)
         {
-            if (stream == null)
+            var writer = new ArrayBufferWriter<byte>();
+
+            foreach (var data in body)
             {
-                return ReadOnlyMemory<byte>.Empty;
+                var dataBytes = GetDataBytes(data);
+                dataBytes.CopyTo(writer.GetMemory(dataBytes.Length));
+
+                writer.Advance(dataBytes.Length);
             }
 
-            using var memStream = new MemoryStream(StreamBufferSizeInBytes);
-            stream.CopyTo(memStream, StreamBufferSizeInBytes);
+            return (writer.WrittenCount > 0)
+                ? BinaryData.FromBytes(writer.WrittenMemory)
+                : new BinaryData(Array.Empty<byte>());
+        }
 
-            return new ReadOnlyMemory<byte>(memStream.ToArray());
+        /// <summary>
+        ///   Gets the bytes that comprise an AMQP data instance.
+        /// </summary>
+        ///
+        /// <param name="data">The data to read the bytes from.</param>
+        ///
+        /// <returns>The set of bytes extracted from the <paramref name="data" />.</returns>
+        ///
+        private static byte[] GetDataBytes(Data data)
+        {
+            switch (data.Value)
+            {
+                case byte[] byteArray:
+                    return byteArray;
+
+                case ArraySegment<byte> segment:
+                {
+                    var byteArray = new byte[segment.Count];
+                    Array.ConstrainedCopy(segment.Array, segment.Offset, byteArray, 0, segment.Count);
+
+                    return byteArray;
+                }
+
+                default:
+                    return Array.Empty<byte>();
+            }
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -34,10 +34,11 @@
 
   <!-- Import Azure.Core shared source -->
   <ItemGroup>
-    <Compile Include="$(AzureCoreSharedSources)Argument.cs" Link="SharedSource\Azure.Core\Argument.cs" />
-    <Compile Include="$(AzureCoreSharedSources)HashCodeBuilder.cs" Link="SharedSource\Azure.Core\HashCodeBuilder.cs" />
-    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" Link="SharedSource\Azure.Core\TaskExtensions.cs" />
-    <Compile Include="$(AzureCoreSharedSources)ValueStopwatch.cs" Link="SharedSource\Azure.Core\ValueStopwatch.cs" />
+    <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)HashCodeBuilder.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)ValueStopwatch.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="SharedSource\Azure.Core" />
   </ItemGroup>
 
   <!--Embed the shared resources -->

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
@@ -812,9 +812,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateEventFromMessagePopulatesTheBody()
         {
             var body = new byte[] { 0x11, 0x22, 0x33 };
-
-            using var bodyStream = new MemoryStream(body, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            using var message = AmqpMessage.Create(new Data { Value = body });
 
             var converter = new AmqpMessageConverter();
             EventData eventData = converter.CreateEventFromMessage(message);
@@ -853,9 +851,9 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var applicationProperties = propertyValues.ToDictionary(value => $"{ value.GetType().Name }Property", value => value);
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
 
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            using var message = AmqpMessage.Create(dataBody);
 
             foreach (KeyValuePair<string, object> pair in applicationProperties)
             {
@@ -893,8 +891,8 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                                  object propertyValueRaw,
                                                                                  Func<object, object> propertyValueAccessor)
         {
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
+            using var message = AmqpMessage.Create(dataBody);
 
             var describedProperty = new DescribedType(typeDescriptor, propertyValueAccessor(propertyValueRaw));
             message.ApplicationProperties.Map.Add(typeDescriptor.ToString(), describedProperty);
@@ -919,8 +917,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CreateEventFromMessagePopulatesAnArrayApplicationPropertyType()
         {
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
+            using var message = AmqpMessage.Create(dataBody);
 
             var propertyKey = "Test";
             var propertyValue = new byte[] { 0x11, 0x15, 0xF8, 0x20 };
@@ -946,8 +944,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CreateEventFromMessagePopulatesAFullArraySegmentApplicationPropertyType()
         {
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
+            using var message = AmqpMessage.Create(dataBody);
 
             var propertyKey = "Test";
             var propertyValue = new byte[] { 0x11, 0x15, 0xF8, 0x20 };
@@ -973,8 +971,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CreateEventFromMessagePopulatesAnArraySegmentApplicationPropertyType()
         {
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
+            using var message = AmqpMessage.Create(dataBody);
 
             var propertyKey = "Test";
             var propertyValue = new byte[] { 0x11, 0x15, 0xF8, 0x20 };
@@ -1000,8 +998,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CreateEventFromMessageDoesNotIncludeUnknownApplicationPropertyType()
         {
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
+            using var message = AmqpMessage.Create(dataBody);
 
             var typeDescriptor = (AmqpSymbol)"INVALID";
             var describedProperty = new DescribedType(typeDescriptor, 1234);
@@ -1031,8 +1029,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var enqueuedTime = DateTimeOffset.Parse("2015-10-27T12:00:00Z");
             var partitionKey = "OMG! partition!";
 
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
+            using var message = AmqpMessage.Create(dataBody);
 
             message.ApplicationProperties.Map.Add("First", 1);
             message.ApplicationProperties.Map.Add("Second", "2");
@@ -1070,8 +1068,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var secondMessageAnnotation = "hello";
             var subjectValue = "Test";
 
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
+            using var message = AmqpMessage.Create(dataBody);
 
             message.ApplicationProperties.Map.Add("First", 1);
             message.ApplicationProperties.Map.Add("Second", "2");
@@ -1112,8 +1110,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var lastRetrievalTime = DateTimeOffset.Parse("203-09-27T04:32:00Z");
             var partitionKey = "OMG! partition!";
 
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
+            using var message = AmqpMessage.Create(dataBody);
 
             message.ApplicationProperties.Map.Add("First", 1);
             message.ApplicationProperties.Map.Add("Second", "2");
@@ -1155,8 +1153,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var enqueuedTime = DateTimeOffset.Parse("2015-10-27T12:00:00Z");
             var lastEnqueuedTime = DateTimeOffset.Parse("2012-03-04T08:42:00Z");
 
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
+            using var message = AmqpMessage.Create(dataBody);
 
             message.MessageAnnotations.Map.Add(AmqpProperty.EnqueuedTime, enqueuedTime.UtcDateTime);
             message.DeliveryAnnotations.Map.Add(AmqpProperty.PartitionLastEnqueuedTimeUtc, lastEnqueuedTime.UtcDateTime);
@@ -1180,8 +1178,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var enqueuedTime = DateTimeOffset.Parse("2015-10-27T12:00:00Z");
             var lastEnqueuedTime = DateTimeOffset.Parse("2012-03-04T08:42:00Z");
 
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
+            using var message = AmqpMessage.Create(dataBody);
 
             message.MessageAnnotations.Map.Add(AmqpProperty.EnqueuedTime, enqueuedTime.UtcTicks);
             message.DeliveryAnnotations.Map.Add(AmqpProperty.PartitionLastEnqueuedTimeUtc, lastEnqueuedTime.UtcTicks);
@@ -1203,9 +1201,9 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateEventFromMessagePopulatesLastRetrievalTimeFromDateTime()
         {
             var lastRetrieval = DateTimeOffset.Parse("2012-03-04T08:42:00Z");
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
 
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            using var message = AmqpMessage.Create(dataBody);
 
             message.DeliveryAnnotations.Map.Add(AmqpProperty.LastPartitionPropertiesRetrievalTimeUtc, lastRetrieval.UtcDateTime);
 
@@ -1225,9 +1223,9 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateEventFromMessagePopulatesLastRetrievalTimeFromTicks()
         {
             var lastRetrieval = DateTimeOffset.Parse("2012-03-04T08:42:00Z");
+            var dataBody = new Data { Value = new byte[] { 0x11, 0x22, 0x33 } };
 
-            using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            using var message = AmqpMessage.Create(dataBody);
 
             message.DeliveryAnnotations.Map.Add(AmqpProperty.LastPartitionPropertiesRetrievalTimeUtc, lastRetrieval.UtcTicks);
 
@@ -1280,9 +1278,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateEventFromMessageDoesNotPopulatePropertiesByDefault()
         {
             var body = new byte[] { 0x11, 0x22, 0x33 };
-
-            using var bodyStream = new MemoryStream(body, false);
-            using var message = AmqpMessage.Create(bodyStream, true);
+            using var message = AmqpMessage.Create(new Data { Value = body } );
 
             var converter = new AmqpMessageConverter();
             var eventData = converter.CreateEventFromMessage(message);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
@@ -6,11 +6,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <ExcludeRecordingFramework>true</ExcludeRecordingFramework>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="Authorization\**" />
-    <EmbeddedResource Remove="Authorization\**" />
-    <None Remove="Authorization\**" />
-  </ItemGroup>
 
    <ItemGroup>
     <Folder Include="Properties\" />


### PR DESCRIPTION
# Summary

The focus of these changes is to apply some of the Service Bus learnings to the `AmqpMessageConverter` for better efficiency and to align more closely with some of the structure that will be needed when adopting the raw AMQP message model.

# Last Upstream Rebase

Tuesday, March 30, 11:30am (EST)

# References and Related

- #19823 
- #19821 
- [Service Bus AmqpMessageExtensions](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageExtensions.cs#L73)
- [Service Bus AmqpMessageConverter](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs#L222)
