### PR TITLE
improve perf for TableSharedKeyPipelinePolicy

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/TableSharedKeyPipelinePolicy.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableSharedKeyPipelinePolicy.cs
@@ -105,32 +105,6 @@ namespace Azure.Data.Tables
 
             return cr.ToString();
         }
-        public static IDictionary<string, string> GetQueryParameters(Uri uri)
-        {
-            var parameters = new Dictionary<string, string>();
-            var query = uri.Query ?? "";
-            if (!string.IsNullOrEmpty(query))
-            {
-                if (query.StartsWith("?", true, CultureInfo.InvariantCulture))
-                {
-                    query = query.Substring(1);
-                }
-                foreach (var param in query.Split(new[] { '&' }, StringSplitOptions.RemoveEmptyEntries))
-                {
-                    var parts = param.Split(new[] { '=' }, 2);
-                    var name = WebUtility.UrlDecode(parts[0]);
-                    if (parts.Length == 1)
-                    {
-                        parameters.Add(name, default);
-                    }
-                    else
-                    {
-                        parameters.Add(name, WebUtility.UrlDecode(parts[1]));
-                    }
-                }
-            }
-            return parameters;
-        }
 
         public static bool TryGetCompQueryParameterValue(Uri uri, out string value)
         {

--- a/sdk/tables/Azure.Data.Tables/src/TableSharedKeyPipelinePolicy.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableSharedKeyPipelinePolicy.cs
@@ -98,9 +98,7 @@ namespace Azure.Data.Tables
             // https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key#shared-key-lite-and-table-service-format-for-2009-09-19-and-later
             if (TryGetCompQueryParameterValue(resource, out string compValue))
             {
-#pragma warning disable CA1308 // Normalize strings to uppercase
                 cr.Append("?=").Append(compValue);
-#pragma warning restore CA1308 // Normalize strings to uppercase
             }
 
             return cr.ToString();


### PR DESCRIPTION
fixes #19672 

Note: input for *QueryFound is a sas token Uri, which is the worst case

```
|                       Method |        Mean |     Error |    StdDev |  Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |------------:|----------:|----------:|-------:|--------:|-------:|------:|------:|----------:|
| GetQueryParametersQueryFound | 2,287.79 ns | 29.147 ns | 24.339 ns | 179.02 |    2.46 | 0.4883 |     - |     - |    4105 B |
|         TryGetCompQueryFound |    99.12 ns |  1.183 ns |  1.106 ns |   7.77 |    0.11 | 0.0057 |     - |     - |      48 B |
|    GetQueryParametersNoQuery |    28.85 ns |  0.591 ns |  0.524 ns |   2.26 |    0.05 | 0.0095 |     - |     - |      80 B |
|            TryGetCompNoQuery |    12.76 ns |  0.135 ns |  0.126 ns |   1.00 |    0.00 |      - |     - |     - |         - |
```

![](https://media.giphy.com/media/26vUzl3ufQxx9dims/giphy.gif)