### PR TITLE
[Event Hubs Client] April Release Preparation (Procesor)

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -76,7 +76,7 @@
     <PackageReference Update="Azure.Core" Version="1.12.0" />
     <PackageReference Update="Azure.Core.Amqp" Version="1.0.0" />
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.10" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.3.1" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.4.0" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.0.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.2.0-beta.1" />
     <PackageReference Update="Azure.Identity" Version="1.2.1" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Azure.Messaging.EventHubs.Processor.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Azure.Messaging.EventHubs.Processor.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{797FF941-76FD-45FD-AC17-A73DFE2BA621}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs", "..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj", "{9E1B2729-AB07-4C4D-A05E-8B1ACDE968A4}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,17 +29,12 @@ Global
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9E1B2729-AB07-4C4D-A05E-8B1ACDE968A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E1B2729-AB07-4C4D-A05E-8B1ACDE968A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9E1B2729-AB07-4C4D-A05E-8B1ACDE968A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9E1B2729-AB07-4C4D-A05E-8B1ACDE968A4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
-		{9E1B2729-AB07-4C4D-A05E-8B1ACDE968A4} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {44BD3BD5-61DF-464D-8627-E00B0BC4B3A3}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.4.0-beta.2 (Unreleased)
+## 5.4.0 (2021-04-05)
 
 ### Acknowledgments
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.4.0-beta.2</Version>
+    <Version>5.4.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.3.1</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--PackageReference Include="Azure.Messaging.EventHubs" /-->
+    <PackageReference Include="Azure.Messaging.EventHubs" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
@@ -22,21 +22,6 @@
     <PackageReference Include="System.Threading.Channels" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
-
-  <!--
-      TEMP:
-        Use a project reference to Event Hubs to allow use of the
-        unreleased AzureNamedKeyCredential and AzureSasCredential overloads.
-
-        This should be reverted to use the package reference (above)
-        before the April release.
-
-        (remember to remove the project from the "External" folder of the solution)
-  -->
-  <ItemGroup>
-      <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
-  </ItemGroup>
-  <!-- END TEMP -->
 
   <!-- Import the Azure.Core reference -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the Processor package for the April release.

# Last Upstream Rebase

Monday, April 5, 12:pm (EST)