### PR TITLE
[Storage] Fix SAS ss parsing ordering bug

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -174,6 +174,25 @@ namespace Azure.Storage.Blobs.Test
                 e => e.Message.Contains($"You cannot use {nameof(AzureSasCredential)} when the resource URI also contains a Shared Access Signature"));
         }
 
+        [Test]
+        public void Ctor_With_Sas_Does_Not_Reorder_Services()
+        {
+            // Arrange
+            var uri = new Uri("http://127.0.0.1/accountName/foo/bar?sv=2015-04-05&ss=bqtf&srt=sco&st=2021-03-29T02%3A25%3A53Z&se=2021-06-09T02%3A40%3A53Z&sp=crwdlaup&sig=XXXXX");
+            var transport = new MockTransport(r => new MockResponse(404));
+            var clientOptions = new BlobClientOptions()
+            {
+                Transport = transport
+            };
+
+            // Act
+            var client = new BlobClient(uri, clientOptions);
+            Assert.ThrowsAsync<RequestFailedException>(async () => await client.GetPropertiesAsync());
+
+            // Act
+            StringAssert.Contains("ss=bqtf", transport.SingleRequest.Uri.ToString());
+        }
+
         #region Upload
 
         [RecordedTest]

--- a/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
@@ -152,6 +152,25 @@ namespace Azure.Storage.Blobs.Test
                 e => e.Message.Contains($"You cannot use {nameof(AzureSasCredential)} when the resource URI also contains a Shared Access Signature"));
         }
 
+        [Test]
+        public void Ctor_With_Sas_Does_Not_Reorder_Services()
+        {
+            // Arrange
+            var uri = new Uri("http://127.0.0.1/accountName?sv=2015-04-05&ss=bqtf&srt=sco&st=2021-03-29T02%3A25%3A53Z&se=2021-06-09T02%3A40%3A53Z&sp=crwdlaup&sig=XXXXX");
+            var transport = new MockTransport(r => new MockResponse(404));
+            var clientOptions = new BlobClientOptions()
+            {
+                Transport = transport
+            };
+
+            // Act
+            var client = new BlobServiceClient(uri, clientOptions);
+            Assert.ThrowsAsync<RequestFailedException>(async () => await client.GetPropertiesAsync());
+
+            // Act
+            StringAssert.Contains("ss=bqtf", transport.SingleRequest.Uri.ToString());
+        }
+
         [RecordedTest]
         public async Task ListContainersSegmentAsync()
         {

--- a/sdk/storage/Azure.Storage.Common/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Common/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 12.8.0-beta.3 (Unreleased)
 - Added ability to specify server timeout.
+- Fixed bug in SasQueryParameters causing services (ss) reorder when parsing externally provided URI.
 
 ## 12.7.1 (2021-03-29)
 - This release contains bug fixes to improve quality.

--- a/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
@@ -32,7 +32,7 @@ namespace Azure.Storage.Sas
         private string _version;
 
         // ss
-        private string _services;
+        private (AccountSasServices? Parsed, string Raw) _services;
 
         // srt
         private AccountSasResourceTypes? _resourceTypes;
@@ -105,12 +105,7 @@ namespace Azure.Storage.Sas
         /// Gets the signed services accessible with an account level shared
         /// access signature.
         /// </summary>
-        public AccountSasServices? Services
-        {
-            get {
-                return _services != null ? SasExtensions.ParseAccountServices(_services) : null;
-            }
-        }
+        public AccountSasServices? Services => _services.Parsed;
 
         /// <summary>
         /// Gets which resources are accessible via the shared access signature.
@@ -276,7 +271,7 @@ namespace Azure.Storage.Sas
                         _version = kv.Value;
                         break;
                     case Constants.Sas.Parameters.ServicesUpper:
-                        _services = kv.Value;
+                        _services = (SasExtensions.ParseAccountServices(kv.Value), kv.Value);
                         break;
                     case Constants.Sas.Parameters.ResourceTypesUpper:
                         _resourceTypes = SasExtensions.ParseResourceTypes(kv.Value);
@@ -371,7 +366,7 @@ namespace Azure.Storage.Sas
             string contentType = default)
         {
             _version = version;
-            _services = services?.ToPermissionsString();
+            _services = (services, services?.ToPermissionsString());
             _resourceTypes = resourceTypes;
             _protocol = protocol;
             _startTime = startsOn;
@@ -420,7 +415,7 @@ namespace Azure.Storage.Sas
             int? directoryDepth = default)
         {
             _version = version;
-            _services = services?.ToPermissionsString();
+            _services = (services, services?.ToPermissionsString());
             _resourceTypes = resourceTypes;
             _protocol = protocol;
             _startTime = startsOn;
@@ -566,7 +561,7 @@ namespace Azure.Storage.Sas
 
             if (Services != null)
             {
-                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Services, _services);
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Services, _services.Raw);
             }
 
             if (ResourceTypes != null)

--- a/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
@@ -32,7 +32,7 @@ namespace Azure.Storage.Sas
         private string _version;
 
         // ss
-        private AccountSasServices? _services;
+        private string _services;
 
         // srt
         private AccountSasResourceTypes? _resourceTypes;
@@ -105,7 +105,12 @@ namespace Azure.Storage.Sas
         /// Gets the signed services accessible with an account level shared
         /// access signature.
         /// </summary>
-        public AccountSasServices? Services => _services;
+        public AccountSasServices? Services
+        {
+            get {
+                return _services != null ? SasExtensions.ParseAccountServices(_services) : null;
+            }
+        }
 
         /// <summary>
         /// Gets which resources are accessible via the shared access signature.
@@ -271,7 +276,7 @@ namespace Azure.Storage.Sas
                         _version = kv.Value;
                         break;
                     case Constants.Sas.Parameters.ServicesUpper:
-                        _services = SasExtensions.ParseAccountServices(kv.Value);
+                        _services = kv.Value;
                         break;
                     case Constants.Sas.Parameters.ResourceTypesUpper:
                         _resourceTypes = SasExtensions.ParseResourceTypes(kv.Value);
@@ -366,7 +371,7 @@ namespace Azure.Storage.Sas
             string contentType = default)
         {
             _version = version;
-            _services = services;
+            _services = services?.ToPermissionsString();
             _resourceTypes = resourceTypes;
             _protocol = protocol;
             _startTime = startsOn;
@@ -415,7 +420,7 @@ namespace Azure.Storage.Sas
             int? directoryDepth = default)
         {
             _version = version;
-            _services = services;
+            _services = services?.ToPermissionsString();
             _resourceTypes = resourceTypes;
             _protocol = protocol;
             _startTime = startsOn;
@@ -561,7 +566,7 @@ namespace Azure.Storage.Sas
 
             if (Services != null)
             {
-                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Services, Services.Value.ToPermissionsString());
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Services, _services);
             }
 
             if (ResourceTypes != null)


### PR DESCRIPTION
The `ss` parameter can be in any order when provided externally.
Modified parsing logic to store this value as raw string internally preserving the order.