### PR TITLE
[Translation] Update samples and fix HasValue bug

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/samples/Sample2_PollIndividualDocuments.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/Sample2_PollIndividualDocuments.md
@@ -27,25 +27,24 @@ DocumentTranslationOperation operation = await client.StartTranslationAsync(inpu
 
 TimeSpan pollingInterval = new(1000);
 
-AsyncPageable<DocumentStatusResult> documents = operation.GetAllDocumentStatusesAsync();
-await foreach (DocumentStatusResult document in documents)
+await foreach (DocumentStatusResult document in operation.GetAllDocumentStatusesAsync())
 {
-    Console.WriteLine($"Polling Status for document{document.TranslatedDocumentUri}");
+    Console.WriteLine($"Polling Status for document{document.SourceDocumentUri}");
 
-    Response<DocumentStatusResult> status = await operation.GetDocumentStatusAsync(document.DocumentId);
+    Response<DocumentStatusResult> responseDocumentStatus = await operation.GetDocumentStatusAsync(document.DocumentId);
 
-    while (!status.Value.HasCompleted)
+    while (!responseDocumentStatus.Value.HasCompleted)
     {
-        if (operation.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
+        if (responseDocumentStatus.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
         {
             pollingInterval = TimeSpan.FromSeconds(Convert.ToInt32(value));
         }
 
         await Task.Delay(pollingInterval);
-        status = await operation.GetDocumentStatusAsync(document.DocumentId);
+        responseDocumentStatus = await operation.GetDocumentStatusAsync(document.DocumentId);
     }
 
-    if (status.Value.Status == TranslationStatus.Succeeded)
+    if (responseDocumentStatus.Value.Status == TranslationStatus.Succeeded)
     {
         Console.WriteLine($"  Translated Document Uri: {document.TranslatedDocumentUri}");
         Console.WriteLine($"  Translated to language: {document.TranslateTo}.");

--- a/sdk/translation/Azure.AI.Translation.Document/samples/Sample4_MultipleInputs.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/Sample4_MultipleInputs.md
@@ -47,27 +47,7 @@ var inputs = new List<DocumentTranslationInput>()
 
 DocumentTranslationOperation operation = await client.StartTranslationAsync(inputs);
 
-TimeSpan pollingInterval = new(1000);
-
-while (!operation.HasCompleted)
-{
-    if (operation.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
-    {
-        pollingInterval = TimeSpan.FromSeconds(Convert.ToInt32(value));
-    }
-
-    await Task.Delay(pollingInterval);
-    await operation.UpdateStatusAsync();
-
-    Console.WriteLine($"  Status: {operation.Status}");
-    Console.WriteLine($"  Created on: {operation.CreatedOn}");
-    Console.WriteLine($"  Last modified: {operation.LastModified}");
-    Console.WriteLine($"  Total documents: {operation.DocumentsTotal}");
-    Console.WriteLine($"    Succeeded: {operation.DocumentsSucceeded}");
-    Console.WriteLine($"    Failed: {operation.DocumentsFailed}");
-    Console.WriteLine($"    In Progress: {operation.DocumentsInProgress}");
-    Console.WriteLine($"    Not started: {operation.DocumentsNotStarted}");
-}
+await operation.WaitForCompletionAsync();
 
 await foreach (DocumentStatusResult document in operation.GetValuesAsync())
 {

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationOperation.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationOperation.cs
@@ -101,6 +101,11 @@ namespace Azure.AI.Translation.Document
         private bool _hasCompleted;
 
         /// <summary>
+        /// <c>true</c> if the long-running operation has a value. Otherwise, <c>false</c>.
+        /// </summary>
+        private bool _hasValue;
+
+        /// <summary>
         /// Returns true if the long-running operation completed.
         /// </summary>
         public override bool HasCompleted => _hasCompleted;
@@ -125,7 +130,7 @@ namespace Azure.AI.Translation.Document
         /// <summary>
         /// Returns true if the long-running operation completed successfully and has produced final result (accessible by Value property).
         /// </summary>
-        public override bool HasValue => _firstPage != null;
+        public override bool HasValue => _hasValue;
 
         /// <summary>
         /// Protected constructor to allow mocking.
@@ -230,7 +235,7 @@ namespace Azure.AI.Translation.Document
                 {
                     var response = await _serviceClient.GetOperationDocumentsStatusAsync(new Guid(Id), cancellationToken: cancellationToken).ConfigureAwait(false);
                     _firstPage = Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
-
+                    _hasValue = true;
                     async Task<Page<DocumentStatusResult>> NextPageFunc(string nextLink, int? pageSizeHint)
                     {
                         // TODO: diagnostics scope?
@@ -289,6 +294,7 @@ namespace Azure.AI.Translation.Document
                         || update.Value.Status == TranslationStatus.Failed)
                     {
                         _hasCompleted = true;
+                        _hasValue = true;
                     }
                     else if (update.Value.Status == TranslationStatus.ValidationFailed)
                     {

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_DocumentStatusAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_DocumentStatusAsync.cs
@@ -19,10 +19,11 @@ namespace Azure.AI.Translation.Document.Samples
         {
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;
-            Uri sourceUri = new Uri("");
-            Uri targetUri = new Uri("");
 
             var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
+
+            Uri sourceUri = new Uri("<source SAS URI>");
+            Uri targetUri = new Uri("<target SAS URI>");
 
             var input = new DocumentTranslationInput(sourceUri, targetUri, "es");
             DocumentTranslationOperation operation = await client.StartTranslationAsync(input);
@@ -31,14 +32,8 @@ namespace Azure.AI.Translation.Document.Samples
 
             var documentscompleted = new HashSet<string>();
 
-            while (!operation.HasCompleted)
+            while (true)
             {
-                if (operation.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
-                {
-                    pollingInterval = TimeSpan.FromSeconds(Convert.ToInt32(value));
-                }
-
-                await Task.Delay(pollingInterval);
                 await operation.UpdateStatusAsync();
 
                 AsyncPageable<DocumentStatusResult> documentsStatus = operation.GetAllDocumentStatusesAsync();
@@ -49,8 +44,21 @@ namespace Azure.AI.Translation.Document.Samples
                     if (docStatus.Status == TranslationStatus.Succeeded || docStatus.Status == TranslationStatus.Failed)
                     {
                         documentscompleted.Add(docStatus.DocumentId);
-                        Console.WriteLine($"Document {docStatus.TranslatedDocumentUri} completed with status ${docStatus.Status}");
+                        Console.WriteLine($"Document {docStatus.TranslatedDocumentUri} completed with status {docStatus.Status}");
                     }
+                }
+
+                if (operation.HasCompleted)
+                {
+                    break;
+                }
+                else
+                {
+                    if (operation.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
+                    {
+                        pollingInterval = TimeSpan.FromSeconds(Convert.ToInt32(value));
+                    }
+                    await Task.Delay(pollingInterval);
                 }
             }
         }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputs.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputs.cs
@@ -55,14 +55,8 @@ namespace Azure.AI.Translation.Document.Samples
 
             TimeSpan pollingInterval = new(1000);
 
-            while (!operation.HasCompleted)
+            while (true)
             {
-                if (operation.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
-                {
-                    pollingInterval = TimeSpan.FromSeconds(Convert.ToInt32(value));
-                }
-
-                Thread.Sleep(pollingInterval);
                 operation.UpdateStatus();
 
                 Console.WriteLine($"  Status: {operation.Status}");
@@ -73,6 +67,19 @@ namespace Azure.AI.Translation.Document.Samples
                 Console.WriteLine($"    Failed: {operation.DocumentsFailed}");
                 Console.WriteLine($"    In Progress: {operation.DocumentsInProgress}");
                 Console.WriteLine($"    Not started: {operation.DocumentsNotStarted}");
+
+                if (operation.HasCompleted)
+                {
+                    break;
+                }
+                else
+                {
+                    if (operation.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
+                    {
+                        pollingInterval = TimeSpan.FromSeconds(Convert.ToInt32(value));
+                    }
+                    Thread.Sleep(pollingInterval);
+                }
             }
 
             foreach (DocumentStatusResult document in operation.GetValues())

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputsAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputsAsync.cs
@@ -53,27 +53,7 @@ namespace Azure.AI.Translation.Document.Samples
 
             DocumentTranslationOperation operation = await client.StartTranslationAsync(inputs);
 
-            TimeSpan pollingInterval = new(1000);
-
-            while (!operation.HasCompleted)
-            {
-                if (operation.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
-                {
-                    pollingInterval = TimeSpan.FromSeconds(Convert.ToInt32(value));
-                }
-
-                await Task.Delay(pollingInterval);
-                await operation.UpdateStatusAsync();
-
-                Console.WriteLine($"  Status: {operation.Status}");
-                Console.WriteLine($"  Created on: {operation.CreatedOn}");
-                Console.WriteLine($"  Last modified: {operation.LastModified}");
-                Console.WriteLine($"  Total documents: {operation.DocumentsTotal}");
-                Console.WriteLine($"    Succeeded: {operation.DocumentsSucceeded}");
-                Console.WriteLine($"    Failed: {operation.DocumentsFailed}");
-                Console.WriteLine($"    In Progress: {operation.DocumentsInProgress}");
-                Console.WriteLine($"    Not started: {operation.DocumentsNotStarted}");
-            }
+            await operation.WaitForCompletionAsync();
 
             await foreach (DocumentStatusResult document in operation.GetValuesAsync())
             {

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocuments.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocuments.cs
@@ -34,25 +34,24 @@ namespace Azure.AI.Translation.Document.Samples
 
             TimeSpan pollingInterval = new(1000);
 
-            Pageable<DocumentStatusResult> documents = operation.GetAllDocumentStatuses();
-            foreach (DocumentStatusResult document in documents)
+            foreach (DocumentStatusResult document in operation.GetAllDocumentStatuses())
             {
-                Console.WriteLine($"Polling Status for document{document.TranslatedDocumentUri}");
+                Console.WriteLine($"Polling Status for document{document.SourceDocumentUri}");
 
-                Response<DocumentStatusResult> status = operation.GetDocumentStatus(document.DocumentId);
+                Response<DocumentStatusResult> responseDocumentStatus = operation.GetDocumentStatus(document.DocumentId);
 
-                while (!status.Value.HasCompleted)
+                while (!responseDocumentStatus.Value.HasCompleted)
                 {
-                    if (operation.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
+                    if (responseDocumentStatus.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
                     {
                         pollingInterval = TimeSpan.FromSeconds(Convert.ToInt32(value));
                     }
 
                     Thread.Sleep(pollingInterval);
-                    status = operation.GetDocumentStatus(document.DocumentId);
+                    responseDocumentStatus = operation.GetDocumentStatus(document.DocumentId);
                 }
 
-                if (status.Value.Status == TranslationStatus.Succeeded)
+                if (responseDocumentStatus.Value.Status == TranslationStatus.Succeeded)
                 {
                     Console.WriteLine($"  Translated Document Uri: {document.TranslatedDocumentUri}");
                     Console.WriteLine($"  Translated to language: {document.TranslateTo}.");

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocumentsAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocumentsAsync.cs
@@ -35,25 +35,24 @@ namespace Azure.AI.Translation.Document.Samples
 
             TimeSpan pollingInterval = new(1000);
 
-            AsyncPageable<DocumentStatusResult> documents = operation.GetAllDocumentStatusesAsync();
-            await foreach (DocumentStatusResult document in documents)
+            await foreach (DocumentStatusResult document in operation.GetAllDocumentStatusesAsync())
             {
-                Console.WriteLine($"Polling Status for document{document.TranslatedDocumentUri}");
+                Console.WriteLine($"Polling Status for document{document.SourceDocumentUri}");
 
-                Response<DocumentStatusResult> status = await operation.GetDocumentStatusAsync(document.DocumentId);
+                Response<DocumentStatusResult> responseDocumentStatus = await operation.GetDocumentStatusAsync(document.DocumentId);
 
-                while (!status.Value.HasCompleted)
+                while (!responseDocumentStatus.Value.HasCompleted)
                 {
-                    if (operation.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
+                    if (responseDocumentStatus.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
                     {
                         pollingInterval = TimeSpan.FromSeconds(Convert.ToInt32(value));
                     }
 
                     await Task.Delay(pollingInterval);
-                    status = await operation.GetDocumentStatusAsync(document.DocumentId);
+                    responseDocumentStatus = await operation.GetDocumentStatusAsync(document.DocumentId);
                 }
 
-                if (status.Value.Status == TranslationStatus.Succeeded)
+                if (responseDocumentStatus.Value.Status == TranslationStatus.Succeeded)
                 {
                     Console.WriteLine($"  Translated Document Uri: {document.TranslatedDocumentUri}");
                     Console.WriteLine($"  Translated to language: {document.TranslateTo}.");

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslation.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslation.cs
@@ -35,14 +35,8 @@ namespace Azure.AI.Translation.Document.Samples
 
             TimeSpan pollingInterval = new(1000);
 
-            while (!operation.HasCompleted)
+            while (true)
             {
-                if (operation.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
-                {
-                    pollingInterval = TimeSpan.FromSeconds(Convert.ToInt32(value));
-                }
-
-                Thread.Sleep(pollingInterval);
                 operation.UpdateStatus();
 
                 Console.WriteLine($"  Status: {operation.Status}");
@@ -53,6 +47,19 @@ namespace Azure.AI.Translation.Document.Samples
                 Console.WriteLine($"    Failed: {operation.DocumentsFailed}");
                 Console.WriteLine($"    In Progress: {operation.DocumentsInProgress}");
                 Console.WriteLine($"    Not started: {operation.DocumentsNotStarted}");
+
+                if (operation.HasCompleted)
+                {
+                    break;
+                }
+                else
+                {
+                    if (operation.GetRawResponse().Headers.TryGetValue("Retry-After", out string value))
+                    {
+                        pollingInterval = TimeSpan.FromSeconds(Convert.ToInt32(value));
+                    }
+                    Thread.Sleep(pollingInterval);
+                }
             }
 
             foreach (DocumentStatusResult document in operation.GetValues())
@@ -72,7 +79,6 @@ namespace Azure.AI.Translation.Document.Samples
                     Console.WriteLine($"  Message: {document.Error.Message}");
                 }
             }
-
             #endregion
         }
     }


### PR DESCRIPTION
While doing the pre-release checklist, I noticed a bug in our Operation class where `HasValue` was only assigned if the user called `WaitForCompletion()` if the user did `Update` or `UpdateAsync` HasValue` was never updated and therefore our code was not getting the documents when the user did `GetValues` or `GetAsyncValues`.

I also did other minor fixes to the samples.
Once we have them running as part of our CI, these "unexpected" problems should go away.