### PR TITLE
[Event Hubs Client] AmqpConsumer Enhancement

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -214,7 +215,6 @@ namespace Azure.Messaging.EventHubs.Amqp
             var operationId = Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture);
             var link = default(ReceivingAmqpLink);
             var retryDelay = default(TimeSpan?);
-            var amqpMessages = default(IEnumerable<AmqpMessage>);
             var receivedEvents = default(List<EventData>);
             var lastReceivedEvent = default(EventData);
 
@@ -236,52 +236,63 @@ namespace Azure.Messaging.EventHubs.Amqp
                         link = await ReceiveLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout)).ConfigureAwait(false);
                         cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-                        var messagesReceived = await Task.Factory.FromAsync
+                        var messagesReceived = await Task.Factory.FromAsync<(ReceivingAmqpLink, int, TimeSpan), IEnumerable<AmqpMessage>>
                         (
-                            (callback, state) => link.BeginReceiveMessages(maximumEventCount, waitTime, callback, state),
-                            (asyncResult) => link.EndReceiveMessages(asyncResult, out amqpMessages),
-                            TaskCreationOptions.RunContinuationsAsynchronously
+                            static (arguments, callback, state) =>
+                            {
+                                var (link, maximumEventCount, waitTime) = arguments;
+                                return link.BeginReceiveMessages(maximumEventCount, waitTime, callback, link);
+                            },
+                            static asyncResult =>
+                            {
+                                var link = (ReceivingAmqpLink)asyncResult.AsyncState;
+                                var received = link.EndReceiveMessages(asyncResult, out var amqpMessages);
+
+                                return received ? amqpMessages : null;
+                            },
+                            (link, maximumEventCount, waitTime),
+                            default
                         ).ConfigureAwait(false);
 
                         cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
+                        // If no messages were received, then just return the empty set.
+
+                        if (messagesReceived == null)
+                        {
+                            return EmptyEventSet;
+                        }
+
                         // If event messages were received, then package them for consumption and
                         // return them.
 
-                        if ((messagesReceived) && (amqpMessages != null))
+                        foreach (AmqpMessage message in messagesReceived)
                         {
                             receivedEvents ??= new List<EventData>();
 
-                            foreach (AmqpMessage message in amqpMessages)
-                            {
-                                link.DisposeDelivery(message, true, AmqpConstants.AcceptedOutcome);
-                                receivedEvents.Add(MessageConverter.CreateEventFromMessage(message));
-                                message.Dispose();
-                            }
+                            link.DisposeDelivery(message, true, AmqpConstants.AcceptedOutcome);
+                            receivedEvents.Add(MessageConverter.CreateEventFromMessage(message));
+                            message.Dispose();
 
                             receivedEventCount = receivedEvents.Count;
-
-                            if (receivedEventCount > 0)
-                            {
-                                lastReceivedEvent = receivedEvents[receivedEventCount - 1];
-
-                                if (lastReceivedEvent.Offset > long.MinValue)
-                                {
-                                    CurrentEventPosition = EventPosition.FromOffset(lastReceivedEvent.Offset, false);
-                                }
-
-                                if (TrackLastEnqueuedEventProperties)
-                                {
-                                    LastReceivedEvent = lastReceivedEvent;
-                                }
-                            }
-
-                            return receivedEvents;
                         }
 
-                        // No events were available.
+                        if (receivedEventCount > 0)
+                        {
+                            lastReceivedEvent = receivedEvents[receivedEventCount - 1];
 
-                        return EmptyEventSet;
+                            if (lastReceivedEvent.Offset > long.MinValue)
+                            {
+                                CurrentEventPosition = EventPosition.FromOffset(lastReceivedEvent.Offset, false);
+                            }
+
+                            if (TrackLastEnqueuedEventProperties)
+                            {
+                                LastReceivedEvent = lastReceivedEvent;
+                            }
+                        }
+
+                        return receivedEvents ?? EmptyEventSet;
                     }
                     catch (EventHubsException ex) when (ex.Reason == EventHubsException.FailureReason.ServiceTimeout)
                     {


### PR DESCRIPTION
# Summary

The focus of these changes is to apply some of the Service Bus learnings to the `AmqpConsumer` for better efficiency and fewer allocations due to the closure.

# Last Upstream Rebase

Tuesday, March 30, 5pm (EST)

# References and Related

- #19884