### PR TITLE
[Translator] Change SAS permissions and add test

### DIFF
--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/samples/Sample1_StartTranslation.md
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/samples/Sample1_StartTranslation.md
@@ -18,8 +18,9 @@ var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCreden
 To Start a translation operation for a single document or documents in a single blob container, call `StartTranslationAsync`. The result is a Long Running operation of type `DocumentTranslationOperation` which polls for the status of the translation operation from the API.
 
 To call `StartTranslationAsync` you need to initialize an object of type `DocumentTranslationInput` which contains the information needed to translate the documents.
-The `sourceUri` is a SAS URI with read access for the document to be translated or read and list access for the blob container holding the documents to be translated.
-The `targetUri` is a SAS URI with write access for the blob container to which the translated documents will be written.
+
+- The `sourceUri` is a SAS URI with read access for the document to be translated or read and list access for the blob container holding the documents to be translated.
+- The `targetUri` is a SAS URI with read and write access for the blob container to which the translated documents will be written.
 
 More on generating SAS Tokens [here](https://docs.microsoft.com/azure/cognitive-services/translator/document-translation/get-started-with-document-translation?tabs=csharp#create-sas-access-tokens-for-document-translation)
 

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/samples/Sample3_OperationsHistory.md
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/samples/Sample3_OperationsHistory.md
@@ -17,7 +17,7 @@ var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCreden
 
 To get the Translation History, call `GetTranslationsAsync` which returns an AsyncPageable object containing the `TranslationStatusResult` for all submitted translation operations.
 
-The sample below gets the total number of documents translated in all submitted operations as well as the details of the operation contining the largest number of documents.
+The sample below gets the total number of documents translated in all submitted operations as well as the details of the operation continuing the largest number of documents.
 
 ```C# Snippet:OperationsHistoryAsync
 int operationsCount = 0;

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/samples/Sample4_MultipleInputs.md
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/samples/Sample4_MultipleInputs.md
@@ -19,8 +19,8 @@ To Start a translation operation for documents in multiple blob containers, call
 
 To call `StartTranslationAsync` you need to initialize a list of `DocumentTranslationInput` which contains the information needed to translate the documents. Each `DocumentTranslationInput` contains a source container and a list of target containers. The `AddTarget` method is used to add targets to the input.
 
-The `sourceUri` is a SAS URI with read access for the blob container holding the documents to be translated.
-The `targetUri` is a SAS URI with write access for the blob container to which the translated documents will be written.
+- The `sourceUri` is a SAS URI with read access for the document to be translated or read and list access for the blob container holding the documents to be translated.
+- The `targetUri` is a SAS URI with read and write access for the blob container to which the translated documents will be written.
 
 More on generating SAS Tokens [here](https://docs.microsoft.com/azure/cognitive-services/translator/document-translation/get-started-with-document-translation?tabs=csharp#create-sas-access-tokens-for-document-translation)
 

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/src/DocumentTranslationInput.cs
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/src/DocumentTranslationInput.cs
@@ -19,8 +19,8 @@ namespace Azure.AI.DocumentTranslation
         /// <summary>
         /// Initializes a new instance of <see cref="DocumentTranslationInput"/>.
         /// </summary>
-        /// <param name="sourceUri">The SAS URI for the source container containing documents to be translated.</param>
-        /// <param name="targetUri">The SAS URI for the target container to which the translated documents will be written.</param>
+        /// <param name="sourceUri">The SAS URI for the source container containing documents to be translated. Read and List permissions are needed.</param>
+        /// <param name="targetUri">The SAS URI for the target container to which the translated documents will be written. Read and Write permissions are needed.</param>
         /// <param name="targetLanguageCode">Language code to translate documents to. For supported languages see
         /// <a href="https://docs.microsoft.com/azure/cognitive-services/translator/language-support#translate"/>.</param>
         /// <param name="glossary">Custom <see cref="TranslationGlossary"/> to be used in the translation operation. For supported file types see
@@ -39,7 +39,7 @@ namespace Azure.AI.DocumentTranslation
         /// <summary>
         /// Add a <see cref="TranslationTarget"/> to the translation input.
         /// </summary>
-        /// <param name="targetUri">The SAS URI for the target container to which the translated documents will be written.</param>
+        /// <param name="targetUri">The SAS URI for the target container to which the translated documents will be written. Read and Write permissions are needed.</param>
         /// <param name="languageCode">Language code to translate documents to. For supported languages see
         /// <a href="https://docs.microsoft.com/azure/cognitive-services/translator/language-support#translate"/>.</param>
         /// <param name="glossary">Custom <see cref="TranslationGlossary"/> to be used in the translation operation. For supported file types see

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/ExistingFileInTargetContainer.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/ExistingFileInTargetContainer.json
@@ -1,0 +1,276 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1404165747?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-6c01652be3e6604692ccc1c25a1ae6fa-45b3d3912c9c3b47-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "e49fd0612a25a18c53dc03ee38845e2b",
+        "x-ms-date": "Wed, 31 Mar 2021 22:22:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 31 Mar 2021 22:22:27 GMT",
+        "ETag": "\u00220x8D8F49378263D92\u0022",
+        "Last-Modified": "Wed, 31 Mar 2021 22:22:28 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "e49fd0612a25a18c53dc03ee38845e2b",
+        "x-ms-request-id": "cf184a71-d01e-002b-577c-26689e000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1404165747/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-c8dd289680f59141b2901c3b8d582c2c-70841fb71d388c47-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3558fb2b9c38f64f8a600d3867389ef8",
+        "x-ms-date": "Wed, 31 Mar 2021 22:22:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Wed, 31 Mar 2021 22:22:27 GMT",
+        "ETag": "\u00220x8D8F493785338EF\u0022",
+        "Last-Modified": "Wed, 31 Mar 2021 22:22:28 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "3558fb2b9c38f64f8a600d3867389ef8",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "cf184af9-d01e-002b-557c-26689e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1858998287?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-860cd03d6f24a64baf887b54be10cad7-6ebfb72b85643f4e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "06a943c0b905da2ca3ca525060802657",
+        "x-ms-date": "Wed, 31 Mar 2021 22:22:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 31 Mar 2021 22:22:28 GMT",
+        "ETag": "\u00220x8D8F49378609211\u0022",
+        "Last-Modified": "Wed, 31 Mar 2021 22:22:28 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "06a943c0b905da2ca3ca525060802657",
+        "x-ms-request-id": "cf184b5f-d01e-002b-397c-26689e000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1858998287/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-52c4ea9319e55d42b0d31cd8dd810d6e-c7c66238d6582642-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7d9269403bc981c4a95ac41c533a1a3e",
+        "x-ms-date": "Wed, 31 Mar 2021 22:22:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Wed, 31 Mar 2021 22:22:28 GMT",
+        "ETag": "\u00220x8D8F4937867AF07\u0022",
+        "Last-Modified": "Wed, 31 Mar 2021 22:22:29 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "7d9269403bc981c4a95ac41c533a1a3e",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "cf184b78-d01e-002b-517c-26689e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e1a7a5baf1fa4e49a1af91fdb28d91be-dbd062f7098a934d-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210331.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "4077de0b25b441252b5b94d1fca62ae0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "5264aa3b-bd2b-405d-b6d5-87bfe83064da",
+        "Content-Length": "0",
+        "Date": "Wed, 31 Mar 2021 22:22:29 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/042051dd-1451-4bc5-9bcf-29093e8f5a98",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "5264aa3b-bd2b-405d-b6d5-87bfe83064da"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/042051dd-1451-4bc5-9bcf-29093e8f5a98",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210331.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "ce26e1e77b0b84457f285cabf50f8668",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "762ce624-b84a-4ff8-b61f-62b7a303e595",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 31 Mar 2021 22:22:30 GMT",
+        "ETag": "\u00224FA23785C6BF8148AD4070369F660FC0723089035FCECDDF2D2F6A3C5EE37524\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "762ce624-b84a-4ff8-b61f-62b7a303e595"
+      },
+      "ResponseBody": {
+        "id": "042051dd-1451-4bc5-9bcf-29093e8f5a98",
+        "createdDateTimeUtc": "2021-03-31T22:22:30.5743328Z",
+        "lastActionDateTimeUtc": "2021-03-31T22:22:30.716282Z",
+        "status": "Failed",
+        "summary": {
+          "total": 1,
+          "failed": 1,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/042051dd-1451-4bc5-9bcf-29093e8f5a98/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210331.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "824514b0e5081ba24350516ea6f28403",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "28986385-6acf-416e-b152-4d797f2fca78",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 31 Mar 2021 22:22:30 GMT",
+        "ETag": "\u002227E3E1FEF3C37EC8BB300F9E9B9F991394AED7926426D0515776444683E23137\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "28986385-6acf-416e-b152-4d797f2fca78"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source1404165747/Document1.txt",
+            "lastActionDateTimeUtc": "2021-03-31T22:22:30.7160794Z",
+            "status": "Failed",
+            "to": "fr",
+            "error": {
+              "code": "InvalidRequest",
+              "message": "Target document file already exists.",
+              "target": "Document",
+              "innerError": {
+                "code": "TargetFileAlreadyExists",
+                "message": "Target document file already exists."
+              }
+            },
+            "progress": 0,
+            "id": "0000483a-0000-0000-0000-000000000000",
+            "characterCharged": 0
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "1336393603"
+  }
+}

--- a/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/ExistingFileInTargetContainerAsync.json
+++ b/sdk/documenttranslation/Azure.AI.DocumentTranslation/tests/SessionRecords/TranslationOperationLiveTests/ExistingFileInTargetContainerAsync.json
@@ -1,0 +1,276 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source10986009?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-00e7b7ae98f49240b9a632bbb30d64b8-4d0babd05504814d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "cca9261f9426b7e4ec050e07ee184c38",
+        "x-ms-date": "Wed, 31 Mar 2021 22:22:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 31 Mar 2021 22:22:31 GMT",
+        "ETag": "\u00220x8D8F4937A2AF6E5\u0022",
+        "Last-Modified": "Wed, 31 Mar 2021 22:22:31 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "cca9261f9426b7e4ec050e07ee184c38",
+        "x-ms-request-id": "cf185462-d01e-002b-7c7c-26689e000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source10986009/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-706445366c46564888c2c51e4d6e69e3-8781c25202a1914e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6a41c8c319bd5aae435081085df095ea",
+        "x-ms-date": "Wed, 31 Mar 2021 22:22:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Wed, 31 Mar 2021 22:22:31 GMT",
+        "ETag": "\u00220x8D8F4937A5532FD\u0022",
+        "Last-Modified": "Wed, 31 Mar 2021 22:22:32 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "6a41c8c319bd5aae435081085df095ea",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "cf1854d7-d01e-002b-4b7c-26689e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target379144463?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-671ed0e9959d7d48a153a97e3e8132b1-094aac8939d02340-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "57ab16e2e6dbea850fa99286b2de26ff",
+        "x-ms-date": "Wed, 31 Mar 2021 22:22:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 31 Mar 2021 22:22:31 GMT",
+        "ETag": "\u00220x8D8F4937A68F594\u0022",
+        "Last-Modified": "Wed, 31 Mar 2021 22:22:32 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "57ab16e2e6dbea850fa99286b2de26ff",
+        "x-ms-request-id": "cf1855ba-d01e-002b-137c-26689e000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target379144463/Document1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "27",
+        "If-None-Match": "*",
+        "traceparent": "00-e5f46e77cd5e7040b56ca6c5a98fffe6-58c3e455521ccd4b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "01ac2d1b5b4e78064f89d613dc59fc70",
+        "x-ms-date": "Wed, 31 Mar 2021 22:22:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "Rmlyc3QgZW5nbGlzaCB0ZXN0IGRvY3VtZW50",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
+        "Date": "Wed, 31 Mar 2021 22:22:31 GMT",
+        "ETag": "\u00220x8D8F4937A9506B4\u0022",
+        "Last-Modified": "Wed, 31 Mar 2021 22:22:32 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "01ac2d1b5b4e78064f89d613dc59fc70",
+        "x-ms-content-crc64": "V7knc5S52gk=",
+        "x-ms-request-id": "cf185658-d01e-002b-147c-26689e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7f139a414b696541b8628486298104ad-4f156f3961ccb544-00",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210331.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "020bf823e1a1e2e7bc7fae701bd39071",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "e0d1f74e-8e93-4b80-9242-9806cce6cdf0",
+        "Content-Length": "0",
+        "Date": "Wed, 31 Mar 2021 22:22:32 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/d692fc54-1518-4c94-ba47-0f74a770f44f",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e0d1f74e-8e93-4b80-9242-9806cce6cdf0"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/d692fc54-1518-4c94-ba47-0f74a770f44f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210331.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "c342085ae8e987c0103307520f710eb6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c158e111-731d-425e-843f-c509ec8a1449",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 31 Mar 2021 22:22:32 GMT",
+        "ETag": "\u0022D81BB815EBDA24AE986A229314B33D944B77F8708E080A3934F8682EC4FB769B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c158e111-731d-425e-843f-c509ec8a1449"
+      },
+      "ResponseBody": {
+        "id": "d692fc54-1518-4c94-ba47-0f74a770f44f",
+        "createdDateTimeUtc": "2021-03-31T22:22:33.1016656Z",
+        "lastActionDateTimeUtc": "2021-03-31T22:22:33.2474281Z",
+        "status": "Failed",
+        "summary": {
+          "total": 1,
+          "failed": 1,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/d692fc54-1518-4c94-ba47-0f74a770f44f/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210331.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "ba6222ad23d23a5e45ca45cead955d7b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3d936b38-5190-4032-bc00-7139022af17d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 31 Mar 2021 22:22:32 GMT",
+        "ETag": "\u00229CDA5FDFFBB13DD8F3A129D1B708C2E5538872A73FE001669B60C0F83665D39E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
+          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "3d936b38-5190-4032-bc00-7139022af17d"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source10986009/Document1.txt",
+            "lastActionDateTimeUtc": "2021-03-31T22:22:33.2472379Z",
+            "status": "Failed",
+            "to": "fr",
+            "error": {
+              "code": "InvalidRequest",
+              "message": "Target document file already exists.",
+              "target": "Document",
+              "innerError": {
+                "code": "TargetFileAlreadyExists",
+                "message": "Target document file already exists."
+              }
+            },
+            "progress": 0,
+            "id": "0000483b-0000-0000-0000-000000000000",
+            "characterCharged": 0
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "373906145"
+  }
+}


### PR DESCRIPTION
We recently learned that the correct permissions for generating SAS token for the Target container should be `Read` and `Write`. `List` is not used.
Thank to this change we were able to add a test for when a file already exists on the Target Container.

PS: Service team will update their documentation to reflect the permission changes too