### PR TITLE
Do not recopy the memory over and over when accessing the body

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using System.Threading;
 using Azure.Core;
 using Azure.Core.Amqp;
 using Azure.Messaging.ServiceBus.Amqp;
@@ -21,6 +22,8 @@ namespace Azure.Messaging.ServiceBus
     /// </remarks>
     public class ServiceBusMessage
     {
+        private Lazy<BinaryData> body;
+
         /// <summary>
         /// Creates a new message.
         /// </summary>
@@ -46,6 +49,8 @@ namespace Azure.Messaging.ServiceBus
         {
             AmqpMessageBody amqpBody = new AmqpMessageBody(new ReadOnlyMemory<byte>[] { body });
             AmqpMessage = new AmqpAnnotatedMessage(amqpBody);
+
+            this.body = new Lazy<BinaryData>(() => AmqpMessage.GetBody(), LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
         /// <summary>
@@ -137,10 +142,11 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         public BinaryData Body
         {
-            get => AmqpMessage.GetBody();
+            get => body.Value;
             set
             {
                 AmqpMessage.Body = new AmqpMessageBody(new ReadOnlyMemory<byte>[] { value });
+                this.body = new Lazy<BinaryData>(() => AmqpMessage.GetBody(), LazyThreadSafetyMode.ExecutionAndPublication);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Threading;
 using Azure.Core;
 using Azure.Core.Amqp;
 using Azure.Messaging.ServiceBus.Amqp;
@@ -21,6 +22,8 @@ namespace Azure.Messaging.ServiceBus
     /// </remarks>
     public class ServiceBusReceivedMessage
     {
+        private readonly Lazy<BinaryData> body;
+
         /// <summary>
         /// Creates a new message from the specified payload.
         /// </summary>
@@ -36,6 +39,7 @@ namespace Azure.Messaging.ServiceBus
         internal ServiceBusReceivedMessage(AmqpAnnotatedMessage message)
         {
             AmqpMessage = message;
+            body = new Lazy<BinaryData>(() => AmqpMessage.GetBody(), LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
         internal ServiceBusReceivedMessage(): this(body: default)
@@ -65,7 +69,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Gets the body of the message.
         /// </summary>
-        public BinaryData Body => AmqpMessage.GetBody();
+        public BinaryData Body => body.Value;
 
         /// <summary>
         /// Gets the MessageId to identify the message.


### PR DESCRIPTION
At the moment accessing the Body method translates the annotated message over and over again into the binary data structure. That seems to be a surprising and expensive side effect for a seemingly harmless property access.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running generate.ps1. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version,

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
