### PR TITLE
Use dedicated agent pool for storage live tests

### DIFF
--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -8,6 +8,9 @@ extends:
     TimeoutInMinutes: 180
     Location: canadacentral
     Clouds: Preview
+    MatrixReplace:
+      # Use dedicated storage pool in canadacentral with higher memory capacity
+      - Pool=(.*)-general/$1-storage
     TestSetupSteps:
     - template: /sdk/storage/tests-install-azurite.yml
     EnvVars:


### PR DESCRIPTION
This PR cuts over the storage pipelines to use a dedicated storage pool that has been provisioned in Central Canada which has more memory for their specialized test scenarios.

This PR is a replacement for https://github.com/Azure/azure-sdk-for-net/pull/19191