### PR TITLE
[Perf][Storage] Replace DataLakeFileClient.Read() with ReadTo()

### DIFF
--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Read.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Read.cs
@@ -100,7 +100,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         ///
         public override void Run(CancellationToken cancellationToken)
         {
-            FileClient.Read(cancellationToken);
+            FileClient.ReadTo(Stream.Null, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         ///
         public async override Task RunAsync(CancellationToken cancellationToken)
         {
-            await FileClient.ReadAsync(cancellationToken);
+            await FileClient.ReadToAsync(Stream.Null, cancellationToken:cancellationToken);
         }
     }
 }


### PR DESCRIPTION
- Read() returns a network stream which must be consumed and/or disposed to unblock the underlying network stream
- Improves perf by 10x to match expected throughput
