### PR TITLE
[FR] Remove transforms

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValueElement.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValueElement.Serialization.cs
@@ -15,7 +15,7 @@ namespace Azure.AI.FormRecognizer.Models
     {
         internal static KeyValueElement DeserializeKeyValueElement(JsonElement element)
         {
-            Optional<KeyValueType?> type = default;
+            Optional<KeyValueType> type = default;
             string text = default;
             Optional<IReadOnlyList<float>> boundingBox = default;
             Optional<IReadOnlyList<string>> elements = default;
@@ -25,7 +25,7 @@ namespace Azure.AI.FormRecognizer.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        type = null;
+                        property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
                     type = new KeyValueType(property.Value.GetString());

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/autorest.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/autorest.md
@@ -44,14 +44,6 @@ directive:
 ``` yaml
 directive:
   from: swagger-document
-  where: $.definitions.KeyValueType
-  transform: >
-    $["x-nullable"] = true;
-```
-
-``` yaml
-directive:
-  from: swagger-document
   where: $.definitions.AnalyzeOperationResult
   transform: >
     $.properties.analyzeResult["x-nullable"] = true;


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/18422

The service fixed the bug on => KeyValuePairs.Key.type is always returned with value = null
As for => ReadResults.selectionMarks is always present with value = null , the service agreed they are compliant with swagger, and because this only affects .NET, I am going to leave the transform for it.