### PR TITLE
[TSI] Extract ModelSettings rest client into a separate file

### DIFF
--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/api/Azure.IoT.TimeSeriesInsights.netstandard2.0.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/api/Azure.IoT.TimeSeriesInsights.netstandard2.0.cs
@@ -190,12 +190,12 @@ namespace Azure.IoT.TimeSeriesInsights
     public partial class ModelSettingsClient
     {
         protected ModelSettingsClient() { }
-        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> GetModelSettings(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> GetModelSettingsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> UpdateModelSettingsDefaultTypeId(string defaultTypeId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> UpdateModelSettingsDefaultTypeIdAsync(string defaultTypeId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> UpdateModelSettingsName(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> UpdateModelSettingsNameAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> Get(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> GetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> UpdateDefaultTypeId(string defaultTypeId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> UpdateDefaultTypeIdAsync(string defaultTypeId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> UpdateName(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> UpdateNameAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class ModelSettingsResponse
     {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/api/Azure.IoT.TimeSeriesInsights.netstandard2.0.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/api/Azure.IoT.TimeSeriesInsights.netstandard2.0.cs
@@ -187,6 +187,16 @@ namespace Azure.IoT.TimeSeriesInsights
         public Azure.IoT.TimeSeriesInsights.Models.InterpolationBoundary Boundary { get { throw null; } set { } }
         public Azure.IoT.TimeSeriesInsights.Models.InterpolationKind? Kind { get { throw null; } set { } }
     }
+    public partial class ModelSettingsClient
+    {
+        protected ModelSettingsClient() { }
+        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> GetModelSettings(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> GetModelSettingsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> UpdateModelSettingsDefaultTypeId(string defaultTypeId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> UpdateModelSettingsDefaultTypeIdAsync(string defaultTypeId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> UpdateModelSettingsName(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> UpdateModelSettingsNameAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
     public partial class ModelSettingsResponse
     {
         internal ModelSettingsResponse() { }
@@ -367,6 +377,7 @@ namespace Azure.IoT.TimeSeriesInsights
         protected TimeSeriesInsightsClient() { }
         public TimeSeriesInsightsClient(string environmentFqdn, Azure.Core.TokenCredential credential) { }
         public TimeSeriesInsightsClient(string environmentFqdn, Azure.Core.TokenCredential credential, Azure.IoT.TimeSeriesInsights.TimeSeriesInsightsClientOptions options) { }
+        public virtual Azure.IoT.TimeSeriesInsights.ModelSettingsClient ModelSettings { get { throw null; } }
         public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesOperationError[]> CreateOrReplaceTimeSeriesInstances(System.Collections.Generic.IEnumerable<Azure.IoT.TimeSeriesInsights.TimeSeriesInstance> timeSeriesInstances, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesOperationError[]>> CreateOrReplaceTimeSeriesInstancesAsync(System.Collections.Generic.IEnumerable<Azure.IoT.TimeSeriesInsights.TimeSeriesInstance> timeSeriesInstances, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesOperationError[]> CreateOrReplaceTimeSeriesTypes(System.Collections.Generic.IEnumerable<Azure.IoT.TimeSeriesInsights.TimeSeriesType> timeSeriesTypes, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -385,8 +396,6 @@ namespace Azure.IoT.TimeSeriesInsights
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.InstancesOperationResult[]>> GetInstancesAsync(System.Collections.Generic.IEnumerable<Azure.IoT.TimeSeriesInsights.TimeSeriesId> timeSeriesIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.InstancesOperationResult[]>> GetInstancesAsync(System.Collections.Generic.IEnumerable<string> timeSeriesNames, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.IoT.TimeSeriesInsights.TimeSeriesInstance> GetInstancesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> GetModelSettings(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> GetModelSettingsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.SearchSuggestion[]> GetSearchSuggestions(string searchString, int? maxNumberOfSuggestions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.SearchSuggestion[]>> GetSearchSuggestionsAsync(string searchString, int? maxNumberOfSuggestions = default(int?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.IoT.TimeSeriesInsights.TimeSeriesType> GetTimeSeriesTypes(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -405,10 +414,6 @@ namespace Azure.IoT.TimeSeriesInsights
         public virtual Azure.AsyncPageable<Azure.IoT.TimeSeriesInsights.QueryResultPage> QuerySeriesAsync(Azure.IoT.TimeSeriesInsights.TimeSeriesId timeSeriesId, System.TimeSpan timeSpan, System.DateTimeOffset? endTime = default(System.DateTimeOffset?), Azure.IoT.TimeSeriesInsights.QuerySeriesRequestOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.InstancesOperationResult[]> ReplaceTimeSeriesInstances(System.Collections.Generic.IEnumerable<Azure.IoT.TimeSeriesInsights.TimeSeriesInstance> timeSeriesInstances, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.InstancesOperationResult[]>> ReplaceTimeSeriesInstancesAsync(System.Collections.Generic.IEnumerable<Azure.IoT.TimeSeriesInsights.TimeSeriesInstance> timeSeriesInstances, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> UpdateModelSettingsDefaultTypeId(string defaultTypeId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> UpdateModelSettingsDefaultTypeIdAsync(string defaultTypeId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings> UpdateModelSettingsName(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.IoT.TimeSeriesInsights.TimeSeriesModelSettings>> UpdateModelSettingsNameAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class TimeSeriesInsightsClientOptions : Azure.Core.ClientOptions
     {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples/TimeSeriesInsightsClientSample/TimeSeriesInsightsLifecycleSamples.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples/TimeSeriesInsightsClientSample/TimeSeriesInsightsLifecycleSamples.cs
@@ -28,7 +28,7 @@ namespace Azure.IoT.TimeSeriesInsights.Samples
                 #region Snippet:TimeSeriesInsightsGetModelSettings
 
                 // Get the model settings for the time series insights environment
-                Response<TimeSeriesModelSettings> currentSettings = await client.ModelSettings.GetModelSettingsAsync();
+                Response<TimeSeriesModelSettings> currentSettings = await client.ModelSettings.GetAsync();
                 Console.WriteLine($"Retrieved model with default type id {currentSettings.Value.DefaultTypeId} " +
                     $"model name {currentSettings.Value.Name}.");
 
@@ -42,7 +42,7 @@ namespace Azure.IoT.TimeSeriesInsights.Samples
                 #region Snippet:TimeSeriesInsightsUpdateModelSettingsModelName
 
                 string name = "sampleModel";
-                Response<TimeSeriesModelSettings> updatedSettings = await client.ModelSettings.UpdateModelSettingsNameAsync(name);
+                Response<TimeSeriesModelSettings> updatedSettings = await client.ModelSettings.UpdateNameAsync(name);
                 Console.WriteLine($"Updated model name to {updatedSettings.Value.Name} ");
 
                 #endregion Snippet:TimeSeriesInsightsUpdateModelSettingsModelName

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples/TimeSeriesInsightsClientSample/TimeSeriesInsightsLifecycleSamples.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples/TimeSeriesInsightsClientSample/TimeSeriesInsightsLifecycleSamples.cs
@@ -28,7 +28,7 @@ namespace Azure.IoT.TimeSeriesInsights.Samples
                 #region Snippet:TimeSeriesInsightsGetModelSettings
 
                 // Get the model settings for the time series insights environment
-                Response<TimeSeriesModelSettings> currentSettings = await client.GetModelSettingsAsync();
+                Response<TimeSeriesModelSettings> currentSettings = await client.ModelSettings.GetModelSettingsAsync();
                 Console.WriteLine($"Retrieved model with default type id {currentSettings.Value.DefaultTypeId} " +
                     $"model name {currentSettings.Value.Name}.");
 
@@ -42,7 +42,7 @@ namespace Azure.IoT.TimeSeriesInsights.Samples
                 #region Snippet:TimeSeriesInsightsUpdateModelSettingsModelName
 
                 string name = "sampleModel";
-                Response<TimeSeriesModelSettings> updatedSettings = await client.UpdateModelSettingsNameAsync(name);
+                Response<TimeSeriesModelSettings> updatedSettings = await client.ModelSettings.UpdateModelSettingsNameAsync(name);
                 Console.WriteLine($"Updated model name to {updatedSettings.Value.Name} ");
 
                 #endregion Snippet:TimeSeriesInsightsUpdateModelSettingsModelName

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/ModelSettingsClient.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/ModelSettingsClient.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.IoT.TimeSeriesInsights
+{
+    /// <summary>
+    /// Model Settings client that can be used to perform operations for Time Series Model configuration settings.
+    /// </summary>
+    public class ModelSettingsClient
+    {
+        private readonly ModelSettingsRestClient _modelSettingsRestClient;
+        private readonly ClientDiagnostics _clientDiagnostics;
+
+        /// <summary>
+        /// Initializes a new instance of ModelSettings. This constructor should only be used for mocking purposes.
+        /// </summary>
+        protected ModelSettingsClient()
+        {
+        }
+
+        internal ModelSettingsClient(ModelSettingsRestClient modelSettingsRestClient, ClientDiagnostics clientDiagnostics)
+        {
+            Argument.AssertNotNull(modelSettingsRestClient, nameof(modelSettingsRestClient));
+            Argument.AssertNotNull(clientDiagnostics, nameof(clientDiagnostics));
+
+            _modelSettingsRestClient = modelSettingsRestClient;
+            _clientDiagnostics = clientDiagnostics;
+        }
+
+        /// <summary>
+        /// Gets Time Series model settings asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The model settings which includes model display name, Time Series Id properties and default type Id with the
+        /// http response <see cref="Response{TimeSeriesModelSettings}"/>.
+        /// </returns>
+        public virtual async Task<Response<TimeSeriesModelSettings>> GetModelSettingsAsync(CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetModelSettings)}");
+            scope.Start();
+            try
+            {
+                // To do: Generate client session Id
+                Response<ModelSettingsResponse> modelSettings = await _modelSettingsRestClient.GetAsync(null, cancellationToken).ConfigureAwait(false);
+                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Gets Time Series model settings synchronously.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The model settings which includes model display name, Time Series Id properties and default type Id with the
+        /// http response <see cref="Response{TimeSeriesModelSettings}"/>.
+        /// </returns>
+        public virtual Response<TimeSeriesModelSettings> GetModelSettings(CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetModelSettings)}");
+            scope.Start();
+            try
+            {
+                // To do: Generate client session Id
+                Response<ModelSettingsResponse> modelSettings = _modelSettingsRestClient.Get(null, cancellationToken);
+                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Updates model name on Time Series model settings asynchronously.
+        /// </summary>
+        /// <param name="name">Model display name which is mutable by the user. Initial value is &quot;DefaultModel&quot;.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
+        public virtual async Task<Response<TimeSeriesModelSettings>> UpdateModelSettingsNameAsync(string name, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsName)}");
+            scope.Start();
+            try
+            {
+                // To do: Generate client session Id
+                var options = new UpdateModelSettingsRequest { Name = name };
+                Response<ModelSettingsResponse> modelSettings = await _modelSettingsRestClient.UpdateAsync(options, null, cancellationToken).ConfigureAwait(false);
+                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Updates model default type Id on Time Series model settings asynchronously.
+        /// </summary>
+        /// <param name="defaultTypeId">Default type Id of the model that new instances will automatically belong to.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
+        public virtual async Task<Response<TimeSeriesModelSettings>> UpdateModelSettingsDefaultTypeIdAsync(string defaultTypeId, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsDefaultTypeId)}");
+            scope.Start();
+            try
+            {
+                // To do: Generate client session Id
+                var options = new UpdateModelSettingsRequest { DefaultTypeId = defaultTypeId };
+                Response<ModelSettingsResponse> modelSettings = await _modelSettingsRestClient.UpdateAsync(options, null, cancellationToken).ConfigureAwait(false);
+                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Updates model name on Time Series model settings synchronously.
+        /// </summary>
+        /// <param name="name">Model display name which is mutable by the user. Initial value is &quot;DefaultModel&quot;.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
+        public virtual Response<TimeSeriesModelSettings> UpdateModelSettingsName(string name, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsName)}");
+            scope.Start();
+            try
+            {
+                // To do: Generate client session Id
+                var options = new UpdateModelSettingsRequest { Name = name };
+                Response<ModelSettingsResponse> modelSettings = _modelSettingsRestClient.Update(options, null, cancellationToken);
+                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Updates default type Id on Time Series model settings synchronously.
+        /// </summary>
+        /// <param name="defaultTypeId">Default type Id of the model that new instances will automatically belong to.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
+        public virtual Response<TimeSeriesModelSettings> UpdateModelSettingsDefaultTypeId(string defaultTypeId, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsDefaultTypeId)}");
+            scope.Start();
+            try
+            {
+                // To do: Generate client session Id
+                var options = new UpdateModelSettingsRequest { DefaultTypeId = defaultTypeId };
+                Response<ModelSettingsResponse> modelSettings = _modelSettingsRestClient.Update(options, null, cancellationToken);
+                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+    }
+}

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/ModelSettingsClient.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/ModelSettingsClient.cs
@@ -41,13 +41,12 @@ namespace Azure.IoT.TimeSeriesInsights
         /// The model settings which includes model display name, Time Series Id properties and default type Id with the
         /// http response <see cref="Response{TimeSeriesModelSettings}"/>.
         /// </returns>
-        public virtual async Task<Response<TimeSeriesModelSettings>> GetModelSettingsAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<TimeSeriesModelSettings>> GetAsync(CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetModelSettings)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(Get)}");
             scope.Start();
             try
             {
-                // To do: Generate client session Id
                 Response<ModelSettingsResponse> modelSettings = await _modelSettingsRestClient.GetAsync(null, cancellationToken).ConfigureAwait(false);
                 return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
             }
@@ -66,13 +65,12 @@ namespace Azure.IoT.TimeSeriesInsights
         /// The model settings which includes model display name, Time Series Id properties and default type Id with the
         /// http response <see cref="Response{TimeSeriesModelSettings}"/>.
         /// </returns>
-        public virtual Response<TimeSeriesModelSettings> GetModelSettings(CancellationToken cancellationToken = default)
+        public virtual Response<TimeSeriesModelSettings> Get(CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetModelSettings)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(Get)}");
             scope.Start();
             try
             {
-                // To do: Generate client session Id
                 Response<ModelSettingsResponse> modelSettings = _modelSettingsRestClient.Get(null, cancellationToken);
                 return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
             }
@@ -89,38 +87,13 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="name">Model display name which is mutable by the user. Initial value is &quot;DefaultModel&quot;.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
-        public virtual async Task<Response<TimeSeriesModelSettings>> UpdateModelSettingsNameAsync(string name, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<TimeSeriesModelSettings>> UpdateNameAsync(string name, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsName)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateName)}");
             scope.Start();
             try
             {
-                // To do: Generate client session Id
                 var options = new UpdateModelSettingsRequest { Name = name };
-                Response<ModelSettingsResponse> modelSettings = await _modelSettingsRestClient.UpdateAsync(options, null, cancellationToken).ConfigureAwait(false);
-                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
-            }
-            catch (Exception ex)
-            {
-                scope.Failed(ex);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Updates model default type Id on Time Series model settings asynchronously.
-        /// </summary>
-        /// <param name="defaultTypeId">Default type Id of the model that new instances will automatically belong to.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
-        public virtual async Task<Response<TimeSeriesModelSettings>> UpdateModelSettingsDefaultTypeIdAsync(string defaultTypeId, CancellationToken cancellationToken = default)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsDefaultTypeId)}");
-            scope.Start();
-            try
-            {
-                // To do: Generate client session Id
-                var options = new UpdateModelSettingsRequest { DefaultTypeId = defaultTypeId };
                 Response<ModelSettingsResponse> modelSettings = await _modelSettingsRestClient.UpdateAsync(options, null, cancellationToken).ConfigureAwait(false);
                 return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
             }
@@ -137,9 +110,9 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="name">Model display name which is mutable by the user. Initial value is &quot;DefaultModel&quot;.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
-        public virtual Response<TimeSeriesModelSettings> UpdateModelSettingsName(string name, CancellationToken cancellationToken = default)
+        public virtual Response<TimeSeriesModelSettings> UpdateName(string name, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsName)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateName)}");
             scope.Start();
             try
             {
@@ -156,18 +129,40 @@ namespace Azure.IoT.TimeSeriesInsights
         }
 
         /// <summary>
+        /// Updates model default type Id on Time Series model settings asynchronously.
+        /// </summary>
+        /// <param name="defaultTypeId">Default type Id of the model that new instances will automatically belong to.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
+        public virtual async Task<Response<TimeSeriesModelSettings>> UpdateDefaultTypeIdAsync(string defaultTypeId, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateDefaultTypeId)}");
+            scope.Start();
+            try
+            {
+                var options = new UpdateModelSettingsRequest { DefaultTypeId = defaultTypeId };
+                Response<ModelSettingsResponse> modelSettings = await _modelSettingsRestClient.UpdateAsync(options, null, cancellationToken).ConfigureAwait(false);
+                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Updates default type Id on Time Series model settings synchronously.
         /// </summary>
         /// <param name="defaultTypeId">Default type Id of the model that new instances will automatically belong to.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
-        public virtual Response<TimeSeriesModelSettings> UpdateModelSettingsDefaultTypeId(string defaultTypeId, CancellationToken cancellationToken = default)
+        public virtual Response<TimeSeriesModelSettings> UpdateDefaultTypeId(string defaultTypeId, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsDefaultTypeId)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateDefaultTypeId)}");
             scope.Start();
             try
             {
-                // To do: Generate client session Id
                 var options = new UpdateModelSettingsRequest { DefaultTypeId = defaultTypeId };
                 Response<ModelSettingsResponse> modelSettings = _modelSettingsRestClient.Update(options, null, cancellationToken);
                 return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsClient.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsClient.cs
@@ -31,6 +31,11 @@ namespace Azure.IoT.TimeSeriesInsights
         private readonly QueryRestClient _queryRestClient;
 
         /// <summary>
+        /// Client to get model settings.
+        /// </summary>
+        public virtual ModelSettingsClient ModelSettings { get; private set; }
+
+        /// <summary>
         /// Creates a new instance of the <see cref="TimeSeriesInsightsClient"/> class.
         /// </summary>
         /// <param name='environmentFqdn'>Per environment FQDN, for example 10000000-0000-0000-0000-100000000109.env.timeseries.azure.com.
@@ -90,6 +95,8 @@ namespace Azure.IoT.TimeSeriesInsights
             _timeSeriesInstancesRestClient = new TimeSeriesInstancesRestClient(_clientDiagnostics, _httpPipeline, environmentFqdn, versionString);
             _timeSeriesTypesRestClient = new TimeSeriesTypesRestClient(_clientDiagnostics, _httpPipeline, environmentFqdn, versionString);
             _queryRestClient = new QueryRestClient(_clientDiagnostics, _httpPipeline, environmentFqdn, versionString);
+
+            ModelSettings = new ModelSettingsClient(_modelSettingsRestClient, _clientDiagnostics);
         }
 
         /// <summary>
@@ -104,152 +111,6 @@ namespace Azure.IoT.TimeSeriesInsights
         /// </summary>
         /// <returns>List of scopes for the specified endpoint.</returns>
         internal static string[] GetAuthorizationScopes() => s_tsiDefaultScopes;
-
-        /// <summary>
-        /// Gets Time Series model settings asynchronously.
-        /// </summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>
-        /// The model settings which includes model display name, Time Series Id properties and default type Id with the
-        /// http response <see cref="Response{TimeSeriesModelSettings}"/>.
-        /// </returns>
-        public virtual async Task<Response<TimeSeriesModelSettings>> GetModelSettingsAsync(CancellationToken cancellationToken = default)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetModelSettings)}");
-            scope.Start();
-            try
-            {
-                // To do: Generate client session Id
-                Response<ModelSettingsResponse> modelSettings = await _modelSettingsRestClient.GetAsync(null, cancellationToken).ConfigureAwait(false);
-                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
-            }
-            catch (Exception ex)
-            {
-                scope.Failed(ex);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Gets Time Series model settings synchronously.
-        /// </summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>
-        /// The model settings which includes model display name, Time Series Id properties and default type Id with the
-        /// http response <see cref="Response{TimeSeriesModelSettings}"/>.
-        /// </returns>
-        public virtual Response<TimeSeriesModelSettings> GetModelSettings(CancellationToken cancellationToken = default)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(GetModelSettings)}");
-            scope.Start();
-            try
-            {
-                // To do: Generate client session Id
-                Response<ModelSettingsResponse> modelSettings = _modelSettingsRestClient.Get(null, cancellationToken);
-                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
-            }
-            catch (Exception ex)
-            {
-                scope.Failed(ex);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Updates model name on Time Series model settings asynchronously.
-        /// </summary>
-        /// <param name="name">Model display name which is mutable by the user. Initial value is &quot;DefaultModel&quot;.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
-        public virtual async Task<Response<TimeSeriesModelSettings>> UpdateModelSettingsNameAsync(string name, CancellationToken cancellationToken = default)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsName)}");
-            scope.Start();
-            try
-            {
-                // To do: Generate client session Id
-                var options = new UpdateModelSettingsRequest { Name = name };
-                Response<ModelSettingsResponse> modelSettings = await _modelSettingsRestClient.UpdateAsync(options, null, cancellationToken).ConfigureAwait(false);
-                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
-            }
-            catch (Exception ex)
-            {
-                scope.Failed(ex);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Updates model default type Id on Time Series model settings asynchronously.
-        /// </summary>
-        /// <param name="defaultTypeId">Default type Id of the model that new instances will automatically belong to.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
-        public virtual async Task<Response<TimeSeriesModelSettings>> UpdateModelSettingsDefaultTypeIdAsync(string defaultTypeId, CancellationToken cancellationToken = default)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsDefaultTypeId)}");
-            scope.Start();
-            try
-            {
-                // To do: Generate client session Id
-                var options = new UpdateModelSettingsRequest { DefaultTypeId = defaultTypeId };
-                Response<ModelSettingsResponse> modelSettings = await _modelSettingsRestClient.UpdateAsync(options, null, cancellationToken).ConfigureAwait(false);
-                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
-            }
-            catch (Exception ex)
-            {
-                scope.Failed(ex);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Updates model name on Time Series model settings synchronously.
-        /// </summary>
-        /// <param name="name">Model display name which is mutable by the user. Initial value is &quot;DefaultModel&quot;.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
-        public virtual Response<TimeSeriesModelSettings> UpdateModelSettingsName(string name, CancellationToken cancellationToken = default)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsName)}");
-            scope.Start();
-            try
-            {
-                // To do: Generate client session Id
-                var options = new UpdateModelSettingsRequest { Name = name };
-                Response<ModelSettingsResponse> modelSettings = _modelSettingsRestClient.Update(options, null, cancellationToken);
-                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
-            }
-            catch (Exception ex)
-            {
-                scope.Failed(ex);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Updates default type Id on Time Series model settings synchronously.
-        /// </summary>
-        /// <param name="defaultTypeId">Default type Id of the model that new instances will automatically belong to.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
-        public virtual Response<TimeSeriesModelSettings> UpdateModelSettingsDefaultTypeId(string defaultTypeId, CancellationToken cancellationToken = default)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TimeSeriesInsightsClient)}.{nameof(UpdateModelSettingsDefaultTypeId)}");
-            scope.Start();
-            try
-            {
-                // To do: Generate client session Id
-                var options = new UpdateModelSettingsRequest { DefaultTypeId = defaultTypeId };
-                Response<ModelSettingsResponse> modelSettings = _modelSettingsRestClient.Update(options, null, cancellationToken);
-                return Response.FromValue(modelSettings.Value.ModelSettings, modelSettings.GetRawResponse());
-            }
-            catch (Exception ex)
-            {
-                scope.Failed(ex);
-                throw;
-            }
-        }
 
         /// <summary>
         /// Gets Time Series instances in pages asynchronously.

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsClient.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsClient.cs
@@ -31,7 +31,7 @@ namespace Azure.IoT.TimeSeriesInsights
         private readonly QueryRestClient _queryRestClient;
 
         /// <summary>
-        /// Client to get model settings.
+        /// Client to get and update model settings.
         /// </summary>
         public virtual ModelSettingsClient ModelSettings { get; private set; }
 

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/E2eTestBase.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/E2eTestBase.cs
@@ -132,7 +132,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
 
         protected async Task<string> getDefaultTypeIdAsync(TimeSeriesInsightsClient client)
         {
-            Response<TimeSeriesModelSettings> currentSettings = await client.ModelSettings.GetModelSettingsAsync().ConfigureAwait(false);
+            Response<TimeSeriesModelSettings> currentSettings = await client.ModelSettings.GetAsync().ConfigureAwait(false);
             return currentSettings.Value.DefaultTypeId;
         }
 

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/E2eTestBase.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/E2eTestBase.cs
@@ -132,7 +132,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
 
         protected async Task<string> getDefaultTypeIdAsync(TimeSeriesInsightsClient client)
         {
-            Response<TimeSeriesModelSettings> currentSettings = await client.GetModelSettingsAsync().ConfigureAwait(false);
+            Response<TimeSeriesModelSettings> currentSettings = await client.ModelSettings.GetModelSettingsAsync().ConfigureAwait(false);
             return currentSettings.Value.DefaultTypeId;
         }
 

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/ModelSettingsTests.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/ModelSettingsTests.cs
@@ -30,7 +30,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             TimeSeriesInsightsClient client = GetClient();
 
             // GET model settings
-            Response<TimeSeriesModelSettings> currentSettings = await client.GetModelSettingsAsync().ConfigureAwait(false);
+            Response<TimeSeriesModelSettings> currentSettings = await client.ModelSettings.GetModelSettingsAsync().ConfigureAwait(false);
             currentSettings.GetRawResponse().Status.Should().Be((int)HttpStatusCode.OK);
             string testName = "testModel";
             // UPDATE model settings
@@ -39,17 +39,17 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
 
             try
             {
-                Response<TimeSeriesModelSettings> updatedSettingsName = await client.UpdateModelSettingsNameAsync(testName).ConfigureAwait(false);
+                Response<TimeSeriesModelSettings> updatedSettingsName = await client.ModelSettings.UpdateModelSettingsNameAsync(testName).ConfigureAwait(false);
                 updatedSettingsName.GetRawResponse().Status.Should().Be((int)HttpStatusCode.OK);
                 updatedSettingsName.Value.Name.Should().Be(testName);
 
                 await TestRetryHelper.RetryAsync<Response<TimeSeriesModelSettings>>(async () =>
                 {
-                    Response<TimeSeriesModelSettings> updatedSettingsId = await client.UpdateModelSettingsDefaultTypeIdAsync(typeId).ConfigureAwait(false);
+                    Response<TimeSeriesModelSettings> updatedSettingsId = await client.ModelSettings.UpdateModelSettingsDefaultTypeIdAsync(typeId).ConfigureAwait(false);
                     updatedSettingsId.Value.DefaultTypeId.Should().Be(typeId);
 
                     // update it back to the default Type Id
-                    updatedSettingsId = await client.UpdateModelSettingsDefaultTypeIdAsync(defaultTypeId).ConfigureAwait(false);
+                    updatedSettingsId = await client.ModelSettings.UpdateModelSettingsDefaultTypeIdAsync(defaultTypeId).ConfigureAwait(false);
                     updatedSettingsId.Value.DefaultTypeId.Should().Be(defaultTypeId);
 
                     return null;
@@ -82,7 +82,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             TimeSeriesInsightsClient client = GetClient();
 
             // act
-            Func<Task> act = async () => await client.UpdateModelSettingsDefaultTypeIdAsync("testId").ConfigureAwait(false);
+            Func<Task> act = async () => await client.ModelSettings.UpdateModelSettingsDefaultTypeIdAsync("testId").ConfigureAwait(false);
 
             // assert
             act.Should().Throw<RequestFailedException>()

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/ModelSettingsTests.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/ModelSettingsTests.cs
@@ -30,7 +30,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             TimeSeriesInsightsClient client = GetClient();
 
             // GET model settings
-            Response<TimeSeriesModelSettings> currentSettings = await client.ModelSettings.GetModelSettingsAsync().ConfigureAwait(false);
+            Response<TimeSeriesModelSettings> currentSettings = await client.ModelSettings.GetAsync().ConfigureAwait(false);
             currentSettings.GetRawResponse().Status.Should().Be((int)HttpStatusCode.OK);
             string testName = "testModel";
             // UPDATE model settings
@@ -39,17 +39,17 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
 
             try
             {
-                Response<TimeSeriesModelSettings> updatedSettingsName = await client.ModelSettings.UpdateModelSettingsNameAsync(testName).ConfigureAwait(false);
+                Response<TimeSeriesModelSettings> updatedSettingsName = await client.ModelSettings.UpdateNameAsync(testName).ConfigureAwait(false);
                 updatedSettingsName.GetRawResponse().Status.Should().Be((int)HttpStatusCode.OK);
                 updatedSettingsName.Value.Name.Should().Be(testName);
 
                 await TestRetryHelper.RetryAsync<Response<TimeSeriesModelSettings>>(async () =>
                 {
-                    Response<TimeSeriesModelSettings> updatedSettingsId = await client.ModelSettings.UpdateModelSettingsDefaultTypeIdAsync(typeId).ConfigureAwait(false);
+                    Response<TimeSeriesModelSettings> updatedSettingsId = await client.ModelSettings.UpdateDefaultTypeIdAsync(typeId).ConfigureAwait(false);
                     updatedSettingsId.Value.DefaultTypeId.Should().Be(typeId);
 
                     // update it back to the default Type Id
-                    updatedSettingsId = await client.ModelSettings.UpdateModelSettingsDefaultTypeIdAsync(defaultTypeId).ConfigureAwait(false);
+                    updatedSettingsId = await client.ModelSettings.UpdateDefaultTypeIdAsync(defaultTypeId).ConfigureAwait(false);
                     updatedSettingsId.Value.DefaultTypeId.Should().Be(defaultTypeId);
 
                     return null;
@@ -82,7 +82,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             TimeSeriesInsightsClient client = GetClient();
 
             // act
-            Func<Task> act = async () => await client.ModelSettings.UpdateModelSettingsDefaultTypeIdAsync("testId").ConfigureAwait(false);
+            Func<Task> act = async () => await client.ModelSettings.UpdateDefaultTypeIdAsync("testId").ConfigureAwait(false);
 
             // assert
             act.Should().Throw<RequestFailedException>()

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsQueryEventsTests.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsQueryEventsTests.cs
@@ -34,7 +34,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             DeviceClient deviceClient = await GetDeviceClient().ConfigureAwait(false);
 
             // Figure out what the Time Series Id is composed of
-            TimeSeriesModelSettings modelSettings = await tsiClient.GetModelSettingsAsync().ConfigureAwait(false);
+            TimeSeriesModelSettings modelSettings = await tsiClient.ModelSettings.GetModelSettingsAsync().ConfigureAwait(false);
 
             // Create a Time Series Id where the number of keys that make up the Time Series Id is fetched from Model Settings
             TimeSeriesId tsiId = await GetUniqueTimeSeriesInstanceIdAsync(tsiClient, modelSettings.TimeSeriesIdProperties.Count)

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsQueryEventsTests.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsQueryEventsTests.cs
@@ -34,7 +34,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             DeviceClient deviceClient = await GetDeviceClient().ConfigureAwait(false);
 
             // Figure out what the Time Series Id is composed of
-            TimeSeriesModelSettings modelSettings = await tsiClient.ModelSettings.GetModelSettingsAsync().ConfigureAwait(false);
+            TimeSeriesModelSettings modelSettings = await tsiClient.ModelSettings.GetAsync().ConfigureAwait(false);
 
             // Create a Time Series Id where the number of keys that make up the Time Series Id is fetched from Model Settings
             TimeSeriesId tsiId = await GetUniqueTimeSeriesInstanceIdAsync(tsiClient, modelSettings.TimeSeriesIdProperties.Count)

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsQuerySeriesTests.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsQuerySeriesTests.cs
@@ -34,7 +34,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             DeviceClient deviceClient = await GetDeviceClient().ConfigureAwait(false);
 
             // Figure out what the Time Series Id is composed of
-            TimeSeriesModelSettings modelSettings = await tsiClient.GetModelSettingsAsync().ConfigureAwait(false);
+            TimeSeriesModelSettings modelSettings = await tsiClient.ModelSettings.GetModelSettingsAsync().ConfigureAwait(false);
 
             // Create a Time Series Id where the number of keys that make up the Time Series Id is fetched from Model Settings
             TimeSeriesId tsiId = await GetUniqueTimeSeriesInstanceIdAsync(tsiClient, modelSettings.TimeSeriesIdProperties.Count)

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsQuerySeriesTests.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsQuerySeriesTests.cs
@@ -34,7 +34,7 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
             DeviceClient deviceClient = await GetDeviceClient().ConfigureAwait(false);
 
             // Figure out what the Time Series Id is composed of
-            TimeSeriesModelSettings modelSettings = await tsiClient.ModelSettings.GetModelSettingsAsync().ConfigureAwait(false);
+            TimeSeriesModelSettings modelSettings = await tsiClient.ModelSettings.GetAsync().ConfigureAwait(false);
 
             // Create a Time Series Id where the number of keys that make up the Time Series Id is fetched from Model Settings
             TimeSeriesId tsiId = await GetUniqueTimeSeriesInstanceIdAsync(tsiClient, modelSettings.TimeSeriesIdProperties.Count)


### PR DESCRIPTION
The TimeSeriesInsights client was getting way too large. This PR extracts the ModelSettings into it's own client file. The rest of the clients will follow in separate PRs.

This PR has no code changes other than moving code from one file to another. The only code change is for tests to reference the ModelSettings client from the TimeSeriesInsights client.