### PR TITLE
Disable canary weekly tests for keyvault

### DIFF
--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -6,6 +6,8 @@ extends:
     ServiceDirectory: keyvault
     MaxParallel: 5
     TimeoutInMinutes: 180
+    # Keyvault test resources are expensive, and managed HSM modules don't necessarily work in Canary
+    UnsupportedClouds: Canary
     AdditionalMatrixConfigs:
       - Name: keyvault_test_matrix_addons
         Path: sdk/keyvault/platform-matrix.json

--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -6,8 +6,16 @@ extends:
     ServiceDirectory: keyvault
     MaxParallel: 5
     TimeoutInMinutes: 180
-    # Keyvault test resources are expensive, and managed HSM modules don't necessarily work in Canary
-    UnsupportedClouds: Canary
+    CloudConfig:
+      Public:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+      Canary:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        Location: 'eastus2euap'
+        # Managed HSM test resources are expensive and provisioning has not been reliable.
+        # Given test coverage of non-canary regions we probably don't need to test in canary.
+        MatrixFilters:
+         - ArmTemplateParameters=^(?!.*enableHsm.*true)
     AdditionalMatrixConfigs:
       - Name: keyvault_test_matrix_addons
         Path: sdk/keyvault/platform-matrix.json


### PR DESCRIPTION
This is primarily driven by a perceived lack of managed HSM support in the Canary region, but also given the expense of keyvault test resources, we don't necessarily need to be running them in Canary.