### PR TITLE
fix TableSharedKeyPipelinePolicyTests live test bug

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/TableSharedKeyPipelinePolicy.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableSharedKeyPipelinePolicy.cs
@@ -75,7 +75,7 @@ namespace Azure.Data.Tables
             return stringToSign;
         }
 
-        private string BuildCanonicalizedResource(Uri resource)
+        internal string BuildCanonicalizedResource(Uri resource)
         {
             // https://docs.microsoft.com/en-us/rest/api/storageservices/authentication-for-the-azure-storage-services
             StringBuilder cr = new StringBuilder("/").Append(_credentials.AccountName);
@@ -98,7 +98,7 @@ namespace Azure.Data.Tables
             // https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key#shared-key-lite-and-table-service-format-for-2009-09-19-and-later
             if (TryGetCompQueryParameterValue(resource, out string compValue))
             {
-                cr.Append("?=").Append(compValue);
+                cr.Append("?comp=").Append(compValue);
             }
 
             return cr.ToString();

--- a/sdk/tables/Azure.Data.Tables/tests/TableSharedKeyPipelinePolicyTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableSharedKeyPipelinePolicyTests.cs
@@ -9,15 +9,17 @@ namespace Azure.Data.Tables.Tests
 {
     public class TableSharedKeyPipelinePolicyTests
     {
-        public static Uri hasQuery = new Uri("https://foo.table.core.windows.net/?restype=service&comp=properties&sv=2019-02-02&ss=t&srt=s&se=2040-01-01T01%3A01%3A00Z&sp=rwdlau&sig=Sanitized");
+        private const string AccountName = "account";
+        private const string CompValue = "comp=properties";
+        public static Uri hasQuery = new Uri($"https://foo.table.core.windows.net/foopath?restype=service&{CompValue}&sv=2019-02-02&ss=t&srt=s&se=2040-01-01T01%3A01%3A00Z&sp=rwdlau&sig=Sanitized");
         public static Uri hasQueryNoComp = new Uri("https://foo.table.core.windows.net/?sv=2019-02-02&ss=t&srt=s&se=2040-01-01T01%3A01%3A00Z&sp=rwdlau&sig=Sanitized");
-        public static Uri hasNoQuery = new Uri("https://foo.table.core.windows.net/test");
+        public static Uri hasNoQuery = new Uri($"https://foo.table.core.windows.net/test");
 
         public static IEnumerable<object[]> inputUris()
         {
-            yield return new object[] { hasQuery, "properties" };
-            yield return new object[] { hasQueryNoComp, null };
-            yield return new object[] { hasNoQuery, null };
+            yield return new object[] { hasQuery, $"/{AccountName}{hasQuery.AbsolutePath}?{CompValue}" };
+            yield return new object[] { hasQueryNoComp,  $"/{AccountName}{hasQueryNoComp.AbsolutePath}"};
+            yield return new object[] { hasNoQuery, $"/{AccountName}{hasNoQuery.AbsolutePath}" };
         }
 
         /// <summary>
@@ -25,9 +27,10 @@ namespace Azure.Data.Tables.Tests
         /// </summary>
         [Test]
         [TestCaseSource(nameof(inputUris))]
-        public void ConstructorValidatesArguments(Uri uri, string expectedValue)
+        public void BuildCanonicalizedResource(Uri uri, string expectedValue)
         {
-            TableSharedKeyPipelinePolicy.TryGetCompQueryParameterValue(uri, out var actualValue);
+            var policy = new TableSharedKeyPipelinePolicy(new TableSharedKeyCredential(AccountName, "Kg=="));
+            var actualValue = policy.BuildCanonicalizedResource(uri);
 
             Assert.That(actualValue, Is.EqualTo(expectedValue));
         }


### PR DESCRIPTION
Discovered this bug after the live tests run. It does not repro in recorded tests because it involves generation of the auth header, which is sanitized.