### PR TITLE
Close link on cancellation

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -986,10 +986,11 @@ namespace Azure.Messaging.ServiceBus.Amqp
             {
                 var openObjectCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                using var registration = cancellationToken.Register(static state =>
+                using var registration = cancellationToken.Register(state =>
                 {
                     var tcs = (TaskCompletionSource<object>)state;
                     tcs.TrySetCanceled();
+                    target.SafeClose();
                 }, openObjectCompletionSource, useSynchronizationContext: false);
 
                 static async Task Open(AmqpObject target, TimeSpan timeout, TaskCompletionSource<object> openObjectCompletionSource)
@@ -997,7 +998,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     try
                     {
                         await target.OpenAsync(timeout).ConfigureAwait(false);
-                        openObjectCompletionSource.TrySetResult(null);
+                        openObjectCompletionSource.SetResult(null);
                     }
                     catch (Exception ex)
                     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -202,14 +202,21 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))
             {
-                var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
-                var duration = TimeSpan.FromSeconds(3);
+                var client = CreateClient(60);
+                var duration = TimeSpan.FromSeconds(5);
                 using var cancellationTokenSource = new CancellationTokenSource(duration);
 
                 var start = DateTime.UtcNow;
                 Assert.ThrowsAsync<TaskCanceledException>(async () => await client.AcceptNextSessionAsync(scope.QueueName, cancellationToken: cancellationTokenSource.Token));
                 var stop = DateTime.UtcNow;
 
+                Assert.Less(stop - start, duration.Add(duration));
+                var sender = client.CreateSender(scope.QueueName);
+                await sender.SendMessageAsync(GetMessage("sessionId"));
+
+                start = DateTime.UtcNow;
+                var receiver = await client.AcceptNextSessionAsync(scope.QueueName);
+                stop = DateTime.UtcNow;
                 Assert.Less(stop - start, duration.Add(duration));
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -132,12 +132,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 Assert.ThrowsAsync<TaskCanceledException>(async () => await receiver.ReceiveMessagesAsync(1, cancellationToken: cancellationTokenSource.Token));
                 var stop = DateTime.UtcNow;
 
-                Assert.That(stop - start,  Is.EqualTo(TimeSpan.FromSeconds(3)).Within(TimeSpan.FromSeconds(3)));
+                Assert.That(stop - start, Is.EqualTo(TimeSpan.FromSeconds(3)).Within(TimeSpan.FromSeconds(3)));
             }
         }
 
         [Test]
-        public async Task CancellingDoesNotLoseMessages()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task CancellingDoesNotLoseMessages(bool prefetch)
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
@@ -150,7 +152,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await sender.SendMessagesAsync(batch);
                 var receiver = client.CreateReceiver(
                     scope.QueueName,
-                    new ServiceBusReceiverOptions { ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete });
+                    new ServiceBusReceiverOptions { ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete, PrefetchCount = prefetch ? 10 : 0 });
 
                 using var cancellationTokenSource = new CancellationTokenSource(500);
                 var received = 0;
@@ -177,6 +179,33 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     received++;
                 }
                 Assert.AreEqual(messageCount, received);
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task CancellingDoesNotBlockSubsequentReceives(bool prefetch)
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = CreateClient();
+
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                var receiver = client.CreateReceiver(scope.QueueName, new ServiceBusReceiverOptions { PrefetchCount = prefetch ? 10 : 0 });
+
+                using var cancellationTokenSource = new CancellationTokenSource(2000);
+                var start = DateTime.UtcNow;
+                Assert.That(
+                    async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(60), cancellationToken: cancellationTokenSource.Token),
+                    Throws.InstanceOf<TaskCanceledException>());
+
+                await sender.SendMessageAsync(GetMessage());
+                var msg = await receiver.ReceiveMessageAsync();
+                Assert.AreEqual(1, msg.DeliveryCount);
+                var end = DateTime.UtcNow;
+                Assert.NotNull(msg);
+                Assert.Less(end - start, TimeSpan.FromSeconds(5));
             }
         }
 
@@ -857,7 +886,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 await sender.SendMessagesAsync(new List<ServiceBusMessage>());
 
-                for (int i = 0; i < sentCount/messagesPerBatch; i++)
+                for (int i = 0; i < sentCount / messagesPerBatch; i++)
                 {
                     await sender.SendMessagesAsync(GetMessages(messagesPerBatch));
                 }


### PR DESCRIPTION
In order to avoid waiting for abandoned receive calls to timeout, we close the link (which will be reconnected on subsequent receive calls). This is not implemented for session receivers as links for sessions are not reconnected, so there is still the issue where you have to wait for the abandoned receive call to timeout. We can fix this in the future if the AMQP lib gets support for stopping a receive as discussed in https://github.com/Azure/azure-sdk-for-net/pull/19955#discussion_r605247324