### PR TITLE
[Event Hubs Client] Shared Key and SAS Samples

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_IdentityAndSharedAccessCredentials.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_IdentityAndSharedAccessCredentials.md
@@ -114,11 +114,139 @@ finally
 
 ## Processing events with Shared Access Signature authorization
 
-**COMING SOON**
+```C# Snippet:EventHubs_Processor_Sample05_SharedAccessSignature
+var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
+
+var credential = new AzureSasCredential("<< SHARED ACCESS KEY STRING >>");
+var fullyQualifiedNamespace = "<< NAMESPACE (likely similar to {your-namespace}.servicebus.windows.net) >>";
+var eventHubName = "<< NAME OF THE EVENT HUB >>";
+var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+
+ var storageClient = new BlobContainerClient(
+    storageConnectionString,
+    blobContainerName);
+
+var processor = new EventProcessorClient(
+    storageClient,
+    consumerGroup,
+    fullyQualifiedNamespace,
+    eventHubName,
+    credential);
+
+try
+{
+    using var cancellationSource = new CancellationTokenSource();
+    cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+
+    // The event handlers are not relevant for this sample; for
+    // illustration, they're delegating the implementation to the
+    // host application.
+
+    processor.ProcessEventAsync += Application.ProcessorEventHandler;
+    processor.ProcessErrorAsync += Application.ProcessorErrorHandler;
+
+    try
+    {
+        await processor.StartProcessingAsync(cancellationSource.Token);
+        await Task.Delay(Timeout.Infinite, cancellationSource.Token);
+    }
+    catch (TaskCanceledException)
+    {
+        // This is expected if the cancellation token is
+        // signaled.
+    }
+    finally
+    {
+        // This may take up to the length of time defined
+        // as part of the configured TryTimeout of the processor;
+        // by default, this is 60 seconds.
+
+        await processor.StopProcessingAsync();
+    }
+}
+catch
+{
+    // If this block is invoked, then something external to the
+    // processor was the source of the exception.
+}
+finally
+{
+   // It is encouraged that you unregister your handlers when you have
+   // finished using the Event Processor to ensure proper cleanup.
+
+   processor.ProcessEventAsync -= Application.ProcessorEventHandler;
+   processor.ProcessErrorAsync -= Application.ProcessorErrorHandler;
+}
+```
 
 ## Processing events with Shared Access Key authorization
 
-**COMING SOON**
+```C# Snippet:EventHubs_Processor_Sample05_SharedAccessKey
+var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
+
+var credential = new AzureNamedKeyCredential("<< SHARED KEY NAME >>", "<< SHARED KEY >>");
+var fullyQualifiedNamespace = "<< NAMESPACE (likely similar to {your-namespace}.servicebus.windows.net) >>";
+var eventHubName = "<< NAME OF THE EVENT HUB >>";
+var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+
+ var storageClient = new BlobContainerClient(
+    storageConnectionString,
+    blobContainerName);
+
+var processor = new EventProcessorClient(
+    storageClient,
+    consumerGroup,
+    fullyQualifiedNamespace,
+    eventHubName,
+    credential);
+
+try
+{
+    using var cancellationSource = new CancellationTokenSource();
+    cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+
+    // The event handlers are not relevant for this sample; for
+    // illustration, they're delegating the implementation to the
+    // host application.
+
+    processor.ProcessEventAsync += Application.ProcessorEventHandler;
+    processor.ProcessErrorAsync += Application.ProcessorErrorHandler;
+
+    try
+    {
+        await processor.StartProcessingAsync(cancellationSource.Token);
+        await Task.Delay(Timeout.Infinite, cancellationSource.Token);
+    }
+    catch (TaskCanceledException)
+    {
+        // This is expected if the cancellation token is
+        // signaled.
+    }
+    finally
+    {
+        // This may take up to the length of time defined
+        // as part of the configured TryTimeout of the processor;
+        // by default, this is 60 seconds.
+
+        await processor.StopProcessingAsync();
+    }
+}
+catch
+{
+    // If this block is invoked, then something external to the
+    // processor was the source of the exception.
+}
+finally
+{
+   // It is encouraged that you unregister your handlers when you have
+   // finished using the Event Processor to ensure proper cleanup.
+
+   processor.ProcessEventAsync -= Application.ProcessorEventHandler;
+   processor.ProcessErrorAsync -= Application.ProcessorErrorHandler;
+}
+```
 
 ## Parsing a connection string for information
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample05_IdentityAndSharedAccessCredentialsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample05_IdentityAndSharedAccessCredentialsLiveTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
+using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Processor;
 using Azure.Storage.Blobs;
 using NUnit.Framework;
@@ -60,6 +61,183 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
             var storageClient = new BlobContainerClient(
                 blobUriBuilder.ToUri(),
                 credential);
+
+            var processor = new EventProcessorClient(
+                storageClient,
+                consumerGroup,
+                fullyQualifiedNamespace,
+                eventHubName,
+                credential);
+
+            try
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+
+                // The event handlers are not relevant for this sample; for
+                // illustration, they're delegating the implementation to the
+                // host application.
+
+                processor.ProcessEventAsync += Application.ProcessorEventHandler;
+                processor.ProcessErrorAsync += Application.ProcessorErrorHandler;
+
+                try
+                {
+                    await processor.StartProcessingAsync(cancellationSource.Token);
+                    await Task.Delay(Timeout.Infinite, cancellationSource.Token);
+                }
+                catch (TaskCanceledException)
+                {
+                    // This is expected if the cancellation token is
+                    // signaled.
+                }
+                finally
+                {
+                    // This may take up to the length of time defined
+                    // as part of the configured TryTimeout of the processor;
+                    // by default, this is 60 seconds.
+
+                    await processor.StopProcessingAsync();
+                }
+            }
+            catch
+            {
+                // If this block is invoked, then something external to the
+                // processor was the source of the exception.
+            }
+            finally
+            {
+               // It is encouraged that you unregister your handlers when you have
+               // finished using the Event Processor to ensure proper cleanup.
+
+               processor.ProcessEventAsync -= Application.ProcessorEventHandler;
+               processor.ProcessErrorAsync -= Application.ProcessorErrorHandler;
+            }
+
+            #endregion
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SharedAccessSignature()
+        {
+            await using var eventHubScope = await EventHubScope.CreateAsync(1);
+            await using var storageScope = await StorageScope.CreateAsync();
+
+            #region Snippet:EventHubs_Processor_Sample05_SharedAccessSignature
+
+            var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+            var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
+            /*@@*/
+            /*@@*/ storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
+            /*@@*/ blobContainerName = storageScope.ContainerName;
+
+            //@@ var credential = new AzureSasCredential("<< SHARED ACCESS KEY STRING >>");
+            var fullyQualifiedNamespace = "<< NAMESPACE (likely similar to {your-namespace}.servicebus.windows.net) >>";
+            var eventHubName = "<< NAME OF THE EVENT HUB >>";
+            var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+            /*@@*/
+            /*@@*/ fullyQualifiedNamespace = EventHubsTestEnvironment.Instance.FullyQualifiedNamespace;
+            /*@@*/ eventHubName = eventHubScope.EventHubName;
+            /*@@*/ consumerGroup = eventHubScope.ConsumerGroups.First();
+            /*@@*/
+            /*@@*/ var resource = $"amqps://{ EventHubsTestEnvironment.Instance.FullyQualifiedNamespace }/{ eventHubScope.EventHubName }".ToLowerInvariant();
+            /*@@*/ var signature = new SharedAccessSignature(resource, EventHubsTestEnvironment.Instance.SharedAccessKeyName, EventHubsTestEnvironment.Instance.SharedAccessKey);
+            /*@@*/ var credential = new AzureSasCredential(signature.Value);
+
+             var storageClient = new BlobContainerClient(
+                storageConnectionString,
+                blobContainerName);
+
+            var processor = new EventProcessorClient(
+                storageClient,
+                consumerGroup,
+                fullyQualifiedNamespace,
+                eventHubName,
+                credential);
+
+            try
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+
+                // The event handlers are not relevant for this sample; for
+                // illustration, they're delegating the implementation to the
+                // host application.
+
+                processor.ProcessEventAsync += Application.ProcessorEventHandler;
+                processor.ProcessErrorAsync += Application.ProcessorErrorHandler;
+
+                try
+                {
+                    await processor.StartProcessingAsync(cancellationSource.Token);
+                    await Task.Delay(Timeout.Infinite, cancellationSource.Token);
+                }
+                catch (TaskCanceledException)
+                {
+                    // This is expected if the cancellation token is
+                    // signaled.
+                }
+                finally
+                {
+                    // This may take up to the length of time defined
+                    // as part of the configured TryTimeout of the processor;
+                    // by default, this is 60 seconds.
+
+                    await processor.StopProcessingAsync();
+                }
+            }
+            catch
+            {
+                // If this block is invoked, then something external to the
+                // processor was the source of the exception.
+            }
+            finally
+            {
+               // It is encouraged that you unregister your handlers when you have
+               // finished using the Event Processor to ensure proper cleanup.
+
+               processor.ProcessEventAsync -= Application.ProcessorEventHandler;
+               processor.ProcessErrorAsync -= Application.ProcessorErrorHandler;
+            }
+
+            #endregion
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SharedAccessKey()
+        {
+            await using var eventHubScope = await EventHubScope.CreateAsync(1);
+            await using var storageScope = await StorageScope.CreateAsync();
+
+            #region Snippet:EventHubs_Processor_Sample05_SharedAccessKey
+
+            var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+            var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
+            /*@@*/
+            /*@@*/ storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
+            /*@@*/ blobContainerName = storageScope.ContainerName;
+
+            var credential = new AzureNamedKeyCredential("<< SHARED KEY NAME >>", "<< SHARED KEY >>");
+            var fullyQualifiedNamespace = "<< NAMESPACE (likely similar to {your-namespace}.servicebus.windows.net) >>";
+            var eventHubName = "<< NAME OF THE EVENT HUB >>";
+            var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+            /*@@*/
+            /*@@*/ fullyQualifiedNamespace = EventHubsTestEnvironment.Instance.FullyQualifiedNamespace;
+            /*@@*/ eventHubName = eventHubScope.EventHubName;
+            /*@@*/ consumerGroup = eventHubScope.ConsumerGroups.First();
+            /*@@*/ credential = new AzureNamedKeyCredential(EventHubsTestEnvironment.Instance.SharedAccessKeyName, EventHubsTestEnvironment.Instance.SharedAccessKey);
+
+             var storageClient = new BlobContainerClient(
+                storageConnectionString,
+                blobContainerName);
 
             var processor = new EventProcessorClient(
                 storageClient,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_IdentityAndSharedAccessCredentials.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_IdentityAndSharedAccessCredentials.md
@@ -45,7 +45,6 @@ TokenCredential credential = new DefaultAzureCredential();
 
 var fullyQualifiedNamespace = "<< NAMESPACE (likely similar to {your-namespace}.servicebus.windows.net) >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
-
 var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, credential);
 
 try
@@ -73,11 +72,67 @@ finally
 
 ## Publishing events with Shared Access Signature authorization
 
-**COMING SOON**
+```C# Snippet:EventHubs_Sample06_SharedAccessSignature
+var credential = new AzureSasCredential("<< SHARED ACCESS KEY STRING >>");
+
+var fullyQualifiedNamespace = "<< NAMESPACE (likely similar to {your-namespace}.servicebus.windows.net) >>";
+var eventHubName = "<< NAME OF THE EVENT HUB >>";
+var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, credential);
+
+try
+{
+    using var eventBatch = await producer.CreateBatchAsync();
+
+    for (var index = 0; index < 5; ++index)
+    {
+        var eventBody = new BinaryData($"Event #{ index }");
+        var eventData = new EventData(eventBody);
+
+        if (!eventBatch.TryAdd(eventData))
+        {
+            throw new Exception($"The event at { index } could not be added.");
+        }
+    }
+
+    await producer.SendAsync(eventBatch);
+}
+finally
+{
+    await producer.CloseAsync();
+}
+```
 
 ## Publishing events with Shared Access Key authorization
 
-**COMING SOON**
+```C# Snippet:EventHubs_Sample06_SharedAccessKey
+var credential = new AzureNamedKeyCredential("<< SHARED KEY NAME >>", "<< SHARED KEY >>");
+
+var fullyQualifiedNamespace = "<< NAMESPACE (likely similar to {your-namespace}.servicebus.windows.net) >>";
+var eventHubName = "<< NAME OF THE EVENT HUB >>";
+var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, credential);
+
+try
+{
+    using var eventBatch = await producer.CreateBatchAsync();
+
+    for (var index = 0; index < 5; ++index)
+    {
+        var eventBody = new BinaryData($"Event #{ index }");
+        var eventData = new EventData(eventBody);
+
+        if (!eventBatch.TryAdd(eventData))
+        {
+            throw new Exception($"The event at { index } could not be added.");
+        }
+    }
+
+    await producer.SendAsync(eventBatch);
+}
+finally
+{
+    await producer.CloseAsync();
+}
+```
 
 ## Parsing a connection string for information
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample06_IdentityAndSharedAccessCredentialsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample06_IdentityAndSharedAccessCredentialsLiveTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
+using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Producer;
 using NUnit.Framework;
 
@@ -41,7 +42,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
             /*@@*/ fullyQualifiedNamespace = EventHubsTestEnvironment.Instance.FullyQualifiedNamespace;
             /*@@*/ eventHubName = scope.EventHubName;
             /*@@*/ credential = EventHubsTestEnvironment.Instance.Credential;
-
+            /*@@*/
             var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, credential);
 
             try
@@ -80,15 +81,18 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
             #region Snippet:EventHubs_Sample06_SharedAccessSignature
 
-            TokenCredential credential = new DefaultAzureCredential();
+            //@@ var credential = new AzureSasCredential("<< SHARED ACCESS KEY STRING >>");
 
             var fullyQualifiedNamespace = "<< NAMESPACE (likely similar to {your-namespace}.servicebus.windows.net) >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
             /*@@*/
             /*@@*/ fullyQualifiedNamespace = EventHubsTestEnvironment.Instance.FullyQualifiedNamespace;
             /*@@*/ eventHubName = scope.EventHubName;
-            /*@@*/ credential = EventHubsTestEnvironment.Instance.Credential;
-
+            /*@@*/
+            /*@@*/ var resource = EventHubConnection.BuildConnectionSignatureAuthorizationResource(new EventHubProducerClientOptions().ConnectionOptions.TransportType, EventHubsTestEnvironment.Instance.FullyQualifiedNamespace, scope.EventHubName);
+            /*@@*/ var signature = new SharedAccessSignature(resource, EventHubsTestEnvironment.Instance.SharedAccessKeyName, EventHubsTestEnvironment.Instance.SharedAccessKey);
+            /*@@*/ var credential = new AzureSasCredential(signature.Value);
+            /*@@*/
             var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, credential);
 
             try
@@ -127,15 +131,15 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
             #region Snippet:EventHubs_Sample06_SharedAccessKey
 
-            TokenCredential credential = new DefaultAzureCredential();
+            var credential = new AzureNamedKeyCredential("<< SHARED KEY NAME >>", "<< SHARED KEY >>");
 
             var fullyQualifiedNamespace = "<< NAMESPACE (likely similar to {your-namespace}.servicebus.windows.net) >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
             /*@@*/
             /*@@*/ fullyQualifiedNamespace = EventHubsTestEnvironment.Instance.FullyQualifiedNamespace;
             /*@@*/ eventHubName = scope.EventHubName;
-            /*@@*/ credential = EventHubsTestEnvironment.Instance.Credential;
-
+            /*@@*/ credential = new AzureNamedKeyCredential(EventHubsTestEnvironment.Instance.SharedAccessKeyName, EventHubsTestEnvironment.Instance.SharedAccessKey);
+            /*@@*/
             var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, credential);
 
             try


### PR DESCRIPTION
# Summary

The focus of these changes is to add the code samples for working with the `AzureNamedKeyCredential` and `AzureSasCredential` types to authenticate with the Event Hubs clients.

# Last Upstream Rebase

Wednesday, March 31, 1pm (EST)