### PR TITLE
[Service Bus Client] Fix List Doc Comments

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/RuleFilter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/RuleFilter.cs
@@ -11,8 +11,8 @@ namespace Azure.Messaging.ServiceBus.Administration
     /// <remarks>
     /// Filter is an abstract class with the following concrete implementations:
     /// <list type="bullet">
-    /// <item><b>SqlRuleFilter</b> that represents a filter using SQL syntax. </item>
-    /// <item><b>CorrelationRuleFilter</b> that provides an optimization for correlation equality expressions.</item>
+    /// <item><description><b>SqlRuleFilter</b> that represents a filter using SQL syntax.</description></item>
+    /// <item><description><b>CorrelationRuleFilter</b> that provides an optimization for correlation equality expressions.</description></item>
     /// </list>
     /// </remarks>
     /// <seealso cref="SqlRuleFilter"/>


### PR DESCRIPTION
# Summary

The focus of these changes is to add the needed child elements to the `<item>` tags of the `<list>` elements in the doc comments.

# Last Upstream Rebase

Monday, April 5, 3pm (EST)

# Related and References

- [Remarks section missing (#20084)](https://github.com/Azure/azure-sdk-for-net/issues/20084)
- [&lt;list&gt; (C# programming guide)](https://docs.microsoft.com/dotnet/csharp/programming-guide/xmldoc/list)