### PR TITLE
Support cancellation of AcceptNextSessionAsync

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -129,11 +129,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
         }
 
         /// <summary>
-        ///   Creates a consumer strongly aligned with the active protocol and transport, responsible
+        ///   Creates a receiver strongly aligned with the active protocol and transport, responsible
         ///   for reading <see cref="ServiceBusMessage" /> from a specific Service Bus entity.
         /// </summary>
-        /// <param name="entityPath"></param>
-        ///
+        /// <param name="entityPath">The entity path to receive from.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         /// <param name="receiveMode">The <see cref="ServiceBusReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -137,12 +137,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         /// <param name="receiveMode">The <see cref="ServiceBusReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
-        /// <param name="identifier"></param>
-        /// <param name="sessionId"></param>
-        /// <param name="isSessionReceiver"></param>
+        /// <param name="identifier">The identifier for the sender.</param>
+        /// <param name="sessionId">The session ID to receive messages for.</param>
+        /// <param name="isSessionReceiver">Whether or not this is a sessionful receiver link.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the
+        /// open link operation. Only applicable for session receivers.</param>
         ///
         /// <returns>A <see cref="TransportReceiver" /> configured in the requested manner.</returns>
-        ///
         public override TransportReceiver CreateReceiver(
             string entityPath,
             ServiceBusRetryPolicy retryPolicy,
@@ -150,7 +151,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
             uint prefetchCount,
             string identifier,
             string sessionId,
-            bool isSessionReceiver)
+            bool isSessionReceiver,
+            CancellationToken cancellationToken)
         {
             Argument.AssertNotDisposed(_closed, nameof(AmqpClient));
 
@@ -163,7 +165,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 retryPolicy,
                 identifier,
                 sessionId,
-                isSessionReceiver
+                isSessionReceiver,
+                cancellationToken
             );
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -992,7 +992,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     tcs.TrySetCanceled();
                 }, openObjectCompletionSource, useSynchronizationContext: false);
 
-                async Task Open()
+                static async Task Open(AmqpObject target, TimeSpan timeout, TaskCompletionSource<object> openObjectCompletionSource)
                 {
                     try
                     {
@@ -1004,7 +1004,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                         openObjectCompletionSource.TrySetException(ex);
                     }
                 }
-                _ = Open();
+                _ = Open(target, timeout, openObjectCompletionSource);
                 await openObjectCompletionSource.Task.ConfigureAwait(false);
             }
             catch

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -268,7 +268,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     timeout.CalculateRemaining(stopWatch.GetElapsedTime()), cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-                await OpenAmqpObjectAsync(link, timeout.CalculateRemaining(stopWatch.GetElapsedTime())).ConfigureAwait(false);
+                await OpenAmqpObjectAsync(link, timeout.CalculateRemaining(stopWatch.GetElapsedTime()), cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                 ServiceBusEventSource.Log.CreateManagementLinkComplete(identifier);
                 return link;
@@ -327,7 +327,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-            await OpenAmqpObjectAsync(link, timeout.CalculateRemaining(stopWatch.GetElapsedTime())).ConfigureAwait(false);
+            await OpenAmqpObjectAsync(link, timeout.CalculateRemaining(stopWatch.GetElapsedTime()), cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             return link;
         }
@@ -363,7 +363,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-            await OpenAmqpObjectAsync(link, timeout.CalculateRemaining(stopWatch.GetElapsedTime())).ConfigureAwait(false);
+            await OpenAmqpObjectAsync(link, timeout.CalculateRemaining(stopWatch.GetElapsedTime()), cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             return link;
@@ -424,7 +424,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             TransportBase transport = await initiator.ConnectTaskAsync(timeout).ConfigureAwait(false);
 
             var connection = new AmqpConnection(transport, amqpSettings, connectionSetings);
-            await OpenAmqpObjectAsync(connection, timeout.CalculateRemaining(stopWatch.GetElapsedTime())).ConfigureAwait(false);
+            await OpenAmqpObjectAsync(connection, timeout.CalculateRemaining(stopWatch.GetElapsedTime()), CancellationToken.None).ConfigureAwait(false);
 
             // Create the CBS link that will be used for authorization.  The act of creating the link will associate
             // it with the connection.
@@ -481,7 +481,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 var sessionSettings = new AmqpSessionSettings { Properties = new Fields() };
                 session = connection.CreateSession(sessionSettings);
 
-                await OpenAmqpObjectAsync(session, timeout).ConfigureAwait(false);
+                await OpenAmqpObjectAsync(session, timeout, cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                 // Create and open the link.
@@ -696,7 +696,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             session = connection.CreateSession(sessionSettings);
 
-            await OpenAmqpObjectAsync(session, timeout).ConfigureAwait(false);
+            await OpenAmqpObjectAsync(session, timeout, CancellationToken.None).ConfigureAwait(false);
             return session;
         }
 
@@ -976,13 +976,51 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///
         /// <param name="target">The target AMQP object to open.</param>
         /// <param name="timeout">The timeout to apply when opening the link.</param>
+        /// <param name="cancellationToken">Token to signal cancellation of the operation.</param>
         protected virtual async Task OpenAmqpObjectAsync(
             AmqpObject target,
-            TimeSpan timeout)
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
         {
             try
             {
-                await target.OpenAsync(timeout).ConfigureAwait(false);
+                var openObjectCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                using var registration = cancellationToken.Register(static state =>
+                {
+                    var tcs = (TaskCompletionSource<object>)state;
+                    tcs.TrySetCanceled();
+                }, openObjectCompletionSource, useSynchronizationContext: false);
+
+                _ = Task.Factory
+                    .FromAsync<(AmqpObject, TimeSpan, TaskCompletionSource<object>)>
+                    (
+                        static (arguments, callback, state) =>
+                        {
+                            var (target, timeout, openObjectCompletionSource) = arguments;
+                            return target.BeginOpen(
+                                timeout,
+                                callback,
+                                (target, openObjectCompletionSource));
+                        },
+                        static asyncResult =>
+                        {
+                            var (target, openObjectCompletionSource) = ((AmqpObject, TaskCompletionSource<object>))asyncResult.AsyncState;
+                            try
+                            {
+                                target.EndOpen(asyncResult);
+                                openObjectCompletionSource.TrySetResult(null);
+                            }
+                            catch (Exception e)
+                            {
+                                openObjectCompletionSource.TrySetException(e);
+                            }
+                        },
+                        (target, timeout, openObjectCompletionSource),
+                        default
+                    ).ConfigureAwait(false);
+
+                await openObjectCompletionSource.Task.ConfigureAwait(false);
             }
             catch
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportClient.cs
@@ -54,7 +54,8 @@ namespace Azure.Messaging.ServiceBus.Core
             uint prefetchCount,
             string identifier,
             string sessionId,
-            bool isSessionReceiver);
+            bool isSessionReceiver,
+            CancellationToken cancellationToken);
 
         /// <summary>
         ///   Closes the connection to the transport client instance.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusConnection.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusConnection.cs
@@ -239,7 +239,8 @@ namespace Azure.Messaging.ServiceBus
             uint prefetchCount,
             string identifier,
             string sessionId,
-            bool isSessionReceiver) =>
+            bool isSessionReceiver,
+            CancellationToken cancellationToken) =>
                 _innerClient.CreateReceiver(
                     entityPath,
                     retryPolicy,
@@ -247,7 +248,8 @@ namespace Azure.Messaging.ServiceBus
                     prefetchCount,
                     identifier,
                     sessionId,
-                    isSessionReceiver);
+                    isSessionReceiver,
+                    cancellationToken);
 
         /// <summary>
         ///   Builds a Service Bus client specific to the protocol and transport specified by the

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -55,6 +55,7 @@ namespace Azure.Messaging.ServiceBus
                 entityPath: entityPath,
                 plugins: plugins,
                 options: options,
+                cancellationToken: cancellationToken,
                 sessionId: sessionId);
             try
             {
@@ -77,14 +78,16 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="entityPath"></param>
         /// <param name="plugins">The set of plugins to apply to incoming messages.</param>
         /// <param name="options">A set of options to apply when configuring the consumer.</param>
+        /// <param name="cancellationToken">The cancellation token to use when opening the receiver link.</param>
         /// <param name="sessionId">An optional session Id to receive from.</param>
         internal ServiceBusSessionReceiver(
             ServiceBusConnection connection,
             string entityPath,
             IList<ServiceBusPlugin> plugins,
             ServiceBusSessionReceiverOptions options,
+            CancellationToken cancellationToken,
             string sessionId = default) :
-            base(connection, entityPath, true, plugins, options?.ToReceiverOptions(), sessionId)
+            base(connection, entityPath, true, plugins, options?.ToReceiverOptions(), sessionId, cancellationToken)
         {
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
@@ -51,7 +51,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 retryPolicy: Mock.Of<ServiceBusRetryPolicy>(),
                 sessionId: default,
                 identifier: "someIdentifier",
-                isSessionReceiver: default),
+                isSessionReceiver: default,
+                cancellationToken: CancellationToken.None),
                 Throws.InstanceOf<ArgumentException>());
         }
 
@@ -70,7 +71,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 retryPolicy: Mock.Of<ServiceBusRetryPolicy>(),
                 identifier: "someIdentifier",
                 sessionId: default,
-                isSessionReceiver: default),
+                isSessionReceiver: default,
+                cancellationToken: CancellationToken.None),
             Throws.InstanceOf<ArgumentNullException>());
         }
 
@@ -89,7 +91,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 retryPolicy: null,
                 identifier: "someIdentifier",
                 sessionId: default,
-                isSessionReceiver: default),
+                isSessionReceiver: default,
+                cancellationToken: CancellationToken.None),
             Throws.InstanceOf<ArgumentNullException>());
         }
 
@@ -166,7 +169,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -222,7 +225,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -286,7 +289,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -345,7 +348,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(exception);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -400,7 +403,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(exception);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -455,7 +458,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(exception);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -482,6 +485,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 Mock.Of<AmqpConnectionScope>(),
                 Mock.Of<ServiceBusRetryPolicy>(),
                 "someIdentifier",
+                default,
                 default,
                 default);
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus.Core;
 using NUnit.Framework;
@@ -193,6 +194,23 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                     await client.AcceptNextSessionAsync(scope.QueueName);
                 }
                 client.CreateProcessor(scope.QueueName);
+            }
+        }
+
+        [Test]
+        public async Task AcceptNextSessionRespectsCancellation()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))
+            {
+                var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                var duration = TimeSpan.FromSeconds(3);
+                using var cancellationTokenSource = new CancellationTokenSource(duration);
+
+                var start = DateTime.UtcNow;
+                Assert.ThrowsAsync<TaskCanceledException>(async () => await client.AcceptNextSessionAsync(scope.QueueName, cancellationToken: cancellationTokenSource.Token));
+                var stop = DateTime.UtcNow;
+
+                Assert.Less(stop - start, duration.Add(duration));
             }
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -982,7 +982,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockLogger = new Mock<ServiceBusEventSource>();
             var mockTransportReceiver = new Mock<TransportReceiver>();
             var mockConnection = GetMockConnection(mockTransportReceiver);
-            var receiver = new ServiceBusSessionReceiver(mockConnection.Object, "queueName", new ServiceBusPlugin[] { }, new ServiceBusSessionReceiverOptions())
+            var receiver = new ServiceBusSessionReceiver(mockConnection.Object, "queueName", new ServiceBusPlugin[] { }, new ServiceBusSessionReceiverOptions(), cancellationToken: CancellationToken.None)
             {
                 Logger = mockLogger.Object
             };
@@ -1016,7 +1016,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 mockConnection.Object,
                 "queueName",
                 new ServiceBusPlugin[] { },
-                new ServiceBusSessionReceiverOptions())
+                new ServiceBusSessionReceiverOptions(),
+                cancellationToken: CancellationToken.None)
             {
                 Logger = mockLogger.Object
             };
@@ -1049,7 +1050,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 mockConnection.Object,
                 "queueName",
                 new ServiceBusPlugin[] { },
-                new ServiceBusSessionReceiverOptions())
+                new ServiceBusSessionReceiverOptions(),
+                cancellationToken: CancellationToken.None)
             {
                 Logger = mockLogger.Object
             };
@@ -1083,7 +1085,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 mockConnection.Object,
                 "queueName",
                 new ServiceBusPlugin[] { },
-                new ServiceBusSessionReceiverOptions())
+                new ServiceBusSessionReceiverOptions(),
+                cancellationToken: CancellationToken.None)
             {
                 Logger = mockLogger.Object
             };
@@ -1116,7 +1119,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 mockConnection.Object,
                 "queueName",
                 new ServiceBusPlugin[] { },
-                new ServiceBusSessionReceiverOptions())
+                new ServiceBusSessionReceiverOptions(),
+                cancellationToken: CancellationToken.None)
             {
                 Logger = mockLogger.Object
             };
@@ -1151,7 +1155,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 mockConnection.Object,
                 "queueName",
                 new ServiceBusPlugin[] { },
-                new ServiceBusSessionReceiverOptions())
+                new ServiceBusSessionReceiverOptions(),
+                cancellationToken: CancellationToken.None)
             {
                 Logger = mockLogger.Object
             };
@@ -1278,7 +1283,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     It.IsAny<uint>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
-                    It.IsAny<bool>()))
+                    It.IsAny<bool>(),
+                    CancellationToken.None))
                 .Returns(mockTransportReceiver.Object);
             return mockConnection;
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestBase.cs
@@ -104,7 +104,8 @@ namespace Azure.Messaging.ServiceBus.Tests
                     It.IsAny<uint>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
-                    It.IsAny<bool>()))
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(mockTransportReceiver.Object);
             return mockConnection.Object;
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Primitives/ServiceBusConnectionTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Primitives/ServiceBusConnectionTests.cs
@@ -538,7 +538,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 return Task.CompletedTask;
             }
 
-            public override TransportReceiver CreateReceiver(string entityPath, ServiceBusRetryPolicy retryPolicy, ServiceBusReceiveMode receiveMode, uint prefetchCount, string identifier, string sessionId, bool isSessionReceiver)
+            public override TransportReceiver CreateReceiver(string entityPath, ServiceBusRetryPolicy retryPolicy, ServiceBusReceiveMode receiveMode, uint prefetchCount, string identifier, string sessionId, bool isSessionReceiver, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -137,6 +137,49 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         }
 
         [Test]
+        public async Task CancellingDoesNotLoseMessages()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = CreateClient();
+
+                var messageCount = 50;
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
+                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+                await sender.SendMessagesAsync(batch);
+                var receiver = client.CreateReceiver(
+                    scope.QueueName,
+                    new ServiceBusReceiverOptions { ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete });
+
+                using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+                var received = 0;
+
+                try
+                {
+                    for (int i = 0; i < messageCount; i++)
+                    {
+                        await receiver.ReceiveMessageAsync(cancellationToken: cancellationTokenSource.Token);
+                        received++;
+                    }
+                }
+                catch (TaskCanceledException)
+                {
+                }
+
+                Assert.Less(received, messageCount);
+
+                var remaining = messageCount - received;
+                for (int i = 0; i < remaining; i++)
+                {
+                    await receiver.ReceiveMessageAsync();
+                    received++;
+                }
+                Assert.AreEqual(messageCount, received);
+            }
+        }
+
+        [Test]
         public async Task ReceiveMessagesInPeekLockMode()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -143,7 +143,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             {
                 await using var client = CreateClient();
 
-                var messageCount = 50;
+                var messageCount = 10;
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
@@ -152,7 +152,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     scope.QueueName,
                     new ServiceBusReceiverOptions { ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete });
 
-                using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+                using var cancellationTokenSource = new CancellationTokenSource(500);
                 var received = 0;
 
                 try
@@ -161,6 +161,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     {
                         await receiver.ReceiveMessageAsync(cancellationToken: cancellationTokenSource.Token);
                         received++;
+                        await Task.Delay(100);
                     }
                 }
                 catch (TaskCanceledException)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -950,7 +950,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             {
                 await using var client = CreateClient();
 
-                var messageCount = 50;
+                var messageCount = 10;
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, "sessionId").AsEnumerable<ServiceBusMessage>();
@@ -960,7 +960,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     "sessionId",
                     new ServiceBusSessionReceiverOptions { ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete });
 
-                using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+                using var cancellationTokenSource = new CancellationTokenSource(500);
                 var received = 0;
 
                 try
@@ -969,6 +969,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     {
                         await receiver.ReceiveMessageAsync(cancellationToken: cancellationTokenSource.Token);
                         received++;
+                        await Task.Delay(100);
                     }
                 }
                 catch (TaskCanceledException)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Azure.Messaging.ServiceBus.Plugins;
 using Moq;
 using NUnit.Framework;
@@ -18,7 +19,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 GetMockedConnection(),
                 "fakeQueue",
                 options: new ServiceBusSessionReceiverOptions(),
-                plugins: new ServiceBusPlugin[] { });
+                plugins: new ServiceBusPlugin[] { },
+                cancellationToken: CancellationToken.None);
 
             Assert.That(async () => await receiver.RenewMessageLockAsync(
                 new ServiceBusReceivedMessage()),


### PR DESCRIPTION
While adding a test for SessionProcessor.StopProcessingAsync, I noticed that the stop call still took a long time. It turns out it is because the processor is attempting to accept another session which will take the TryTimeout.
I used the approach that @danielmarbach used for receiving messages to support cancellation of accepting a session. Ideally we will have this support for all operations, but these two operations are the only ones that are expected to potentially take a long time.