### PR TITLE
Add public API spell check to Analyze job

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,0 +1,38 @@
+{
+    "version": "0.1",
+    "language": "en_US",
+    "languageId": "csharp",
+    "dictionaries": [
+      "powershell"
+    ],
+    "ignorePaths": [
+      "**/SessionRecords/**",
+      "**/packages/**",
+      "artifacts/**/*",
+      "*.exe",
+      "*.dll",
+      "*.nupkg",
+      "*.bmp",
+      "*.png",
+      "*.gif",
+      "*.jpg",
+      "*.tiff",
+      "*.wav",
+      "*.pdf",
+      "*.zip",
+      "*.sha512",
+      "*.ico",
+      "*.pri",
+      "common/Perf/Azure.Test.Perf/PerfProgram.cs",
+      "common/SmokeTests/smoke-tests.yml",
+      "common/SmokeTests/SmokeTest/BlobStorageTest.cs",
+      "common/SmokeTests/SmokeTest/CosmosDBTest.cs",
+      "common/SmokeTests/SmokeTest/EventHubsTest.cs",
+      "common/SmokeTests/SmokeTest/KeyVaultTest.cs",
+      "common/SmokeTests/SmokeTest/test-resources.json",
+      "common/SmokeTests/SmokeTest/Update-Dependencies.ps1"
+    ],
+    "words": [],
+    "allowCompoundWords": true
+  }
+  

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -23,5 +23,8 @@
     "*.pri"
   ],
   "words": [],
+  "overrides": [
+    { "filename": "**/sdk/formrecognizer/**/*.cs", "words": ["ZhHant"] }
+  ],
   "allowCompoundWords": true
 }

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -20,8 +20,11 @@
     "*.zip",
     "*.sha512",
     "*.ico",
-    "*.pri"
+    "*.pri",
+    ".vscode/cspell.json"
   ],
+  // cspell is not case sensitive
+  // Sort words alphabetically to make this list easier to use
   "words": [],
   "overrides": [
     { "filename": "**/sdk/formrecognizer/**/*.cs", "words": ["ZhHant"] }

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,38 +1,27 @@
 {
-    "version": "0.1",
-    "language": "en_US",
-    "languageId": "csharp",
-    "dictionaries": [
-      "powershell"
-    ],
-    "ignorePaths": [
-      "**/SessionRecords/**",
-      "**/packages/**",
-      "artifacts/**/*",
-      "*.exe",
-      "*.dll",
-      "*.nupkg",
-      "*.bmp",
-      "*.png",
-      "*.gif",
-      "*.jpg",
-      "*.tiff",
-      "*.wav",
-      "*.pdf",
-      "*.zip",
-      "*.sha512",
-      "*.ico",
-      "*.pri",
-      "common/Perf/Azure.Test.Perf/PerfProgram.cs",
-      "common/SmokeTests/smoke-tests.yml",
-      "common/SmokeTests/SmokeTest/BlobStorageTest.cs",
-      "common/SmokeTests/SmokeTest/CosmosDBTest.cs",
-      "common/SmokeTests/SmokeTest/EventHubsTest.cs",
-      "common/SmokeTests/SmokeTest/KeyVaultTest.cs",
-      "common/SmokeTests/SmokeTest/test-resources.json",
-      "common/SmokeTests/SmokeTest/Update-Dependencies.ps1"
-    ],
-    "words": [],
-    "allowCompoundWords": true
-  }
-  
+  "version": "0.1",
+  "language": "en_US",
+  "languageId": "csharp",
+  "dictionaries": ["powershell"],
+  "ignorePaths": [
+    "**/SessionRecords/**",
+    "**/packages/**",
+    "artifacts/**/*",
+    "*.exe",
+    "*.dll",
+    "*.nupkg",
+    "*.bmp",
+    "*.png",
+    "*.gif",
+    "*.jpg",
+    "*.tiff",
+    "*.wav",
+    "*.pdf",
+    "*.zip",
+    "*.sha512",
+    "*.ico",
+    "*.pri"
+  ],
+  "words": [],
+  "allowCompoundWords": true
+}

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -37,6 +37,13 @@ jobs:
             --config ./.vscode/cspell.json `
             ./sdk/**/api/*.cs
         displayName: Check spelling of public API surface
+        # Spelling errors in public api surface are not blockers yet but will 
+        # become blockers when this is rolled out to all services. For now, turn
+        # the pipeline yellow if spelling errors are detected but do not block.
+        # Individual services can be blocked on spelling errors using: 
+        # `SpellCheckPublicApiSurface: true` 
+        # in the archetype-sdk-client.yml template invocation
+        continueOnError: true
 
       - template: /eng/common/pipelines/templates/steps/verify-links.yml
         parameters:

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -32,6 +32,12 @@ jobs:
         artifact: packages
         patterns: '*'
 
+      - pwsh: |
+          npx cspell lint `
+            --config ./.vscode/cspell.json `
+            ./sdk/**/api/*.cs
+        displayName: Check spelling of public API surface
+
       - template: /eng/common/pipelines/templates/steps/verify-links.yml
         parameters:
           Directory: ""

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -100,6 +100,11 @@ jobs:
       name: azsdk-pool-mms-ubuntu-1804-general
       vmImage: MMSUbuntu18.04
     steps:
+      - pwsh: |
+          npx cspell lint `
+            --config .\.vscode\cspell.json `
+            ./sdk/${{ parameters.ServiceDirectory }}/*/api/*.cs
+        displayName: Check spelling of public API surface
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
         inputs:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -103,9 +103,6 @@ jobs:
       name: azsdk-pool-mms-ubuntu-1804-general
       vmImage: MMSUbuntu18.04
     steps:
-      - pwsh: |
-
-        displayName: Check spelling of public API surface
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
         inputs:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -102,7 +102,7 @@ jobs:
     steps:
       - pwsh: |
           npx cspell lint `
-            --config .\.vscode\cspell.json `
+            --config ./.vscode/cspell.json `
             ./sdk/${{ parameters.ServiceDirectory }}/*/api/*.cs
         displayName: Check spelling of public API surface
       - task: UsePythonVersion@0

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -33,6 +33,9 @@ parameters:
 - name: MatrixReplace
   type: object
   default: []
+- name: SpellCheckPublicApiSurface
+  type: boolean
+  default: false
 
 jobs:
   - job: Build
@@ -101,9 +104,7 @@ jobs:
       vmImage: MMSUbuntu18.04
     steps:
       - pwsh: |
-          npx cspell lint `
-            --config ./.vscode/cspell.json `
-            ./sdk/${{ parameters.ServiceDirectory }}/*/api/*.cs
+
         displayName: Check spelling of public API surface
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
@@ -140,6 +141,7 @@ jobs:
           arguments: >
            -ServiceDirectory ${{ parameters.ServiceToTest }}
            -SDKType ${{ parameters.SDKType }}
+           -SpellCheckPublicApiSurface:$${{ parameters.SpellCheckPublicApiSurface }}
           pwsh: true
           failOnStderr:  false
       - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -53,6 +53,9 @@ parameters:
 - name: MatrixReplace
   type: object
   default: []
+- name: SpellCheckPublicApiSurface
+  type: boolean
+  default: false
 
 variables:
   - template: ../variables/globals.yml
@@ -71,6 +74,7 @@ stages:
         ArtifactName: packages
         TestSetupSteps: ${{ parameters.TestSetupSteps }}
         TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+        SpellCheckPublicApiSurface: ${{ parameters.SpellCheckPublicApiSurface }}
         MatrixConfigs:
           - ${{ each config in parameters.MatrixConfigs }}:
             -  ${{ config }}

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -9,7 +9,10 @@ param (
     [string] $ProjectDirectory,
 
     [Parameter()]
-    [string] $SDKType = "all"
+    [string] $SDKType = "all",
+
+    [Parameter()]
+    [switch] $SpellCheckPublicApiSurface
 )
 
 $ErrorActionPreference = 'Stop'
@@ -87,7 +90,7 @@ try {
 
     Write-Host "Re-generating listings"
     Invoke-Block {
-        & $PSScriptRoot\Export-API.ps1 -ServiceDirectory $ServiceDirectory -SDKType $SDKType
+        & $PSScriptRoot\Export-API.ps1 -ServiceDirectory $ServiceDirectory -SDKType $SDKType -SpellCheckPublicApiSurface:$SpellCheckPublicApiSurface
     }
 
     if (-not $ProjectDirectory)

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -7,7 +7,7 @@ param (
     [switch] $SpellCheckPublicApiSurface
 )
 
-if ($SpellCheckPublicApiSurface -and (Get-Command npx | Measure-Object).Count -eq 0) { 
+if ($SpellCheckPublicApiSurface -and (Get-Command npx)) { 
     Write-Error "Could not locate npx. Install NodeJS (includes npm and npx) https://nodejs.org/en/download/"
     exit 1
 }

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -3,9 +3,25 @@ param (
     [Parameter(Position=0)]
     [ValidateNotNullOrEmpty()]
     [string] $ServiceDirectory,
-    [string] $SDKType = "all"
+    [string] $SDKType = "all", 
+    [switch] $SpellCheckPublicApiSurface
 )
+
+if ($SpellCheckPublicApiSurface -and (Get-Command npx | Measure-Object).Count -eq 0) { 
+    Write-Error "Could not locate npx. Install NodeJS (includes npm and npx) https://nodejs.org/en/download/"
+    exit 1
+}
 
 $servicesProj = Resolve-Path "$PSScriptRoot/../service.proj"
 
 dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$ServiceDirectory" /p:SDKType=$SDKType /restore $servicesProj
+
+if ($SpellCheckPublicApiSurface) { 
+    Write-Host "Spell check public API surface"
+    npx cspell lint `
+        --config "$PSScriptRoot/../../.vscode/cspell.json" `
+        "$PSScriptRoot/../../sdk/$ServiceDirectory/*/api/*.cs"
+    if ($LASTEXITCODE) { 
+        Write-Host "##vso[task.LogIssue type=error;]Spelling errors detected. To correct false positives or learn about spell checking see: https://aka.ms/azsdk/engsys/spellcheck"
+    }
+}

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -7,7 +7,7 @@ param (
     [switch] $SpellCheckPublicApiSurface
 )
 
-if ($SpellCheckPublicApiSurface -and (Get-Command npx)) { 
+if ($SpellCheckPublicApiSurface -and -not (Get-Command 'npx')) { 
     Write-Error "Could not locate npx. Install NodeJS (includes npm and npx) https://nodejs.org/en/download/"
     exit 1
 }

--- a/sdk/formrecognizer/ci.yml
+++ b/sdk/formrecognizer/ci.yml
@@ -27,6 +27,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: formrecognizer
+    SpellCheckPublicApiSurface: true
     ArtifactName: packages
     Artifacts:
     - name: Azure.AI.FormRecognizer


### PR DESCRIPTION
Example spelling error -- https://dev.azure.com/azure-sdk/public/_build/results?buildId=873177&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=2102385d-609d-5572-64d2-932661c7902f&l=150

It looks like the `net - aggregate-reports` pipeline is failing because it's not written to run in the context of a PR. I'll see if we can get some better testing coverage for this. 