### PR TITLE
Close link on open cancellation

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -986,10 +986,11 @@ namespace Azure.Messaging.ServiceBus.Amqp
             {
                 var openObjectCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                using var registration = cancellationToken.Register(static state =>
+                using var registration = cancellationToken.Register(state =>
                 {
                     var tcs = (TaskCompletionSource<object>)state;
                     tcs.TrySetCanceled();
+                    target.SafeClose();
                 }, openObjectCompletionSource, useSynchronizationContext: false);
 
                 static async Task Open(AmqpObject target, TimeSpan timeout, TaskCompletionSource<object> openObjectCompletionSource)
@@ -997,7 +998,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     try
                     {
                         await target.OpenAsync(timeout).ConfigureAwait(false);
-                        openObjectCompletionSource.TrySetResult(null);
+                        openObjectCompletionSource.SetResult(null);
                     }
                     catch (Exception ex)
                     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -989,8 +989,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 using var registration = cancellationToken.Register(state =>
                 {
                     var tcs = (TaskCompletionSource<object>)state;
-                    tcs.TrySetCanceled();
-                    target.SafeClose();
+                    if (tcs.TrySetCanceled())
+                    {
+                        target.SafeClose();
+                    }
                 }, openObjectCompletionSource, useSynchronizationContext: false);
 
                 static async Task Open(AmqpObject target, TimeSpan timeout, TaskCompletionSource<object> openObjectCompletionSource)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -998,7 +998,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     try
                     {
                         await target.OpenAsync(timeout).ConfigureAwait(false);
-                        openObjectCompletionSource.SetResult(null);
+                        openObjectCompletionSource.TrySetResult(null);
                     }
                     catch (Exception ex)
                     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -330,7 +330,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                             {
                                 bool received =
                                     link.EndReceiveMessages(asyncResult, out IEnumerable<AmqpMessage> amqpMessages);
-                                receiveMessagesCompletionSource.TrySetResult(received
+                                receiveMessagesCompletionSource.SetResult(received
                                     ? amqpMessages
                                     : Enumerable.Empty<AmqpMessage>());
                             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -330,7 +330,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                             {
                                 bool received =
                                     link.EndReceiveMessages(asyncResult, out IEnumerable<AmqpMessage> amqpMessages);
-                                receiveMessagesCompletionSource.SetResult(received
+                                receiveMessagesCompletionSource.TrySetResult(received
                                     ? amqpMessages
                                     : Enumerable.Empty<AmqpMessage>());
                             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -202,14 +202,21 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))
             {
-                var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
-                var duration = TimeSpan.FromSeconds(3);
+                var client = CreateClient(60);
+                var duration = TimeSpan.FromSeconds(5);
                 using var cancellationTokenSource = new CancellationTokenSource(duration);
 
                 var start = DateTime.UtcNow;
                 Assert.ThrowsAsync<TaskCanceledException>(async () => await client.AcceptNextSessionAsync(scope.QueueName, cancellationToken: cancellationTokenSource.Token));
                 var stop = DateTime.UtcNow;
 
+                Assert.Less(stop - start, duration.Add(duration));
+                var sender = client.CreateSender(scope.QueueName);
+                await sender.SendMessageAsync(GetMessage("sessionId"));
+
+                start = DateTime.UtcNow;
+                var receiver = await client.AcceptNextSessionAsync(scope.QueueName);
+                stop = DateTime.UtcNow;
                 Assert.Less(stop - start, duration.Add(duration));
             }
         }


### PR DESCRIPTION
If the OpenAsync operation is cancelled before it is completed, call SafeClose to clean up the pending open operation.