### PR TITLE
Fix DownloadCertificate test failures

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -853,7 +853,6 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         }
 
         [Test]
-        [Ignore("Currently failing on linux; investigation underway")]
         public async Task DownloadECDsaCertificateSignRemoteVerifyLocal([EnumValues] CertificateContentType contentType, [EnumValues] CertificateKeyCurveName keyCurveName)
         {
 #if NET461
@@ -906,19 +905,11 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         }
 
         [Test]
-        [Ignore("Currently failing on linux; investigation underway")]
         public async Task DownloadECDsaCertificateSignLocalVerifyRemote([EnumValues] CertificateContentType contentType, [EnumValues] CertificateKeyCurveName keyCurveName)
         {
 #if NET461
             Assert.Ignore("ECC is not supported before .NET Framework 4.7");
 #endif
-            // BUGBUG: This suddenly started failing on linux blocking an important release.
-            // TODO: Remove this once https://github.com/Azure/azure-sdk-for-net/issues/20204 is resolved.
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Assert.Ignore("No longer working on linux; see #20204 for details.");
-            }
-
             string name = Recording.GenerateId();
 
             CertificatePolicy policy = new CertificatePolicy

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -912,6 +912,13 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 #if NET461
             Assert.Ignore("ECC is not supported before .NET Framework 4.7");
 #endif
+            // BUGBUG: This suddenly started failing on linux blocking an important release.
+            // TODO: Remove this once https://github.com/Azure/azure-sdk-for-net/issues/20204 is resolved.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Assert.Ignore("No longer working on linux; see #20204 for details.");
+            }
+
             string name = Recording.GenerateId();
 
             CertificatePolicy policy = new CertificatePolicy

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -30,6 +31,8 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 {
     public partial class CertificateClientLiveTests : CertificatesTestBase
     {
+        private static MethodInfo s_clearCacheMethod;
+
         public CertificateClientLiveTests(bool isAsync, CertificateClientOptions.ServiceVersion serviceVersion)
             : base(isAsync, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
@@ -47,6 +50,16 @@ namespace Azure.Security.KeyVault.Certificates.Tests
                 Client = GetClient();
 
                 ChallengeBasedAuthenticationPolicy.ClearCache();
+
+                // Make sure the shared source copy of ChallengeBasedAuthenticationPolicy is cleared as well for Keys.
+                if (s_clearCacheMethod is null)
+                {
+                    s_clearCacheMethod = typeof(CryptographyClient).Assembly.GetType("Azure.Security.KeyVault.ChallengeBasedAuthenticationPolicy", true, false)
+                        .GetMethod(nameof(ChallengeBasedAuthenticationPolicy.ClearCache), BindingFlags.Static | BindingFlags.NonPublic)
+                        ?? throw new NotSupportedException($"{nameof(ChallengeBasedAuthenticationPolicy)}.{nameof(ChallengeBasedAuthenticationPolicy.ClearCache)} not found in {typeof(CryptographyClient).Assembly}");
+                }
+
+                s_clearCacheMethod.Invoke(null, null);
             }
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatePolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatePolicyTests.cs
@@ -135,16 +135,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(1482188947), policy.CreatedOn);
             Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(1482188947), policy.UpdatedOn);
 
-            using (JsonStream json = new JsonStream())
-            {
-                JsonWriterOptions options = new JsonWriterOptions
-                {
-                    Indented = true,
-                };
-
-                json.WriteObject(policy, options);
-
-                string expectedJson = @"{
+            const string expectedJson = @"{
   ""key_props"": {
     ""kty"": ""RSA"",
     ""reuse_key"": false,
@@ -176,8 +167,17 @@ namespace Azure.Security.KeyVault.Certificates.Tests
   ]
 }";
 
-                Assert.AreEqual(expectedJson, json.ToString());
+            using JsonStream expectedStream = new JsonStream();
+            using (Utf8JsonWriter expectedWriter = expectedStream.CreateWriter())
+            {
+                using JsonDocument expectedDocument = JsonDocument.Parse(expectedJson);
+                expectedDocument.WriteTo(expectedWriter);
             }
+
+            using JsonStream actualStream = new JsonStream();
+            actualStream.WriteObject(policy);
+
+            Assert.AreEqual(expectedStream.ToString(), actualStream.ToString());
         }
 
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Azure.Core;
+using Azure.Core.TestFramework;
 using NUnit.Framework;
 
 namespace Azure.Security.KeyVault.Certificates.Tests
@@ -16,15 +17,9 @@ namespace Azure.Security.KeyVault.Certificates.Tests
     public class LightweightPkcs8DecoderTests
     {
         [Test]
-        public void VerifyECDecoderPrime256v1Imported()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                Assert.Ignore("The curve is not supported by the current platform");
-            }
-
+        [RunOnlyOnPlatforms(Linux = true, Windows = true, Reason = "The curve is not supported by the current platform")]
+        public void VerifyECDecoderPrime256v1Imported() =>
             VerifyECDecoder(EcPrime256v1PrivateKeyImported, CertificateKeyCurveName.P256, @"DFTTJrKrtao7G/B0bK5yv+mX0/3Sefv2MS1gzd6DfYH2ASe9Tw7rSbLjZ8wM0p7I/opbIG1+zHhpYqOGnQNQyw==", EcPrime256v1CertificateImported);
-        }
 
         [Test]
         public void VerifyECDecoderSecp256k1() =>

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-256).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-256).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/601438262/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/601438262/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-8c53eb37483d7f48b9361cede97677f7-e5cac147b85f4244-00",
+        "traceparent": "00-dc674cb27dd3c741a7f00ec447c1e835-b2d058f6e49a484a-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "103d05436a448a9c8377c6f095734bc9",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:51 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "103d05436a448a9c8377c6f095734bc9",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e2629d84-8852-48ab-9a3b-24302708fab1",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "215267b4-6371-4fab-962d-927815569c72",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/601438262/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/601438262/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-8c53eb37483d7f48b9361cede97677f7-e5cac147b85f4244-00",
+        "traceparent": "00-dc674cb27dd3c741a7f00ec447c1e835-b2d058f6e49a484a-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "103d05436a448a9c8377c6f095734bc9",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:43 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:51 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending?api-version=7.2\u0026request_id=5ba782e8f8b3469cac39a8c67fa8591c",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/601438262/pending?api-version=7.2\u0026request_id=11c1bc5e600c4486a70792cf2844fa9c",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "103d05436a448a9c8377c6f095734bc9",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "24f61bf5-82e6-4600-91a1-1474f3be06cc",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "54656ff1-705f-460b-a7c0-fd4524ba60b5",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/601438262/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEj2nDZGgdEtgjt7DZuUxX\u002BRwVZUX615MC7Ef6yZayHAtBqpkp8E8QhEDkWKS5OQ1uxS4WnTpvH/mKgW2EzcjPk6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIBh7V\u002Ba1OhQZ08A/iOOFHWB30V/pr0KFThEcdm6OPV/UAiB4jnaUSDxgV8eOxpjeDpxgwBgYmPBSliTa7H6dGM4YDQ==",
+        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEr1GS2btyKSHv62ksvhQpV6uGwkPRSIhwMoiPkh6FmiS7fUFEAoHUQQ\u002Bji9pHkzmVGKeinBr/EHRWh21FJd9PB6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCICLaXQtTeGlWDoWXkey9YaxzEOLYQeWFxY\u002Bpeqrlxhb7AiBrjGW9DD5R2nSHDhF8RdvMlYcB2sS669lJHXLgh\u002BMBnQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5ba782e8f8b3469cac39a8c67fa8591c"
+        "request_id": "11c1bc5e600c4486a70792cf2844fa9c"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/601438262/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "85c49519a62c4c28cf4e881063abf280",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:43 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:51 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "85c49519a62c4c28cf4e881063abf280",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f2ff4256-1bbd-4251-8d01-f522e58a9c33",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "66415be4-c551-43fd-876b-3d814eda6004",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/601438262/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEj2nDZGgdEtgjt7DZuUxX\u002BRwVZUX615MC7Ef6yZayHAtBqpkp8E8QhEDkWKS5OQ1uxS4WnTpvH/mKgW2EzcjPk6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIBh7V\u002Ba1OhQZ08A/iOOFHWB30V/pr0KFThEcdm6OPV/UAiB4jnaUSDxgV8eOxpjeDpxgwBgYmPBSliTa7H6dGM4YDQ==",
+        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEr1GS2btyKSHv62ksvhQpV6uGwkPRSIhwMoiPkh6FmiS7fUFEAoHUQQ\u002Bji9pHkzmVGKeinBr/EHRWh21FJd9PB6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCICLaXQtTeGlWDoWXkey9YaxzEOLYQeWFxY\u002Bpeqrlxhb7AiBrjGW9DD5R2nSHDhF8RdvMlYcB2sS669lJHXLgh\u002BMBnQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5ba782e8f8b3469cac39a8c67fa8591c"
+        "request_id": "11c1bc5e600c4486a70792cf2844fa9c"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/601438262/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "5729a4f6d77a8e83cfc6c59bf6c5d00e",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:48 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:56 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5729a4f6d77a8e83cfc6c59bf6c5d00e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2cef33f1-81a7-45b7-8022-d68ef6de409c",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bc02f242-114c-4b78-97d4-86b1102e45fe",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/601438262/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEj2nDZGgdEtgjt7DZuUxX\u002BRwVZUX615MC7Ef6yZayHAtBqpkp8E8QhEDkWKS5OQ1uxS4WnTpvH/mKgW2EzcjPk6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIBh7V\u002Ba1OhQZ08A/iOOFHWB30V/pr0KFThEcdm6OPV/UAiB4jnaUSDxgV8eOxpjeDpxgwBgYmPBSliTa7H6dGM4YDQ==",
+        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEr1GS2btyKSHv62ksvhQpV6uGwkPRSIhwMoiPkh6FmiS7fUFEAoHUQQ\u002Bji9pHkzmVGKeinBr/EHRWh21FJd9PB6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCICLaXQtTeGlWDoWXkey9YaxzEOLYQeWFxY\u002Bpeqrlxhb7AiBrjGW9DD5R2nSHDhF8RdvMlYcB2sS669lJHXLgh\u002BMBnQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5ba782e8f8b3469cac39a8c67fa8591c"
+        "request_id": "11c1bc5e600c4486a70792cf2844fa9c"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/601438262/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "2b32ce9564f99d09dcf041f5e28b27d7",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "663",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:53 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2b32ce9564f99d09dcf041f5e28b27d7",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "31361ec4-97ae-43bd-aa87-1d2a24b5752e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b9ffc965-cfc7-4517-89e6-9879aa1b4d95",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/601438262/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEj2nDZGgdEtgjt7DZuUxX\u002BRwVZUX615MC7Ef6yZayHAtBqpkp8E8QhEDkWKS5OQ1uxS4WnTpvH/mKgW2EzcjPk6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIBh7V\u002Ba1OhQZ08A/iOOFHWB30V/pr0KFThEcdm6OPV/UAiB4jnaUSDxgV8eOxpjeDpxgwBgYmPBSliTa7H6dGM4YDQ==",
+        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEr1GS2btyKSHv62ksvhQpV6uGwkPRSIhwMoiPkh6FmiS7fUFEAoHUQQ\u002Bji9pHkzmVGKeinBr/EHRWh21FJd9PB6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCICLaXQtTeGlWDoWXkey9YaxzEOLYQeWFxY\u002Bpeqrlxhb7AiBrjGW9DD5R2nSHDhF8RdvMlYcB2sS669lJHXLgh\u002BMBnQ==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5ba782e8f8b3469cac39a8c67fa8591c"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/601438262",
+        "request_id": "11c1bc5e600c4486a70792cf2844fa9c"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/601438262?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "f0fa4585f34a424e1236b666e18d5509",
         "x-ms-return-client-request-id": "true"
@@ -256,211 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:58 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "53f6393e-39ca-482a-a642-22756ef7b698",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEj2nDZGgdEtgjt7DZuUxX\u002BRwVZUX615MC7Ef6yZayHAtBqpkp8E8QhEDkWKS5OQ1uxS4WnTpvH/mKgW2EzcjPk6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIBh7V\u002Ba1OhQZ08A/iOOFHWB30V/pr0KFThEcdm6OPV/UAiB4jnaUSDxgV8eOxpjeDpxgwBgYmPBSliTa7H6dGM4YDQ==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5ba782e8f8b3469cac39a8c67fa8591c"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "947a7a7dc67991879b8c7b8a958dab43",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "757",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:03 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "abed3c6b-5fab-48e3-9c8f-2c446a9d4a62",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEj2nDZGgdEtgjt7DZuUxX\u002BRwVZUX615MC7Ef6yZayHAtBqpkp8E8QhEDkWKS5OQ1uxS4WnTpvH/mKgW2EzcjPk6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIBh7V\u002Ba1OhQZ08A/iOOFHWB30V/pr0KFThEcdm6OPV/UAiB4jnaUSDxgV8eOxpjeDpxgwBgYmPBSliTa7H6dGM4YDQ==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5ba782e8f8b3469cac39a8c67fa8591c"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "b015ed9ee0cba2c47fef19c2ada3bb4e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "757",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "83a60d6d-a6c7-4af8-b96b-4eae6f64f93a",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEj2nDZGgdEtgjt7DZuUxX\u002BRwVZUX615MC7Ef6yZayHAtBqpkp8E8QhEDkWKS5OQ1uxS4WnTpvH/mKgW2EzcjPk6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIBh7V\u002Ba1OhQZ08A/iOOFHWB30V/pr0KFThEcdm6OPV/UAiB4jnaUSDxgV8eOxpjeDpxgwBgYmPBSliTa7H6dGM4YDQ==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5ba782e8f8b3469cac39a8c67fa8591c"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "6778389a9210be5ebe6855bd77c4ad85",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "665",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:13 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f0fa4585f34a424e1236b666e18d5509",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9c41865c-cc9d-46e7-a61c-7972995dee15",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "de7751fc-3426-4b99-ad70-8404f1c7c905",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEj2nDZGgdEtgjt7DZuUxX\u002BRwVZUX615MC7Ef6yZayHAtBqpkp8E8QhEDkWKS5OQ1uxS4WnTpvH/mKgW2EzcjPk6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIBh7V\u002Ba1OhQZ08A/iOOFHWB30V/pr0KFThEcdm6OPV/UAiB4jnaUSDxgV8eOxpjeDpxgwBgYmPBSliTa7H6dGM4YDQ==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/601438262",
-        "request_id": "5ba782e8f8b3469cac39a8c67fa8591c"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/601438262?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "f3c7728aa4779c3eb6d81589adc4e4f7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1758",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "618e150e-fb82-4d72-b947-deceedf8b552",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/aefe3a43f20f4198bcbbb0e9c83f8179",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/601438262/aefe3a43f20f4198bcbbb0e9c83f8179",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/601438262/aefe3a43f20f4198bcbbb0e9c83f8179",
-        "x5t": "fLIuxeAP2CY8msnSz7_bCrsXrhM",
-        "cer": "MIIBnjCCAUSgAwIBAgIQW2Kx98IeQMmsb5HdLVkmgDAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTExMVoXDTIyMDMwNTIzMDExMVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI9pw2RoHRLYI7ew2blMV/kcFWVF\u002BteTAuxH\u002BsmWshwLQaqZKfBPEIRA5FikuTkNbsUuFp06bx/5ioFthM3Iz5OjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTnZTCgWsq6vCM1opmRIsUc4RAW7jAdBgNVHQ4EFgQU52UwoFrKurwjNaKZkSLFHOEQFu4wCgYIKoZIzj0EAwIDSAAwRQIgRbSAtHKV1jGp0I1h9jFgeQp/ao20Z1EmyMQU4CcNuwMCIQD4S2ekYcTftmXpSWpH3aKCDh6Djh5odbfPq3J1BqIpfA==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/601438262/57f09a9616b34bcab49984e938106af2",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/601438262/57f09a9616b34bcab49984e938106af2",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/601438262/57f09a9616b34bcab49984e938106af2",
+        "x5t": "qTwr1Ylvmd8-g1fM1Ck7HKsCNe4",
+        "cer": "MIIBnjCCAUSgAwIBAgIQCAoysFCtRZSWNgjciwVMoTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTk1OVoXDTIyMDQwODAyMjk1OVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABK9Rktm7cikh7\u002BtpLL4UKVerhsJD0UiIcDKIj5IehZoku31BRAKB1EEPo4vaR5M5lRinopwa/xB0VodtRSXfTwejfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSXMd\u002BFUklH7VFE8XeziCXLGjjmFzAdBgNVHQ4EFgQUlzHfhVJJR\u002B1RRPF3s4glyxo45hcwCgYIKoZIzj0EAwIDSAAwRQIgE97je/BVR0LfAb9iPVaCeOFpx8Deyqu8wvrH3t7dxFkCIQDk9tEB96YCOmJoOM61RrQrpvUPIguVmQ3UDPG2Ma2uAw==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984671,
-          "exp": 1646521271,
-          "created": 1614985271,
-          "updated": 1614985271,
+          "nbf": 1617848399,
+          "exp": 1649384999,
+          "created": 1617848999,
+          "updated": 1617848999,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/601438262/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -500,166 +330,209 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985243,
-            "updated": 1614985243
+            "created": 1617848991,
+            "updated": 1617848991
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/601438262/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/601438262/aefe3a43f20f4198bcbbb0e9c83f8179?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/601438262/57f09a9616b34bcab49984e938106af2?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-b938850c915d5443ba842157ab12f5fd-e346287769eedd47-00",
+        "traceparent": "00-8f358b493cafed49b87c3fe5cb73e008-165b531e8e88574e-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "5def2cd043150c328f57f2628b062abb",
+        "x-ms-client-request-id": "947a7a7dc67991879b8c7b8a958dab43",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1163",
+        "Content-Length": "1160",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:18 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:06 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "947a7a7dc67991879b8c7b8a958dab43",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "bac50553-6f26-4a7f-b175-7d884c4862bb",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f86e899b-b75b-4dc4-a009-55c045bb3167",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/601438262/aefe3a43f20f4198bcbbb0e9c83f8179",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/601438262/aefe3a43f20f4198bcbbb0e9c83f8179",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/601438262/aefe3a43f20f4198bcbbb0e9c83f8179",
-        "x5t": "fLIuxeAP2CY8msnSz7_bCrsXrhM",
-        "cer": "MIIBnjCCAUSgAwIBAgIQW2Kx98IeQMmsb5HdLVkmgDAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTExMVoXDTIyMDMwNTIzMDExMVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI9pw2RoHRLYI7ew2blMV/kcFWVF\u002BteTAuxH\u002BsmWshwLQaqZKfBPEIRA5FikuTkNbsUuFp06bx/5ioFthM3Iz5OjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTnZTCgWsq6vCM1opmRIsUc4RAW7jAdBgNVHQ4EFgQU52UwoFrKurwjNaKZkSLFHOEQFu4wCgYIKoZIzj0EAwIDSAAwRQIgRbSAtHKV1jGp0I1h9jFgeQp/ao20Z1EmyMQU4CcNuwMCIQD4S2ekYcTftmXpSWpH3aKCDh6Djh5odbfPq3J1BqIpfA==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/601438262/57f09a9616b34bcab49984e938106af2",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/601438262/57f09a9616b34bcab49984e938106af2",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/601438262/57f09a9616b34bcab49984e938106af2",
+        "x5t": "qTwr1Ylvmd8-g1fM1Ck7HKsCNe4",
+        "cer": "MIIBnjCCAUSgAwIBAgIQCAoysFCtRZSWNgjciwVMoTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTk1OVoXDTIyMDQwODAyMjk1OVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABK9Rktm7cikh7\u002BtpLL4UKVerhsJD0UiIcDKIj5IehZoku31BRAKB1EEPo4vaR5M5lRinopwa/xB0VodtRSXfTwejfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSXMd\u002BFUklH7VFE8XeziCXLGjjmFzAdBgNVHQ4EFgQUlzHfhVJJR\u002B1RRPF3s4glyxo45hcwCgYIKoZIzj0EAwIDSAAwRQIgE97je/BVR0LfAb9iPVaCeOFpx8Deyqu8wvrH3t7dxFkCIQDk9tEB96YCOmJoOM61RrQrpvUPIguVmQ3UDPG2Ma2uAw==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984671,
-          "exp": 1646521271,
-          "created": 1614985271,
-          "updated": 1614985271,
+          "nbf": 1617848399,
+          "exp": 1649384999,
+          "created": 1617848999,
+          "updated": 1617848999,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "5B62B1F7C21E40C9AC6F91DD2D592680"
+        "serialnumber": "080A32B050AD4594963608DC8B054CA1"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/601438262/aefe3a43f20f4198bcbbb0e9c83f8179?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/601438262/57f09a9616b34bcab49984e938106af2?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-b938850c915d5443ba842157ab12f5fd-17ec61009bd87442-00",
+        "traceparent": "00-8f358b493cafed49b87c3fe5cb73e008-0de6828df0216f43-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "3b389442c8dcf5d7f9dbb1387dd511f9",
+        "x-ms-client-request-id": "b015ed9ee0cba2c47fef19c2ada3bb4e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1343",
+        "Content-Length": "1341",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:18 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:06 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b015ed9ee0cba2c47fef19c2ada3bb4e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "42c7fa41-e0fa-4e7e-ae55-55cb51eab165",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3dd9cd92-64ba-45ae-b447-8f19b668eadd",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIGiAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg79QyyQfoi1fWmwRV\n\u002Be\u002BYX3fS8JjBmsE4a7ZxcfMP7fCgCgYIKoZIzj0DAQehRANCAASPacNkaB0S2CO3\nsNm5TFf5HBVlRfrXkwLsR/rJlrIcC0GqmSnwTxCEQORYpLk5DW7FLhadOm8f\u002BYqB\nbYTNyM\u002BToA0wCwYDVR0PMQQDAgCA\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIBnjCCAUSgAwIBAgIQW2Kx98IeQMmsb5HdLVkmgDAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTExMVoXDTIyMDMwNTIzMDExMVow\nEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI9p\nw2RoHRLYI7ew2blMV/kcFWVF\u002BteTAuxH\u002BsmWshwLQaqZKfBPEIRA5FikuTkNbsUu\nFp06bx/5ioFthM3Iz5OjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0G\nA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTnZTCgWsq6\nvCM1opmRIsUc4RAW7jAdBgNVHQ4EFgQU52UwoFrKurwjNaKZkSLFHOEQFu4wCgYI\nKoZIzj0EAwIDSAAwRQIgRbSAtHKV1jGp0I1h9jFgeQp/ao20Z1EmyMQU4CcNuwMC\nIQD4S2ekYcTftmXpSWpH3aKCDh6Djh5odbfPq3J1BqIpfA==\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIGiAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg/uAbXEZ9IXihpG8e\ngE6pCZ2pICMqVD4HgkUjzRTeNUqgCgYIKoZIzj0DAQehRANCAASvUZLZu3IpIe/r\naSy\u002BFClXq4bCQ9FIiHAyiI\u002BSHoWaJLt9QUQCgdRBD6OL2keTOZUYp6KcGv8QdFaH\nbUUl308HoA0wCwYDVR0PMQQDAgCA\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIBnjCCAUSgAwIBAgIQCAoysFCtRZSWNgjciwVMoTAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTk1OVoXDTIyMDQwODAyMjk1OVow\nEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABK9R\nktm7cikh7\u002BtpLL4UKVerhsJD0UiIcDKIj5IehZoku31BRAKB1EEPo4vaR5M5lRin\nopwa/xB0VodtRSXfTwejfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0G\nA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSXMd\u002BFUklH\n7VFE8XeziCXLGjjmFzAdBgNVHQ4EFgQUlzHfhVJJR\u002B1RRPF3s4glyxo45hcwCgYI\nKoZIzj0EAwIDSAAwRQIgE97je/BVR0LfAb9iPVaCeOFpx8Deyqu8wvrH3t7dxFkC\nIQDk9tEB96YCOmJoOM61RrQrpvUPIguVmQ3UDPG2Ma2uAw==\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/601438262/aefe3a43f20f4198bcbbb0e9c83f8179",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/601438262/57f09a9616b34bcab49984e938106af2",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614984671,
-          "exp": 1646521271,
-          "created": 1614985271,
-          "updated": 1614985271,
+          "nbf": 1617848399,
+          "exp": 1649384999,
+          "created": 1617848999,
+          "updated": 1617848999,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/601438262/aefe3a43f20f4198bcbbb0e9c83f8179"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/601438262/57f09a9616b34bcab49984e938106af2"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/601438262/aefe3a43f20f4198bcbbb0e9c83f8179?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/601438262/57f09a9616b34bcab49984e938106af2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-d103c3487995bb478b6b843c487bbc69-b1853664288ffa4a-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "6778389a9210be5ebe6855bd77c4ad85",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:30:06 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6778389a9210be5ebe6855bd77c4ad85",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a3dd790c-d288-4b78-83ab-f3d6332609c9",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/601438262/57f09a9616b34bcab49984e938106af2?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-e6515b26e818084a8fc04b43e3d5fe9b-6a083bab2b9b524e-00",
+        "traceparent": "00-d103c3487995bb478b6b843c487bbc69-b1853664288ffa4a-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "4bed5e844fd5466f3fba6420b2db11af",
+        "x-ms-client-request-id": "6778389a9210be5ebe6855bd77c4ad85",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "439",
+        "Content-Length": "438",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:18 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:06 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6778389a9210be5ebe6855bd77c4ad85",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "86211be6-91de-4a8d-97b9-785ff3a7b47c",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "652b914c-8cdd-4975-9288-0b144266300a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/601438262/aefe3a43f20f4198bcbbb0e9c83f8179",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/601438262/57f09a9616b34bcab49984e938106af2",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256",
-          "x": "j2nDZGgdEtgjt7DZuUxX-RwVZUX615MC7Ef6yZayHAs",
-          "y": "QaqZKfBPEIRA5FikuTkNbsUuFp06bx_5ioFthM3Iz5M"
+          "x": "r1GS2btyKSHv62ksvhQpV6uGwkPRSIhwMoiPkh6FmiQ",
+          "y": "u31BRAKB1EEPo4vaR5M5lRinopwa_xB0VodtRSXfTwc"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984671,
-          "exp": 1646521271,
-          "created": 1614985271,
-          "updated": 1614985271,
+          "nbf": 1617848399,
+          "exp": 1649384999,
+          "created": 1617848999,
+          "updated": 1617848999,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -668,7 +541,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1582101738"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-256)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-256)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1709464779/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-cd08d15f9cf9484f81fc01136013a5d8-d6a215bee9dbcd46-00",
+        "traceparent": "00-a4fbab0892f7f14ca53fe31d0ef17b10-ebbbde034d4f6b46-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "250e0e382fe152212c0c7279a23b9881",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:32 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "250e0e382fe152212c0c7279a23b9881",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "aeeef87f-41c1-4ed2-b897-7c508a7eee1e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "fd7c7a02-5210-47f5-aad1-c1ee488062d5",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1709464779/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-cd08d15f9cf9484f81fc01136013a5d8-d6a215bee9dbcd46-00",
+        "traceparent": "00-a4fbab0892f7f14ca53fe31d0ef17b10-ebbbde034d4f6b46-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "250e0e382fe152212c0c7279a23b9881",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "757",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:32 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:54 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending?api-version=7.2\u0026request_id=7c4c09230e9e4d5995faf7d1f4426f6a",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1709464779/pending?api-version=7.2\u0026request_id=691435bd258b42218c0777d74b594210",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "250e0e382fe152212c0c7279a23b9881",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ea977ebe-4fa0-474d-a312-d6d08b636c2b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ba78c762-4a61-47bb-9ba0-3c49216431bd",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1709464779/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1pDVGjvKl/ktp09CWPbc4AEA8zZzZfcROIfRkn56jtxpSNhYKlVBDiomTU5WbQz0yTIRztGU4lIKyEfUKo8/8KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCRHX1jZCoT73vLgBbXxPW3FYZVzJvbnWUHvkXPnq0SEgIhAM6IXtaCeS/w9JTrDQZiQSSbGL5Do5u6eVtXn\u002BNRN0yS",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPzxxrOhzOns4esiyU1LZlkEA\u002BULSY2UZc9SJYCY3mCYB0PA2nymFUAvR7RvXnNsGuTRpGRjlfTTM5VNacITbX6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBpayo5a9j3u8ueEgwn9Jz7cZzRNThbR3e9s7QrXT/mlAiEA6Ws5nAfo9Vf2f89h62DqCdEoGZJFZ9uVs/\u002BJ4Mv/Rqk=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "7c4c09230e9e4d5995faf7d1f4426f6a"
+        "request_id": "691435bd258b42218c0777d74b594210"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "5cf1950cb5d63f21dd692fed3dd3292d",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "757",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:32 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5cf1950cb5d63f21dd692fed3dd3292d",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "b6ca977f-5160-4e89-ac7a-ab23fa792c7e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "dfe25259-6a86-43f0-8be9-f28dd0fca7a7",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1709464779/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1pDVGjvKl/ktp09CWPbc4AEA8zZzZfcROIfRkn56jtxpSNhYKlVBDiomTU5WbQz0yTIRztGU4lIKyEfUKo8/8KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCRHX1jZCoT73vLgBbXxPW3FYZVzJvbnWUHvkXPnq0SEgIhAM6IXtaCeS/w9JTrDQZiQSSbGL5Do5u6eVtXn\u002BNRN0yS",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPzxxrOhzOns4esiyU1LZlkEA\u002BULSY2UZc9SJYCY3mCYB0PA2nymFUAvR7RvXnNsGuTRpGRjlfTTM5VNacITbX6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBpayo5a9j3u8ueEgwn9Jz7cZzRNThbR3e9s7QrXT/mlAiEA6Ws5nAfo9Vf2f89h62DqCdEoGZJFZ9uVs/\u002BJ4Mv/Rqk=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "7c4c09230e9e4d5995faf7d1f4426f6a"
+        "request_id": "691435bd258b42218c0777d74b594210"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "adc4298796a15bdaf6714734b94850e4",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "757",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "adc4298796a15bdaf6714734b94850e4",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "b3b00671-f76c-4bac-a2a7-344b100ebd23",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "be3af906-0099-4ab3-8a98-968e0d04faab",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1709464779/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1pDVGjvKl/ktp09CWPbc4AEA8zZzZfcROIfRkn56jtxpSNhYKlVBDiomTU5WbQz0yTIRztGU4lIKyEfUKo8/8KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCRHX1jZCoT73vLgBbXxPW3FYZVzJvbnWUHvkXPnq0SEgIhAM6IXtaCeS/w9JTrDQZiQSSbGL5Do5u6eVtXn\u002BNRN0yS",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPzxxrOhzOns4esiyU1LZlkEA\u002BULSY2UZc9SJYCY3mCYB0PA2nymFUAvR7RvXnNsGuTRpGRjlfTTM5VNacITbX6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBpayo5a9j3u8ueEgwn9Jz7cZzRNThbR3e9s7QrXT/mlAiEA6Ws5nAfo9Vf2f89h62DqCdEoGZJFZ9uVs/\u002BJ4Mv/Rqk=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "7c4c09230e9e4d5995faf7d1f4426f6a"
+        "request_id": "691435bd258b42218c0777d74b594210"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "f19e249669c783f5ecce477800341558",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "665",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:43 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f19e249669c783f5ecce477800341558",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7bf9d866-635e-470d-bce6-981c7e5617bc",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "400205c7-19e4-479d-a360-1d8830b12d90",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1709464779/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1pDVGjvKl/ktp09CWPbc4AEA8zZzZfcROIfRkn56jtxpSNhYKlVBDiomTU5WbQz0yTIRztGU4lIKyEfUKo8/8KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCRHX1jZCoT73vLgBbXxPW3FYZVzJvbnWUHvkXPnq0SEgIhAM6IXtaCeS/w9JTrDQZiQSSbGL5Do5u6eVtXn\u002BNRN0yS",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPzxxrOhzOns4esiyU1LZlkEA\u002BULSY2UZc9SJYCY3mCYB0PA2nymFUAvR7RvXnNsGuTRpGRjlfTTM5VNacITbX6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBpayo5a9j3u8ueEgwn9Jz7cZzRNThbR3e9s7QrXT/mlAiEA6Ws5nAfo9Vf2f89h62DqCdEoGZJFZ9uVs/\u002BJ4Mv/Rqk=",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "7c4c09230e9e4d5995faf7d1f4426f6a"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1709464779",
+        "request_id": "691435bd258b42218c0777d74b594210"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1709464779?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "79f245e3eb7775dfbb9666646eed8695",
         "x-ms-return-client-request-id": "true"
@@ -256,299 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "1758",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:48 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2eb8c5fc-3ed5-4bcc-bb4e-4d21d8b79225",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1pDVGjvKl/ktp09CWPbc4AEA8zZzZfcROIfRkn56jtxpSNhYKlVBDiomTU5WbQz0yTIRztGU4lIKyEfUKo8/8KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCRHX1jZCoT73vLgBbXxPW3FYZVzJvbnWUHvkXPnq0SEgIhAM6IXtaCeS/w9JTrDQZiQSSbGL5Do5u6eVtXn\u002BNRN0yS",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "7c4c09230e9e4d5995faf7d1f4426f6a"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "18564a1838351d663341c0d24f615ac2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "758",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:52 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "69438a33-7e69-4cc2-a369-3115feaba9a2",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1pDVGjvKl/ktp09CWPbc4AEA8zZzZfcROIfRkn56jtxpSNhYKlVBDiomTU5WbQz0yTIRztGU4lIKyEfUKo8/8KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCRHX1jZCoT73vLgBbXxPW3FYZVzJvbnWUHvkXPnq0SEgIhAM6IXtaCeS/w9JTrDQZiQSSbGL5Do5u6eVtXn\u002BNRN0yS",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "7c4c09230e9e4d5995faf7d1f4426f6a"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "7350ee5cd756ab6d45283530039014ff",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "758",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:58 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "dfb1e542-9c16-425e-a041-b376e4b945ff",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1pDVGjvKl/ktp09CWPbc4AEA8zZzZfcROIfRkn56jtxpSNhYKlVBDiomTU5WbQz0yTIRztGU4lIKyEfUKo8/8KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCRHX1jZCoT73vLgBbXxPW3FYZVzJvbnWUHvkXPnq0SEgIhAM6IXtaCeS/w9JTrDQZiQSSbGL5Do5u6eVtXn\u002BNRN0yS",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "7c4c09230e9e4d5995faf7d1f4426f6a"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "b55fb248fcddab23ded445362a0c2659",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "758",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:03 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "275afe93-2dc9-4c91-bffb-48eb1c3085e1",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1pDVGjvKl/ktp09CWPbc4AEA8zZzZfcROIfRkn56jtxpSNhYKlVBDiomTU5WbQz0yTIRztGU4lIKyEfUKo8/8KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCRHX1jZCoT73vLgBbXxPW3FYZVzJvbnWUHvkXPnq0SEgIhAM6IXtaCeS/w9JTrDQZiQSSbGL5Do5u6eVtXn\u002BNRN0yS",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "7c4c09230e9e4d5995faf7d1f4426f6a"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "8008a43c129c413eddaad30c02361aa3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "758",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0e8e8225-b668-461b-831a-b8107010a266",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1pDVGjvKl/ktp09CWPbc4AEA8zZzZfcROIfRkn56jtxpSNhYKlVBDiomTU5WbQz0yTIRztGU4lIKyEfUKo8/8KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCRHX1jZCoT73vLgBbXxPW3FYZVzJvbnWUHvkXPnq0SEgIhAM6IXtaCeS/w9JTrDQZiQSSbGL5Do5u6eVtXn\u002BNRN0yS",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "7c4c09230e9e4d5995faf7d1f4426f6a"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "9d8ac12ca5025fe4caa5958192368138",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "667",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:13 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "79f245e3eb7775dfbb9666646eed8695",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0596e358-019b-4864-80d3-deee26386eac",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3d178be7-4326-4965-9f61-b9a750586a50",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1pDVGjvKl/ktp09CWPbc4AEA8zZzZfcROIfRkn56jtxpSNhYKlVBDiomTU5WbQz0yTIRztGU4lIKyEfUKo8/8KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCRHX1jZCoT73vLgBbXxPW3FYZVzJvbnWUHvkXPnq0SEgIhAM6IXtaCeS/w9JTrDQZiQSSbGL5Do5u6eVtXn\u002BNRN0yS",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1709464779",
-        "request_id": "7c4c09230e9e4d5995faf7d1f4426f6a"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "5ef4db0294883562731dd7332917a9a7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1763",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a4acbed6-cf3a-43cc-8ba6-1e0ab482dac8",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/6f9e056dd08c4974bb6715322a3b5aa8",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1709464779/6f9e056dd08c4974bb6715322a3b5aa8",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1709464779/6f9e056dd08c4974bb6715322a3b5aa8",
-        "x5t": "ABAZssdVW-1H3Sp0JvKHEsstj8o",
-        "cer": "MIIBnjCCAUSgAwIBAgIQF1TEPbxSR9OwJOkFYjUqgzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDExMFoXDTIyMDMwNTIzMTExMFowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNaQ1Ro7ypf5LadPQlj23OABAPM2c2X3ETiH0ZJ\u002Beo7caUjYWCpVQQ4qJk1OVm0M9MkyEc7RlOJSCshH1CqPP/CjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQJ7ps6azbSi0iHkgNlwfg/1IXpSzAdBgNVHQ4EFgQUCe6bOms20otIh5IDZcH4P9SF6UswCgYIKoZIzj0EAwIDSAAwRQIhAO6xMpLTWKg/L3l9LgBRecEB8kmhKhmeV0aMeyhJFvLPAiA7HGR2CNEgDBWh/LZl7Io2L3tKlyMyoL7vkPdl5bk0nQ==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1709464779/403366a253414fe8abc12b335bf0a003",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1709464779/403366a253414fe8abc12b335bf0a003",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1709464779/403366a253414fe8abc12b335bf0a003",
+        "x5t": "JlQNvzZOH4DcAlGA9F3wDffnicU",
+        "cer": "MIIBnzCCAUSgAwIBAgIQGNKOiQ93S2e\u002BggOl6dcF6DAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQwMloXDTIyMDQwODAyMzQwMlowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD88cazoczp7OHrIslNS2ZZBAPlC0mNlGXPUiWAmN5gmAdDwNp8phVAL0e0b15zbBrk0aRkY5X00zOVTWnCE21\u002BjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTf5D54WgbbPNjJCQKF4\u002BTIlcs2HDAdBgNVHQ4EFgQU3\u002BQ\u002BeFoG2zzYyQkChePkyJXLNhwwCgYIKoZIzj0EAwIDSQAwRgIhAIdhK3rQzRVoFM9CVV3PG/Z4GpbkAUArHl1jNjOGITJiAiEA00gmTnOJvYZJek7ZVYe0csLIV4xnIF11nX1ZnWd/Qms=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985270,
-          "exp": 1646521870,
-          "created": 1614985870,
-          "updated": 1614985870,
+          "nbf": 1617848642,
+          "exp": 1649385242,
+          "created": 1617849242,
+          "updated": 1617849242,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1709464779/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -588,166 +330,209 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985833,
-            "updated": 1614985833
+            "created": 1617849234,
+            "updated": 1617849234
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1709464779/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1709464779/6f9e056dd08c4974bb6715322a3b5aa8?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1709464779/403366a253414fe8abc12b335bf0a003?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-cb42efb8728cc2479f118faec8d999ec-10afca9d1c867248-00",
+        "traceparent": "00-820cca4fa12ac84aad2145f99f0781d5-af7422c61e600c48-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "6809a1ba88829657c0a8b5f77cbdafa6",
+        "x-ms-client-request-id": "18564a1838351d663341c0d24f615ac2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1166",
+        "Content-Length": "1163",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "18564a1838351d663341c0d24f615ac2",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7d3048ab-16ec-4588-9f87-5694f07f8435",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "dd8fa723-a5f3-4633-bfff-ee39630f7606",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1709464779/6f9e056dd08c4974bb6715322a3b5aa8",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1709464779/6f9e056dd08c4974bb6715322a3b5aa8",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1709464779/6f9e056dd08c4974bb6715322a3b5aa8",
-        "x5t": "ABAZssdVW-1H3Sp0JvKHEsstj8o",
-        "cer": "MIIBnjCCAUSgAwIBAgIQF1TEPbxSR9OwJOkFYjUqgzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDExMFoXDTIyMDMwNTIzMTExMFowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNaQ1Ro7ypf5LadPQlj23OABAPM2c2X3ETiH0ZJ\u002Beo7caUjYWCpVQQ4qJk1OVm0M9MkyEc7RlOJSCshH1CqPP/CjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQJ7ps6azbSi0iHkgNlwfg/1IXpSzAdBgNVHQ4EFgQUCe6bOms20otIh5IDZcH4P9SF6UswCgYIKoZIzj0EAwIDSAAwRQIhAO6xMpLTWKg/L3l9LgBRecEB8kmhKhmeV0aMeyhJFvLPAiA7HGR2CNEgDBWh/LZl7Io2L3tKlyMyoL7vkPdl5bk0nQ==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1709464779/403366a253414fe8abc12b335bf0a003",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1709464779/403366a253414fe8abc12b335bf0a003",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1709464779/403366a253414fe8abc12b335bf0a003",
+        "x5t": "JlQNvzZOH4DcAlGA9F3wDffnicU",
+        "cer": "MIIBnzCCAUSgAwIBAgIQGNKOiQ93S2e\u002BggOl6dcF6DAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQwMloXDTIyMDQwODAyMzQwMlowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD88cazoczp7OHrIslNS2ZZBAPlC0mNlGXPUiWAmN5gmAdDwNp8phVAL0e0b15zbBrk0aRkY5X00zOVTWnCE21\u002BjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTf5D54WgbbPNjJCQKF4\u002BTIlcs2HDAdBgNVHQ4EFgQU3\u002BQ\u002BeFoG2zzYyQkChePkyJXLNhwwCgYIKoZIzj0EAwIDSQAwRgIhAIdhK3rQzRVoFM9CVV3PG/Z4GpbkAUArHl1jNjOGITJiAiEA00gmTnOJvYZJek7ZVYe0csLIV4xnIF11nX1ZnWd/Qms=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985270,
-          "exp": 1646521870,
-          "created": 1614985870,
-          "updated": 1614985870,
+          "nbf": 1617848642,
+          "exp": 1649385242,
+          "created": 1617849242,
+          "updated": 1617849242,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "1754C43DBC5247D3B024E90562352A83"
+        "serialnumber": "18D28E890F774B67BE8203A5E9D705E8"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1709464779/6f9e056dd08c4974bb6715322a3b5aa8?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1709464779/403366a253414fe8abc12b335bf0a003?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-cb42efb8728cc2479f118faec8d999ec-936c273741ea8848-00",
+        "traceparent": "00-820cca4fa12ac84aad2145f99f0781d5-2f4b40c91dda6645-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "26099b29bb42981b5f5429e4ceb036b3",
+        "x-ms-client-request-id": "7350ee5cd756ab6d45283530039014ff",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1345",
+        "Content-Length": "1343",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7350ee5cd756ab6d45283530039014ff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "8c1aab2e-0701-4d5f-929c-b40558c90383",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "75853e3e-579c-4a06-94e9-18e50ab84ec0",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIGiAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgtvqCO0uokHEXLfGU\n8/\u002Bxmsj1Oshh8W/yMfombiHrQaugCgYIKoZIzj0DAQehRANCAATWkNUaO8qX\u002BS2n\nT0JY9tzgAQDzNnNl9xE4h9GSfnqO3GlI2FgqVUEOKiZNTlZtDPTJMhHO0ZTiUgrI\nR9Qqjz/woA0wCwYDVR0PMQQDAgCA\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIBnjCCAUSgAwIBAgIQF1TEPbxSR9OwJOkFYjUqgzAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDExMFoXDTIyMDMwNTIzMTExMFow\nEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNaQ\n1Ro7ypf5LadPQlj23OABAPM2c2X3ETiH0ZJ\u002Beo7caUjYWCpVQQ4qJk1OVm0M9Mky\nEc7RlOJSCshH1CqPP/CjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0G\nA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQJ7ps6azbS\ni0iHkgNlwfg/1IXpSzAdBgNVHQ4EFgQUCe6bOms20otIh5IDZcH4P9SF6UswCgYI\nKoZIzj0EAwIDSAAwRQIhAO6xMpLTWKg/L3l9LgBRecEB8kmhKhmeV0aMeyhJFvLP\nAiA7HGR2CNEgDBWh/LZl7Io2L3tKlyMyoL7vkPdl5bk0nQ==\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIGiAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgSIXoCXooeGaKcsed\nqs7MAZ49Ps816JqhU1CcC54wdpGgCgYIKoZIzj0DAQehRANCAAQ/PHGs6HM6ezh6\nyLJTUtmWQQD5QtJjZRlz1IlgJjeYJgHQ8DafKYVQC9HtG9ec2wa5NGkZGOV9NMzl\nU1pwhNtfoA0wCwYDVR0PMQQDAgCA\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIBnzCCAUSgAwIBAgIQGNKOiQ93S2e\u002BggOl6dcF6DAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQwMloXDTIyMDQwODAyMzQwMlow\nEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD88\ncazoczp7OHrIslNS2ZZBAPlC0mNlGXPUiWAmN5gmAdDwNp8phVAL0e0b15zbBrk0\naRkY5X00zOVTWnCE21\u002BjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0G\nA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTf5D54Wgbb\nPNjJCQKF4\u002BTIlcs2HDAdBgNVHQ4EFgQU3\u002BQ\u002BeFoG2zzYyQkChePkyJXLNhwwCgYI\nKoZIzj0EAwIDSQAwRgIhAIdhK3rQzRVoFM9CVV3PG/Z4GpbkAUArHl1jNjOGITJi\nAiEA00gmTnOJvYZJek7ZVYe0csLIV4xnIF11nX1ZnWd/Qms=\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1709464779/6f9e056dd08c4974bb6715322a3b5aa8",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1709464779/403366a253414fe8abc12b335bf0a003",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985270,
-          "exp": 1646521870,
-          "created": 1614985870,
-          "updated": 1614985870,
+          "nbf": 1617848642,
+          "exp": 1649385242,
+          "created": 1617849242,
+          "updated": 1617849242,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1709464779/6f9e056dd08c4974bb6715322a3b5aa8"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1709464779/403366a253414fe8abc12b335bf0a003"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1709464779/6f9e056dd08c4974bb6715322a3b5aa8?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1709464779/403366a253414fe8abc12b335bf0a003?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-3556e9e9411028409740538303c59af9-247f5c66ff250046-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "b55fb248fcddab23ded445362a0c2659",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:34:04 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b55fb248fcddab23ded445362a0c2659",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d8df4395-a1a5-4ba3-a487-ab13b1f34a0c",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1709464779/403366a253414fe8abc12b335bf0a003?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-c77746e3c347c14f8dbd9a077bc45d5d-acd69fbf71ad4540-00",
+        "traceparent": "00-3556e9e9411028409740538303c59af9-247f5c66ff250046-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "f0c7edfb192d79b6835d9edfdf6ab9b6",
+        "x-ms-client-request-id": "b55fb248fcddab23ded445362a0c2659",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "440",
+        "Content-Length": "439",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b55fb248fcddab23ded445362a0c2659",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c0734cbc-fda5-42e7-9c10-29eaad0872bb",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "fad9203d-3de8-4ea7-a81c-a342adaac547",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1709464779/6f9e056dd08c4974bb6715322a3b5aa8",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1709464779/403366a253414fe8abc12b335bf0a003",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256",
-          "x": "1pDVGjvKl_ktp09CWPbc4AEA8zZzZfcROIfRkn56jtw",
-          "y": "aUjYWCpVQQ4qJk1OVm0M9MkyEc7RlOJSCshH1CqPP_A"
+          "x": "PzxxrOhzOns4esiyU1LZlkEA-ULSY2UZc9SJYCY3mCY",
+          "y": "AdDwNp8phVAL0e0b15zbBrk0aRkY5X00zOVTWnCE218"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985270,
-          "exp": 1646521870,
-          "created": 1614985870,
-          "updated": 1614985870,
+          "nbf": 1617848642,
+          "exp": 1649385242,
+          "created": 1617849242,
+          "updated": 1617849242,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -756,7 +541,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "605336940"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-256K).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-256K).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1611882269/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1611882269/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-9195a39335899248a5ded6af07bfc4ad-ec7164b48b2c704e-00",
+        "traceparent": "00-e8a091bc72f3604db4dbde77531effa2-09cdbbe092f58242-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "fbc622a0aeff688d908834a135b20fda",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:52 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "fbc622a0aeff688d908834a135b20fda",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1d5c0a6b-c573-4ec6-be17-bf8c190f7d8a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "fb81648c-1995-460c-8d73-a718014125a9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1611882269/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1611882269/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "222",
         "Content-Type": "application/json",
-        "traceparent": "00-9195a39335899248a5ded6af07bfc4ad-ec7164b48b2c704e-00",
+        "traceparent": "00-e8a091bc72f3604db4dbde77531effa2-09cdbbe092f58242-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "fbc622a0aeff688d908834a135b20fda",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:53 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:45 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending?api-version=7.2\u0026request_id=e8b9e05795ea4d35a0771eb20da31b3b",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1611882269/pending?api-version=7.2\u0026request_id=9c91c261557142cba112ab46894aae3e",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "fbc622a0aeff688d908834a135b20fda",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3e9eede0-f264-4986-aa19-acad3299ab0b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d4dae799-04aa-4ffb-9b24-0281e63f224e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1611882269/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASYM9Q5XGdVVkVYNQvKAOJY9q\u002BzOKbYU1UYC12LSluSFeJxvNLNpkmWOjLZWoJEv\u002Bth/y4jXQexMRiQu\u002BSmitXfoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgOexEj5c0mqHY5Qzckt4MUifRv/OH/IJpMGtPcU707Q4CIQDvXnJtsQfa2cmw1zdQjQQTbeB6k4Ct8RuVm2aD/GwLmA==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAS0EXP85B4043WHvUA91qrz1gTSOMoaZTpH\u002BuD1CsctV5zc5hNZzGtSDSl7M2i95ztDKymdspITtQ2lAdraZhfeoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgIRaqV6Ml2PBQRUjlHzXd9Yp61nQiEeQ7tzV3rwcciwUCIClTv2PzknaN9/NTPcug03oMv8T0SRYD\u002BR38h3/ejmUV",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e8b9e05795ea4d35a0771eb20da31b3b"
+        "request_id": "9c91c261557142cba112ab46894aae3e"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1611882269/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "8545628c1a244c07a7441af76cdf0851",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:53 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "8545628c1a244c07a7441af76cdf0851",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e20f7cd3-784d-4a17-82a9-961c231e4b99",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "2085fe61-b6eb-42b8-98ee-a3d7d9ab609f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1611882269/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASYM9Q5XGdVVkVYNQvKAOJY9q\u002BzOKbYU1UYC12LSluSFeJxvNLNpkmWOjLZWoJEv\u002Bth/y4jXQexMRiQu\u002BSmitXfoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgOexEj5c0mqHY5Qzckt4MUifRv/OH/IJpMGtPcU707Q4CIQDvXnJtsQfa2cmw1zdQjQQTbeB6k4Ct8RuVm2aD/GwLmA==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAS0EXP85B4043WHvUA91qrz1gTSOMoaZTpH\u002BuD1CsctV5zc5hNZzGtSDSl7M2i95ztDKymdspITtQ2lAdraZhfeoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgIRaqV6Ml2PBQRUjlHzXd9Yp61nQiEeQ7tzV3rwcciwUCIClTv2PzknaN9/NTPcug03oMv8T0SRYD\u002BR38h3/ejmUV",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e8b9e05795ea4d35a0771eb20da31b3b"
+        "request_id": "9c91c261557142cba112ab46894aae3e"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1611882269/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "304d1872d2d88da08e0d0d464f76e9b7",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:58 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:50 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "304d1872d2d88da08e0d0d464f76e9b7",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "03154d0f-b823-40a5-8006-36b0f2c262b9",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "748e9310-0ccc-43b5-8c2b-d79fa16bc494",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1611882269/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASYM9Q5XGdVVkVYNQvKAOJY9q\u002BzOKbYU1UYC12LSluSFeJxvNLNpkmWOjLZWoJEv\u002Bth/y4jXQexMRiQu\u002BSmitXfoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgOexEj5c0mqHY5Qzckt4MUifRv/OH/IJpMGtPcU707Q4CIQDvXnJtsQfa2cmw1zdQjQQTbeB6k4Ct8RuVm2aD/GwLmA==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAS0EXP85B4043WHvUA91qrz1gTSOMoaZTpH\u002BuD1CsctV5zc5hNZzGtSDSl7M2i95ztDKymdspITtQ2lAdraZhfeoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgIRaqV6Ml2PBQRUjlHzXd9Yp61nQiEeQ7tzV3rwcciwUCIClTv2PzknaN9/NTPcug03oMv8T0SRYD\u002BR38h3/ejmUV",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e8b9e05795ea4d35a0771eb20da31b3b"
+        "request_id": "9c91c261557142cba112ab46894aae3e"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1611882269/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "01b5f58500fb86f81a7a54bb9396fbb1",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:03 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "01b5f58500fb86f81a7a54bb9396fbb1",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "77b13c66-e9a6-4811-88e8-fac203617c5e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "68840f8f-3f40-4f41-a20b-be6bb3247d60",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1611882269/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASYM9Q5XGdVVkVYNQvKAOJY9q\u002BzOKbYU1UYC12LSluSFeJxvNLNpkmWOjLZWoJEv\u002Bth/y4jXQexMRiQu\u002BSmitXfoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgOexEj5c0mqHY5Qzckt4MUifRv/OH/IJpMGtPcU707Q4CIQDvXnJtsQfa2cmw1zdQjQQTbeB6k4Ct8RuVm2aD/GwLmA==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAS0EXP85B4043WHvUA91qrz1gTSOMoaZTpH\u002BuD1CsctV5zc5hNZzGtSDSl7M2i95ztDKymdspITtQ2lAdraZhfeoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgIRaqV6Ml2PBQRUjlHzXd9Yp61nQiEeQ7tzV3rwcciwUCIClTv2PzknaN9/NTPcug03oMv8T0SRYD\u002BR38h3/ejmUV",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e8b9e05795ea4d35a0771eb20da31b3b"
+        "request_id": "9c91c261557142cba112ab46894aae3e"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1611882269/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "1d2ee27fde64b902c2b8f7170cc1fd30",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "873",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:08 GMT",
+        "Date": "Thu, 08 Apr 2021 02:31:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1d2ee27fde64b902c2b8f7170cc1fd30",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a4dac78a-bd61-4ca8-83c6-aae45b36aff4",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "fee6320c-8be4-4af9-99d5-f952c319c081",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1611882269/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASYM9Q5XGdVVkVYNQvKAOJY9q\u002BzOKbYU1UYC12LSluSFeJxvNLNpkmWOjLZWoJEv\u002Bth/y4jXQexMRiQu\u002BSmitXfoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgOexEj5c0mqHY5Qzckt4MUifRv/OH/IJpMGtPcU707Q4CIQDvXnJtsQfa2cmw1zdQjQQTbeB6k4Ct8RuVm2aD/GwLmA==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAS0EXP85B4043WHvUA91qrz1gTSOMoaZTpH\u002BuD1CsctV5zc5hNZzGtSDSl7M2i95ztDKymdspITtQ2lAdraZhfeoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgIRaqV6Ml2PBQRUjlHzXd9Yp61nQiEeQ7tzV3rwcciwUCIClTv2PzknaN9/NTPcug03oMv8T0SRYD\u002BR38h3/ejmUV",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e8b9e05795ea4d35a0771eb20da31b3b"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1611882269",
+        "request_id": "9c91c261557142cba112ab46894aae3e"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1611882269?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "7772625a072972551fc7165e7de4f9f8",
         "x-ms-return-client-request-id": "true"
@@ -300,123 +305,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "1967",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:14 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "315d06bb-a102-4c0a-a178-948827733aa9",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASYM9Q5XGdVVkVYNQvKAOJY9q\u002BzOKbYU1UYC12LSluSFeJxvNLNpkmWOjLZWoJEv\u002Bth/y4jXQexMRiQu\u002BSmitXfoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgOexEj5c0mqHY5Qzckt4MUifRv/OH/IJpMGtPcU707Q4CIQDvXnJtsQfa2cmw1zdQjQQTbeB6k4Ct8RuVm2aD/GwLmA==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e8b9e05795ea4d35a0771eb20da31b3b"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "6cc65c11cb48a653f3fc3f4308e17959",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "879",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:19 GMT",
+        "Date": "Thu, 08 Apr 2021 02:31:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7772625a072972551fc7165e7de4f9f8",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c298496e-887a-4174-a5b6-709019fe5837",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "965dbd0a-c824-48c7-b45a-37ed3ee12d22",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASYM9Q5XGdVVkVYNQvKAOJY9q\u002BzOKbYU1UYC12LSluSFeJxvNLNpkmWOjLZWoJEv\u002Bth/y4jXQexMRiQu\u002BSmitXfoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgOexEj5c0mqHY5Qzckt4MUifRv/OH/IJpMGtPcU707Q4CIQDvXnJtsQfa2cmw1zdQjQQTbeB6k4Ct8RuVm2aD/GwLmA==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1611882269",
-        "request_id": "e8b9e05795ea4d35a0771eb20da31b3b"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1611882269?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "3060247c842378878dbcfe9dc8a33bdd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1972",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:19 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4b12af07-ffb3-4d09-988e-42c673dd8cf9",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1611882269/4a7b905f193747f195370599c4f4e660",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1611882269/4a7b905f193747f195370599c4f4e660",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1611882269/4a7b905f193747f195370599c4f4e660",
-        "x5t": "iB4KX8WA55gl021T7eOQmC8Iv5o",
-        "cer": "MIICOzCCAeGgAwIBAgIQY5Zy04BdQfelyXpw2X5p3TAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTMxNloXDTIyMDMwNTIzMDMxNlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASYM9Q5XGdVVkVYNQvKAOJY9q\u002BzOKbYU1UYC12LSluSFeJxvNLNpkmWOjLZWoJEv\u002Bth/y4jXQexMRiQu\u002BSmitXfo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAU314NP1COUAxCkANmW5uXQltajF0wHQYDVR0OBBYEFN9eDT9QjlAMQpADZlubl0JbWoxdMAoGCCqGSM49BAMCA0gAMEUCIQClydHAS/3bb8ev7HvYmf2koUXk68ebSkBAS4XjJO6twwIgOk2oln9VwMhY9RVIx\u002Bfo9DQzs\u002BRP//UzyGj82\u002BBV4L0=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1611882269/c4c0907e37d84a90b177af9aef2a0706",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1611882269/c4c0907e37d84a90b177af9aef2a0706",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1611882269/c4c0907e37d84a90b177af9aef2a0706",
+        "x5t": "cjWKlkbx66A_zCwntFtyEt2C4Xs",
+        "cer": "MIICOzCCAeGgAwIBAgIQZS0pXX6uTae7YgpQB3t4FTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjA1OVoXDTIyMDQwODAyMzA1OVowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAS0EXP85B4043WHvUA91qrz1gTSOMoaZTpH\u002BuD1CsctV5zc5hNZzGtSDSl7M2i95ztDKymdspITtQ2lAdraZhfeo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUIaL2IKYFJjo40J7WiiwoZzkoAvUwHQYDVR0OBBYEFCGi9iCmBSY6ONCe1oosKGc5KAL1MAoGCCqGSM49BAMCA0gAMEUCIQDk93MRucSh\u002B793\u002BfenGOmZBBR5h9\u002BbyCIvi2M9inFX2gIgNQ\u002B9mE8I7Y8dD3NjMNxic2rNPYA6SJIuEtHAnLfJ2o0=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984796,
-          "exp": 1646521396,
-          "created": 1614985396,
-          "updated": 1614985396,
+          "nbf": 1617848459,
+          "exp": 1649385059,
+          "created": 1617849059,
+          "updated": 1617849059,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1611882269/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1611882269/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -456,26 +375,169 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985373,
-            "updated": 1614985373
+            "created": 1617849045,
+            "updated": 1617849045
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1611882269/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1611882269/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1611882269/4a7b905f193747f195370599c4f4e660?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1611882269/c4c0907e37d84a90b177af9aef2a0706?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-810670d83d26a74c94931c8ebc43b09c-db7d6cd9056f714f-00",
+        "traceparent": "00-3e0a913b6eb32c4ab20268bb1b05cce0-c92553f57f720f49-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "6cc65c11cb48a653f3fc3f4308e17959",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1371",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:31:05 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6cc65c11cb48a653f3fc3f4308e17959",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "7b71cde7-afbe-4435-98b9-995d4b9320d3",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1611882269/c4c0907e37d84a90b177af9aef2a0706",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1611882269/c4c0907e37d84a90b177af9aef2a0706",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1611882269/c4c0907e37d84a90b177af9aef2a0706",
+        "x5t": "cjWKlkbx66A_zCwntFtyEt2C4Xs",
+        "cer": "MIICOzCCAeGgAwIBAgIQZS0pXX6uTae7YgpQB3t4FTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjA1OVoXDTIyMDQwODAyMzA1OVowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAS0EXP85B4043WHvUA91qrz1gTSOMoaZTpH\u002BuD1CsctV5zc5hNZzGtSDSl7M2i95ztDKymdspITtQ2lAdraZhfeo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUIaL2IKYFJjo40J7WiiwoZzkoAvUwHQYDVR0OBBYEFCGi9iCmBSY6ONCe1oosKGc5KAL1MAoGCCqGSM49BAMCA0gAMEUCIQDk93MRucSh\u002B793\u002BfenGOmZBBR5h9\u002BbyCIvi2M9inFX2gIgNQ\u002B9mE8I7Y8dD3NjMNxic2rNPYA6SJIuEtHAnLfJ2o0=",
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848459,
+          "exp": 1649385059,
+          "created": 1617849059,
+          "updated": 1617849059,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "subject": "CN=default",
+        "issuer": "CN=default",
+        "serialnumber": "652D295D7EAE4DA7BB620A50077B7815"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1611882269/c4c0907e37d84a90b177af9aef2a0706?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-3e0a913b6eb32c4ab20268bb1b05cce0-b398b7d162f25e44-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "3060247c842378878dbcfe9dc8a33bdd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1759",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:31:05 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3060247c842378878dbcfe9dc8a33bdd",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "80292f2d-f0e3-4f4a-8fcb-fbc947b97a77",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "value": "-----BEGIN PRIVATE KEY-----\nMIIBMgIBADCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA////////////\n/////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6H\nCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ\n1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQRtMGsCAQEE\nIJxxilgfEKOeRwCAcZpRK\u002BB4S378rm31ZBHaSgGd5WkRoUQDQgAEtBFz/OQeNON1\nh71APdaq89YE0jjKGmU6R/rg9QrHLVec3OYTWcxrUg0pezNovec7QyspnbKSE7UN\npQHa2mYX3qANMAsGA1UdDzEEAwIAgA==\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICOzCCAeGgAwIBAgIQZS0pXX6uTae7YgpQB3t4FTAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjA1OVoXDTIyMDQwODAyMzA1OVow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjO\nPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRB\nBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEI\nqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M\n0DZBQQIBAQNCAAS0EXP85B4043WHvUA91qrz1gTSOMoaZTpH\u002BuD1CsctV5zc5hNZ\nzGtSDSl7M2i95ztDKymdspITtQ2lAdraZhfeo3wwejAOBgNVHQ8BAf8EBAMCB4Aw\nCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0j\nBBgwFoAUIaL2IKYFJjo40J7WiiwoZzkoAvUwHQYDVR0OBBYEFCGi9iCmBSY6ONCe\n1oosKGc5KAL1MAoGCCqGSM49BAMCA0gAMEUCIQDk93MRucSh\u002B793\u002BfenGOmZBBR5\nh9\u002BbyCIvi2M9inFX2gIgNQ\u002B9mE8I7Y8dD3NjMNxic2rNPYA6SJIuEtHAnLfJ2o0=\n-----END CERTIFICATE-----\n",
+        "contentType": "application/x-pem-file",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1611882269/c4c0907e37d84a90b177af9aef2a0706",
+        "managed": true,
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848459,
+          "exp": 1649385059,
+          "created": 1617849059,
+          "updated": 1617849059,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1611882269/c4c0907e37d84a90b177af9aef2a0706"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1611882269/c4c0907e37d84a90b177af9aef2a0706?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-787ad40f6af0954a96681ee37ca3df35-f0f8d0c329e8f144-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "b005ffbe90fa8fe80fcc832dc811693d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:31:05 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b005ffbe90fa8fe80fcc832dc811693d",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "aa514c34-ed0e-4722-9709-2b00c99a1fc2",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1611882269/c4c0907e37d84a90b177af9aef2a0706?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-787ad40f6af0954a96681ee37ca3df35-f0f8d0c329e8f144-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "b005ffbe90fa8fe80fcc832dc811693d",
         "x-ms-return-client-request-id": "true"
@@ -484,138 +546,38 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1374",
+        "Content-Length": "440",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:23 GMT",
+        "Date": "Thu, 08 Apr 2021 02:31:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b005ffbe90fa8fe80fcc832dc811693d",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "d52c3ca8-fd8e-4aa1-91e9-e27ef18c84bf",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1611882269/4a7b905f193747f195370599c4f4e660",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1611882269/4a7b905f193747f195370599c4f4e660",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1611882269/4a7b905f193747f195370599c4f4e660",
-        "x5t": "iB4KX8WA55gl021T7eOQmC8Iv5o",
-        "cer": "MIICOzCCAeGgAwIBAgIQY5Zy04BdQfelyXpw2X5p3TAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTMxNloXDTIyMDMwNTIzMDMxNlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASYM9Q5XGdVVkVYNQvKAOJY9q\u002BzOKbYU1UYC12LSluSFeJxvNLNpkmWOjLZWoJEv\u002Bth/y4jXQexMRiQu\u002BSmitXfo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAU314NP1COUAxCkANmW5uXQltajF0wHQYDVR0OBBYEFN9eDT9QjlAMQpADZlubl0JbWoxdMAoGCCqGSM49BAMCA0gAMEUCIQClydHAS/3bb8ev7HvYmf2koUXk68ebSkBAS4XjJO6twwIgOk2oln9VwMhY9RVIx\u002Bfo9DQzs\u002BRP//UzyGj82\u002BBV4L0=",
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614984796,
-          "exp": 1646521396,
-          "created": 1614985396,
-          "updated": 1614985396,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "subject": "CN=default",
-        "issuer": "CN=default",
-        "serialnumber": "639672D3805D41F7A5C97A70D97E69DD"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1611882269/4a7b905f193747f195370599c4f4e660?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-810670d83d26a74c94931c8ebc43b09c-40cb69ad0469d442-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "59e1bc4ec9848dd4d44ddf8ccdb5dd4f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1761",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:23 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "34b746bc-e173-405c-9678-c9e362520d41",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIIBMgIBADCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA////////////\n/////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6H\nCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ\n1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQRtMGsCAQEE\nIMm7Xo5ItySw/VUJcFXYWH1376zD94l6EhMHMQm26ew/oUQDQgAEmDPUOVxnVVZF\nWDULygDiWPavszim2FNVGAtdi0pbkhXicbzSzaZJljoy2VqCRL/rYf8uI10HsTEY\nkLvkporV36ANMAsGA1UdDzEEAwIAgA==\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICOzCCAeGgAwIBAgIQY5Zy04BdQfelyXpw2X5p3TAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTMxNloXDTIyMDMwNTIzMDMxNlow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjO\nPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRB\nBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEI\nqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M\n0DZBQQIBAQNCAASYM9Q5XGdVVkVYNQvKAOJY9q\u002BzOKbYU1UYC12LSluSFeJxvNLN\npkmWOjLZWoJEv\u002Bth/y4jXQexMRiQu\u002BSmitXfo3wwejAOBgNVHQ8BAf8EBAMCB4Aw\nCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0j\nBBgwFoAU314NP1COUAxCkANmW5uXQltajF0wHQYDVR0OBBYEFN9eDT9QjlAMQpAD\nZlubl0JbWoxdMAoGCCqGSM49BAMCA0gAMEUCIQClydHAS/3bb8ev7HvYmf2koUXk\n68ebSkBAS4XjJO6twwIgOk2oln9VwMhY9RVIx\u002Bfo9DQzs\u002BRP//UzyGj82\u002BBV4L0=\n-----END CERTIFICATE-----\n",
-        "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1611882269/4a7b905f193747f195370599c4f4e660",
-        "managed": true,
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614984796,
-          "exp": 1646521396,
-          "created": 1614985396,
-          "updated": 1614985396,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1611882269/4a7b905f193747f195370599c4f4e660"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1611882269/4a7b905f193747f195370599c4f4e660?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-9b393d7874f13748bb55aa1789d1a2dc-c84d16e9e82aaf4b-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "098561c0c9dcec5e3cd12056005ab07b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "441",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:24 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4c5ccced-ce8d-4f1b-ab50-16960362800f",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3a1bed0b-9862-4882-b042-fc71a4577708",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1611882269/4a7b905f193747f195370599c4f4e660",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1611882269/c4c0907e37d84a90b177af9aef2a0706",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256K",
-          "x": "mDPUOVxnVVZFWDULygDiWPavszim2FNVGAtdi0pbkhU",
-          "y": "4nG80s2mSZY6MtlagkS_62H_LiNdB7ExGJC75KaK1d8"
+          "x": "tBFz_OQeNON1h71APdaq89YE0jjKGmU6R_rg9QrHLVc",
+          "y": "nNzmE1nMa1INKXszaL3nO0MrKZ2ykhO1DaUB2tpmF94"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984796,
-          "exp": 1646521396,
-          "created": 1614985396,
-          "updated": 1614985396,
+          "nbf": 1617848459,
+          "exp": 1649385059,
+          "created": 1617849059,
+          "updated": 1617849059,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -624,7 +586,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "456727359"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-256K)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-256K)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/763049486/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/763049486/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-6dc6694d5b89c64085371fc8791748aa-ffa76ae85d1b624f-00",
+        "traceparent": "00-7ddc8dfe43b0424ba78ea5e6d03b17ea-02cee7b339976a49-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "4dedcfaf244397dfb9d96fab06dd114b",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:07 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:36 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4dedcfaf244397dfb9d96fab06dd114b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "46c7e2e4-6096-4000-9e0e-17d91033ac84",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "e9039ca8-e935-481a-bf28-82799f5529ad",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/763049486/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/763049486/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "222",
         "Content-Type": "application/json",
-        "traceparent": "00-6dc6694d5b89c64085371fc8791748aa-ffa76ae85d1b624f-00",
+        "traceparent": "00-7ddc8dfe43b0424ba78ea5e6d03b17ea-02cee7b339976a49-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "4dedcfaf244397dfb9d96fab06dd114b",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "968",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:07 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:37 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending?api-version=7.2\u0026request_id=8f939715a2ff4a0c9bc5a325cd78853d",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/763049486/pending?api-version=7.2\u0026request_id=3253445a51ab4f28bb47e77226d61ad3",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4dedcfaf244397dfb9d96fab06dd114b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "8216ee76-fb8e-405e-9e12-97724b392325",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "eb695182-88ff-4bf3-952a-8eed174bff04",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/763049486/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtzCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQtNPWVHmidvxXNtRndSgYpDucdfm\u002BJ2VENSL0FQ45sF3FVHnxGaNoiIil86paNRccjZKQdS9ux7zZxuRKqIlqboEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSQAwRgIhALh84Vv1PZjUF1ckfyJjm/qsNNjTCVqj1DlOsov8y3ccAiEAhsxSjMNzetN3nTsYTKv/8uUe4Dl3vBcyvuaIeeKLqlg=",
+        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATsF54PzTyWXKYfiAdHVDqIzZ/qNF21bh/q6/TDxcjqp2Icgh8e0cQ6yi36ic\u002BH/RIK9tHlgWjdNKBsQOgcAzhnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgJfVI1U6eYxMfWO1gDnZOUdRuybMbpZo5YuLOotPzXDkCIQC1io7NIi6JlA2pR01J9\u002BFSfEqBJqPCSo/z4\u002BtFd0ky7w==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "8f939715a2ff4a0c9bc5a325cd78853d"
+        "request_id": "3253445a51ab4f28bb47e77226d61ad3"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/763049486/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "d195f2c482e03b024765bc6ae6c54a1e",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "968",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:07 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "d195f2c482e03b024765bc6ae6c54a1e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f219c589-355a-457f-8eb9-af41df2f58c1",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6b5c9f2d-a645-4c6e-9dbf-3dec1b2c1799",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/763049486/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtzCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQtNPWVHmidvxXNtRndSgYpDucdfm\u002BJ2VENSL0FQ45sF3FVHnxGaNoiIil86paNRccjZKQdS9ux7zZxuRKqIlqboEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSQAwRgIhALh84Vv1PZjUF1ckfyJjm/qsNNjTCVqj1DlOsov8y3ccAiEAhsxSjMNzetN3nTsYTKv/8uUe4Dl3vBcyvuaIeeKLqlg=",
+        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATsF54PzTyWXKYfiAdHVDqIzZ/qNF21bh/q6/TDxcjqp2Icgh8e0cQ6yi36ic\u002BH/RIK9tHlgWjdNKBsQOgcAzhnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgJfVI1U6eYxMfWO1gDnZOUdRuybMbpZo5YuLOotPzXDkCIQC1io7NIi6JlA2pR01J9\u002BFSfEqBJqPCSo/z4\u002BtFd0ky7w==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "8f939715a2ff4a0c9bc5a325cd78853d"
+        "request_id": "3253445a51ab4f28bb47e77226d61ad3"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/763049486/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "5eb54ba6b77e7f25abba34e8567ce5c3",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "968",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:13 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5eb54ba6b77e7f25abba34e8567ce5c3",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f5ee130f-3441-4064-86c6-c1c94f86a42c",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "77d494f8-0600-480e-8195-09bacfe8d1ef",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/763049486/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtzCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQtNPWVHmidvxXNtRndSgYpDucdfm\u002BJ2VENSL0FQ45sF3FVHnxGaNoiIil86paNRccjZKQdS9ux7zZxuRKqIlqboEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSQAwRgIhALh84Vv1PZjUF1ckfyJjm/qsNNjTCVqj1DlOsov8y3ccAiEAhsxSjMNzetN3nTsYTKv/8uUe4Dl3vBcyvuaIeeKLqlg=",
+        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATsF54PzTyWXKYfiAdHVDqIzZ/qNF21bh/q6/TDxcjqp2Icgh8e0cQ6yi36ic\u002BH/RIK9tHlgWjdNKBsQOgcAzhnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgJfVI1U6eYxMfWO1gDnZOUdRuybMbpZo5YuLOotPzXDkCIQC1io7NIi6JlA2pR01J9\u002BFSfEqBJqPCSo/z4\u002BtFd0ky7w==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "8f939715a2ff4a0c9bc5a325cd78853d"
+        "request_id": "3253445a51ab4f28bb47e77226d61ad3"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/763049486/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "2d39d6504cf82c2dccb206de6875b1f4",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "968",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:18 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:48 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2d39d6504cf82c2dccb206de6875b1f4",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "aedde4e0-2933-4c7e-8897-01f554d38a13",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "535af168-6e65-4a15-9e35-2999f1df79a9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/763049486/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtzCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQtNPWVHmidvxXNtRndSgYpDucdfm\u002BJ2VENSL0FQ45sF3FVHnxGaNoiIil86paNRccjZKQdS9ux7zZxuRKqIlqboEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSQAwRgIhALh84Vv1PZjUF1ckfyJjm/qsNNjTCVqj1DlOsov8y3ccAiEAhsxSjMNzetN3nTsYTKv/8uUe4Dl3vBcyvuaIeeKLqlg=",
+        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATsF54PzTyWXKYfiAdHVDqIzZ/qNF21bh/q6/TDxcjqp2Icgh8e0cQ6yi36ic\u002BH/RIK9tHlgWjdNKBsQOgcAzhnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgJfVI1U6eYxMfWO1gDnZOUdRuybMbpZo5YuLOotPzXDkCIQC1io7NIi6JlA2pR01J9\u002BFSfEqBJqPCSo/z4\u002BtFd0ky7w==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "8f939715a2ff4a0c9bc5a325cd78853d"
+        "request_id": "3253445a51ab4f28bb47e77226d61ad3"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/763049486/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "bb05508fb2270ccccd1526264d19e4cb",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "875",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:23 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:52 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bb05508fb2270ccccd1526264d19e4cb",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "55ca3f05-a362-4df2-bbb5-a4903ff2b3a3",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ed00534c-3b6a-409a-95df-c036b87645ec",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/763049486/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtzCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQtNPWVHmidvxXNtRndSgYpDucdfm\u002BJ2VENSL0FQ45sF3FVHnxGaNoiIil86paNRccjZKQdS9ux7zZxuRKqIlqboEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSQAwRgIhALh84Vv1PZjUF1ckfyJjm/qsNNjTCVqj1DlOsov8y3ccAiEAhsxSjMNzetN3nTsYTKv/8uUe4Dl3vBcyvuaIeeKLqlg=",
+        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATsF54PzTyWXKYfiAdHVDqIzZ/qNF21bh/q6/TDxcjqp2Icgh8e0cQ6yi36ic\u002BH/RIK9tHlgWjdNKBsQOgcAzhnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgJfVI1U6eYxMfWO1gDnZOUdRuybMbpZo5YuLOotPzXDkCIQC1io7NIi6JlA2pR01J9\u002BFSfEqBJqPCSo/z4\u002BtFd0ky7w==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "8f939715a2ff4a0c9bc5a325cd78853d"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/763049486",
+        "request_id": "3253445a51ab4f28bb47e77226d61ad3"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/763049486?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "0f1af8801c8b59261d8891ccb0471736",
         "x-ms-return-client-request-id": "true"
@@ -300,167 +305,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "1962",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:28 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1e75e8cf-e47b-4d74-9828-99cc9658b5fd",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtzCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQtNPWVHmidvxXNtRndSgYpDucdfm\u002BJ2VENSL0FQ45sF3FVHnxGaNoiIil86paNRccjZKQdS9ux7zZxuRKqIlqboEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSQAwRgIhALh84Vv1PZjUF1ckfyJjm/qsNNjTCVqj1DlOsov8y3ccAiEAhsxSjMNzetN3nTsYTKv/8uUe4Dl3vBcyvuaIeeKLqlg=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "8f939715a2ff4a0c9bc5a325cd78853d"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0558400829769d9c092c60e22607deb2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "969",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:33 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6f47a607-6ab4-4402-a83e-2e483bf9f8dc",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtzCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQtNPWVHmidvxXNtRndSgYpDucdfm\u002BJ2VENSL0FQ45sF3FVHnxGaNoiIil86paNRccjZKQdS9ux7zZxuRKqIlqboEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSQAwRgIhALh84Vv1PZjUF1ckfyJjm/qsNNjTCVqj1DlOsov8y3ccAiEAhsxSjMNzetN3nTsYTKv/8uUe4Dl3vBcyvuaIeeKLqlg=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "8f939715a2ff4a0c9bc5a325cd78853d"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "6f5d3bcda25a73682aac9e9e21005c85",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "877",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0f1af8801c8b59261d8891ccb0471736",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "b5dcc8a5-01e0-4238-8edc-86998691bd20",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "835fe9cd-03ae-475a-b5ed-07c01d0fc3a1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtzCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQtNPWVHmidvxXNtRndSgYpDucdfm\u002BJ2VENSL0FQ45sF3FVHnxGaNoiIil86paNRccjZKQdS9ux7zZxuRKqIlqboEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSQAwRgIhALh84Vv1PZjUF1ckfyJjm/qsNNjTCVqj1DlOsov8y3ccAiEAhsxSjMNzetN3nTsYTKv/8uUe4Dl3vBcyvuaIeeKLqlg=",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/763049486",
-        "request_id": "8f939715a2ff4a0c9bc5a325cd78853d"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/763049486?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0d1df0fedfc156545b7d065fbb443315",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1967",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:38 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "195b2ce3-64fb-4d63-9030-07128be6294e",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/cef616aaa6a94affb73146aee9868691",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/763049486/cef616aaa6a94affb73146aee9868691",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/763049486/cef616aaa6a94affb73146aee9868691",
-        "x5t": "vaPNaPe1GLKs5DJ3KVoRXEtjHVA",
-        "cer": "MIICOzCCAeGgAwIBAgIQYQ6gOu3wQFWwBVcl0UhDlzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDIzNloXDTIyMDMwNTIzMTIzNlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQtNPWVHmidvxXNtRndSgYpDucdfm\u002BJ2VENSL0FQ45sF3FVHnxGaNoiIil86paNRccjZKQdS9ux7zZxuRKqIlqbo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUw//qbnih6FlmkfYvcpP\u002BClXhqEswHQYDVR0OBBYEFMP/6m54oehZZpH2L3KT/gpV4ahLMAoGCCqGSM49BAMCA0gAMEUCIQDe/HTjChCVFwSnGoaODCcGylij9QHvGBDNMcTh7dRwBAIgXJr3PvKI/6a1PnGmvL7uQd\u002BAzaSZZaME6Ulldn5e2/w=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/763049486/bcef811bcd984e11bd1c02318484d082",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/763049486/bcef811bcd984e11bd1c02318484d082",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/763049486/bcef811bcd984e11bd1c02318484d082",
+        "x5t": "P50II93zLNDe-z4oOm51vpGYGZM",
+        "cer": "MIICOzCCAeGgAwIBAgIQe7/aI97IQB6Dld4d6yga\u002BDAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQ1MloXDTIyMDQwODAyMzQ1MlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATsF54PzTyWXKYfiAdHVDqIzZ/qNF21bh/q6/TDxcjqp2Icgh8e0cQ6yi36ic\u002BH/RIK9tHlgWjdNKBsQOgcAzhno3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUjOnZSJ1ZC/rdBffpQV2OoCsz8powHQYDVR0OBBYEFIzp2UidWQv63QX36UFdjqArM/KaMAoGCCqGSM49BAMCA0gAMEUCIQDQYO/0kWVUPv1R\u002BiASnQfLdWwBjXGNKp1UxCtEJ1MXoQIgWinNt2C2aDduyLdzuSaS6qG\u002B7oUKusnG\u002B9V/hFR6taE=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985356,
-          "exp": 1646521956,
-          "created": 1614985956,
-          "updated": 1614985956,
+          "nbf": 1617848692,
+          "exp": 1649385292,
+          "created": 1617849292,
+          "updated": 1617849292,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/763049486/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -500,166 +375,209 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985928,
-            "updated": 1614985928
+            "created": 1617849277,
+            "updated": 1617849277
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/763049486/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/763049486/cef616aaa6a94affb73146aee9868691?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/763049486/bcef811bcd984e11bd1c02318484d082?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-c5540c0cd777d44c926789d7c95757a1-a17f60d19298fd4d-00",
+        "traceparent": "00-9f9aaf6c0920d54b90b8fa5360e5bfcb-210db28897695c4c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "75ffdeaaa7ea66dbd8e5dbca8bfd7c09",
+        "x-ms-client-request-id": "0558400829769d9c092c60e22607deb2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1371",
+        "Content-Length": "1368",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0558400829769d9c092c60e22607deb2",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "83710e80-fc18-4f92-bead-703a3c0ff77c",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3ac324dd-3622-4093-8f80-332775f7e23b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/763049486/cef616aaa6a94affb73146aee9868691",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/763049486/cef616aaa6a94affb73146aee9868691",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/763049486/cef616aaa6a94affb73146aee9868691",
-        "x5t": "vaPNaPe1GLKs5DJ3KVoRXEtjHVA",
-        "cer": "MIICOzCCAeGgAwIBAgIQYQ6gOu3wQFWwBVcl0UhDlzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDIzNloXDTIyMDMwNTIzMTIzNlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQtNPWVHmidvxXNtRndSgYpDucdfm\u002BJ2VENSL0FQ45sF3FVHnxGaNoiIil86paNRccjZKQdS9ux7zZxuRKqIlqbo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUw//qbnih6FlmkfYvcpP\u002BClXhqEswHQYDVR0OBBYEFMP/6m54oehZZpH2L3KT/gpV4ahLMAoGCCqGSM49BAMCA0gAMEUCIQDe/HTjChCVFwSnGoaODCcGylij9QHvGBDNMcTh7dRwBAIgXJr3PvKI/6a1PnGmvL7uQd\u002BAzaSZZaME6Ulldn5e2/w=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/763049486/bcef811bcd984e11bd1c02318484d082",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/763049486/bcef811bcd984e11bd1c02318484d082",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/763049486/bcef811bcd984e11bd1c02318484d082",
+        "x5t": "P50II93zLNDe-z4oOm51vpGYGZM",
+        "cer": "MIICOzCCAeGgAwIBAgIQe7/aI97IQB6Dld4d6yga\u002BDAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQ1MloXDTIyMDQwODAyMzQ1MlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATsF54PzTyWXKYfiAdHVDqIzZ/qNF21bh/q6/TDxcjqp2Icgh8e0cQ6yi36ic\u002BH/RIK9tHlgWjdNKBsQOgcAzhno3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUjOnZSJ1ZC/rdBffpQV2OoCsz8powHQYDVR0OBBYEFIzp2UidWQv63QX36UFdjqArM/KaMAoGCCqGSM49BAMCA0gAMEUCIQDQYO/0kWVUPv1R\u002BiASnQfLdWwBjXGNKp1UxCtEJ1MXoQIgWinNt2C2aDduyLdzuSaS6qG\u002B7oUKusnG\u002B9V/hFR6taE=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985356,
-          "exp": 1646521956,
-          "created": 1614985956,
-          "updated": 1614985956,
+          "nbf": 1617848692,
+          "exp": 1649385292,
+          "created": 1617849292,
+          "updated": 1617849292,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "610EA03AEDF04055B0055725D1484397"
+        "serialnumber": "7BBFDA23DEC8401E8395DE1DEB281AF8"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/763049486/cef616aaa6a94affb73146aee9868691?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/763049486/bcef811bcd984e11bd1c02318484d082?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-c5540c0cd777d44c926789d7c95757a1-8f28c277e2e64648-00",
+        "traceparent": "00-9f9aaf6c0920d54b90b8fa5360e5bfcb-b5554896ed717f44-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "36e4dbd0d1eaedf1e60614dd9b09b7e6",
+        "x-ms-client-request-id": "6f5d3bcda25a73682aac9e9e21005c85",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1759",
+        "Content-Length": "1757",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6f5d3bcda25a73682aac9e9e21005c85",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "28b8a3ec-2fa2-464e-a0bb-b87423c986e1",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "c9cc5b46-bdd5-4ff5-8c07-130e277353c9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIIBMgIBADCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA////////////\n/////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6H\nCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ\n1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQRtMGsCAQEE\nIPGPaCjYB73d0T1kE3y9XIEIB6AAl8hBgEpsetCAkYk2oUQDQgAELTT1lR5onb8V\nzbUZ3UoGKQ7nHX5vidlRDUi9BUOObBdxVR58RmjaIiIpfOqWjUXHI2SkHUvbse82\ncbkSqiJam6ANMAsGA1UdDzEEAwIAgA==\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICOzCCAeGgAwIBAgIQYQ6gOu3wQFWwBVcl0UhDlzAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDIzNloXDTIyMDMwNTIzMTIzNlow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjO\nPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRB\nBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEI\nqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M\n0DZBQQIBAQNCAAQtNPWVHmidvxXNtRndSgYpDucdfm\u002BJ2VENSL0FQ45sF3FVHnxG\naNoiIil86paNRccjZKQdS9ux7zZxuRKqIlqbo3wwejAOBgNVHQ8BAf8EBAMCB4Aw\nCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0j\nBBgwFoAUw//qbnih6FlmkfYvcpP\u002BClXhqEswHQYDVR0OBBYEFMP/6m54oehZZpH2\nL3KT/gpV4ahLMAoGCCqGSM49BAMCA0gAMEUCIQDe/HTjChCVFwSnGoaODCcGylij\n9QHvGBDNMcTh7dRwBAIgXJr3PvKI/6a1PnGmvL7uQd\u002BAzaSZZaME6Ulldn5e2/w=\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIIBMgIBADCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA////////////\n/////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6H\nCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ\n1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQRtMGsCAQEE\nIF5OAsDEmiDh76vayNHJn2nwejcrrysTIXNN9Yg\u002BH1P1oUQDQgAE7BeeD808llym\nH4gHR1Q6iM2f6jRdtW4f6uv0w8XI6qdiHIIfHtHEOsot\u002BonPh/0SCvbR5YFo3TSg\nbEDoHAM4Z6ANMAsGA1UdDzEEAwIAgA==\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICOzCCAeGgAwIBAgIQe7/aI97IQB6Dld4d6yga\u002BDAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQ1MloXDTIyMDQwODAyMzQ1Mlow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjO\nPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRB\nBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEI\nqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M\n0DZBQQIBAQNCAATsF54PzTyWXKYfiAdHVDqIzZ/qNF21bh/q6/TDxcjqp2Icgh8e\n0cQ6yi36ic\u002BH/RIK9tHlgWjdNKBsQOgcAzhno3wwejAOBgNVHQ8BAf8EBAMCB4Aw\nCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0j\nBBgwFoAUjOnZSJ1ZC/rdBffpQV2OoCsz8powHQYDVR0OBBYEFIzp2UidWQv63QX3\n6UFdjqArM/KaMAoGCCqGSM49BAMCA0gAMEUCIQDQYO/0kWVUPv1R\u002BiASnQfLdWwB\njXGNKp1UxCtEJ1MXoQIgWinNt2C2aDduyLdzuSaS6qG\u002B7oUKusnG\u002B9V/hFR6taE=\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/763049486/cef616aaa6a94affb73146aee9868691",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/763049486/bcef811bcd984e11bd1c02318484d082",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985356,
-          "exp": 1646521956,
-          "created": 1614985956,
-          "updated": 1614985956,
+          "nbf": 1617848692,
+          "exp": 1649385292,
+          "created": 1617849292,
+          "updated": 1617849292,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/763049486/cef616aaa6a94affb73146aee9868691"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/763049486/bcef811bcd984e11bd1c02318484d082"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/763049486/cef616aaa6a94affb73146aee9868691?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/763049486/bcef811bcd984e11bd1c02318484d082?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-2777b2ecbf77f3439ae59d1d7209a75a-61c3cd357aa1b24a-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "0d1df0fedfc156545b7d065fbb443315",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:34:53 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0d1df0fedfc156545b7d065fbb443315",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d0a545ca-37aa-4c4c-a23e-585ce7b53061",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/763049486/bcef811bcd984e11bd1c02318484d082?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-11e20087ed0fb84f94eb307525c2be0a-d6dc67619cb0094e-00",
+        "traceparent": "00-2777b2ecbf77f3439ae59d1d7209a75a-61c3cd357aa1b24a-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "42f48878e600569a15b635db038acb5e",
+        "x-ms-client-request-id": "0d1df0fedfc156545b7d065fbb443315",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "440",
+        "Content-Length": "439",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0d1df0fedfc156545b7d065fbb443315",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "561a1e90-0e17-4e24-9968-6954155e7552",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f23a4006-b7d8-4d2d-b3af-8f2d6cb721f8",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/763049486/cef616aaa6a94affb73146aee9868691",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/763049486/bcef811bcd984e11bd1c02318484d082",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256K",
-          "x": "LTT1lR5onb8VzbUZ3UoGKQ7nHX5vidlRDUi9BUOObBc",
-          "y": "cVUefEZo2iIiKXzqlo1FxyNkpB1L27HvNnG5EqoiWps"
+          "x": "7BeeD808llymH4gHR1Q6iM2f6jRdtW4f6uv0w8XI6qc",
+          "y": "YhyCHx7RxDrKLfqJz4f9Egr20eWBaN00oGxA6BwDOGc"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985356,
-          "exp": 1646521956,
-          "created": 1614985956,
-          "updated": 1614985956,
+          "nbf": 1617848692,
+          "exp": 1649385292,
+          "created": 1617849292,
+          "updated": 1617849292,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -668,7 +586,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1819847329"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-384).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-384).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1303047381/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-52de692316295449ac1fb40d7675c903-082718787d938446-00",
+        "traceparent": "00-92244fff5311444e8cc54a5b9349c83d-d85b022f0475fa42-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "ccdad266abea6cbbf4d11d3ef211d398",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:18 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:06 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ccdad266abea6cbbf4d11d3ef211d398",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3525095d-d06c-404d-919d-9ab6db6b625b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3de32999-25e2-470c-a775-84557f07243a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1303047381/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-52de692316295449ac1fb40d7675c903-082718787d938446-00",
+        "traceparent": "00-92244fff5311444e8cc54a5b9349c83d-d85b022f0475fa42-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "ccdad266abea6cbbf4d11d3ef211d398",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "841",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:19 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:07 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending?api-version=7.2\u0026request_id=e3b1e688be2047b58a40756ede8cab28",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1303047381/pending?api-version=7.2\u0026request_id=cce431d8113f432fbfecabcbaf4ddff1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ccdad266abea6cbbf4d11d3ef211d398",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "dbea9496-4991-47e6-be8f-13b4710a92ea",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5aee9c7f-7a37-4dea-855f-5d88d0e34a23",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1303047381/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvfLPGgsHTMByL/zJK980NEDQHk7WrlkXPzhm8tAIOhqXW\u002BsuUkj5vgfmVYjXiQ6Xon36bjMEYGXjAG/oTGZaGepTwfhNrwfbxwFKsBvHIHFyeFbYSgzgSzeLbNTYKLUBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwTpQdZ1T5OUBl/T\u002BV6BTAO\u002BW258/T6kDWDb6KKulPF3058kbSD3VEJiAxWVHYNRKLAjAEwJ96pgcgyicohMDO0ZA6FdoHIHdsz/k0/fyndBPifYYDQ1d0Cd7RkpZGOKp0hiM=",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEaSllmcVALDG\u002BhHsuZdmRazZrUjBVHu\u002BJXJvQdTqnGbeM4No8FyvWD93IlXVWhYVaWTtSfWCAmaCvIB5DSurBEUhoA07Dtfx2o4GM6MIhdFVgxmPjvbf8hijMP46WggodoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMidFzsVKUKOPqImhUgvPDdtuuuxKZLQ\u002Bs4hm\u002BAb\u002BIcwgivfn4YKNUAAQQddIEsl9QIxAIDXX4cWRFE9ECr4bJJ8s7zJYB/NR1oEwVmunboEVuZ7n5k6nh0fGh1DPmnfctJwqQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e3b1e688be2047b58a40756ede8cab28"
+        "request_id": "cce431d8113f432fbfecabcbaf4ddff1"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1303047381/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "2c3061015ba7180981e16f4b88314d44",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "841",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:19 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:07 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2c3061015ba7180981e16f4b88314d44",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0ba67430-a459-4206-8e31-673a17c7a2e5",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b3e2e4e2-4994-4e49-a373-8b00c32cfc47",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1303047381/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvfLPGgsHTMByL/zJK980NEDQHk7WrlkXPzhm8tAIOhqXW\u002BsuUkj5vgfmVYjXiQ6Xon36bjMEYGXjAG/oTGZaGepTwfhNrwfbxwFKsBvHIHFyeFbYSgzgSzeLbNTYKLUBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwTpQdZ1T5OUBl/T\u002BV6BTAO\u002BW258/T6kDWDb6KKulPF3058kbSD3VEJiAxWVHYNRKLAjAEwJ96pgcgyicohMDO0ZA6FdoHIHdsz/k0/fyndBPifYYDQ1d0Cd7RkpZGOKp0hiM=",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEaSllmcVALDG\u002BhHsuZdmRazZrUjBVHu\u002BJXJvQdTqnGbeM4No8FyvWD93IlXVWhYVaWTtSfWCAmaCvIB5DSurBEUhoA07Dtfx2o4GM6MIhdFVgxmPjvbf8hijMP46WggodoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMidFzsVKUKOPqImhUgvPDdtuuuxKZLQ\u002Bs4hm\u002BAb\u002BIcwgivfn4YKNUAAQQddIEsl9QIxAIDXX4cWRFE9ECr4bJJ8s7zJYB/NR1oEwVmunboEVuZ7n5k6nh0fGh1DPmnfctJwqQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e3b1e688be2047b58a40756ede8cab28"
+        "request_id": "cce431d8113f432fbfecabcbaf4ddff1"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1303047381/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "01102c44cf44857889d5e92fdbff2247",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "841",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:25 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "01102c44cf44857889d5e92fdbff2247",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "bf8010b6-44fd-46b7-a5bd-5c0cf1379983",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "dca6a70f-9315-4758-a5fd-bac3a08fbff4",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1303047381/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvfLPGgsHTMByL/zJK980NEDQHk7WrlkXPzhm8tAIOhqXW\u002BsuUkj5vgfmVYjXiQ6Xon36bjMEYGXjAG/oTGZaGepTwfhNrwfbxwFKsBvHIHFyeFbYSgzgSzeLbNTYKLUBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwTpQdZ1T5OUBl/T\u002BV6BTAO\u002BW258/T6kDWDb6KKulPF3058kbSD3VEJiAxWVHYNRKLAjAEwJ96pgcgyicohMDO0ZA6FdoHIHdsz/k0/fyndBPifYYDQ1d0Cd7RkpZGOKp0hiM=",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEaSllmcVALDG\u002BhHsuZdmRazZrUjBVHu\u002BJXJvQdTqnGbeM4No8FyvWD93IlXVWhYVaWTtSfWCAmaCvIB5DSurBEUhoA07Dtfx2o4GM6MIhdFVgxmPjvbf8hijMP46WggodoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMidFzsVKUKOPqImhUgvPDdtuuuxKZLQ\u002Bs4hm\u002BAb\u002BIcwgivfn4YKNUAAQQddIEsl9QIxAIDXX4cWRFE9ECr4bJJ8s7zJYB/NR1oEwVmunboEVuZ7n5k6nh0fGh1DPmnfctJwqQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e3b1e688be2047b58a40756ede8cab28"
+        "request_id": "cce431d8113f432fbfecabcbaf4ddff1"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1303047381/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "e0d301d0c7650b2dc8c24a093c70e4c3",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "749",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:30 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e0d301d0c7650b2dc8c24a093c70e4c3",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "592e5e83-f112-4eee-b9cf-dabfee794537",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "56293ddc-be7a-4157-9ab4-39ea721fd9b0",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1303047381/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvfLPGgsHTMByL/zJK980NEDQHk7WrlkXPzhm8tAIOhqXW\u002BsuUkj5vgfmVYjXiQ6Xon36bjMEYGXjAG/oTGZaGepTwfhNrwfbxwFKsBvHIHFyeFbYSgzgSzeLbNTYKLUBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwTpQdZ1T5OUBl/T\u002BV6BTAO\u002BW258/T6kDWDb6KKulPF3058kbSD3VEJiAxWVHYNRKLAjAEwJ96pgcgyicohMDO0ZA6FdoHIHdsz/k0/fyndBPifYYDQ1d0Cd7RkpZGOKp0hiM=",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEaSllmcVALDG\u002BhHsuZdmRazZrUjBVHu\u002BJXJvQdTqnGbeM4No8FyvWD93IlXVWhYVaWTtSfWCAmaCvIB5DSurBEUhoA07Dtfx2o4GM6MIhdFVgxmPjvbf8hijMP46WggodoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMidFzsVKUKOPqImhUgvPDdtuuuxKZLQ\u002Bs4hm\u002BAb\u002BIcwgivfn4YKNUAAQQddIEsl9QIxAIDXX4cWRFE9ECr4bJJ8s7zJYB/NR1oEwVmunboEVuZ7n5k6nh0fGh1DPmnfctJwqQ==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e3b1e688be2047b58a40756ede8cab28"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1303047381",
+        "request_id": "cce431d8113f432fbfecabcbaf4ddff1"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1303047381?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "c6fad984d1003253e9aba2d172d93c82",
         "x-ms-return-client-request-id": "true"
@@ -256,255 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "1838",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:34 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a8ddaec8-1650-4afb-ad95-961200dd0cd2",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvfLPGgsHTMByL/zJK980NEDQHk7WrlkXPzhm8tAIOhqXW\u002BsuUkj5vgfmVYjXiQ6Xon36bjMEYGXjAG/oTGZaGepTwfhNrwfbxwFKsBvHIHFyeFbYSgzgSzeLbNTYKLUBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwTpQdZ1T5OUBl/T\u002BV6BTAO\u002BW258/T6kDWDb6KKulPF3058kbSD3VEJiAxWVHYNRKLAjAEwJ96pgcgyicohMDO0ZA6FdoHIHdsz/k0/fyndBPifYYDQ1d0Cd7RkpZGOKp0hiM=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e3b1e688be2047b58a40756ede8cab28"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "867a27be6c5d7cdefe053982846e4819",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "838",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7688a5f9-3061-472f-a79e-904edd1169ad",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvfLPGgsHTMByL/zJK980NEDQHk7WrlkXPzhm8tAIOhqXW\u002BsuUkj5vgfmVYjXiQ6Xon36bjMEYGXjAG/oTGZaGepTwfhNrwfbxwFKsBvHIHFyeFbYSgzgSzeLbNTYKLUBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwTpQdZ1T5OUBl/T\u002BV6BTAO\u002BW258/T6kDWDb6KKulPF3058kbSD3VEJiAxWVHYNRKLAjAEwJ96pgcgyicohMDO0ZA6FdoHIHdsz/k0/fyndBPifYYDQ1d0Cd7RkpZGOKp0hiM=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e3b1e688be2047b58a40756ede8cab28"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "02ab25f15c04ff47ada1f7ba245c98ef",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "838",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:45 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "fb8b47ff-7ec5-4086-bb66-c7732fc83778",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvfLPGgsHTMByL/zJK980NEDQHk7WrlkXPzhm8tAIOhqXW\u002BsuUkj5vgfmVYjXiQ6Xon36bjMEYGXjAG/oTGZaGepTwfhNrwfbxwFKsBvHIHFyeFbYSgzgSzeLbNTYKLUBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwTpQdZ1T5OUBl/T\u002BV6BTAO\u002BW258/T6kDWDb6KKulPF3058kbSD3VEJiAxWVHYNRKLAjAEwJ96pgcgyicohMDO0ZA6FdoHIHdsz/k0/fyndBPifYYDQ1d0Cd7RkpZGOKp0hiM=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e3b1e688be2047b58a40756ede8cab28"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "144ac8865df51865fa7ec7fa98d1ad7a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "838",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:50 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6996bdd5-3f7f-44bf-a9d1-27e84665d646",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvfLPGgsHTMByL/zJK980NEDQHk7WrlkXPzhm8tAIOhqXW\u002BsuUkj5vgfmVYjXiQ6Xon36bjMEYGXjAG/oTGZaGepTwfhNrwfbxwFKsBvHIHFyeFbYSgzgSzeLbNTYKLUBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwTpQdZ1T5OUBl/T\u002BV6BTAO\u002BW258/T6kDWDb6KKulPF3058kbSD3VEJiAxWVHYNRKLAjAEwJ96pgcgyicohMDO0ZA6FdoHIHdsz/k0/fyndBPifYYDQ1d0Cd7RkpZGOKp0hiM=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e3b1e688be2047b58a40756ede8cab28"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "4ce08962392e627edf7bd9bc752457a2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "747",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:55 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c6fad984d1003253e9aba2d172d93c82",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "88460be9-74da-4dac-8525-acaad7ff924f",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "2ac7b7c8-742e-4063-a2ba-5245c61b340b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvfLPGgsHTMByL/zJK980NEDQHk7WrlkXPzhm8tAIOhqXW\u002BsuUkj5vgfmVYjXiQ6Xon36bjMEYGXjAG/oTGZaGepTwfhNrwfbxwFKsBvHIHFyeFbYSgzgSzeLbNTYKLUBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwTpQdZ1T5OUBl/T\u002BV6BTAO\u002BW258/T6kDWDb6KKulPF3058kbSD3VEJiAxWVHYNRKLAjAEwJ96pgcgyicohMDO0ZA6FdoHIHdsz/k0/fyndBPifYYDQ1d0Cd7RkpZGOKp0hiM=",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1303047381",
-        "request_id": "e3b1e688be2047b58a40756ede8cab28"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "bbfc4a6c33249423c0920885954c66dc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1843",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:01:55 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "fbc0519e-cb2a-4c01-8b85-c00b0ed10a1b",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/cc68265eced54bfdb2b56efc1896e20e",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1303047381/cc68265eced54bfdb2b56efc1896e20e",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1303047381/cc68265eced54bfdb2b56efc1896e20e",
-        "x5t": "GOuAm_aTh12P7-PBDprjmUnvxME",
-        "cer": "MIIB2zCCAWGgAwIBAgIQAQU8lV8sR8WrPFz5MGcrODAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTE1MloXDTIyMDMwNTIzMDE1MlowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABL3yzxoLB0zAci/8ySvfNDRA0B5O1q5ZFz84ZvLQCDoal1vrLlJI\u002Bb4H5lWI14kOl6J9\u002Bm4zBGBl4wBv6ExmWhnqU8H4Ta8H28cBSrAbxyBxcnhW2EoM4Es3i2zU2Ci1AaN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFNlTgN0puCtYgC9/EN8aJL6YE3YEMB0GA1UdDgQWBBTZU4DdKbgrWIAvfxDfGiS\u002BmBN2BDAKBggqhkjOPQQDAwNoADBlAjEA/WSyoinqhskQ8nIo97ALtApEnlxmaU2ohBz4OENIzhUakfaEzngWUI5e\u002BEVj5MfbAjBzBU/gd5pcJS8gnTRKPkMzY9fpCbqkLs8czHA\u002BBSJm8ztf54eHhY3VHQz4kdX1KWI=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1303047381/79f6602b0d0a4292b8a418fe67e8817f",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1303047381/79f6602b0d0a4292b8a418fe67e8817f",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1303047381/79f6602b0d0a4292b8a418fe67e8817f",
+        "x5t": "Ici4_Tnrc1L3dlcDmUXOLK0Dfn8",
+        "cer": "MIIB2zCCAWGgAwIBAgIQbV\u002Bvlp/qSMCKD51XMbRAizAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjAxNVoXDTIyMDQwODAyMzAxNVowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABGkpZZnFQCwxvoR7LmXZkWs2a1IwVR7viVyb0HU6pxm3jODaPBcr1g/dyJV1VoWFWlk7Un1ggJmgryAeQ0rqwRFIaANOw7X8dqOBjOjCIXRVYMZj4723/IYozD\u002BOloIKHaN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFH4Z5wNsgZPORJsskn\u002BmrYIM5OtuMB0GA1UdDgQWBBR\u002BGecDbIGTzkSbLJJ/pq2CDOTrbjAKBggqhkjOPQQDAwNoADBlAjBj22nxcTiP7RJSh1KUtFH2GjsWakq7PZV0tpGQ1guta//Jhx6guWgWPYK6fzyJ128CMQDy9YE5ZRln2v4aVIGoEAvOWbfRAN060Ui53LtVPuUWVwscW0Y2M/9pdX3dp\u002BcW33g=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984712,
-          "exp": 1646521312,
-          "created": 1614985312,
-          "updated": 1614985312,
+          "nbf": 1617848415,
+          "exp": 1649385015,
+          "created": 1617849015,
+          "updated": 1617849015,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1303047381/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -544,166 +330,209 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985280,
-            "updated": 1614985280
+            "created": 1617849007,
+            "updated": 1617849007
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1303047381/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1303047381/cc68265eced54bfdb2b56efc1896e20e?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1303047381/79f6602b0d0a4292b8a418fe67e8817f?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-a51c9b00169e5c4fa03ea2cca6611caa-535b1653aa20ea4d-00",
+        "traceparent": "00-5f6571c2cfa54e4ebfd342e95f292044-f6f15f3d88589a44-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "9b577df34c7b4cc049e8357a84a8a3d5",
+        "x-ms-client-request-id": "867a27be6c5d7cdefe053982846e4819",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1246",
+        "Content-Length": "1243",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:00 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:23 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "867a27be6c5d7cdefe053982846e4819",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c7444773-0ca7-46c7-9a96-45c0ccbd73c7",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "59ac9c94-3e8d-4f38-8323-54c289a0c854",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1303047381/cc68265eced54bfdb2b56efc1896e20e",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1303047381/cc68265eced54bfdb2b56efc1896e20e",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1303047381/cc68265eced54bfdb2b56efc1896e20e",
-        "x5t": "GOuAm_aTh12P7-PBDprjmUnvxME",
-        "cer": "MIIB2zCCAWGgAwIBAgIQAQU8lV8sR8WrPFz5MGcrODAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTE1MloXDTIyMDMwNTIzMDE1MlowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABL3yzxoLB0zAci/8ySvfNDRA0B5O1q5ZFz84ZvLQCDoal1vrLlJI\u002Bb4H5lWI14kOl6J9\u002Bm4zBGBl4wBv6ExmWhnqU8H4Ta8H28cBSrAbxyBxcnhW2EoM4Es3i2zU2Ci1AaN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFNlTgN0puCtYgC9/EN8aJL6YE3YEMB0GA1UdDgQWBBTZU4DdKbgrWIAvfxDfGiS\u002BmBN2BDAKBggqhkjOPQQDAwNoADBlAjEA/WSyoinqhskQ8nIo97ALtApEnlxmaU2ohBz4OENIzhUakfaEzngWUI5e\u002BEVj5MfbAjBzBU/gd5pcJS8gnTRKPkMzY9fpCbqkLs8czHA\u002BBSJm8ztf54eHhY3VHQz4kdX1KWI=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1303047381/79f6602b0d0a4292b8a418fe67e8817f",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1303047381/79f6602b0d0a4292b8a418fe67e8817f",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1303047381/79f6602b0d0a4292b8a418fe67e8817f",
+        "x5t": "Ici4_Tnrc1L3dlcDmUXOLK0Dfn8",
+        "cer": "MIIB2zCCAWGgAwIBAgIQbV\u002Bvlp/qSMCKD51XMbRAizAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjAxNVoXDTIyMDQwODAyMzAxNVowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABGkpZZnFQCwxvoR7LmXZkWs2a1IwVR7viVyb0HU6pxm3jODaPBcr1g/dyJV1VoWFWlk7Un1ggJmgryAeQ0rqwRFIaANOw7X8dqOBjOjCIXRVYMZj4723/IYozD\u002BOloIKHaN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFH4Z5wNsgZPORJsskn\u002BmrYIM5OtuMB0GA1UdDgQWBBR\u002BGecDbIGTzkSbLJJ/pq2CDOTrbjAKBggqhkjOPQQDAwNoADBlAjBj22nxcTiP7RJSh1KUtFH2GjsWakq7PZV0tpGQ1guta//Jhx6guWgWPYK6fzyJ128CMQDy9YE5ZRln2v4aVIGoEAvOWbfRAN060Ui53LtVPuUWVwscW0Y2M/9pdX3dp\u002BcW33g=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984712,
-          "exp": 1646521312,
-          "created": 1614985312,
-          "updated": 1614985312,
+          "nbf": 1617848415,
+          "exp": 1649385015,
+          "created": 1617849015,
+          "updated": 1617849015,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "01053C955F2C47C5AB3C5CF930672B38"
+        "serialnumber": "6D5FAF969FEA48C08A0F9D5731B4408B"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1303047381/cc68265eced54bfdb2b56efc1896e20e?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1303047381/79f6602b0d0a4292b8a418fe67e8817f?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-a51c9b00169e5c4fa03ea2cca6611caa-b66e6342924a1846-00",
+        "traceparent": "00-5f6571c2cfa54e4ebfd342e95f292044-81bfd59eed8a4843-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "4e8d2526f1d42e55654b8c9b31f8cd92",
+        "x-ms-client-request-id": "02ab25f15c04ff47ada1f7ba245c98ef",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1489",
+        "Content-Length": "1487",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:00 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:23 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "02ab25f15c04ff47ada1f7ba245c98ef",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "51662036-6e58-453a-9858-de67f589a542",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "dcb881cf-3afe-4c23-a268-23097b79ed4f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIHOAgEAMBAGByqGSM49AgEGBSuBBAAiBIGnMIGkAgEBBDCkSLAfsD6rTTOwSIHA\ny9UaJ3z3sh8AXjq6hyHlIZo6BhB65SZpEuq4\u002BWxmN7S8zVqgBwYFK4EEACKhZANi\nAAS98s8aCwdMwHIv/Mkr3zQ0QNAeTtauWRc/OGby0Ag6Gpdb6y5SSPm\u002BB\u002BZViNeJ\nDpeiffpuMwRgZeMAb\u002BhMZloZ6lPB\u002BE2vB9vHAUqwG8cgcXJ4VthKDOBLN4ts1Ngo\ntQGgDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIB2zCCAWGgAwIBAgIQAQU8lV8sR8WrPFz5MGcrODAKBggqhkjOPQQDAzASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTE1MloXDTIyMDMwNTIzMDE1Mlow\nEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABL3yzxoL\nB0zAci/8ySvfNDRA0B5O1q5ZFz84ZvLQCDoal1vrLlJI\u002Bb4H5lWI14kOl6J9\u002Bm4z\nBGBl4wBv6ExmWhnqU8H4Ta8H28cBSrAbxyBxcnhW2EoM4Es3i2zU2Ci1AaN8MHow\nDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEG\nCCsGAQUFBwMCMB8GA1UdIwQYMBaAFNlTgN0puCtYgC9/EN8aJL6YE3YEMB0GA1Ud\nDgQWBBTZU4DdKbgrWIAvfxDfGiS\u002BmBN2BDAKBggqhkjOPQQDAwNoADBlAjEA/WSy\noinqhskQ8nIo97ALtApEnlxmaU2ohBz4OENIzhUakfaEzngWUI5e\u002BEVj5MfbAjBz\nBU/gd5pcJS8gnTRKPkMzY9fpCbqkLs8czHA\u002BBSJm8ztf54eHhY3VHQz4kdX1KWI=\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIHOAgEAMBAGByqGSM49AgEGBSuBBAAiBIGnMIGkAgEBBDDnhPMw4Tl70GfBTm0q\nkjX0ibELxaW0yEM2DG6EgkEJccHM5kgEpENdEvWLhlQp/xqgBwYFK4EEACKhZANi\nAARpKWWZxUAsMb6Eey5l2ZFrNmtSMFUe74lcm9B1OqcZt4zg2jwXK9YP3ciVdVaF\nhVpZO1J9YICZoK8gHkNK6sERSGgDTsO1/HajgYzowiF0VWDGY\u002BO9t/yGKMw/jpaC\nCh2gDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIB2zCCAWGgAwIBAgIQbV\u002Bvlp/qSMCKD51XMbRAizAKBggqhkjOPQQDAzASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjAxNVoXDTIyMDQwODAyMzAxNVow\nEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABGkpZZnF\nQCwxvoR7LmXZkWs2a1IwVR7viVyb0HU6pxm3jODaPBcr1g/dyJV1VoWFWlk7Un1g\ngJmgryAeQ0rqwRFIaANOw7X8dqOBjOjCIXRVYMZj4723/IYozD\u002BOloIKHaN8MHow\nDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEG\nCCsGAQUFBwMCMB8GA1UdIwQYMBaAFH4Z5wNsgZPORJsskn\u002BmrYIM5OtuMB0GA1Ud\nDgQWBBR\u002BGecDbIGTzkSbLJJ/pq2CDOTrbjAKBggqhkjOPQQDAwNoADBlAjBj22nx\ncTiP7RJSh1KUtFH2GjsWakq7PZV0tpGQ1guta//Jhx6guWgWPYK6fzyJ128CMQDy\n9YE5ZRln2v4aVIGoEAvOWbfRAN060Ui53LtVPuUWVwscW0Y2M/9pdX3dp\u002BcW33g=\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1303047381/cc68265eced54bfdb2b56efc1896e20e",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1303047381/79f6602b0d0a4292b8a418fe67e8817f",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614984712,
-          "exp": 1646521312,
-          "created": 1614985312,
-          "updated": 1614985312,
+          "nbf": 1617848415,
+          "exp": 1649385015,
+          "created": 1617849015,
+          "updated": 1617849015,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1303047381/cc68265eced54bfdb2b56efc1896e20e"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1303047381/79f6602b0d0a4292b8a418fe67e8817f"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1303047381/cc68265eced54bfdb2b56efc1896e20e?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1303047381/79f6602b0d0a4292b8a418fe67e8817f?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-bac70c7997829a4b9a57d50d598462ff-8e176d1b5e174641-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "144ac8865df51865fa7ec7fa98d1ad7a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:30:23 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "144ac8865df51865fa7ec7fa98d1ad7a",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d993911f-9edc-46fe-9a62-8a75a269fb97",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1303047381/79f6602b0d0a4292b8a418fe67e8817f?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-4537fcfa01ebd34ba5a19acdffa3fad1-933d02ba5211824b-00",
+        "traceparent": "00-bac70c7997829a4b9a57d50d598462ff-8e176d1b5e174641-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "f7c9fc14bccc202689af723cfea91017",
+        "x-ms-client-request-id": "144ac8865df51865fa7ec7fa98d1ad7a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "482",
+        "Content-Length": "481",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:00 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:23 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "144ac8865df51865fa7ec7fa98d1ad7a",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4dd2b23c-3084-46ad-964d-772c38c9634e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d824a98f-f962-4447-9c6a-dcf9fc5596fd",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1303047381/cc68265eced54bfdb2b56efc1896e20e",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1303047381/79f6602b0d0a4292b8a418fe67e8817f",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-384",
-          "x": "vfLPGgsHTMByL_zJK980NEDQHk7WrlkXPzhm8tAIOhqXW-suUkj5vgfmVYjXiQ6X",
-          "y": "on36bjMEYGXjAG_oTGZaGepTwfhNrwfbxwFKsBvHIHFyeFbYSgzgSzeLbNTYKLUB"
+          "x": "aSllmcVALDG-hHsuZdmRazZrUjBVHu-JXJvQdTqnGbeM4No8FyvWD93IlXVWhYVa",
+          "y": "WTtSfWCAmaCvIB5DSurBEUhoA07Dtfx2o4GM6MIhdFVgxmPjvbf8hijMP46Wggod"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984712,
-          "exp": 1646521312,
-          "created": 1614985312,
-          "updated": 1614985312,
+          "nbf": 1617848415,
+          "exp": 1649385015,
+          "created": 1617849015,
+          "updated": 1617849015,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -712,7 +541,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "413842959"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-384)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-384)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/366712349/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/366712349/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-e6e8dfc595c1f9448a86ee13da575092-0c8522ac52dfba4c-00",
+        "traceparent": "00-bdbcce16143b29449c0a11067ae191fd-64e15f081e15cf4f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "e723cf9c36215ea5482fa14fb45c9474",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e723cf9c36215ea5482fa14fb45c9474",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2f5b0962-e7f8-4862-932e-f52efb82b6ea",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6cfb0757-51a0-4919-9ee2-056f17171707",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/366712349/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/366712349/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-e6e8dfc595c1f9448a86ee13da575092-0c8522ac52dfba4c-00",
+        "traceparent": "00-bdbcce16143b29449c0a11067ae191fd-64e15f081e15cf4f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "e723cf9c36215ea5482fa14fb45c9474",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "841",
+        "Content-Length": "836",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:04 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending?api-version=7.2\u0026request_id=ca0a08210cda4e7abf6655cc9bb4113b",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/366712349/pending?api-version=7.2\u0026request_id=b4c0a984f0d3443e88fc571432b7f1f2",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e723cf9c36215ea5482fa14fb45c9474",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ed4f2545-d409-409d-975c-6847c7109e83",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "4a5de667-2fd7-4707-91e9-0080756c038b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/366712349/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgLS3US1DqDBPWFV\u002BeX9\u002BsTAalAcQ3pzQhTf2SeVPkP8FWZ7V0Eq0HRYDhxT2yPYOx46brstfdHCKt0oY1nJ0BaX4BBIZiR9n8WQQry\u002BBPBD3SzkAmsod/MtVV50N9QKnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxANGqt3Sv3ZtUy1bMK/YX7qZhmg3oYeym/lzrYhzj81WzLpCdAMi3QaQRg\u002BZgZ\u002BvKbQIxAL0mFQVUcWQ7gI/s0GPd0RdH4/0g763xefI9svNsQYck0gnZeh/XDYwl6Sh1UnpqQA==",
+        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEh5uijSwHfIdyvsXerYrCTn32r3GnazYH9bZ825ucI8UdH/jX3db9DYR5CmPD3Ccy1zLiKUowFPKC5jBrgxDKOWoj0c5\u002BCUh2LuB8Lzp8j0QTDTSTXKLLLBIGE8GF282voEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwa1BJOL\u002BgVH2aRzgMPFnx\u002Bg9NfD4Ci74fZFCmFVlmcRHUZtkzebIz3aC06wsqO9SKAjBOJgrUZYtPqW\u002BKwOkVKV/aRcrPLKNldSktHl/fDvmDw8bQ8O5L/f72AaARNwB9Kws=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ca0a08210cda4e7abf6655cc9bb4113b"
+        "request_id": "b4c0a984f0d3443e88fc571432b7f1f2"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/366712349/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "be1c418ec86e2dea26499e0cfe00ab62",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "841",
+        "Content-Length": "836",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "be1c418ec86e2dea26499e0cfe00ab62",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1d2a3230-3415-441c-89cc-e65062684b11",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ba7768ea-6ac4-4be9-a183-4b4596e04543",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/366712349/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgLS3US1DqDBPWFV\u002BeX9\u002BsTAalAcQ3pzQhTf2SeVPkP8FWZ7V0Eq0HRYDhxT2yPYOx46brstfdHCKt0oY1nJ0BaX4BBIZiR9n8WQQry\u002BBPBD3SzkAmsod/MtVV50N9QKnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxANGqt3Sv3ZtUy1bMK/YX7qZhmg3oYeym/lzrYhzj81WzLpCdAMi3QaQRg\u002BZgZ\u002BvKbQIxAL0mFQVUcWQ7gI/s0GPd0RdH4/0g763xefI9svNsQYck0gnZeh/XDYwl6Sh1UnpqQA==",
+        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEh5uijSwHfIdyvsXerYrCTn32r3GnazYH9bZ825ucI8UdH/jX3db9DYR5CmPD3Ccy1zLiKUowFPKC5jBrgxDKOWoj0c5\u002BCUh2LuB8Lzp8j0QTDTSTXKLLLBIGE8GF282voEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwa1BJOL\u002BgVH2aRzgMPFnx\u002Bg9NfD4Ci74fZFCmFVlmcRHUZtkzebIz3aC06wsqO9SKAjBOJgrUZYtPqW\u002BKwOkVKV/aRcrPLKNldSktHl/fDvmDw8bQ8O5L/f72AaARNwB9Kws=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ca0a08210cda4e7abf6655cc9bb4113b"
+        "request_id": "b4c0a984f0d3443e88fc571432b7f1f2"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/366712349/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "442a89383e73c16be8b070b12b8e4632",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "841",
+        "Content-Length": "836",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:19 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:10 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "442a89383e73c16be8b070b12b8e4632",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e144e731-703f-4a60-b0a1-47ec3560d745",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "e36b8b88-efeb-4e41-bc10-9e642a8526cc",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/366712349/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgLS3US1DqDBPWFV\u002BeX9\u002BsTAalAcQ3pzQhTf2SeVPkP8FWZ7V0Eq0HRYDhxT2yPYOx46brstfdHCKt0oY1nJ0BaX4BBIZiR9n8WQQry\u002BBPBD3SzkAmsod/MtVV50N9QKnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxANGqt3Sv3ZtUy1bMK/YX7qZhmg3oYeym/lzrYhzj81WzLpCdAMi3QaQRg\u002BZgZ\u002BvKbQIxAL0mFQVUcWQ7gI/s0GPd0RdH4/0g763xefI9svNsQYck0gnZeh/XDYwl6Sh1UnpqQA==",
+        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEh5uijSwHfIdyvsXerYrCTn32r3GnazYH9bZ825ucI8UdH/jX3db9DYR5CmPD3Ccy1zLiKUowFPKC5jBrgxDKOWoj0c5\u002BCUh2LuB8Lzp8j0QTDTSTXKLLLBIGE8GF282voEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwa1BJOL\u002BgVH2aRzgMPFnx\u002Bg9NfD4Ci74fZFCmFVlmcRHUZtkzebIz3aC06wsqO9SKAjBOJgrUZYtPqW\u002BKwOkVKV/aRcrPLKNldSktHl/fDvmDw8bQ8O5L/f72AaARNwB9Kws=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ca0a08210cda4e7abf6655cc9bb4113b"
+        "request_id": "b4c0a984f0d3443e88fc571432b7f1f2"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/366712349/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "868e21257525d3afe5f6c1d797985f48",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "841",
+        "Content-Length": "836",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:24 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "868e21257525d3afe5f6c1d797985f48",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "d70cba65-74f8-4c24-87cb-c240e12487b4",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "c173392a-dce4-4a1a-8e0e-f072e66e1d39",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/366712349/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgLS3US1DqDBPWFV\u002BeX9\u002BsTAalAcQ3pzQhTf2SeVPkP8FWZ7V0Eq0HRYDhxT2yPYOx46brstfdHCKt0oY1nJ0BaX4BBIZiR9n8WQQry\u002BBPBD3SzkAmsod/MtVV50N9QKnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxANGqt3Sv3ZtUy1bMK/YX7qZhmg3oYeym/lzrYhzj81WzLpCdAMi3QaQRg\u002BZgZ\u002BvKbQIxAL0mFQVUcWQ7gI/s0GPd0RdH4/0g763xefI9svNsQYck0gnZeh/XDYwl6Sh1UnpqQA==",
+        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEh5uijSwHfIdyvsXerYrCTn32r3GnazYH9bZ825ucI8UdH/jX3db9DYR5CmPD3Ccy1zLiKUowFPKC5jBrgxDKOWoj0c5\u002BCUh2LuB8Lzp8j0QTDTSTXKLLLBIGE8GF282voEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwa1BJOL\u002BgVH2aRzgMPFnx\u002Bg9NfD4Ci74fZFCmFVlmcRHUZtkzebIz3aC06wsqO9SKAjBOJgrUZYtPqW\u002BKwOkVKV/aRcrPLKNldSktHl/fDvmDw8bQ8O5L/f72AaARNwB9Kws=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ca0a08210cda4e7abf6655cc9bb4113b"
+        "request_id": "b4c0a984f0d3443e88fc571432b7f1f2"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/366712349/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "2a173e8350315000d55ad6bd58390198",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "841",
+        "Content-Length": "743",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:29 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2a173e8350315000d55ad6bd58390198",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ca7f6afe-f3a5-4dd1-b4be-571a347845a2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "07ca202b-f5f1-4b7e-b0e8-bbe166139aa6",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/366712349/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgLS3US1DqDBPWFV\u002BeX9\u002BsTAalAcQ3pzQhTf2SeVPkP8FWZ7V0Eq0HRYDhxT2yPYOx46brstfdHCKt0oY1nJ0BaX4BBIZiR9n8WQQry\u002BBPBD3SzkAmsod/MtVV50N9QKnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxANGqt3Sv3ZtUy1bMK/YX7qZhmg3oYeym/lzrYhzj81WzLpCdAMi3QaQRg\u002BZgZ\u002BvKbQIxAL0mFQVUcWQ7gI/s0GPd0RdH4/0g763xefI9svNsQYck0gnZeh/XDYwl6Sh1UnpqQA==",
+        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEh5uijSwHfIdyvsXerYrCTn32r3GnazYH9bZ825ucI8UdH/jX3db9DYR5CmPD3Ccy1zLiKUowFPKC5jBrgxDKOWoj0c5\u002BCUh2LuB8Lzp8j0QTDTSTXKLLLBIGE8GF282voEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwa1BJOL\u002BgVH2aRzgMPFnx\u002Bg9NfD4Ci74fZFCmFVlmcRHUZtkzebIz3aC06wsqO9SKAjBOJgrUZYtPqW\u002BKwOkVKV/aRcrPLKNldSktHl/fDvmDw8bQ8O5L/f72AaARNwB9Kws=",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ca0a08210cda4e7abf6655cc9bb4113b"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/366712349",
+        "request_id": "b4c0a984f0d3443e88fc571432b7f1f2"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/366712349?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "dce76b032471c33cda575e7d7c94294f",
         "x-ms-return-client-request-id": "true"
@@ -300,123 +305,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "841",
+        "Content-Length": "1833",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:35 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f4760503-98d9-49dd-b929-0eda655ac006",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgLS3US1DqDBPWFV\u002BeX9\u002BsTAalAcQ3pzQhTf2SeVPkP8FWZ7V0Eq0HRYDhxT2yPYOx46brstfdHCKt0oY1nJ0BaX4BBIZiR9n8WQQry\u002BBPBD3SzkAmsod/MtVV50N9QKnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxANGqt3Sv3ZtUy1bMK/YX7qZhmg3oYeym/lzrYhzj81WzLpCdAMi3QaQRg\u002BZgZ\u002BvKbQIxAL0mFQVUcWQ7gI/s0GPd0RdH4/0g763xefI9svNsQYck0gnZeh/XDYwl6Sh1UnpqQA==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ca0a08210cda4e7abf6655cc9bb4113b"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ec2d27501b76d401213eb1ca9ff17aac",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "749",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "dce76b032471c33cda575e7d7c94294f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7cba05d6-1a97-4fbc-a459-fef628ff2035",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3b51c40e-198b-4040-b343-2f67e0caabbb",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgLS3US1DqDBPWFV\u002BeX9\u002BsTAalAcQ3pzQhTf2SeVPkP8FWZ7V0Eq0HRYDhxT2yPYOx46brstfdHCKt0oY1nJ0BaX4BBIZiR9n8WQQry\u002BBPBD3SzkAmsod/MtVV50N9QKnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxANGqt3Sv3ZtUy1bMK/YX7qZhmg3oYeym/lzrYhzj81WzLpCdAMi3QaQRg\u002BZgZ\u002BvKbQIxAL0mFQVUcWQ7gI/s0GPd0RdH4/0g763xefI9svNsQYck0gnZeh/XDYwl6Sh1UnpqQA==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/366712349",
-        "request_id": "ca0a08210cda4e7abf6655cc9bb4113b"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/366712349?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "2bd429f483b15fd6015350daf183d341",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1838",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "62b50d9d-f88e-4ac6-bced-cc070f766017",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/366712349/341e62c818d24d93af9abbf2672bc0c8",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/366712349/341e62c818d24d93af9abbf2672bc0c8",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/366712349/341e62c818d24d93af9abbf2672bc0c8",
-        "x5t": "xlcTywykZhTCtriJqLFUGffMXdk",
-        "cer": "MIIB2zCCAWGgAwIBAgIQJM7umCa9QlaYK1/uB6BepTAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDEzNVoXDTIyMDMwNTIzMTEzNVowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABIC0t1EtQ6gwT1hVfnl/frEwGpQHEN6c0IU39knlT5D/BVme1dBKtB0WA4cU9sj2DseOm67LX3RwirdKGNZydAWl\u002BAQSGYkfZ/FkEK8vgTwQ90s5AJrKHfzLVVedDfUCp6N8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFBU5dHdqduaZIUqhvFTolMhVEvWGMB0GA1UdDgQWBBQVOXR3anbmmSFKobxU6JTIVRL1hjAKBggqhkjOPQQDAwNoADBlAjAmTos/Y\u002BsjdfHSkcwpGl3QQXmuBb2P941LubNMF9kkEuY2lD1/oIE1738r6qcst1YCMQDXpmMFt4zzp0B9yYGFNT74jYGvSd9PeDudhQbrjjhi6HHW0cviLM5XZ0kIFSFPohA=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/366712349/a46479653d1b47a9932f4f8e47eb9ae6",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/366712349/a46479653d1b47a9932f4f8e47eb9ae6",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/366712349/a46479653d1b47a9932f4f8e47eb9ae6",
+        "x5t": "QcxBbTeoNsZB9oGhBElfOWK8tXw",
+        "cer": "MIIB2zCCAWGgAwIBAgIQdBJcjPLdTbC0dYttWwVn3zAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQyMFoXDTIyMDQwODAyMzQyMFowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABIeboo0sB3yHcr7F3q2Kwk599q9xp2s2B/W2fNubnCPFHR/4193W/Q2EeQpjw9wnMtcy4ilKMBTyguYwa4MQyjlqI9HOfglIdi7gfC86fI9EEw00k1yiyywSBhPBhdvNr6N8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFAwHaA9htQeHpUt8O2/doxLtsbK3MB0GA1UdDgQWBBQMB2gPYbUHh6VLfDtv3aMS7bGytzAKBggqhkjOPQQDAwNoADBlAjB1quJIWKuEPX5xf8NkNNxzeL6X/CORkimOXEfWkdap01JYvV7r0hyCJgpimQTswCICMQC5zMtxoBatvfyA\u002BPvt3AopcVrqiiCThrvV2ySNNmd1VT0z9IsDxPb\u002BtZ0gpRzZZE0=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985295,
-          "exp": 1646521895,
-          "created": 1614985895,
-          "updated": 1614985895,
+          "nbf": 1617848660,
+          "exp": 1649385260,
+          "created": 1617849260,
+          "updated": 1617849260,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/366712349/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/366712349/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -456,26 +375,169 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985874,
-            "updated": 1614985874
+            "created": 1617849245,
+            "updated": 1617849245
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/366712349/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/366712349/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/366712349/341e62c818d24d93af9abbf2672bc0c8?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/366712349/a46479653d1b47a9932f4f8e47eb9ae6?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-dbd0a2aab905db46988af4a88e0798cf-a98ffa293a37394b-00",
+        "traceparent": "00-d012f3231495994c83a032be01d7e129-0cf494374706c84c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "ec2d27501b76d401213eb1ca9ff17aac",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1240",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:34:20 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ec2d27501b76d401213eb1ca9ff17aac",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "0e39eac0-d633-42e6-bd40-784fe051df42",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "id": "https://heathskvtest2.vault.azure.net/certificates/366712349/a46479653d1b47a9932f4f8e47eb9ae6",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/366712349/a46479653d1b47a9932f4f8e47eb9ae6",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/366712349/a46479653d1b47a9932f4f8e47eb9ae6",
+        "x5t": "QcxBbTeoNsZB9oGhBElfOWK8tXw",
+        "cer": "MIIB2zCCAWGgAwIBAgIQdBJcjPLdTbC0dYttWwVn3zAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQyMFoXDTIyMDQwODAyMzQyMFowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABIeboo0sB3yHcr7F3q2Kwk599q9xp2s2B/W2fNubnCPFHR/4193W/Q2EeQpjw9wnMtcy4ilKMBTyguYwa4MQyjlqI9HOfglIdi7gfC86fI9EEw00k1yiyywSBhPBhdvNr6N8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFAwHaA9htQeHpUt8O2/doxLtsbK3MB0GA1UdDgQWBBQMB2gPYbUHh6VLfDtv3aMS7bGytzAKBggqhkjOPQQDAwNoADBlAjB1quJIWKuEPX5xf8NkNNxzeL6X/CORkimOXEfWkdap01JYvV7r0hyCJgpimQTswCICMQC5zMtxoBatvfyA\u002BPvt3AopcVrqiiCThrvV2ySNNmd1VT0z9IsDxPb\u002BtZ0gpRzZZE0=",
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848660,
+          "exp": 1649385260,
+          "created": 1617849260,
+          "updated": 1617849260,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "subject": "CN=default",
+        "issuer": "CN=default",
+        "serialnumber": "74125C8CF2DD4DB0B4758B6D5B0567DF"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/366712349/a46479653d1b47a9932f4f8e47eb9ae6?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-d012f3231495994c83a032be01d7e129-2fe42ef98a85da4e-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "2bd429f483b15fd6015350daf183d341",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1485",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:34:20 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2bd429f483b15fd6015350daf183d341",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b6ef89ab-79d2-4c7c-9ada-f851d247501a",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "value": "-----BEGIN PRIVATE KEY-----\nMIHOAgEAMBAGByqGSM49AgEGBSuBBAAiBIGnMIGkAgEBBDDxqJgbGG27RX5Z5s3e\ni4N7Vl4V\u002Bgs1wIuyw4EPUDz7fLKbG3g0T1zgXUAXoW9OU/ugBwYFK4EEACKhZANi\nAASHm6KNLAd8h3K\u002Bxd6tisJOffavcadrNgf1tnzbm5wjxR0f\u002BNfd1v0NhHkKY8Pc\nJzLXMuIpSjAU8oLmMGuDEMo5aiPRzn4JSHYu4HwvOnyPRBMNNJNcosssEgYTwYXb\nza\u002BgDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIB2zCCAWGgAwIBAgIQdBJcjPLdTbC0dYttWwVn3zAKBggqhkjOPQQDAzASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQyMFoXDTIyMDQwODAyMzQyMFow\nEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABIeboo0s\nB3yHcr7F3q2Kwk599q9xp2s2B/W2fNubnCPFHR/4193W/Q2EeQpjw9wnMtcy4ilK\nMBTyguYwa4MQyjlqI9HOfglIdi7gfC86fI9EEw00k1yiyywSBhPBhdvNr6N8MHow\nDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEG\nCCsGAQUFBwMCMB8GA1UdIwQYMBaAFAwHaA9htQeHpUt8O2/doxLtsbK3MB0GA1Ud\nDgQWBBQMB2gPYbUHh6VLfDtv3aMS7bGytzAKBggqhkjOPQQDAwNoADBlAjB1quJI\nWKuEPX5xf8NkNNxzeL6X/CORkimOXEfWkdap01JYvV7r0hyCJgpimQTswCICMQC5\nzMtxoBatvfyA\u002BPvt3AopcVrqiiCThrvV2ySNNmd1VT0z9IsDxPb\u002BtZ0gpRzZZE0=\n-----END CERTIFICATE-----\n",
+        "contentType": "application/x-pem-file",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/366712349/a46479653d1b47a9932f4f8e47eb9ae6",
+        "managed": true,
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848660,
+          "exp": 1649385260,
+          "created": 1617849260,
+          "updated": 1617849260,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "kid": "https://heathskvtest2.vault.azure.net/keys/366712349/a46479653d1b47a9932f4f8e47eb9ae6"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/366712349/a46479653d1b47a9932f4f8e47eb9ae6?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-79e1611e7a95214693e40428a2dfc020-5b7b64350a245d47-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "306d8631140be7216a12bb33737124e9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:34:20 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "306d8631140be7216a12bb33737124e9",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "9b65a9f6-2996-4cc0-8546-f575a97454d1",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/366712349/a46479653d1b47a9932f4f8e47eb9ae6?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-79e1611e7a95214693e40428a2dfc020-5b7b64350a245d47-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "306d8631140be7216a12bb33737124e9",
         "x-ms-return-client-request-id": "true"
@@ -484,138 +546,38 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1243",
+        "Content-Length": "480",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "306d8631140be7216a12bb33737124e9",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ee5b4343-b640-4026-90e2-09593675c6a7",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/366712349/341e62c818d24d93af9abbf2672bc0c8",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/366712349/341e62c818d24d93af9abbf2672bc0c8",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/366712349/341e62c818d24d93af9abbf2672bc0c8",
-        "x5t": "xlcTywykZhTCtriJqLFUGffMXdk",
-        "cer": "MIIB2zCCAWGgAwIBAgIQJM7umCa9QlaYK1/uB6BepTAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDEzNVoXDTIyMDMwNTIzMTEzNVowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABIC0t1EtQ6gwT1hVfnl/frEwGpQHEN6c0IU39knlT5D/BVme1dBKtB0WA4cU9sj2DseOm67LX3RwirdKGNZydAWl\u002BAQSGYkfZ/FkEK8vgTwQ90s5AJrKHfzLVVedDfUCp6N8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFBU5dHdqduaZIUqhvFTolMhVEvWGMB0GA1UdDgQWBBQVOXR3anbmmSFKobxU6JTIVRL1hjAKBggqhkjOPQQDAwNoADBlAjAmTos/Y\u002BsjdfHSkcwpGl3QQXmuBb2P941LubNMF9kkEuY2lD1/oIE1738r6qcst1YCMQDXpmMFt4zzp0B9yYGFNT74jYGvSd9PeDudhQbrjjhi6HHW0cviLM5XZ0kIFSFPohA=",
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614985295,
-          "exp": 1646521895,
-          "created": 1614985895,
-          "updated": 1614985895,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "subject": "CN=default",
-        "issuer": "CN=default",
-        "serialnumber": "24CEEE9826BD4256982B5FEE07A05EA5"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/366712349/341e62c818d24d93af9abbf2672bc0c8?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-dbd0a2aab905db46988af4a88e0798cf-8a9eaf7d6e618344-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "5388b2dcfdbfcc9e51ceeb23cb27e29d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1487",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:40 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "8dbdab96-6d75-4f17-8707-7181be3752b4",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIHOAgEAMBAGByqGSM49AgEGBSuBBAAiBIGnMIGkAgEBBDBVCCriv4ZoYLUbCnTZ\nYTxrwd1Pfe0EafUb74ysrRSjy0rA5aEpmoeQFjgDA6bdkmKgBwYFK4EEACKhZANi\nAASAtLdRLUOoME9YVX55f36xMBqUBxDenNCFN/ZJ5U\u002BQ/wVZntXQSrQdFgOHFPbI\n9g7Hjpuuy190cIq3ShjWcnQFpfgEEhmJH2fxZBCvL4E8EPdLOQCayh38y1VXnQ31\nAqegDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIB2zCCAWGgAwIBAgIQJM7umCa9QlaYK1/uB6BepTAKBggqhkjOPQQDAzASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDEzNVoXDTIyMDMwNTIzMTEzNVow\nEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABIC0t1Et\nQ6gwT1hVfnl/frEwGpQHEN6c0IU39knlT5D/BVme1dBKtB0WA4cU9sj2DseOm67L\nX3RwirdKGNZydAWl\u002BAQSGYkfZ/FkEK8vgTwQ90s5AJrKHfzLVVedDfUCp6N8MHow\nDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEG\nCCsGAQUFBwMCMB8GA1UdIwQYMBaAFBU5dHdqduaZIUqhvFTolMhVEvWGMB0GA1Ud\nDgQWBBQVOXR3anbmmSFKobxU6JTIVRL1hjAKBggqhkjOPQQDAwNoADBlAjAmTos/\nY\u002BsjdfHSkcwpGl3QQXmuBb2P941LubNMF9kkEuY2lD1/oIE1738r6qcst1YCMQDX\npmMFt4zzp0B9yYGFNT74jYGvSd9PeDudhQbrjjhi6HHW0cviLM5XZ0kIFSFPohA=\n-----END CERTIFICATE-----\n",
-        "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/366712349/341e62c818d24d93af9abbf2672bc0c8",
-        "managed": true,
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614985295,
-          "exp": 1646521895,
-          "created": 1614985895,
-          "updated": 1614985895,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/366712349/341e62c818d24d93af9abbf2672bc0c8"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/366712349/341e62c818d24d93af9abbf2672bc0c8?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-3c1f0abc7f0fdb48aa80102629022da5-c42c743a3e59e641-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "18996f6b4983dfa008edc19ec8a3eb8f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "481",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:40 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "b4854745-34d7-4685-95f3-7cf4618dec43",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "46b2b886-6d99-440e-b0c1-62fb9fc06459",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/366712349/341e62c818d24d93af9abbf2672bc0c8",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/366712349/a46479653d1b47a9932f4f8e47eb9ae6",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-384",
-          "x": "gLS3US1DqDBPWFV-eX9-sTAalAcQ3pzQhTf2SeVPkP8FWZ7V0Eq0HRYDhxT2yPYO",
-          "y": "x46brstfdHCKt0oY1nJ0BaX4BBIZiR9n8WQQry-BPBD3SzkAmsod_MtVV50N9QKn"
+          "x": "h5uijSwHfIdyvsXerYrCTn32r3GnazYH9bZ825ucI8UdH_jX3db9DYR5CmPD3Ccy",
+          "y": "1zLiKUowFPKC5jBrgxDKOWoj0c5-CUh2LuB8Lzp8j0QTDTSTXKLLLBIGE8GF282v"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985295,
-          "exp": 1646521895,
-          "created": 1614985895,
-          "updated": 1614985895,
+          "nbf": 1617848660,
+          "exp": 1649385260,
+          "created": 1617849260,
+          "updated": 1617849260,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -624,7 +586,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1346297902"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-521).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-521).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/3894040/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-0371224d4f001f46b5f2ece19ef1dc6a-aef4e0de993d3e46-00",
+        "traceparent": "00-c0cf6e14b86739488e212c463c01040d-10a3414fc6b9a949-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "878fbea0c04211b724fe855662fb60c9",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:00 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:23 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "878fbea0c04211b724fe855662fb60c9",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c7a00074-5dd6-4751-a3ca-6527368ed658",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "44489cfa-9bbf-4bee-8ad1-457a428b367d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/3894040/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-0371224d4f001f46b5f2ece19ef1dc6a-aef4e0de993d3e46-00",
+        "traceparent": "00-c0cf6e14b86739488e212c463c01040d-10a3414fc6b9a949-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "878fbea0c04211b724fe855662fb60c9",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "939",
+        "Content-Length": "934",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:00 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:24 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending?api-version=7.2\u0026request_id=6bc49a1605e949999b719fd3c48427eb",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/3894040/pending?api-version=7.2\u0026request_id=18d05517018844ad891304503f1cf4f6",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "878fbea0c04211b724fe855662fb60c9",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "eacd7ee3-9856-448f-b5b9-1ab6fbaf5118",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "12941f20-68ba-4739-a9a1-bde55f3f96de",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/3894040/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBo3d/LqtP4PMxVRK5TAcK7QpV2nGBn1OAA\u002BSqdIfo7dhRb8atp9Gl5p\u002BoMGpS69c17lFYnCjam7yJb/tCW1hcAOoCQgEDlfgyhyQRDBctQdvcGicO/jLCTNaBUL\u002Ba41H0sX8aJbtu93OtEA755ufZiT3XvqSEr9tp62ANXATmHHUrlL2pAA==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfPp3M2SCRuoDWyZxou2lZiqDnNQKJfd6hwcIOirDPcxrdFG1BdmJY6M4H04BLjr\u002BhcC9fKPn0VVTgtIGwquSLosABe9yktMdyVCseXfs4L3nlKIr7SWvCa3JthLcGoSsHcVRP6fmJXkLPM96TKi3sKp1CRjQfFshDsu0w/5n8O67YC2oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBuCkEWsU/6bNIxWfFoXKaK94yM/oqBXjsqu2emSvbEDYQiq8oQEzk1LG01w4ZUvICID/XgxP2qKOstXwAl417enMCQUmA4AQgC4dGehJtXAczOihQ4Evymsp9AsG8i2gN2KB9OP0a3DRyFzY7fF/CHytx6KPcrr7v\u002B7P7XSjS2s/LA1V2",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "6bc49a1605e949999b719fd3c48427eb"
+        "request_id": "18d05517018844ad891304503f1cf4f6"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/3894040/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "b451da135236f287e7b2c890bfdc0904",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "939",
+        "Content-Length": "934",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:01 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b451da135236f287e7b2c890bfdc0904",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2320b612-3c37-4ab8-8b66-6d65f36098cb",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "27fe142b-027c-4414-825c-b0d901c01d2f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/3894040/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBo3d/LqtP4PMxVRK5TAcK7QpV2nGBn1OAA\u002BSqdIfo7dhRb8atp9Gl5p\u002BoMGpS69c17lFYnCjam7yJb/tCW1hcAOoCQgEDlfgyhyQRDBctQdvcGicO/jLCTNaBUL\u002Ba41H0sX8aJbtu93OtEA755ufZiT3XvqSEr9tp62ANXATmHHUrlL2pAA==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfPp3M2SCRuoDWyZxou2lZiqDnNQKJfd6hwcIOirDPcxrdFG1BdmJY6M4H04BLjr\u002BhcC9fKPn0VVTgtIGwquSLosABe9yktMdyVCseXfs4L3nlKIr7SWvCa3JthLcGoSsHcVRP6fmJXkLPM96TKi3sKp1CRjQfFshDsu0w/5n8O67YC2oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBuCkEWsU/6bNIxWfFoXKaK94yM/oqBXjsqu2emSvbEDYQiq8oQEzk1LG01w4ZUvICID/XgxP2qKOstXwAl417enMCQUmA4AQgC4dGehJtXAczOihQ4Evymsp9AsG8i2gN2KB9OP0a3DRyFzY7fF/CHytx6KPcrr7v\u002B7P7XSjS2s/LA1V2",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "6bc49a1605e949999b719fd3c48427eb"
+        "request_id": "18d05517018844ad891304503f1cf4f6"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/3894040/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "948e69079c52623c0c02df1f32f2c976",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "939",
+        "Content-Length": "934",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:06 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "948e69079c52623c0c02df1f32f2c976",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ea0feca7-a801-4567-9f37-5a117ffcadfd",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "409f5565-3b0e-469c-8783-116681a63824",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/3894040/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBo3d/LqtP4PMxVRK5TAcK7QpV2nGBn1OAA\u002BSqdIfo7dhRb8atp9Gl5p\u002BoMGpS69c17lFYnCjam7yJb/tCW1hcAOoCQgEDlfgyhyQRDBctQdvcGicO/jLCTNaBUL\u002Ba41H0sX8aJbtu93OtEA755ufZiT3XvqSEr9tp62ANXATmHHUrlL2pAA==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfPp3M2SCRuoDWyZxou2lZiqDnNQKJfd6hwcIOirDPcxrdFG1BdmJY6M4H04BLjr\u002BhcC9fKPn0VVTgtIGwquSLosABe9yktMdyVCseXfs4L3nlKIr7SWvCa3JthLcGoSsHcVRP6fmJXkLPM96TKi3sKp1CRjQfFshDsu0w/5n8O67YC2oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBuCkEWsU/6bNIxWfFoXKaK94yM/oqBXjsqu2emSvbEDYQiq8oQEzk1LG01w4ZUvICID/XgxP2qKOstXwAl417enMCQUmA4AQgC4dGehJtXAczOihQ4Evymsp9AsG8i2gN2KB9OP0a3DRyFzY7fF/CHytx6KPcrr7v\u002B7P7XSjS2s/LA1V2",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "6bc49a1605e949999b719fd3c48427eb"
+        "request_id": "18d05517018844ad891304503f1cf4f6"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/3894040/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "ee5188ca041e4ee1369ca08ff7265148",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "939",
+        "Content-Length": "934",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:11 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:34 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ee5188ca041e4ee1369ca08ff7265148",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1261bd2d-e074-4257-aa44-18d0dc734390",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "cc0eff0f-ab46-4af7-ade8-6f02b96e4c43",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/3894040/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBo3d/LqtP4PMxVRK5TAcK7QpV2nGBn1OAA\u002BSqdIfo7dhRb8atp9Gl5p\u002BoMGpS69c17lFYnCjam7yJb/tCW1hcAOoCQgEDlfgyhyQRDBctQdvcGicO/jLCTNaBUL\u002Ba41H0sX8aJbtu93OtEA755ufZiT3XvqSEr9tp62ANXATmHHUrlL2pAA==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfPp3M2SCRuoDWyZxou2lZiqDnNQKJfd6hwcIOirDPcxrdFG1BdmJY6M4H04BLjr\u002BhcC9fKPn0VVTgtIGwquSLosABe9yktMdyVCseXfs4L3nlKIr7SWvCa3JthLcGoSsHcVRP6fmJXkLPM96TKi3sKp1CRjQfFshDsu0w/5n8O67YC2oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBuCkEWsU/6bNIxWfFoXKaK94yM/oqBXjsqu2emSvbEDYQiq8oQEzk1LG01w4ZUvICID/XgxP2qKOstXwAl417enMCQUmA4AQgC4dGehJtXAczOihQ4Evymsp9AsG8i2gN2KB9OP0a3DRyFzY7fF/CHytx6KPcrr7v\u002B7P7XSjS2s/LA1V2",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "6bc49a1605e949999b719fd3c48427eb"
+        "request_id": "18d05517018844ad891304503f1cf4f6"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/3894040/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "f94f81f4cb6c76779eefa7337268c0f5",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "939",
+        "Content-Length": "839",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:39 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f94f81f4cb6c76779eefa7337268c0f5",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9a543a72-b2c0-4cb2-83d6-b213c144fcfb",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5f5ce6b9-f92d-46c2-9908-bfd1eeb1233f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/3894040/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBo3d/LqtP4PMxVRK5TAcK7QpV2nGBn1OAA\u002BSqdIfo7dhRb8atp9Gl5p\u002BoMGpS69c17lFYnCjam7yJb/tCW1hcAOoCQgEDlfgyhyQRDBctQdvcGicO/jLCTNaBUL\u002Ba41H0sX8aJbtu93OtEA755ufZiT3XvqSEr9tp62ANXATmHHUrlL2pAA==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfPp3M2SCRuoDWyZxou2lZiqDnNQKJfd6hwcIOirDPcxrdFG1BdmJY6M4H04BLjr\u002BhcC9fKPn0VVTgtIGwquSLosABe9yktMdyVCseXfs4L3nlKIr7SWvCa3JthLcGoSsHcVRP6fmJXkLPM96TKi3sKp1CRjQfFshDsu0w/5n8O67YC2oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBuCkEWsU/6bNIxWfFoXKaK94yM/oqBXjsqu2emSvbEDYQiq8oQEzk1LG01w4ZUvICID/XgxP2qKOstXwAl417enMCQUmA4AQgC4dGehJtXAczOihQ4Evymsp9AsG8i2gN2KB9OP0a3DRyFzY7fF/CHytx6KPcrr7v\u002B7P7XSjS2s/LA1V2",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "6bc49a1605e949999b719fd3c48427eb"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/3894040",
+        "request_id": "18d05517018844ad891304503f1cf4f6"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/3894040?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "36c651e91b8a02e587405eb6fcac6be5",
         "x-ms-return-client-request-id": "true"
@@ -300,299 +305,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "939",
+        "Content-Length": "1923",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:22 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7121833b-9fc9-4998-9981-83cba2527f3a",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBo3d/LqtP4PMxVRK5TAcK7QpV2nGBn1OAA\u002BSqdIfo7dhRb8atp9Gl5p\u002BoMGpS69c17lFYnCjam7yJb/tCW1hcAOoCQgEDlfgyhyQRDBctQdvcGicO/jLCTNaBUL\u002Ba41H0sX8aJbtu93OtEA755ufZiT3XvqSEr9tp62ANXATmHHUrlL2pAA==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "6bc49a1605e949999b719fd3c48427eb"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "b02a97b1cfa2fe0a11da502f5caddcce",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "939",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "8287d605-2164-47e4-9397-ea0553ffb0f3",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBo3d/LqtP4PMxVRK5TAcK7QpV2nGBn1OAA\u002BSqdIfo7dhRb8atp9Gl5p\u002BoMGpS69c17lFYnCjam7yJb/tCW1hcAOoCQgEDlfgyhyQRDBctQdvcGicO/jLCTNaBUL\u002Ba41H0sX8aJbtu93OtEA755ufZiT3XvqSEr9tp62ANXATmHHUrlL2pAA==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "6bc49a1605e949999b719fd3c48427eb"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "a5a6abdb1b60d8be9b4c712c6dc07af1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "939",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:31 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "cbc1c8d6-fc71-4c84-b14b-e9eeb763b1b1",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBo3d/LqtP4PMxVRK5TAcK7QpV2nGBn1OAA\u002BSqdIfo7dhRb8atp9Gl5p\u002BoMGpS69c17lFYnCjam7yJb/tCW1hcAOoCQgEDlfgyhyQRDBctQdvcGicO/jLCTNaBUL\u002Ba41H0sX8aJbtu93OtEA755ufZiT3XvqSEr9tp62ANXATmHHUrlL2pAA==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "6bc49a1605e949999b719fd3c48427eb"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "db82c1840f3d195247c724afcbb5a6da",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "939",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "44147f9c-d9cf-44a9-8173-bd49ad479610",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBo3d/LqtP4PMxVRK5TAcK7QpV2nGBn1OAA\u002BSqdIfo7dhRb8atp9Gl5p\u002BoMGpS69c17lFYnCjam7yJb/tCW1hcAOoCQgEDlfgyhyQRDBctQdvcGicO/jLCTNaBUL\u002Ba41H0sX8aJbtu93OtEA755ufZiT3XvqSEr9tp62ANXATmHHUrlL2pAA==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "6bc49a1605e949999b719fd3c48427eb"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "51da8f63c5069685d95215565ddd9151",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "939",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:41 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e26fdae6-2c6f-4096-9abb-ab5ebd63f618",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBo3d/LqtP4PMxVRK5TAcK7QpV2nGBn1OAA\u002BSqdIfo7dhRb8atp9Gl5p\u002BoMGpS69c17lFYnCjam7yJb/tCW1hcAOoCQgEDlfgyhyQRDBctQdvcGicO/jLCTNaBUL\u002Ba41H0sX8aJbtu93OtEA755ufZiT3XvqSEr9tp62ANXATmHHUrlL2pAA==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "6bc49a1605e949999b719fd3c48427eb"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "9aab5f60002acc90588d5e99f60e0de5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "845",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:47 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:39 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "36c651e91b8a02e587405eb6fcac6be5",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "709e060e-bcf8-41eb-8452-e054d24fe25d",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "8d9d7372-4aa7-401a-b4a3-37dcf950d11f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBo3d/LqtP4PMxVRK5TAcK7QpV2nGBn1OAA\u002BSqdIfo7dhRb8atp9Gl5p\u002BoMGpS69c17lFYnCjam7yJb/tCW1hcAOoCQgEDlfgyhyQRDBctQdvcGicO/jLCTNaBUL\u002Ba41H0sX8aJbtu93OtEA755ufZiT3XvqSEr9tp62ANXATmHHUrlL2pAA==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/3894040",
-        "request_id": "6bc49a1605e949999b719fd3c48427eb"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ddc897a629e6beea3cec02ebfafcbb6a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1928",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:47 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0462a69f-b201-4f6b-9ac7-0cd158b55c8e",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/65c877f8796b46fd828715a679d32d83",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/3894040/65c877f8796b46fd828715a679d32d83",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/3894040/65c877f8796b46fd828715a679d32d83",
-        "x5t": "Lh8YZctQL0wsjR1vDmZm24JINkg",
-        "cer": "MIICJjCCAYegAwIBAgIQWqciL2LoRnykwvPCaZZ2KTAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTI0M1oXDTIyMDMwNTIzMDI0M1owEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUzTIMPo2EhZlmJHizOCjMqbiTKdEwHQYDVR0OBBYEFM0yDD6NhIWZZiR4szgozKm4kynRMAoGCCqGSM49BAMEA4GMADCBiAJCAR97JH0AwtDng5pjm3C58bkCh1LmxH1aP49v5\u002BZrLRuGpHnTy/s\u002BjKXtjo8CLrZgbRQPRw/NdezYjxKJNoZ5zc9KAkIBMq0TGVosftj7O4TH74bL9wlW9RAoGP8DYN5ymrI/tdM2dgo7hbYczyk6TLaFGWpuGpY1hF\u002BoB3xH6rymsqimEjo=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/3894040/2cf4b92225e749d1895296c4e1cf806b",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/3894040/2cf4b92225e749d1895296c4e1cf806b",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/3894040/2cf4b92225e749d1895296c4e1cf806b",
+        "x5t": "zUXPG8hm5Erfpt1A2_suNYqUEcM",
+        "cer": "MIICJjCCAYegAwIBAgIQVtMyVE5\u002BR\u002BmHd4a/eeiJhjAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjAzOFoXDTIyMDQwODAyMzAzOFowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfPp3M2SCRuoDWyZxou2lZiqDnNQKJfd6hwcIOirDPcxrdFG1BdmJY6M4H04BLjr\u002BhcC9fKPn0VVTgtIGwquSLosABe9yktMdyVCseXfs4L3nlKIr7SWvCa3JthLcGoSsHcVRP6fmJXkLPM96TKi3sKp1CRjQfFshDsu0w/5n8O67YC2o3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAU4yTcP\u002BgD0kcpUZMxKWc0lJZD1wEwHQYDVR0OBBYEFOMk3D/oA9JHKVGTMSlnNJSWQ9cBMAoGCCqGSM49BAMEA4GMADCBiAJCAZj\u002B7V3O1TnOmtxtqh2oLXmnSx7K7c3yVvDlAcOA4TxrDGhgmjBimT8\u002BSO\u002B13WIZqwb\u002BrnNwq5UdFRYsPw\u002BZgTwQAkIBYIjCFA6WY4\u002BCy/LgiIo9gO\u002BWrj6GnDrq/b87ybM1o8F/ZC5g510LkCmphSeLWw\u002BQXMSAIhH8s4XBlhuGHgdIOnQ=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984763,
-          "exp": 1646521363,
-          "created": 1614985363,
-          "updated": 1614985363,
+          "nbf": 1617848438,
+          "exp": 1649385038,
+          "created": 1617849038,
+          "updated": 1617849038,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/3894040/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -632,166 +375,209 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985321,
-            "updated": 1614985321
+            "created": 1617849024,
+            "updated": 1617849024
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/3894040/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/3894040/65c877f8796b46fd828715a679d32d83?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/3894040/2cf4b92225e749d1895296c4e1cf806b?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-74441ef17daf8c46b7d64034ad2ac739-dff4e50bd058ce42-00",
+        "traceparent": "00-1e6adaf82617964c80051a08221db482-ad9a15d8a1c31c4c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "6c4fd3350c0962b0ff0ef87967ec9fca",
+        "x-ms-client-request-id": "b02a97b1cfa2fe0a11da502f5caddcce",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1337",
+        "Content-Length": "1334",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:52 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b02a97b1cfa2fe0a11da502f5caddcce",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "34134924-de96-40fa-9fb9-c6af24f3e442",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b132dc5f-3de8-4317-8d24-66392d383a6f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/3894040/65c877f8796b46fd828715a679d32d83",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/3894040/65c877f8796b46fd828715a679d32d83",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/3894040/65c877f8796b46fd828715a679d32d83",
-        "x5t": "Lh8YZctQL0wsjR1vDmZm24JINkg",
-        "cer": "MIICJjCCAYegAwIBAgIQWqciL2LoRnykwvPCaZZ2KTAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTI0M1oXDTIyMDMwNTIzMDI0M1owEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGnglcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUzTIMPo2EhZlmJHizOCjMqbiTKdEwHQYDVR0OBBYEFM0yDD6NhIWZZiR4szgozKm4kynRMAoGCCqGSM49BAMEA4GMADCBiAJCAR97JH0AwtDng5pjm3C58bkCh1LmxH1aP49v5\u002BZrLRuGpHnTy/s\u002BjKXtjo8CLrZgbRQPRw/NdezYjxKJNoZ5zc9KAkIBMq0TGVosftj7O4TH74bL9wlW9RAoGP8DYN5ymrI/tdM2dgo7hbYczyk6TLaFGWpuGpY1hF\u002BoB3xH6rymsqimEjo=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/3894040/2cf4b92225e749d1895296c4e1cf806b",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/3894040/2cf4b92225e749d1895296c4e1cf806b",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/3894040/2cf4b92225e749d1895296c4e1cf806b",
+        "x5t": "zUXPG8hm5Erfpt1A2_suNYqUEcM",
+        "cer": "MIICJjCCAYegAwIBAgIQVtMyVE5\u002BR\u002BmHd4a/eeiJhjAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjAzOFoXDTIyMDQwODAyMzAzOFowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfPp3M2SCRuoDWyZxou2lZiqDnNQKJfd6hwcIOirDPcxrdFG1BdmJY6M4H04BLjr\u002BhcC9fKPn0VVTgtIGwquSLosABe9yktMdyVCseXfs4L3nlKIr7SWvCa3JthLcGoSsHcVRP6fmJXkLPM96TKi3sKp1CRjQfFshDsu0w/5n8O67YC2o3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAU4yTcP\u002BgD0kcpUZMxKWc0lJZD1wEwHQYDVR0OBBYEFOMk3D/oA9JHKVGTMSlnNJSWQ9cBMAoGCCqGSM49BAMEA4GMADCBiAJCAZj\u002B7V3O1TnOmtxtqh2oLXmnSx7K7c3yVvDlAcOA4TxrDGhgmjBimT8\u002BSO\u002B13WIZqwb\u002BrnNwq5UdFRYsPw\u002BZgTwQAkIBYIjCFA6WY4\u002BCy/LgiIo9gO\u002BWrj6GnDrq/b87ybM1o8F/ZC5g510LkCmphSeLWw\u002BQXMSAIhH8s4XBlhuGHgdIOnQ=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984763,
-          "exp": 1646521363,
-          "created": 1614985363,
-          "updated": 1614985363,
+          "nbf": 1617848438,
+          "exp": 1649385038,
+          "created": 1617849038,
+          "updated": 1617849038,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "5AA7222F62E8467CA4C2F3C269967629"
+        "serialnumber": "56D332544E7E47E9877786BF79E88986"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/3894040/65c877f8796b46fd828715a679d32d83?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/3894040/2cf4b92225e749d1895296c4e1cf806b?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-74441ef17daf8c46b7d64034ad2ac739-f78539080899944d-00",
+        "traceparent": "00-1e6adaf82617964c80051a08221db482-14471cbc31759b44-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "c6af2f44b414376a74ed5d3dfea5d15c",
+        "x-ms-client-request-id": "a5a6abdb1b60d8be9b4c712c6dc07af1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1665",
+        "Content-Length": "1663",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:52 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a5a6abdb1b60d8be9b4c712c6dc07af1",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7f9da6b9-2391-44db-9d26-75e9a39e7452",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "38e44238-fd68-4db7-b976-1f8c1b98896a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIIBBgIBADAQBgcqhkjOPQIBBgUrgQQAIwSB3zCB3AIBAQRCAfi5yZZln/\u002BbLpTG\n9J74uYlNx/l3qt5WjgKDPHaEmJrkCiejpCiaFClBOfmOYhb9c83MYKDQeLgu3zTS\nnX3tY4ifoAcGBSuBBAAjoYGJA4GGAAQAaeCVwiKOvetjof1x\u002B2FTpK7Pyrf\u002BzAiF\nhoUtniTSHyMgLF5wHlT1yQc\u002BpDORjYe\u002B5U\u002BJnm8Rl\u002BJ1ifaaZCpfUzcAvL3\u002BFoc9\ns8SGWqbd6vD8\u002B\u002Beq2/9kszPXB8CTOaea\u002BcjMFUcNa2AgujCETPT15IqdKpEz0vz2\nNa4vRfyJJ62sSpWgDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICJjCCAYegAwIBAgIQWqciL2LoRnykwvPCaZZ2KTAKBggqhkjOPQQDBDASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTI0M1oXDTIyMDMwNTIzMDI0M1ow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGng\nlcIijr3rY6H9cfthU6Suz8q3/swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVP\niZ5vEZfidYn2mmQqX1M3ALy9/haHPbPEhlqm3erw/Pvnqtv/ZLMz1wfAkzmnmvnI\nzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqVo3wwejAOBgNVHQ8BAf8E\nBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw\nHwYDVR0jBBgwFoAUzTIMPo2EhZlmJHizOCjMqbiTKdEwHQYDVR0OBBYEFM0yDD6N\nhIWZZiR4szgozKm4kynRMAoGCCqGSM49BAMEA4GMADCBiAJCAR97JH0AwtDng5pj\nm3C58bkCh1LmxH1aP49v5\u002BZrLRuGpHnTy/s\u002BjKXtjo8CLrZgbRQPRw/NdezYjxKJ\nNoZ5zc9KAkIBMq0TGVosftj7O4TH74bL9wlW9RAoGP8DYN5ymrI/tdM2dgo7hbYc\nzyk6TLaFGWpuGpY1hF\u002BoB3xH6rymsqimEjo=\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIIBBgIBADAQBgcqhkjOPQIBBgUrgQQAIwSB3zCB3AIBAQRCAaUjvyfyn5Mm69aR\nq/f22AAb4vNquXm3otOgiHi6Pkn/LsqKeQ\u002Bf4YVUphRRTLJNfp9TuiQFKLg2ES7p\nOTC1JXpaoAcGBSuBBAAjoYGJA4GGAAQB8\u002BnczZIJG6gNbJnGi7aVmKoOc1Aol93q\nHBwg6KsM9zGt0UbUF2YljozgfTgEuOv6FwL18o\u002BfRVVOC0gbCq5IuiwAF73KS0x3\nJUKx5d\u002BzgveeUoivtJa8Jrcm2EtwahKwdxVE/p\u002BYleQs8z3pMqLewqnUJGNB8WyE\nOy7TD/mfw7rtgLagDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICJjCCAYegAwIBAgIQVtMyVE5\u002BR\u002BmHd4a/eeiJhjAKBggqhkjOPQQDBDASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjAzOFoXDTIyMDQwODAyMzAzOFow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfPp\n3M2SCRuoDWyZxou2lZiqDnNQKJfd6hwcIOirDPcxrdFG1BdmJY6M4H04BLjr\u002BhcC\n9fKPn0VVTgtIGwquSLosABe9yktMdyVCseXfs4L3nlKIr7SWvCa3JthLcGoSsHcV\nRP6fmJXkLPM96TKi3sKp1CRjQfFshDsu0w/5n8O67YC2o3wwejAOBgNVHQ8BAf8E\nBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw\nHwYDVR0jBBgwFoAU4yTcP\u002BgD0kcpUZMxKWc0lJZD1wEwHQYDVR0OBBYEFOMk3D/o\nA9JHKVGTMSlnNJSWQ9cBMAoGCCqGSM49BAMEA4GMADCBiAJCAZj\u002B7V3O1TnOmtxt\nqh2oLXmnSx7K7c3yVvDlAcOA4TxrDGhgmjBimT8\u002BSO\u002B13WIZqwb\u002BrnNwq5UdFRYs\nPw\u002BZgTwQAkIBYIjCFA6WY4\u002BCy/LgiIo9gO\u002BWrj6GnDrq/b87ybM1o8F/ZC5g510L\nkCmphSeLWw\u002BQXMSAIhH8s4XBlhuGHgdIOnQ=\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/3894040/65c877f8796b46fd828715a679d32d83",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/3894040/2cf4b92225e749d1895296c4e1cf806b",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614984763,
-          "exp": 1646521363,
-          "created": 1614985363,
-          "updated": 1614985363,
+          "nbf": 1617848438,
+          "exp": 1649385038,
+          "created": 1617849038,
+          "updated": 1617849038,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/3894040/65c877f8796b46fd828715a679d32d83"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/3894040/2cf4b92225e749d1895296c4e1cf806b"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/3894040/65c877f8796b46fd828715a679d32d83?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/3894040/2cf4b92225e749d1895296c4e1cf806b?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-2568ceaff6838c488355bf8d5c0d34f2-7e135396959d1046-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "db82c1840f3d195247c724afcbb5a6da",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:30:45 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "db82c1840f3d195247c724afcbb5a6da",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "7e50f3db-ee60-469d-ad61-8891c0bf649d",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/3894040/2cf4b92225e749d1895296c4e1cf806b?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-1efb22d5327fae49aaaba14278a4f664-2f47732ebb07ee40-00",
+        "traceparent": "00-2568ceaff6838c488355bf8d5c0d34f2-7e135396959d1046-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "2363f3d1a1be9adce765ded830715750",
+        "x-ms-client-request-id": "db82c1840f3d195247c724afcbb5a6da",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "527",
+        "Content-Length": "526",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:02:52 GMT",
+        "Date": "Thu, 08 Apr 2021 02:30:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "db82c1840f3d195247c724afcbb5a6da",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5e0d4aae-4669-4651-9ca6-c7e8e74e5b63",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1b1787c7-bfd9-4544-92e0-dbb206a6f179",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/3894040/65c877f8796b46fd828715a679d32d83",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/3894040/2cf4b92225e749d1895296c4e1cf806b",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-521",
-          "x": "AGnglcIijr3rY6H9cfthU6Suz8q3_swIhYaFLZ4k0h8jICxecB5U9ckHPqQzkY2HvuVPiZ5vEZfidYn2mmQqX1M3",
-          "y": "ALy9_haHPbPEhlqm3erw_Pvnqtv_ZLMz1wfAkzmnmvnIzBVHDWtgILowhEz09eSKnSqRM9L89jWuL0X8iSetrEqV"
+          "x": "AfPp3M2SCRuoDWyZxou2lZiqDnNQKJfd6hwcIOirDPcxrdFG1BdmJY6M4H04BLjr-hcC9fKPn0VVTgtIGwquSLos",
+          "y": "ABe9yktMdyVCseXfs4L3nlKIr7SWvCa3JthLcGoSsHcVRP6fmJXkLPM96TKi3sKp1CRjQfFshDsu0w_5n8O67YC2"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984763,
-          "exp": 1646521363,
-          "created": 1614985363,
-          "updated": 1614985363,
+          "nbf": 1617848438,
+          "exp": 1649385038,
+          "created": 1617849038,
+          "updated": 1617849038,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -800,7 +586,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "865694550"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-521)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pem-file,P-521)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1952125127/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1952125127/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-f75306f6041dac4c924e65ce71f378ba-5bd6b4689f088146-00",
+        "traceparent": "00-1f386c57f2ee00439234e8a985f9bbfc-366f9f262a95b84a-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "e8ff8f911f8eb3174519388f99dbcc01",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:40 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e8ff8f911f8eb3174519388f99dbcc01",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7ce38ba2-3c30-4e28-a110-497aae390615",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "448d4d1a-61b2-4b7d-b6bf-6292eb5aeadc",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1952125127/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1952125127/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-f75306f6041dac4c924e65ce71f378ba-5bd6b4689f088146-00",
+        "traceparent": "00-1f386c57f2ee00439234e8a985f9bbfc-366f9f262a95b84a-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "e8ff8f911f8eb3174519388f99dbcc01",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "938",
+        "Content-Length": "941",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:40 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:21 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending?api-version=7.2\u0026request_id=ccccda7188ea403f964dcbab9d363781",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1952125127/pending?api-version=7.2\u0026request_id=df44a220ecec4f12a5c96c1a948f29f4",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e8ff8f911f8eb3174519388f99dbcc01",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "826c6239-17ba-46c0-a36a-ff365eeeeccf",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "9994eeff-36c8-4f23-a263-d9b09fb85adb",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1952125127/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAOTt/p4DurqxMqyKwMgZ\u002BU9/NlcuDzqHImya2G0ClaZSq2IdDUX1GQrs7wDZhT\u002Br/7MJRHaMmh4PcoBi8VNzTr4pAZXIejryfHlDwGW511HSco36itLuqQAYlbr9Ta7In8lcA\u002BVBomXv/IozLgbVh9OwCMuh8WRNF04t6KWID25fWmEyoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBiFRVo02qNsTPYR6lMQ07elUx5HM6Rcqx1Ms8T7/iut6joQW0xFsK6kjvz2WE9nHMlrBJu5M7xoIZZQ0tRfLzmT4CQVlMUum1QnltPpMV5MuBZiWzP019NN7kXWp\u002BdsfteDDUNCUjbRI17Et34kvs3F1NnoFa55G2k3Qn4Ae8wlbk1CsM",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEALMIrzMVFGNHyaacwxFZmG5VEEaNL0wVY8ddZAKqKZvswMlojxhIx3\u002B5A4XzuX/eZeykj61XGl6URtsbjdlwXuRJAdWTKYoroSiNy\u002BayoCimt6Go1duF7HqIAntJxiLuP86nsX/YMCKv3lePuYXihc4lp3oF2vdXoxmYohYNsv\u002Bwwr6foEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIAo36Hh7A2kajq5vYNINwGQPkqynuTfu2QGjLjBWNly9rDwyQBt/rSukwSKx1M7fXZgeeMpyOQXkQrUGp97OMpqS8CQgC78W0sr/gs0yb2Jgd\u002Bq2U8NzBLGRkp5RfpmtraRJ8CRo4xA2cFi955/8O97oS08/SYqkxq9Gc6JJShHzMQ3IEuUw==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ccccda7188ea403f964dcbab9d363781"
+        "request_id": "df44a220ecec4f12a5c96c1a948f29f4"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1952125127/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "72bb3e79edd2afe332abc8d9a0bfc585",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "938",
+        "Content-Length": "941",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:40 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "72bb3e79edd2afe332abc8d9a0bfc585",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c4228055-8128-44e5-925d-704b7f7461d9",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "eed343de-f481-42da-943a-3f588bcf51b1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1952125127/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAOTt/p4DurqxMqyKwMgZ\u002BU9/NlcuDzqHImya2G0ClaZSq2IdDUX1GQrs7wDZhT\u002Br/7MJRHaMmh4PcoBi8VNzTr4pAZXIejryfHlDwGW511HSco36itLuqQAYlbr9Ta7In8lcA\u002BVBomXv/IozLgbVh9OwCMuh8WRNF04t6KWID25fWmEyoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBiFRVo02qNsTPYR6lMQ07elUx5HM6Rcqx1Ms8T7/iut6joQW0xFsK6kjvz2WE9nHMlrBJu5M7xoIZZQ0tRfLzmT4CQVlMUum1QnltPpMV5MuBZiWzP019NN7kXWp\u002BdsfteDDUNCUjbRI17Et34kvs3F1NnoFa55G2k3Qn4Ae8wlbk1CsM",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEALMIrzMVFGNHyaacwxFZmG5VEEaNL0wVY8ddZAKqKZvswMlojxhIx3\u002B5A4XzuX/eZeykj61XGl6URtsbjdlwXuRJAdWTKYoroSiNy\u002BayoCimt6Go1duF7HqIAntJxiLuP86nsX/YMCKv3lePuYXihc4lp3oF2vdXoxmYohYNsv\u002Bwwr6foEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIAo36Hh7A2kajq5vYNINwGQPkqynuTfu2QGjLjBWNly9rDwyQBt/rSukwSKx1M7fXZgeeMpyOQXkQrUGp97OMpqS8CQgC78W0sr/gs0yb2Jgd\u002Bq2U8NzBLGRkp5RfpmtraRJ8CRo4xA2cFi955/8O97oS08/SYqkxq9Gc6JJShHzMQ3IEuUw==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ccccda7188ea403f964dcbab9d363781"
+        "request_id": "df44a220ecec4f12a5c96c1a948f29f4"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1952125127/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "c1818e7671ea1fb16dfc2ecab480f7ae",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "938",
+        "Content-Length": "941",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:45 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:26 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c1818e7671ea1fb16dfc2ecab480f7ae",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c97946f3-1e2d-4974-b74e-c7946c13b557",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6655adb2-8515-4b93-893f-f3f6aba7139c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1952125127/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAOTt/p4DurqxMqyKwMgZ\u002BU9/NlcuDzqHImya2G0ClaZSq2IdDUX1GQrs7wDZhT\u002Br/7MJRHaMmh4PcoBi8VNzTr4pAZXIejryfHlDwGW511HSco36itLuqQAYlbr9Ta7In8lcA\u002BVBomXv/IozLgbVh9OwCMuh8WRNF04t6KWID25fWmEyoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBiFRVo02qNsTPYR6lMQ07elUx5HM6Rcqx1Ms8T7/iut6joQW0xFsK6kjvz2WE9nHMlrBJu5M7xoIZZQ0tRfLzmT4CQVlMUum1QnltPpMV5MuBZiWzP019NN7kXWp\u002BdsfteDDUNCUjbRI17Et34kvs3F1NnoFa55G2k3Qn4Ae8wlbk1CsM",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEALMIrzMVFGNHyaacwxFZmG5VEEaNL0wVY8ddZAKqKZvswMlojxhIx3\u002B5A4XzuX/eZeykj61XGl6URtsbjdlwXuRJAdWTKYoroSiNy\u002BayoCimt6Go1duF7HqIAntJxiLuP86nsX/YMCKv3lePuYXihc4lp3oF2vdXoxmYohYNsv\u002Bwwr6foEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIAo36Hh7A2kajq5vYNINwGQPkqynuTfu2QGjLjBWNly9rDwyQBt/rSukwSKx1M7fXZgeeMpyOQXkQrUGp97OMpqS8CQgC78W0sr/gs0yb2Jgd\u002Bq2U8NzBLGRkp5RfpmtraRJ8CRo4xA2cFi955/8O97oS08/SYqkxq9Gc6JJShHzMQ3IEuUw==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ccccda7188ea403f964dcbab9d363781"
+        "request_id": "df44a220ecec4f12a5c96c1a948f29f4"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1952125127/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "a9cac5f489b2a3f5ab50b6e2573d1285",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "938",
+        "Content-Length": "941",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:51 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:31 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a9cac5f489b2a3f5ab50b6e2573d1285",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0966ece7-47e9-4fa1-9d13-5a8fc4ff88f5",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f50f3104-eac2-4a3f-b865-1f3274978be0",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1952125127/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAOTt/p4DurqxMqyKwMgZ\u002BU9/NlcuDzqHImya2G0ClaZSq2IdDUX1GQrs7wDZhT\u002Br/7MJRHaMmh4PcoBi8VNzTr4pAZXIejryfHlDwGW511HSco36itLuqQAYlbr9Ta7In8lcA\u002BVBomXv/IozLgbVh9OwCMuh8WRNF04t6KWID25fWmEyoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBiFRVo02qNsTPYR6lMQ07elUx5HM6Rcqx1Ms8T7/iut6joQW0xFsK6kjvz2WE9nHMlrBJu5M7xoIZZQ0tRfLzmT4CQVlMUum1QnltPpMV5MuBZiWzP019NN7kXWp\u002BdsfteDDUNCUjbRI17Et34kvs3F1NnoFa55G2k3Qn4Ae8wlbk1CsM",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEALMIrzMVFGNHyaacwxFZmG5VEEaNL0wVY8ddZAKqKZvswMlojxhIx3\u002B5A4XzuX/eZeykj61XGl6URtsbjdlwXuRJAdWTKYoroSiNy\u002BayoCimt6Go1duF7HqIAntJxiLuP86nsX/YMCKv3lePuYXihc4lp3oF2vdXoxmYohYNsv\u002Bwwr6foEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIAo36Hh7A2kajq5vYNINwGQPkqynuTfu2QGjLjBWNly9rDwyQBt/rSukwSKx1M7fXZgeeMpyOQXkQrUGp97OMpqS8CQgC78W0sr/gs0yb2Jgd\u002Bq2U8NzBLGRkp5RfpmtraRJ8CRo4xA2cFi955/8O97oS08/SYqkxq9Gc6JJShHzMQ3IEuUw==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ccccda7188ea403f964dcbab9d363781"
+        "request_id": "df44a220ecec4f12a5c96c1a948f29f4"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1952125127/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "0a19b2540b5908168c9c05d5be19fbb1",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "938",
+        "Content-Length": "849",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:11:56 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:36 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0a19b2540b5908168c9c05d5be19fbb1",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "034f6468-bba7-45e5-a723-d32fc109e1c6",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "9828a4e8-e28c-410b-87ea-b3acfab45231",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1952125127/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAOTt/p4DurqxMqyKwMgZ\u002BU9/NlcuDzqHImya2G0ClaZSq2IdDUX1GQrs7wDZhT\u002Br/7MJRHaMmh4PcoBi8VNzTr4pAZXIejryfHlDwGW511HSco36itLuqQAYlbr9Ta7In8lcA\u002BVBomXv/IozLgbVh9OwCMuh8WRNF04t6KWID25fWmEyoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBiFRVo02qNsTPYR6lMQ07elUx5HM6Rcqx1Ms8T7/iut6joQW0xFsK6kjvz2WE9nHMlrBJu5M7xoIZZQ0tRfLzmT4CQVlMUum1QnltPpMV5MuBZiWzP019NN7kXWp\u002BdsfteDDUNCUjbRI17Et34kvs3F1NnoFa55G2k3Qn4Ae8wlbk1CsM",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEALMIrzMVFGNHyaacwxFZmG5VEEaNL0wVY8ddZAKqKZvswMlojxhIx3\u002B5A4XzuX/eZeykj61XGl6URtsbjdlwXuRJAdWTKYoroSiNy\u002BayoCimt6Go1duF7HqIAntJxiLuP86nsX/YMCKv3lePuYXihc4lp3oF2vdXoxmYohYNsv\u002Bwwr6foEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIAo36Hh7A2kajq5vYNINwGQPkqynuTfu2QGjLjBWNly9rDwyQBt/rSukwSKx1M7fXZgeeMpyOQXkQrUGp97OMpqS8CQgC78W0sr/gs0yb2Jgd\u002Bq2U8NzBLGRkp5RfpmtraRJ8CRo4xA2cFi955/8O97oS08/SYqkxq9Gc6JJShHzMQ3IEuUw==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ccccda7188ea403f964dcbab9d363781"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1952125127",
+        "request_id": "df44a220ecec4f12a5c96c1a948f29f4"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1952125127?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "dae51ab41bf5ecd399de169abbcfc830",
         "x-ms-return-client-request-id": "true"
@@ -300,123 +305,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "938",
+        "Content-Length": "1934",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "cbdee301-9136-46b2-811d-10c7f6640c3f",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAOTt/p4DurqxMqyKwMgZ\u002BU9/NlcuDzqHImya2G0ClaZSq2IdDUX1GQrs7wDZhT\u002Br/7MJRHaMmh4PcoBi8VNzTr4pAZXIejryfHlDwGW511HSco36itLuqQAYlbr9Ta7In8lcA\u002BVBomXv/IozLgbVh9OwCMuh8WRNF04t6KWID25fWmEyoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBiFRVo02qNsTPYR6lMQ07elUx5HM6Rcqx1Ms8T7/iut6joQW0xFsK6kjvz2WE9nHMlrBJu5M7xoIZZQ0tRfLzmT4CQVlMUum1QnltPpMV5MuBZiWzP019NN7kXWp\u002BdsfteDDUNCUjbRI17Et34kvs3F1NnoFa55G2k3Qn4Ae8wlbk1CsM",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "ccccda7188ea403f964dcbab9d363781"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0175a8e9ec67e955afc21c168420e492",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "847",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:06 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:36 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "dae51ab41bf5ecd399de169abbcfc830",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4999c597-6238-4acf-a436-044bb43dba65",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f6d68642-1592-4350-b6b9-c3e662181638",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAOTt/p4DurqxMqyKwMgZ\u002BU9/NlcuDzqHImya2G0ClaZSq2IdDUX1GQrs7wDZhT\u002Br/7MJRHaMmh4PcoBi8VNzTr4pAZXIejryfHlDwGW511HSco36itLuqQAYlbr9Ta7In8lcA\u002BVBomXv/IozLgbVh9OwCMuh8WRNF04t6KWID25fWmEyoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBiFRVo02qNsTPYR6lMQ07elUx5HM6Rcqx1Ms8T7/iut6joQW0xFsK6kjvz2WE9nHMlrBJu5M7xoIZZQ0tRfLzmT4CQVlMUum1QnltPpMV5MuBZiWzP019NN7kXWp\u002BdsfteDDUNCUjbRI17Et34kvs3F1NnoFa55G2k3Qn4Ae8wlbk1CsM",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1952125127",
-        "request_id": "ccccda7188ea403f964dcbab9d363781"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1952125127?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "3c2e045538583890df2d717bf47c4cbd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1943",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:06 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0f310196-d8f4-4f25-a32e-5d28a3e593a7",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1952125127/05c969b873d64957949278967e5f0c2f",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1952125127/05c969b873d64957949278967e5f0c2f",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1952125127/05c969b873d64957949278967e5f0c2f",
-        "x5t": "TUJLmv2YYHZg9RL9Q5qC01RHLk0",
-        "cer": "MIICJjCCAYegAwIBAgIQGRwKDyqRRguaYfA4CrA5UjAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDIwM1oXDTIyMDMwNTIzMTIwM1owEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAOTt/p4DurqxMqyKwMgZ\u002BU9/NlcuDzqHImya2G0ClaZSq2IdDUX1GQrs7wDZhT\u002Br/7MJRHaMmh4PcoBi8VNzTr4pAZXIejryfHlDwGW511HSco36itLuqQAYlbr9Ta7In8lcA\u002BVBomXv/IozLgbVh9OwCMuh8WRNF04t6KWID25fWmEyo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUTWZvWV4V5p2e4\u002Be2acOBf2\u002BC2sYwHQYDVR0OBBYEFE1mb1leFeadnuPntmnDgX9vgtrGMAoGCCqGSM49BAMEA4GMADCBiAJCAPu5fr3Iq1\u002BgKK9pnYaTzfbvs8qqjKK1zUW\u002Bhn\u002Br971E8zgn1nNGN9kC9QsLfbXI9byxjmA9lFavS9kjMMLILEn4AkIA\u002BouSJ\u002BXcoaCIKFr6nZrRmycWh5o5F\u002BqGlf8iFya3bCRB3Kv0Cd4/iovPV2lOhAFp929lChuvIZnxSub1vSNY2Qw=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1952125127/34135e05a84a464098e62b0be2b1caf8",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1952125127/34135e05a84a464098e62b0be2b1caf8",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1952125127/34135e05a84a464098e62b0be2b1caf8",
+        "x5t": "UBdMbEmPYFeJk8a6lWhlJ8R_CMI",
+        "cer": "MIICJDCCAYegAwIBAgIQa/gzUKjbRMuDuU9NfOubLzAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQzMloXDTIyMDQwODAyMzQzMlowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEALMIrzMVFGNHyaacwxFZmG5VEEaNL0wVY8ddZAKqKZvswMlojxhIx3\u002B5A4XzuX/eZeykj61XGl6URtsbjdlwXuRJAdWTKYoroSiNy\u002BayoCimt6Go1duF7HqIAntJxiLuP86nsX/YMCKv3lePuYXihc4lp3oF2vdXoxmYohYNsv\u002Bwwr6fo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAU6FNvUAxJndwkDfvly8aTCmt3OMMwHQYDVR0OBBYEFOhTb1AMSZ3cJA375cvGkwprdzjDMAoGCCqGSM49BAMEA4GKADCBhgJBWwQww8knvDfwtYKlvJziiUwRDURwifufkZlWKnpNwdB4zeG7DAy2NIXquVR\u002BPOcRXwnr5K/nI9DmHOpvQbx9A08CQTTasYe93Zv0VR/A\u002BYeNG6Zu\u002BJ4PAhQv9sO8tThi1E2Pp3CP\u002BhIuYTTd3dAoURZgQ0QxywWVXY3BUAz7YnSTu993",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985323,
-          "exp": 1646521923,
-          "created": 1614985923,
-          "updated": 1614985923,
+          "nbf": 1617848672,
+          "exp": 1649385272,
+          "created": 1617849272,
+          "updated": 1617849272,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1952125127/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1952125127/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -456,26 +375,169 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985901,
-            "updated": 1614985901
+            "created": 1617849261,
+            "updated": 1617849261
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1952125127/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1952125127/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1952125127/05c969b873d64957949278967e5f0c2f?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1952125127/34135e05a84a464098e62b0be2b1caf8?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-3834b20e09f6674fa61434d9471e791e-17754e21422f5b47-00",
+        "traceparent": "00-7fcd8babb22f2546a12d5817fac95d44-bf5e5f3afc09fc49-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "0175a8e9ec67e955afc21c168420e492",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1339",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:34:36 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0175a8e9ec67e955afc21c168420e492",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "febb93cb-ac6e-4731-90a3-29698f1927e6",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1952125127/34135e05a84a464098e62b0be2b1caf8",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1952125127/34135e05a84a464098e62b0be2b1caf8",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1952125127/34135e05a84a464098e62b0be2b1caf8",
+        "x5t": "UBdMbEmPYFeJk8a6lWhlJ8R_CMI",
+        "cer": "MIICJDCCAYegAwIBAgIQa/gzUKjbRMuDuU9NfOubLzAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQzMloXDTIyMDQwODAyMzQzMlowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEALMIrzMVFGNHyaacwxFZmG5VEEaNL0wVY8ddZAKqKZvswMlojxhIx3\u002B5A4XzuX/eZeykj61XGl6URtsbjdlwXuRJAdWTKYoroSiNy\u002BayoCimt6Go1duF7HqIAntJxiLuP86nsX/YMCKv3lePuYXihc4lp3oF2vdXoxmYohYNsv\u002Bwwr6fo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAU6FNvUAxJndwkDfvly8aTCmt3OMMwHQYDVR0OBBYEFOhTb1AMSZ3cJA375cvGkwprdzjDMAoGCCqGSM49BAMEA4GKADCBhgJBWwQww8knvDfwtYKlvJziiUwRDURwifufkZlWKnpNwdB4zeG7DAy2NIXquVR\u002BPOcRXwnr5K/nI9DmHOpvQbx9A08CQTTasYe93Zv0VR/A\u002BYeNG6Zu\u002BJ4PAhQv9sO8tThi1E2Pp3CP\u002BhIuYTTd3dAoURZgQ0QxywWVXY3BUAz7YnSTu993",
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848672,
+          "exp": 1649385272,
+          "created": 1617849272,
+          "updated": 1617849272,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "subject": "CN=default",
+        "issuer": "CN=default",
+        "serialnumber": "6BF83350A8DB44CB83B94F4D7CEB9B2F"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1952125127/34135e05a84a464098e62b0be2b1caf8?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-7fcd8babb22f2546a12d5817fac95d44-2fbb10abd2985b4f-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "3c2e045538583890df2d717bf47c4cbd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1665",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:34:36 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3c2e045538583890df2d717bf47c4cbd",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "9111a879-7f0e-4af5-b9ca-49688ccc8bf6",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "value": "-----BEGIN PRIVATE KEY-----\nMIIBBgIBADAQBgcqhkjOPQIBBgUrgQQAIwSB3zCB3AIBAQRCAAVKNt2wpd02spb/\nwIq3PbyczGR9OUs\u002BNIlmVu0ovcBr9ohYaH\u002B1282jJRSi29b0moKsy5OTvRO3sa93\naWpW/nEmoAcGBSuBBAAjoYGJA4GGAAQAswivMxUUY0fJppzDEVmYblUQRo0vTBVj\nx11kAqopm\u002BzAyWiPGEjHf7kDhfO5f95l7KSPrVcaXpRG2xuN2XBe5EkB1ZMpiiuh\nKI3L5rKgKKa3oajV24XseogCe0nGIu4/zqexf9gwIq/eV4\u002B5heKFziWnegXa91ej\nGZiiFg2y/7DCvp\u002BgDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICJDCCAYegAwIBAgIQa/gzUKjbRMuDuU9NfOubLzAKBggqhkjOPQQDBDASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjQzMloXDTIyMDQwODAyMzQzMlow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEALMI\nrzMVFGNHyaacwxFZmG5VEEaNL0wVY8ddZAKqKZvswMlojxhIx3\u002B5A4XzuX/eZeyk\nj61XGl6URtsbjdlwXuRJAdWTKYoroSiNy\u002BayoCimt6Go1duF7HqIAntJxiLuP86n\nsX/YMCKv3lePuYXihc4lp3oF2vdXoxmYohYNsv\u002Bwwr6fo3wwejAOBgNVHQ8BAf8E\nBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw\nHwYDVR0jBBgwFoAU6FNvUAxJndwkDfvly8aTCmt3OMMwHQYDVR0OBBYEFOhTb1AM\nSZ3cJA375cvGkwprdzjDMAoGCCqGSM49BAMEA4GKADCBhgJBWwQww8knvDfwtYKl\nvJziiUwRDURwifufkZlWKnpNwdB4zeG7DAy2NIXquVR\u002BPOcRXwnr5K/nI9DmHOpv\nQbx9A08CQTTasYe93Zv0VR/A\u002BYeNG6Zu\u002BJ4PAhQv9sO8tThi1E2Pp3CP\u002BhIuYTTd\n3dAoURZgQ0QxywWVXY3BUAz7YnSTu993\n-----END CERTIFICATE-----\n",
+        "contentType": "application/x-pem-file",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1952125127/34135e05a84a464098e62b0be2b1caf8",
+        "managed": true,
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848672,
+          "exp": 1649385272,
+          "created": 1617849272,
+          "updated": 1617849272,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1952125127/34135e05a84a464098e62b0be2b1caf8"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1952125127/34135e05a84a464098e62b0be2b1caf8?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-1722989271ce5b4fb405efc7a7a448a5-900ba840daf06e42-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "15ebd4d3f9a3c74ac5fb2b33ffbc6778",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:34:36 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "15ebd4d3f9a3c74ac5fb2b33ffbc6778",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ae7c8f30-4c7f-41db-b81b-9462d834831d",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1952125127/34135e05a84a464098e62b0be2b1caf8?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-1722989271ce5b4fb405efc7a7a448a5-900ba840daf06e42-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "15ebd4d3f9a3c74ac5fb2b33ffbc6778",
         "x-ms-return-client-request-id": "true"
@@ -484,138 +546,38 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1346",
+        "Content-Length": "529",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:06 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:36 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "15ebd4d3f9a3c74ac5fb2b33ffbc6778",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "628edaa7-f7c6-44d2-a200-8d42dcdfdb72",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1952125127/05c969b873d64957949278967e5f0c2f",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1952125127/05c969b873d64957949278967e5f0c2f",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1952125127/05c969b873d64957949278967e5f0c2f",
-        "x5t": "TUJLmv2YYHZg9RL9Q5qC01RHLk0",
-        "cer": "MIICJjCCAYegAwIBAgIQGRwKDyqRRguaYfA4CrA5UjAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDIwM1oXDTIyMDMwNTIzMTIwM1owEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAOTt/p4DurqxMqyKwMgZ\u002BU9/NlcuDzqHImya2G0ClaZSq2IdDUX1GQrs7wDZhT\u002Br/7MJRHaMmh4PcoBi8VNzTr4pAZXIejryfHlDwGW511HSco36itLuqQAYlbr9Ta7In8lcA\u002BVBomXv/IozLgbVh9OwCMuh8WRNF04t6KWID25fWmEyo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUTWZvWV4V5p2e4\u002Be2acOBf2\u002BC2sYwHQYDVR0OBBYEFE1mb1leFeadnuPntmnDgX9vgtrGMAoGCCqGSM49BAMEA4GMADCBiAJCAPu5fr3Iq1\u002BgKK9pnYaTzfbvs8qqjKK1zUW\u002Bhn\u002Br971E8zgn1nNGN9kC9QsLfbXI9byxjmA9lFavS9kjMMLILEn4AkIA\u002BouSJ\u002BXcoaCIKFr6nZrRmycWh5o5F\u002BqGlf8iFya3bCRB3Kv0Cd4/iovPV2lOhAFp929lChuvIZnxSub1vSNY2Qw=",
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614985323,
-          "exp": 1646521923,
-          "created": 1614985923,
-          "updated": 1614985923,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "subject": "CN=default",
-        "issuer": "CN=default",
-        "serialnumber": "191C0A0F2A91460B9A61F0380AB03952"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1952125127/05c969b873d64957949278967e5f0c2f?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-3834b20e09f6674fa61434d9471e791e-a9381664f599bb40-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "b74483f98ba0b1d8183c22397bd9f433",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1671",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:06 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4db85e8f-cda7-43cb-888d-89e94b061db8",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIIBBgIBADAQBgcqhkjOPQIBBgUrgQQAIwSB3zCB3AIBAQRCAcsh9VzoGQWb55Fb\nyMP7tfUvgqiIbZA2SfiML3EyDzjnhVCGXFSZNraTnbPrACczZ\u002ByBQJCpF8r6VdQV\n57O6jru8oAcGBSuBBAAjoYGJA4GGAAQA5O3\u002BngO6urEyrIrAyBn5T382Vy4POoci\nbJrYbQKVplKrYh0NRfUZCuzvANmFP6v/swlEdoyaHg9ygGLxU3NOvikBlch6OvJ8\neUPAZbnXUdJyjfqK0u6pABiVuv1NrsifyVwD5UGiZe/8ijMuBtWH07AIy6HxZE0X\nTi3opYgPbl9aYTKgDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICJjCCAYegAwIBAgIQGRwKDyqRRguaYfA4CrA5UjAKBggqhkjOPQQDBDASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDIwM1oXDTIyMDMwNTIzMTIwM1ow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAOTt\n/p4DurqxMqyKwMgZ\u002BU9/NlcuDzqHImya2G0ClaZSq2IdDUX1GQrs7wDZhT\u002Br/7MJ\nRHaMmh4PcoBi8VNzTr4pAZXIejryfHlDwGW511HSco36itLuqQAYlbr9Ta7In8lc\nA\u002BVBomXv/IozLgbVh9OwCMuh8WRNF04t6KWID25fWmEyo3wwejAOBgNVHQ8BAf8E\nBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw\nHwYDVR0jBBgwFoAUTWZvWV4V5p2e4\u002Be2acOBf2\u002BC2sYwHQYDVR0OBBYEFE1mb1le\nFeadnuPntmnDgX9vgtrGMAoGCCqGSM49BAMEA4GMADCBiAJCAPu5fr3Iq1\u002BgKK9p\nnYaTzfbvs8qqjKK1zUW\u002Bhn\u002Br971E8zgn1nNGN9kC9QsLfbXI9byxjmA9lFavS9kj\nMMLILEn4AkIA\u002BouSJ\u002BXcoaCIKFr6nZrRmycWh5o5F\u002BqGlf8iFya3bCRB3Kv0Cd4/\niovPV2lOhAFp929lChuvIZnxSub1vSNY2Qw=\n-----END CERTIFICATE-----\n",
-        "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1952125127/05c969b873d64957949278967e5f0c2f",
-        "managed": true,
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614985323,
-          "exp": 1646521923,
-          "created": 1614985923,
-          "updated": 1614985923,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1952125127/05c969b873d64957949278967e5f0c2f"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1952125127/05c969b873d64957949278967e5f0c2f?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-c9dfc5f379c8e743bab6cd707e878b2e-04271c4494a5d949-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "b0425f75ce345ceeb966775c0c5c3922",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "530",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:06 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7d75d8b8-f1cd-43d8-9645-58efc519137f",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b8e5337c-e588-4787-bed0-997a2e92d02d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1952125127/05c969b873d64957949278967e5f0c2f",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1952125127/34135e05a84a464098e62b0be2b1caf8",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-521",
-          "x": "AOTt_p4DurqxMqyKwMgZ-U9_NlcuDzqHImya2G0ClaZSq2IdDUX1GQrs7wDZhT-r_7MJRHaMmh4PcoBi8VNzTr4p",
-          "y": "AZXIejryfHlDwGW511HSco36itLuqQAYlbr9Ta7In8lcA-VBomXv_IozLgbVh9OwCMuh8WRNF04t6KWID25fWmEy"
+          "x": "ALMIrzMVFGNHyaacwxFZmG5VEEaNL0wVY8ddZAKqKZvswMlojxhIx3-5A4XzuX_eZeykj61XGl6URtsbjdlwXuRJ",
+          "y": "AdWTKYoroSiNy-ayoCimt6Go1duF7HqIAntJxiLuP86nsX_YMCKv3lePuYXihc4lp3oF2vdXoxmYohYNsv-wwr6f"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985323,
-          "exp": 1646521923,
-          "created": 1614985923,
-          "updated": 1614985923,
+          "nbf": 1617848672,
+          "exp": 1649385272,
+          "created": 1617849272,
+          "updated": 1617849272,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -624,7 +586,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1368497557"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-256).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-256).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1455109331/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-4cb427f8a20ac647852ad06f9f3dc22e-8e275a905b374f4b-00",
+        "traceparent": "00-db47205e4ab9b445a4bc0cb1a7c2c24f-3e26390679f09041-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "25b61f8f458235c98a1adc1c056e0863",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:57:59 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "25b61f8f458235c98a1adc1c056e0863",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4ed2560d-b0b4-4eab-adc0-933f3deb8e57",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1aff9864-f5ba-4d5a-b844-e4321815ee06",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1455109331/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-4cb427f8a20ac647852ad06f9f3dc22e-8e275a905b374f4b-00",
+        "traceparent": "00-db47205e4ab9b445a4bc0cb1a7c2c24f-3e26390679f09041-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "25b61f8f458235c98a1adc1c056e0863",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "757",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:01 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:30 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending?api-version=7.2\u0026request_id=08d6babdc8a4473dba42a93322ac889c",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1455109331/pending?api-version=7.2\u0026request_id=a4acae841616419387e19fbdae4df169",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "25b61f8f458235c98a1adc1c056e0863",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e2369b8f-0ac2-4608-9f61-3d76bf1f656a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "263da541-6036-4ddd-a26d-05de10265cec",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1455109331/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEitDJWrDf4S/2ynMofJ\u002BdRxRN32jG33IaNya97vRkyEw1c7iiDFu6jQFB1nVQj/M/BxPWLLmeLW5gGoeAukpplKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBPecgDWGnx2SuobzvIdK3q/PiSTV6Y8\u002BsqetwAQ1doyAiEA/OAOowypYCtdjEMQPbo10BT9\u002BB5PknCzZQaPqttHKMU=",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKNAoBUkr/ArYERseevTQth\u002Bbk04pDUQVFrsTfCYVq/aeiSVxzjOBu1LaYS6zTL44fIZcJ7ep1s33I\u002BXeVtoCHKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIDM6ojAu3r3Qr/OyhQa69kAEwSqIdK84V2YT4CmHQ7wfAiEA4A5DjRJrrdxlxj3KYxbUaVB2iJuZ7zFv2WkXH\u002BELUAo=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "08d6babdc8a4473dba42a93322ac889c"
+        "request_id": "a4acae841616419387e19fbdae4df169"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1455109331/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "763c919772b75783ca7a081e90158f90",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "757",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:01 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "763c919772b75783ca7a081e90158f90",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5bcf2827-489f-48c5-ba85-f2d406ef4bf2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5f98f9f6-f1a1-489b-9cfa-8ad03a935339",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1455109331/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEitDJWrDf4S/2ynMofJ\u002BdRxRN32jG33IaNya97vRkyEw1c7iiDFu6jQFB1nVQj/M/BxPWLLmeLW5gGoeAukpplKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBPecgDWGnx2SuobzvIdK3q/PiSTV6Y8\u002BsqetwAQ1doyAiEA/OAOowypYCtdjEMQPbo10BT9\u002BB5PknCzZQaPqttHKMU=",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKNAoBUkr/ArYERseevTQth\u002Bbk04pDUQVFrsTfCYVq/aeiSVxzjOBu1LaYS6zTL44fIZcJ7ep1s33I\u002BXeVtoCHKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIDM6ojAu3r3Qr/OyhQa69kAEwSqIdK84V2YT4CmHQ7wfAiEA4A5DjRJrrdxlxj3KYxbUaVB2iJuZ7zFv2WkXH\u002BELUAo=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "08d6babdc8a4473dba42a93322ac889c"
+        "request_id": "a4acae841616419387e19fbdae4df169"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1455109331/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "e5a6429c813c7293c85dd040851cbff8",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "757",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:06 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:35 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e5a6429c813c7293c85dd040851cbff8",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6c6c2e28-ae34-4dfd-9e05-9f227ab33cce",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "12db606e-53ef-4d10-93f8-1277593678aa",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1455109331/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEitDJWrDf4S/2ynMofJ\u002BdRxRN32jG33IaNya97vRkyEw1c7iiDFu6jQFB1nVQj/M/BxPWLLmeLW5gGoeAukpplKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBPecgDWGnx2SuobzvIdK3q/PiSTV6Y8\u002BsqetwAQ1doyAiEA/OAOowypYCtdjEMQPbo10BT9\u002BB5PknCzZQaPqttHKMU=",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKNAoBUkr/ArYERseevTQth\u002Bbk04pDUQVFrsTfCYVq/aeiSVxzjOBu1LaYS6zTL44fIZcJ7ep1s33I\u002BXeVtoCHKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIDM6ojAu3r3Qr/OyhQa69kAEwSqIdK84V2YT4CmHQ7wfAiEA4A5DjRJrrdxlxj3KYxbUaVB2iJuZ7zFv2WkXH\u002BELUAo=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "08d6babdc8a4473dba42a93322ac889c"
+        "request_id": "a4acae841616419387e19fbdae4df169"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1455109331/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "a7947c3340741c1c9c5e5b073daaa574",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "665",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:12 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a7947c3340741c1c9c5e5b073daaa574",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c5e4c021-b982-4c3b-830d-0345334a6829",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b1d0ead4-ab03-4d2e-8add-ed21716bbee7",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1455109331/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEitDJWrDf4S/2ynMofJ\u002BdRxRN32jG33IaNya97vRkyEw1c7iiDFu6jQFB1nVQj/M/BxPWLLmeLW5gGoeAukpplKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBPecgDWGnx2SuobzvIdK3q/PiSTV6Y8\u002BsqetwAQ1doyAiEA/OAOowypYCtdjEMQPbo10BT9\u002BB5PknCzZQaPqttHKMU=",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKNAoBUkr/ArYERseevTQth\u002Bbk04pDUQVFrsTfCYVq/aeiSVxzjOBu1LaYS6zTL44fIZcJ7ep1s33I\u002BXeVtoCHKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIDM6ojAu3r3Qr/OyhQa69kAEwSqIdK84V2YT4CmHQ7wfAiEA4A5DjRJrrdxlxj3KYxbUaVB2iJuZ7zFv2WkXH\u002BELUAo=",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "08d6babdc8a4473dba42a93322ac889c"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1455109331",
+        "request_id": "a4acae841616419387e19fbdae4df169"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1455109331?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "c3804b8a23c71627fecaae5aa143d1ad",
         "x-ms-return-client-request-id": "true"
@@ -256,255 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "1756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:17 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ba77ad8b-b5e0-41a3-aeab-7a91261fe3c1",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEitDJWrDf4S/2ynMofJ\u002BdRxRN32jG33IaNya97vRkyEw1c7iiDFu6jQFB1nVQj/M/BxPWLLmeLW5gGoeAukpplKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBPecgDWGnx2SuobzvIdK3q/PiSTV6Y8\u002BsqetwAQ1doyAiEA/OAOowypYCtdjEMQPbo10BT9\u002BB5PknCzZQaPqttHKMU=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "08d6babdc8a4473dba42a93322ac889c"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "14eb0fbbe8815c1c258a49dd268b351d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "758",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:21 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "73b79614-6621-4247-a94e-13232bdaba31",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEitDJWrDf4S/2ynMofJ\u002BdRxRN32jG33IaNya97vRkyEw1c7iiDFu6jQFB1nVQj/M/BxPWLLmeLW5gGoeAukpplKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBPecgDWGnx2SuobzvIdK3q/PiSTV6Y8\u002BsqetwAQ1doyAiEA/OAOowypYCtdjEMQPbo10BT9\u002BB5PknCzZQaPqttHKMU=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "08d6babdc8a4473dba42a93322ac889c"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "39b55bb7fb9c1030557ea9a991c27a58",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "758",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:27 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5f70b69f-34c7-459d-af62-94f9b915dbdd",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEitDJWrDf4S/2ynMofJ\u002BdRxRN32jG33IaNya97vRkyEw1c7iiDFu6jQFB1nVQj/M/BxPWLLmeLW5gGoeAukpplKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBPecgDWGnx2SuobzvIdK3q/PiSTV6Y8\u002BsqetwAQ1doyAiEA/OAOowypYCtdjEMQPbo10BT9\u002BB5PknCzZQaPqttHKMU=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "08d6babdc8a4473dba42a93322ac889c"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "2d4bad8c91bfa2f32f239d3dda49ef72",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "758",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:32 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ecaa763b-d5aa-4f7e-8c39-b0e930d18201",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEitDJWrDf4S/2ynMofJ\u002BdRxRN32jG33IaNya97vRkyEw1c7iiDFu6jQFB1nVQj/M/BxPWLLmeLW5gGoeAukpplKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBPecgDWGnx2SuobzvIdK3q/PiSTV6Y8\u002BsqetwAQ1doyAiEA/OAOowypYCtdjEMQPbo10BT9\u002BB5PknCzZQaPqttHKMU=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "08d6babdc8a4473dba42a93322ac889c"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "45a29195988dc011dedabe033e72cb63",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "667",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:36 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c3804b8a23c71627fecaae5aa143d1ad",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "91e5d3b7-d6f8-4913-938d-f29ebc8659e9",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "e89f1564-2e36-4cdc-83e5-05d53b298715",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEitDJWrDf4S/2ynMofJ\u002BdRxRN32jG33IaNya97vRkyEw1c7iiDFu6jQFB1nVQj/M/BxPWLLmeLW5gGoeAukpplKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBPecgDWGnx2SuobzvIdK3q/PiSTV6Y8\u002BsqetwAQ1doyAiEA/OAOowypYCtdjEMQPbo10BT9\u002BB5PknCzZQaPqttHKMU=",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1455109331",
-        "request_id": "08d6babdc8a4473dba42a93322ac889c"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "7950f00f073f265d681309785df3360b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1761",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "789ab1a5-a666-4929-a737-f39dea56ad6f",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/aa9ecdb4e29245ef8508b783e08a88ad",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1455109331/aa9ecdb4e29245ef8508b783e08a88ad",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1455109331/aa9ecdb4e29245ef8508b783e08a88ad",
-        "x5t": "6-2oLanPpCdK_fLssTK5ZvfjiOY",
-        "cer": "MIIBnzCCAUSgAwIBAgIQDxulboAXTmSudguCBbQ8JTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNDgzM1oXDTIyMDMwNTIyNTgzM1owEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIrQyVqw3\u002BEv9spzKHyfnUcUTd9oxt9yGjcmve70ZMhMNXO4ogxbuo0BQdZ1UI/zPwcT1iy5ni1uYBqHgLpKaZSjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQl3JpuSfD9Z29Wz/S2VTCtY6pSDzAdBgNVHQ4EFgQUJdyabknw/WdvVs/0tlUwrWOqUg8wCgYIKoZIzj0EAwIDSQAwRgIhAK3HF33PgqrGmCD/Lps3So9xJbc0hw17AEvlf1SQ\u002BeFjAiEA6R15r66DPKSEnuJLCtdgtxQCV1JaYxGluRHL5YCxsA4=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf",
+        "x5t": "vCPSEI5GyoOj_CBBGyZKNOdSd-E",
+        "cer": "MIIBnjCCAUSgAwIBAgIQaKF81BTjSSaKcawl3zxrfDAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTgzOFoXDTIyMDQwODAyMjgzOFowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABCjQKAVJK/wK2BEbHnr00LYfm5NOKQ1EFRa7E3wmFav2noklcc4zgbtS2mEus0y\u002BOHyGXCe3qdbN9yPl3lbaAhyjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTdWbGRhyLxnKmhVsUee4Y06/RjxTAdBgNVHQ4EFgQU3VmxkYci8ZypoVbFHnuGNOv0Y8UwCgYIKoZIzj0EAwIDSAAwRQIhAPiRXOupqJJeHYe7O7nTlEZlAhJDda9UpsGA4OAVOg4cAiBAT5XKAcJ1ICYhrcCGWd1TN6BaVLv1aRwt9/nNq9fCjw==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984513,
-          "exp": 1646521113,
-          "created": 1614985114,
-          "updated": 1614985114,
+          "nbf": 1617848318,
+          "exp": 1649384918,
+          "created": 1617848918,
+          "updated": 1617848918,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1455109331/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -544,128 +330,130 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985081,
-            "updated": 1614985081
+            "created": 1617848910,
+            "updated": 1617848910
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1455109331/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1455109331/aa9ecdb4e29245ef8508b783e08a88ad?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-74d7dc96d69bf744bcbbd237f0592d3b-21dcfe3fc3c7c340-00",
+        "traceparent": "00-09ed76f1ff0c174c8226bd5ef8c9731b-d0254099ddb0e142-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "0014378f3420f4cb9b8b4ee5d2f063bd",
+        "x-ms-client-request-id": "14eb0fbbe8815c1c258a49dd268b351d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1166",
+        "Content-Length": "1163",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "14eb0fbbe8815c1c258a49dd268b351d",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5a7cc068-8ba4-4823-8cf6-2845d28d472d",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ba4236a2-6a0f-41d0-b861-905ba820da34",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1455109331/aa9ecdb4e29245ef8508b783e08a88ad",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1455109331/aa9ecdb4e29245ef8508b783e08a88ad",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1455109331/aa9ecdb4e29245ef8508b783e08a88ad",
-        "x5t": "6-2oLanPpCdK_fLssTK5ZvfjiOY",
-        "cer": "MIIBnzCCAUSgAwIBAgIQDxulboAXTmSudguCBbQ8JTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNDgzM1oXDTIyMDMwNTIyNTgzM1owEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIrQyVqw3\u002BEv9spzKHyfnUcUTd9oxt9yGjcmve70ZMhMNXO4ogxbuo0BQdZ1UI/zPwcT1iy5ni1uYBqHgLpKaZSjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQl3JpuSfD9Z29Wz/S2VTCtY6pSDzAdBgNVHQ4EFgQUJdyabknw/WdvVs/0tlUwrWOqUg8wCgYIKoZIzj0EAwIDSQAwRgIhAK3HF33PgqrGmCD/Lps3So9xJbc0hw17AEvlf1SQ\u002BeFjAiEA6R15r66DPKSEnuJLCtdgtxQCV1JaYxGluRHL5YCxsA4=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf",
+        "x5t": "vCPSEI5GyoOj_CBBGyZKNOdSd-E",
+        "cer": "MIIBnjCCAUSgAwIBAgIQaKF81BTjSSaKcawl3zxrfDAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTgzOFoXDTIyMDQwODAyMjgzOFowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABCjQKAVJK/wK2BEbHnr00LYfm5NOKQ1EFRa7E3wmFav2noklcc4zgbtS2mEus0y\u002BOHyGXCe3qdbN9yPl3lbaAhyjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTdWbGRhyLxnKmhVsUee4Y06/RjxTAdBgNVHQ4EFgQU3VmxkYci8ZypoVbFHnuGNOv0Y8UwCgYIKoZIzj0EAwIDSAAwRQIhAPiRXOupqJJeHYe7O7nTlEZlAhJDda9UpsGA4OAVOg4cAiBAT5XKAcJ1ICYhrcCGWd1TN6BaVLv1aRwt9/nNq9fCjw==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984513,
-          "exp": 1646521113,
-          "created": 1614985114,
-          "updated": 1614985114,
+          "nbf": 1617848318,
+          "exp": 1649384918,
+          "created": 1617848918,
+          "updated": 1617848918,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "0F1BA56E80174E64AE760B8205B43C25"
+        "serialnumber": "68A17CD414E349268A71AC25DF3C6B7C"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1455109331/aa9ecdb4e29245ef8508b783e08a88ad?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-74d7dc96d69bf744bcbbd237f0592d3b-6062ed332fd54140-00",
+        "traceparent": "00-09ed76f1ff0c174c8226bd5ef8c9731b-8a0b5dec41566547-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "ea2d3a5875f88e32337bdd798e9862eb",
+        "x-ms-client-request-id": "39b55bb7fb9c1030557ea9a991c27a58",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1805",
+        "Content-Length": "1803",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "39b55bb7fb9c1030557ea9a991c27a58",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "64ffc45f-15b2-4801-8fb5-3500aded98ac",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "80886901-7c61-431e-be24-3418a34ee8e5",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIEBwIBAzCCA8MGCSqGSIb3DQEHAaCCA7QEggOwMIIDrDCCAW0GCSqGSIb3DQEHAaCCAV4EggFaMIIBVjCCAVIGCyqGSIb3DQEMCgECoIHMMIHJMBwGCiqGSIb3DQEMAQMwDgQIhm2CZXnhpDcCAgfQBIGocD/nRZGGCQr80LtWDSEr3IWK9WpD1AJwoCSOqDwr6TwwzZXNGZvtbPPmeoKNPtViWZAtBaEnHC/m9XHJIaEMKqf8SyodbqItly75gAyE/9s3l60JxItY3E/HzWB9Im7iJikKfnEDOpCpcMKT71goVJI8iDnIjQxKpyG0AuMZvTIUx6tXHdkzFTQvOg6yF7byPAm80FtbvyaMv90eH5Zn5DBnllrbdWeDMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAjcGCSqGSIb3DQEHBqCCAigwggIkAgEAMIICHQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIH7yMi7SZSJkCAgfQgIIB8EErMkSuqzD5fk0RXpSFnL1I9gE\u002BFA1WWkNV88l4pO4BIYRwQQrsPG\u002BCpD/ARPvhEG2PY39f8PNG0G2O\u002Bkx6JD4jWHGxQPEmj2Rp2xXqQvBKb0gK8mXHD1aemcnzpIfcgt1SK1Jb\u002BzlfpM4pRZykR\u002BatJ56tcE\u002Bc16GCgf3SpNX\u002BvhZawpaK8KNWRUzRnXxEpyQ6idcqC5L/A70gs30rj6RsbVtzGBXo6OGOQGZBD8WbrzXcIWUAeOygfej8Ynl7z60z8uKwUtVP8YlunXEPoTE0725br37oj2zGpBVq/3tEzNBIxrCfO3MdVgfeygl37dR4QgpJNXFKIFebol43/iG\u002Bo9VZJ/sgpCcNRtiDvClW\u002BCp9pQEO\u002BXPpB/5W8qo\u002BWKKFngybX/8C02wfyJXP7hzEcBMAJuEJlqWY8TT8yIudjl114Ll6gL2biHVqoVcJ7W18wyyI5ULvXo83xCxGSMeUkJoUG/rbGxQZSHO5/ohwApA10Dr/t1AXuVtuDxt92rKvrCOGHJhEFJ\u002BSQ5hgVnlRbzBJeHkkQwpbbCVzEhw8tmmJCOcWQfQJAHndSKIsNHMse\u002BECTFnGmsR5Fbd3IYEtwOKZjmIA6H04HmYmzwQk0x\u002B5w8wzssdg/HvWyJjs/m/wSfWdpz0Ayphw4wiSufwwOzAfMAcGBSsOAwIaBBTNpkAS1YlcGyzpiU5/smnxI\u002BsLaAQUzt8x5pb48YsCfYDLx6D6Uw8XRP4CAgfQ",
+        "value": "MIIEBwIBAzCCA8MGCSqGSIb3DQEHAaCCA7QEggOwMIIDrDCCAW0GCSqGSIb3DQEHAaCCAV4EggFaMIIBVjCCAVIGCyqGSIb3DQEMCgECoIHMMIHJMBwGCiqGSIb3DQEMAQMwDgQIaFsdTcDWdYgCAgfQBIGop5lJipM1yieMey4MUg6t9Iag1ahaEs2zkFUkWJ3pwGVHHk4JyDWTkueck\u002Bw9agKY13UqOr87\u002BT4UCxrq8D3M07tq\u002BwYbawX4qSaAxp7by9I8MbiysOS4VPcBI2DxYC9fsSI5Zc0nkkz0eQnj6\u002BMCi\u002BgrFlLL7hR50CVAKs\u002BWt7l\u002BPFk1L3KA6wKWLlBFZ8wtgxnzPHntKPIfHDFR7zHxKYNZx0pre6rFMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAjcGCSqGSIb3DQEHBqCCAigwggIkAgEAMIICHQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQI21P1\u002BkzLGawCAgfQgIIB8O31BhSAF9YZFxe1T1jrvGQADXWji6k3jdqMb5UU96N/7xATr\u002BXMu2C8kn/YyhYMShC/tQ1wk7ly9Gh4U9k\u002BuEJnV1OdFoMfReoRmdPU3/HDEwJiovSUVzJ15HzYCEjSaDuA/\u002Ba0xerawbw8j9Dfpaq9PZLbSdkxjqOL3Gq4pmkQphTkMgkMb/RuPcIealn2PnP/Aks7q9bCDTyQXKOnFyPcW/I5m1Z9bm0uPVmAdIj95Ser0X4x\u002BwDAXnmM3dIfBn3i/jRiAFpAG6T\u002BlT0rTsasax5XqYdK1lBVLyH0JIy7WQkCO7DGh\u002BRijoaHXBTh0\u002BMORyNyW7ZjEeTbGNWblJAo\u002BPN\u002BYiyaC8Mlw\u002BXTNZHVDYkG2fJRuD2McetjPsRd2BpAdckxldtjL2PfLdWV5Wrd4P1xOvuZsMDqAaX1bUPx46\u002B3ePkkmCs7wbyfKsYc2H9gAvOW1C3MA\u002B/QsLvmHoNb6C4JCHr04znTWm\u002Bp3y4ZHWTpOmiWMTHPDU4NJduHhR0/XosSQxI8oIBlBkzNLqs\u002BVAVL\u002BM97uTvruwK84mdBWQzicuf3Zmkeo6D/yFmfyNWfSp0KoDZyamdVd1jyILMCRnlRb9EGRZeIxSM1lat085IRuaX2yPfqQDAfQCzKJGdbf1ANB2LNoh6qpVvLxq4wOzAfMAcGBSsOAwIaBBSYaaRpaTviGHy8bdBlE/LEhTwWRwQUgvE6UmcCUT5pxAuiDgLo36iRDskCAgfQ",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1455109331/aa9ecdb4e29245ef8508b783e08a88ad",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614984513,
-          "exp": 1646521113,
-          "created": 1614985114,
-          "updated": 1614985114,
+          "nbf": 1617848318,
+          "exp": 1649384918,
+          "created": 1617848918,
+          "updated": 1617848918,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1455109331/aa9ecdb4e29245ef8508b783e08a88ad"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1455109331/aa9ecdb4e29245ef8508b783e08a88ad?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-91020306564dc6419d45411ec8a7af7e-802a13ff5376d847-00",
+        "traceparent": "00-98b48b8a24e0db4880a7e895ede9b4f4-f548f2e43e9d6742-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "0774b2a4cb5edb42245cdeb4b8785478",
+        "x-ms-client-request-id": "2d4bad8c91bfa2f32f239d3dda49ef72",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -674,16 +462,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:43 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:46 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2d4bad8c91bfa2f32f239d3dda49ef72",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3a2cc946-c356-469c-93b9-50c70dbefa89",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "307802c2-61ea-48df-a5b6-e753642aba32",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -694,55 +483,56 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1455109331/aa9ecdb4e29245ef8508b783e08a88ad?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-91020306564dc6419d45411ec8a7af7e-802a13ff5376d847-00",
+        "traceparent": "00-98b48b8a24e0db4880a7e895ede9b4f4-f548f2e43e9d6742-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "0774b2a4cb5edb42245cdeb4b8785478",
+        "x-ms-client-request-id": "2d4bad8c91bfa2f32f239d3dda49ef72",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "440",
+        "Content-Length": "439",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:43 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:46 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2d4bad8c91bfa2f32f239d3dda49ef72",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0b21b7ba-df40-49fc-8ae8-b158388f6cbf",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f6ff0c6c-307d-404f-a63b-de9b6490d220",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1455109331/aa9ecdb4e29245ef8508b783e08a88ad",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1455109331/457fd1d5486c4ddabb56f22cd9a9fecf",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256",
-          "x": "itDJWrDf4S_2ynMofJ-dRxRN32jG33IaNya97vRkyEw",
-          "y": "NXO4ogxbuo0BQdZ1UI_zPwcT1iy5ni1uYBqHgLpKaZQ"
+          "x": "KNAoBUkr_ArYERseevTQth-bk04pDUQVFrsTfCYVq_Y",
+          "y": "noklcc4zgbtS2mEus0y-OHyGXCe3qdbN9yPl3lbaAhw"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984513,
-          "exp": 1646521113,
-          "created": 1614985114,
-          "updated": 1614985114,
+          "nbf": 1617848318,
+          "exp": 1649384918,
+          "created": 1617848918,
+          "updated": 1617848918,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -751,7 +541,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1127315151"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-256)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-256)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1317480634/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1317480634/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-264bb03d64d1e84f8c06aefa6946951d-cd104dd849ac6547-00",
+        "traceparent": "00-c096b79601bc8e48985f7779e80fa87a-0f3e9d424d37e248-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "b7e0128b53b4c199f6a16794d210052c",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:51 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b7e0128b53b4c199f6a16794d210052c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "09966a75-6cbb-4f13-87d7-67335393f704",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "0dcf89ae-f44d-4626-8334-af87a2db1659",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1317480634/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1317480634/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-264bb03d64d1e84f8c06aefa6946951d-cd104dd849ac6547-00",
+        "traceparent": "00-c096b79601bc8e48985f7779e80fa87a-0f3e9d424d37e248-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "b7e0128b53b4c199f6a16794d210052c",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "757",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:52 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:02 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending?api-version=7.2\u0026request_id=a0f803656d7942b3b070d0b825c3e553",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1317480634/pending?api-version=7.2\u0026request_id=78f4a66ca06f49a68e276f90053629db",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b7e0128b53b4c199f6a16794d210052c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f0d8c622-f9b7-4ebd-98d1-8bbac1a8d0a9",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5392d94b-660b-466d-8d9b-1acecb9e7d5d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1317480634/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpOe\u002BH/\u002B61J1z\u002B4KUROB8ICsyCcuBCNwWQvHHiNNXo1ggs5dqcqeWqZGlCWGpL9eu0Ww\u002BR3jdUkwlCoGAHcYU9qBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQDNuoR\u002BmA3zt\u002B4g7YgKd7BccFehTuYWC7PNXQ3//DscewIhAMLPoANU8NZEyQShw78rEa6iB4novF\u002BMXIRz9M4Kbk1S",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0C5rsiCM5v98pr164b6bKphkbXI1vkIzCI90jjmPohW7oUXuWiCPAYVitoBtt0lQXfM61ULurESEtYDt0/9Wh6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIEDAPfncZUEs8DZAbXFJIXiEVJQLPXtrGppqkC8aiKQMAiEA31e\u002B4ZTam/vfPD/RK\u002BwqWV\u002BOk/6YlA7YfMyusfhpVDg=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a0f803656d7942b3b070d0b825c3e553"
+        "request_id": "78f4a66ca06f49a68e276f90053629db"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1317480634/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "55b9ad89cf1bdb1fd3cd38ef2217c100",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "757",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:52 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "55b9ad89cf1bdb1fd3cd38ef2217c100",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6186e543-b2ea-440d-9439-853820f8d0af",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a42ebdf1-9516-4cda-91fb-76f815643205",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1317480634/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpOe\u002BH/\u002B61J1z\u002B4KUROB8ICsyCcuBCNwWQvHHiNNXo1ggs5dqcqeWqZGlCWGpL9eu0Ww\u002BR3jdUkwlCoGAHcYU9qBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQDNuoR\u002BmA3zt\u002B4g7YgKd7BccFehTuYWC7PNXQ3//DscewIhAMLPoANU8NZEyQShw78rEa6iB4novF\u002BMXIRz9M4Kbk1S",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0C5rsiCM5v98pr164b6bKphkbXI1vkIzCI90jjmPohW7oUXuWiCPAYVitoBtt0lQXfM61ULurESEtYDt0/9Wh6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIEDAPfncZUEs8DZAbXFJIXiEVJQLPXtrGppqkC8aiKQMAiEA31e\u002B4ZTam/vfPD/RK\u002BwqWV\u002BOk/6YlA7YfMyusfhpVDg=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a0f803656d7942b3b070d0b825c3e553"
+        "request_id": "78f4a66ca06f49a68e276f90053629db"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1317480634/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "4491883cb82b7b3ffb52a2f47cd49c78",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "757",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:57 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:08 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4491883cb82b7b3ffb52a2f47cd49c78",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "8623c5e0-a42b-4224-94fe-2854d0c53edc",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "03e43a15-775c-406c-93d2-c3a726645167",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1317480634/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpOe\u002BH/\u002B61J1z\u002B4KUROB8ICsyCcuBCNwWQvHHiNNXo1ggs5dqcqeWqZGlCWGpL9eu0Ww\u002BR3jdUkwlCoGAHcYU9qBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQDNuoR\u002BmA3zt\u002B4g7YgKd7BccFehTuYWC7PNXQ3//DscewIhAMLPoANU8NZEyQShw78rEa6iB4novF\u002BMXIRz9M4Kbk1S",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0C5rsiCM5v98pr164b6bKphkbXI1vkIzCI90jjmPohW7oUXuWiCPAYVitoBtt0lQXfM61ULurESEtYDt0/9Wh6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIEDAPfncZUEs8DZAbXFJIXiEVJQLPXtrGppqkC8aiKQMAiEA31e\u002B4ZTam/vfPD/RK\u002BwqWV\u002BOk/6YlA7YfMyusfhpVDg=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a0f803656d7942b3b070d0b825c3e553"
+        "request_id": "78f4a66ca06f49a68e276f90053629db"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1317480634/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "e2e30d9d3fccbc9ef205e4e71aa99fdf",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "665",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:03 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e2e30d9d3fccbc9ef205e4e71aa99fdf",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "345d8ab0-844a-4246-8f27-e79dd957ff72",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b8eeed44-fe61-4c32-a39a-0a3cead30cde",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1317480634/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpOe\u002BH/\u002B61J1z\u002B4KUROB8ICsyCcuBCNwWQvHHiNNXo1ggs5dqcqeWqZGlCWGpL9eu0Ww\u002BR3jdUkwlCoGAHcYU9qBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQDNuoR\u002BmA3zt\u002B4g7YgKd7BccFehTuYWC7PNXQ3//DscewIhAMLPoANU8NZEyQShw78rEa6iB4novF\u002BMXIRz9M4Kbk1S",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0C5rsiCM5v98pr164b6bKphkbXI1vkIzCI90jjmPohW7oUXuWiCPAYVitoBtt0lQXfM61ULurESEtYDt0/9Wh6BLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIEDAPfncZUEs8DZAbXFJIXiEVJQLPXtrGppqkC8aiKQMAiEA31e\u002B4ZTam/vfPD/RK\u002BwqWV\u002BOk/6YlA7YfMyusfhpVDg=",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a0f803656d7942b3b070d0b825c3e553"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1317480634",
+        "request_id": "78f4a66ca06f49a68e276f90053629db"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1317480634?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "495766dfc17ed1016e3d5ac92c2b5ffe",
         "x-ms-return-client-request-id": "true"
@@ -256,167 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "758",
+        "Content-Length": "1756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:07 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "81982a3e-5e2f-4c20-9266-79d633c579b6",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpOe\u002BH/\u002B61J1z\u002B4KUROB8ICsyCcuBCNwWQvHHiNNXo1ggs5dqcqeWqZGlCWGpL9eu0Ww\u002BR3jdUkwlCoGAHcYU9qBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQDNuoR\u002BmA3zt\u002B4g7YgKd7BccFehTuYWC7PNXQ3//DscewIhAMLPoANU8NZEyQShw78rEa6iB4novF\u002BMXIRz9M4Kbk1S",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a0f803656d7942b3b070d0b825c3e553"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "1452c030df33fc34ead55226d3586051",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "758",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c6b6ed74-78ab-46a2-91ce-5abe5714103f",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpOe\u002BH/\u002B61J1z\u002B4KUROB8ICsyCcuBCNwWQvHHiNNXo1ggs5dqcqeWqZGlCWGpL9eu0Ww\u002BR3jdUkwlCoGAHcYU9qBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQDNuoR\u002BmA3zt\u002B4g7YgKd7BccFehTuYWC7PNXQ3//DscewIhAMLPoANU8NZEyQShw78rEa6iB4novF\u002BMXIRz9M4Kbk1S",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a0f803656d7942b3b070d0b825c3e553"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "1615c3b2537ddbf90c12738ee5d490c7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "667",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "495766dfc17ed1016e3d5ac92c2b5ffe",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ea4d762d-187a-4326-9609-ec62d3832f23",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d1c37f94-7116-4fdf-83fb-97be8c25a11b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpOe\u002BH/\u002B61J1z\u002B4KUROB8ICsyCcuBCNwWQvHHiNNXo1ggs5dqcqeWqZGlCWGpL9eu0Ww\u002BR3jdUkwlCoGAHcYU9qBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQDNuoR\u002BmA3zt\u002B4g7YgKd7BccFehTuYWC7PNXQ3//DscewIhAMLPoANU8NZEyQShw78rEa6iB4novF\u002BMXIRz9M4Kbk1S",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1317480634",
-        "request_id": "a0f803656d7942b3b070d0b825c3e553"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1317480634?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "5ab6e5a68a5700ab325a5fa96edbfd16",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1761",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:17 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "d7b35793-6dbc-4b97-9143-e442a8061532",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1317480634/aa88898d5a114510ad884eaea4662d90",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1317480634/aa88898d5a114510ad884eaea4662d90",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1317480634/aa88898d5a114510ad884eaea4662d90",
-        "x5t": "CTvRAYIqdSD_yljP7_UyZZVTxRA",
-        "cer": "MIIBnjCCAUSgAwIBAgIQLCv8v9C6QD2K6yXoQyK7CjAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTkxOFoXDTIyMDMwNTIzMDkxOFowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABKTnvh//utSdc/uClETgfCArMgnLgQjcFkLxx4jTV6NYILOXanKnlqmRpQlhqS/XrtFsPkd43VJMJQqBgB3GFPajfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQHyKS1ynUnq1UO5p1ofEo7OfKoeDAdBgNVHQ4EFgQUB8iktcp1J6tVDuadaHxKOznyqHgwCgYIKoZIzj0EAwIDSAAwRQIgDSbg6wa3tnEhsAZR1KcHwUA5/bQJMBqlxXl1VY6G/QcCIQCwDqJPt9dPIpvGSRWFVDDonXdiYYnWON7uedGjvfZ1qg==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1317480634/a30e2086042e4aacb9675bbf8666ca9b",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1317480634/a30e2086042e4aacb9675bbf8666ca9b",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1317480634/a30e2086042e4aacb9675bbf8666ca9b",
+        "x5t": "KPngeq0-EZvsTPTySNDuYK0_gQI",
+        "cer": "MIIBnjCCAUSgAwIBAgIQON4jhoPrTxaoeluRWl268DAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjMxMVoXDTIyMDQwODAyMzMxMVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNAua7IgjOb/fKa9euG\u002BmyqYZG1yNb5CMwiPdI45j6IVu6FF7logjwGFYraAbbdJUF3zOtVC7qxEhLWA7dP/VoejfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQZ2mdVTNKXsgCs/wH78NYAdQyBcjAdBgNVHQ4EFgQUGdpnVUzSl7IArP8B\u002B/DWAHUMgXIwCgYIKoZIzj0EAwIDSAAwRQIhAPX8Qi/MxUcvm2M6XTQBntFS5OfjLiTNgV4xPl5IHPQKAiBAi3Oplj4GtjOGJThb1n48\u002B\u002BKUFLKQXOWOo64u62\u002BoAg==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985158,
-          "exp": 1646521758,
-          "created": 1614985758,
-          "updated": 1614985758,
+          "nbf": 1617848591,
+          "exp": 1649385191,
+          "created": 1617849191,
+          "updated": 1617849191,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1317480634/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1317480634/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -456,166 +330,209 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985732,
-            "updated": 1614985732
+            "created": 1617849183,
+            "updated": 1617849183
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1317480634/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1317480634/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1317480634/aa88898d5a114510ad884eaea4662d90?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1317480634/a30e2086042e4aacb9675bbf8666ca9b?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-95a378098463da46a828d5d09cdcf37a-a03f80f5cd7aee42-00",
+        "traceparent": "00-ca22375e9a63c24d9d5fb31c6a8ba09a-4b3429e7e6992e45-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "691708dc4816dd81c67608216ca51715",
+        "x-ms-client-request-id": "1452c030df33fc34ead55226d3586051",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1166",
+        "Content-Length": "1163",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1452c030df33fc34ead55226d3586051",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a1607460-7e19-409f-91e5-0f15c14af60b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "0e7e6d2d-2a4b-40e0-be05-8a88e7d0190e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1317480634/aa88898d5a114510ad884eaea4662d90",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1317480634/aa88898d5a114510ad884eaea4662d90",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1317480634/aa88898d5a114510ad884eaea4662d90",
-        "x5t": "CTvRAYIqdSD_yljP7_UyZZVTxRA",
-        "cer": "MIIBnjCCAUSgAwIBAgIQLCv8v9C6QD2K6yXoQyK7CjAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTkxOFoXDTIyMDMwNTIzMDkxOFowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABKTnvh//utSdc/uClETgfCArMgnLgQjcFkLxx4jTV6NYILOXanKnlqmRpQlhqS/XrtFsPkd43VJMJQqBgB3GFPajfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQHyKS1ynUnq1UO5p1ofEo7OfKoeDAdBgNVHQ4EFgQUB8iktcp1J6tVDuadaHxKOznyqHgwCgYIKoZIzj0EAwIDSAAwRQIgDSbg6wa3tnEhsAZR1KcHwUA5/bQJMBqlxXl1VY6G/QcCIQCwDqJPt9dPIpvGSRWFVDDonXdiYYnWON7uedGjvfZ1qg==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1317480634/a30e2086042e4aacb9675bbf8666ca9b",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1317480634/a30e2086042e4aacb9675bbf8666ca9b",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1317480634/a30e2086042e4aacb9675bbf8666ca9b",
+        "x5t": "KPngeq0-EZvsTPTySNDuYK0_gQI",
+        "cer": "MIIBnjCCAUSgAwIBAgIQON4jhoPrTxaoeluRWl268DAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjMxMVoXDTIyMDQwODAyMzMxMVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNAua7IgjOb/fKa9euG\u002BmyqYZG1yNb5CMwiPdI45j6IVu6FF7logjwGFYraAbbdJUF3zOtVC7qxEhLWA7dP/VoejfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQZ2mdVTNKXsgCs/wH78NYAdQyBcjAdBgNVHQ4EFgQUGdpnVUzSl7IArP8B\u002B/DWAHUMgXIwCgYIKoZIzj0EAwIDSAAwRQIhAPX8Qi/MxUcvm2M6XTQBntFS5OfjLiTNgV4xPl5IHPQKAiBAi3Oplj4GtjOGJThb1n48\u002B\u002BKUFLKQXOWOo64u62\u002BoAg==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985158,
-          "exp": 1646521758,
-          "created": 1614985758,
-          "updated": 1614985758,
+          "nbf": 1617848591,
+          "exp": 1649385191,
+          "created": 1617849191,
+          "updated": 1617849191,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "2C2BFCBFD0BA403D8AEB25E84322BB0A"
+        "serialnumber": "38DE238683EB4F16A87A5B915A5DBAF0"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1317480634/aa88898d5a114510ad884eaea4662d90?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1317480634/a30e2086042e4aacb9675bbf8666ca9b?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-95a378098463da46a828d5d09cdcf37a-c42f24aca9e91249-00",
+        "traceparent": "00-ca22375e9a63c24d9d5fb31c6a8ba09a-110d247806b83e44-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "ee808b4406a227fa1715e322f44f6d31",
+        "x-ms-client-request-id": "1615c3b2537ddbf90c12738ee5d490c7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1805",
+        "Content-Length": "1803",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1615c3b2537ddbf90c12738ee5d490c7",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7a88826d-6091-4239-8bfc-547fe0ad41ec",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "414472e1-cf1e-40cb-b5b6-ace9acc30793",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIEBwIBAzCCA8MGCSqGSIb3DQEHAaCCA7QEggOwMIIDrDCCAW0GCSqGSIb3DQEHAaCCAV4EggFaMIIBVjCCAVIGCyqGSIb3DQEMCgECoIHMMIHJMBwGCiqGSIb3DQEMAQMwDgQIs3thDNX1xVICAgfQBIGoBgT5XZTSS5LmaFBM\u002B/PxcBsefbye5dP36Q9mgF73o/vO\u002Bf7hIZiVirGielKGma/Pl9PVQWA9R9ZEb0U5Qwm6oOUUpsFyQSWDyERbgoMBajMhGYjjc4ty58aZn8UaBW5qkMKwANYW5T\u002BYVdcU5eeiwdyzy91\u002BjM/y/NMTAgPUbKHEnCZuffrvVARAbfO11d/vsjXsjzeuJUieSfWwOW\u002BP2/tJB2ZcjShIMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAjcGCSqGSIb3DQEHBqCCAigwggIkAgEAMIICHQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQI1HcVWCk0w3UCAgfQgIIB8FTFDyRXYHMg21e1cY1P\u002BI8l4Lz7B4b7uoSc01G8IsEXwe36/9Pw3uoLCFdSpUYkDG0R27ReLm2vMr0yXn2dZkMNGYkS/ERGlDdD3KZjRN6KLuqQvtvH\u002BW2dVqnXapft4\u002BhjmsE60GG7\u002ByiH31lw\u002BatsxOD3c/q6ApmhIQraQRfYrDwIqD3lzzoL2U8\u002B7g2YRXq9OpEZ1Frryc9vibScIcEj9pwjs1PRAxW4gw0PSY0Xkdi0Sx271DpuENZ1V5z6cc0qPtNIYUq8GC7GGXcY\u002BeLCd1uixXGK3Sne9h/\u002BHENWcthwvvorAeYD6zQ7sPCEE7fYzWbwmeiPElOIAix7xdK/5hrd\u002B0YLFI\u002B44NesMejMup8XT31JSTBUD7NIAJl8USWx\u002BeXTipSovsf367S3yYF9fChOY4KRRJseieGvfh0GiCgnH6BBd4Lcag436ARe15A8uHrdX6JmNY/Bj\u002BlDq8JVY9HHmHxuVGIs3YM9jeqnaEkd6prW5RV3S50qWp1tVgJmGxVBFNRVIfI6hiK9gSN4a1FTMnxeOAMtAJmsIF6ijE9OW1UZFqcJglN3jzGW6WrpVw7BFZ1dlKoV4YNkex0ACEBrFgN9ddneANIPLctFmaclXELySRLt65gWsBtSMdXZe3WIwOZYbaegXlXSZocwOzAfMAcGBSsOAwIaBBTSZiwVWztvPV16PW2hm7ECTyhZhAQU8y0K1KHq7uwb1O6lBXaq4Syl9eECAgfQ",
+        "value": "MIIEBwIBAzCCA8MGCSqGSIb3DQEHAaCCA7QEggOwMIIDrDCCAW0GCSqGSIb3DQEHAaCCAV4EggFaMIIBVjCCAVIGCyqGSIb3DQEMCgECoIHMMIHJMBwGCiqGSIb3DQEMAQMwDgQIWYpEnqXQyikCAgfQBIGokD5a6npn8kbr7JdYsFZ5PyjwRkjltW3z71J9aeLJflqH17ZDUu3Jl0JqPPuFJzLk1FWM3dy5wUYYxjHzw3JzZQoE\u002BkGfQHDJcv8HWsV2ltlDktQLQlfreqCxo7kiyQmslwF3DCvh/iC0GxMN5mz7oHGbIJQNdR/zzfAeempZW/MSIU3wreLb81vpsEabSURIijNeDVW\u002B6yF3NayavaNimnSa6JQxH5wAMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAjcGCSqGSIb3DQEHBqCCAigwggIkAgEAMIICHQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIfFok9aEsnDACAgfQgIIB8HyHc2vJp8MhSfcDIwT6AUqcG68IArR/CXCdOL77NDnhWBz\u002BtCvrFGtqkasSzL8k7Iv5u8mVESu9U0S8u8T8Sv\u002BGNHvOb4GNUW6C0vm2pUNF0FdpaczGm02XWIdeym1EHDBsKRPRD/ndadiJztsK04fHUZYs1VBb5zroOlad5YbtrlJLncGAHDJ7zAptdpcJ5AO8RZDBJmqCB1INDPj2HD5KQvezL3VrGf8Xy5vwQDsZEx\u002Be\u002Byo1nfhlmW3oleFuQ4mjGdBxpOr2WFVvdg9VaLCiPp90KUZIFdU\u002BoWaMn9zmxWMyvTE/0rKixVdBWs1JZ6IaQ\u002BXPcEI6giQJX41EkkaVHpPehnWvAz7nS/X51nmEnDpvLx1BbDqCNRFmz0H\u002Bw5msfUtY\u002B/OqwAB8SjAlfc1mHHvRIFKWG8gEQypTNA2MVQr5AYZ\u002B27ESvVvljRnaeWP\u002BvkRyELse18N/L0Zi4SoFa0asFtSdQoZe4c04VLG8O2m9R8v6CIV7RW0hB4X2FBiAQzkch2M1klBXftkeWame21gDLmU5Dm6WGjORco\u002B\u002BibeKE2iXMzLjp9BHiAoyErE3Yce9zIjxACZNUCZprP/WDPWylX2mNJZ0WRLAR0Ehtj2Dd7IXlzlo/f0aeIIpOVLiUDYGNYSj8mMh4s2JSuEwOzAfMAcGBSsOAwIaBBTOZ9natoH0ysgzHcy8CBDvq2Uo2gQUCqu7S/jD4gZOTrmt5CD7KsImYpECAgfQ",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1317480634/aa88898d5a114510ad884eaea4662d90",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1317480634/a30e2086042e4aacb9675bbf8666ca9b",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985158,
-          "exp": 1646521758,
-          "created": 1614985758,
-          "updated": 1614985758,
+          "nbf": 1617848591,
+          "exp": 1649385191,
+          "created": 1617849191,
+          "updated": 1617849191,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1317480634/aa88898d5a114510ad884eaea4662d90"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1317480634/a30e2086042e4aacb9675bbf8666ca9b"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1317480634/aa88898d5a114510ad884eaea4662d90?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1317480634/a30e2086042e4aacb9675bbf8666ca9b?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-8384368b5e34c443ab04e8aa7e69108a-544608cb501c0f41-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "5ab6e5a68a5700ab325a5fa96edbfd16",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:33:14 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5ab6e5a68a5700ab325a5fa96edbfd16",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f6e3a38e-0a35-459b-bae9-4afbbf129785",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1317480634/a30e2086042e4aacb9675bbf8666ca9b?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-6ace9288bd16974497ee93abb9c7c3af-8889613cded0eb45-00",
+        "traceparent": "00-8384368b5e34c443ab04e8aa7e69108a-544608cb501c0f41-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "ddb15c1426bd5db164d893e1828a948d",
+        "x-ms-client-request-id": "5ab6e5a68a5700ab325a5fa96edbfd16",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "440",
+        "Content-Length": "439",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5ab6e5a68a5700ab325a5fa96edbfd16",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5b3bd849-5af0-4dc6-8bbc-4ccf5ec4b1a5",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f5ecc4ff-d0c9-495c-94f7-a48c0975bd1b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1317480634/aa88898d5a114510ad884eaea4662d90",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1317480634/a30e2086042e4aacb9675bbf8666ca9b",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256",
-          "x": "pOe-H_-61J1z-4KUROB8ICsyCcuBCNwWQvHHiNNXo1g",
-          "y": "ILOXanKnlqmRpQlhqS_XrtFsPkd43VJMJQqBgB3GFPY"
+          "x": "0C5rsiCM5v98pr164b6bKphkbXI1vkIzCI90jjmPohU",
+          "y": "u6FF7logjwGFYraAbbdJUF3zOtVC7qxEhLWA7dP_Voc"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985158,
-          "exp": 1646521758,
-          "created": 1614985758,
-          "updated": 1614985758,
+          "nbf": 1617848591,
+          "exp": 1649385191,
+          "created": 1617849191,
+          "updated": 1617849191,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -624,7 +541,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1101407306"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-256K).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-256K).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2064834413/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2064834413/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-e53ed6367ac24549b66a47f7540100d6-5d1c5078eb11d84c-00",
+        "traceparent": "00-61d373487cc59748b3951dcc59bb4912-7e227258657eec4f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "33ed97663ac5da9d8dacddac6ae25b0d",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:06 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "33ed97663ac5da9d8dacddac6ae25b0d",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9b8f7a1b-c2ef-4b93-a9b8-d5e5d20efb80",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1a92a904-8139-4c47-b530-44db2ffb6a03",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2064834413/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2064834413/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "220",
         "Content-Type": "application/json",
-        "traceparent": "00-e53ed6367ac24549b66a47f7540100d6-5d1c5078eb11d84c-00",
+        "traceparent": "00-61d373487cc59748b3951dcc59bb4912-7e227258657eec4f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "33ed97663ac5da9d8dacddac6ae25b0d",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:06 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:25 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending?api-version=7.2\u0026request_id=79054fd2e4ed48a1b0197ce5eea32001",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending?api-version=7.2\u0026request_id=667915794cb14108bc4ee1195d857737",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "33ed97663ac5da9d8dacddac6ae25b0d",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9362d69f-7880-4356-a3c9-1ec3cc037e83",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1749e27b-b562-43d1-80fe-c38e0712bd4d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARINBQniUNOURjZSMqEYNaD8K66Zyd2Zbnk9ciyVqYPhqy31M4A8fbx8\u002BLmrK1hgOGSLeOCcDTCNS84/f3/J2JioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgQL\u002BDi32Ohws7FN6C3KJUs5vRvcCHwdaahem36yRcEqwCIQD5lESlCVZryNn903\u002B5KhCzqLKgamqfDnOdw87\u002B4Gg1IQ==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ\u002B5fw1YSJY0ebl8y4UoSPVnOXsenN8H3qFdw1byWJTFNPVaO4O824j23SE\u002Ba1f9Nl\u002Bpj/hm0GhAtf6BXs6YbGpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgeV0HeTxz\u002B5snDat2K7zkcqlrEVwDSTkcr6Wjs0593T4CIDI6l31gHEfZEj1vhsul3Cq7rAqneoSPIxbBIp9iC/cw",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "79054fd2e4ed48a1b0197ce5eea32001"
+        "request_id": "667915794cb14108bc4ee1195d857737"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "17a35432f2eb505c4cbbf8689ac2496b",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:06 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "17a35432f2eb505c4cbbf8689ac2496b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "54397a70-1a8b-4b07-8538-ebd02153ccee",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bd7f2057-c553-4a90-8f2a-50968e12f0db",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARINBQniUNOURjZSMqEYNaD8K66Zyd2Zbnk9ciyVqYPhqy31M4A8fbx8\u002BLmrK1hgOGSLeOCcDTCNS84/f3/J2JioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgQL\u002BDi32Ohws7FN6C3KJUs5vRvcCHwdaahem36yRcEqwCIQD5lESlCVZryNn903\u002B5KhCzqLKgamqfDnOdw87\u002B4Gg1IQ==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ\u002B5fw1YSJY0ebl8y4UoSPVnOXsenN8H3qFdw1byWJTFNPVaO4O824j23SE\u002Ba1f9Nl\u002Bpj/hm0GhAtf6BXs6YbGpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgeV0HeTxz\u002B5snDat2K7zkcqlrEVwDSTkcr6Wjs0593T4CIDI6l31gHEfZEj1vhsul3Cq7rAqneoSPIxbBIp9iC/cw",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "79054fd2e4ed48a1b0197ce5eea32001"
+        "request_id": "667915794cb14108bc4ee1195d857737"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "264544bb60db7f85713e259ff6d5303e",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:11 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "264544bb60db7f85713e259ff6d5303e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ae85259e-5f84-4081-8f88-526d75308bad",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f6a0bf9a-b528-4928-ab86-8101c6e7ba83",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARINBQniUNOURjZSMqEYNaD8K66Zyd2Zbnk9ciyVqYPhqy31M4A8fbx8\u002BLmrK1hgOGSLeOCcDTCNS84/f3/J2JioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgQL\u002BDi32Ohws7FN6C3KJUs5vRvcCHwdaahem36yRcEqwCIQD5lESlCVZryNn903\u002B5KhCzqLKgamqfDnOdw87\u002B4Gg1IQ==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ\u002B5fw1YSJY0ebl8y4UoSPVnOXsenN8H3qFdw1byWJTFNPVaO4O824j23SE\u002Ba1f9Nl\u002Bpj/hm0GhAtf6BXs6YbGpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgeV0HeTxz\u002B5snDat2K7zkcqlrEVwDSTkcr6Wjs0593T4CIDI6l31gHEfZEj1vhsul3Cq7rAqneoSPIxbBIp9iC/cw",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "79054fd2e4ed48a1b0197ce5eea32001"
+        "request_id": "667915794cb14108bc4ee1195d857737"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "ee2fdea662a773823a9de60a42353fca",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:35 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ee2fdea662a773823a9de60a42353fca",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "88e74ff9-53bf-457d-85aa-dd3c63615924",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "81468435-eed9-4d11-9c56-d718b07467fb",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARINBQniUNOURjZSMqEYNaD8K66Zyd2Zbnk9ciyVqYPhqy31M4A8fbx8\u002BLmrK1hgOGSLeOCcDTCNS84/f3/J2JioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgQL\u002BDi32Ohws7FN6C3KJUs5vRvcCHwdaahem36yRcEqwCIQD5lESlCVZryNn903\u002B5KhCzqLKgamqfDnOdw87\u002B4Gg1IQ==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ\u002B5fw1YSJY0ebl8y4UoSPVnOXsenN8H3qFdw1byWJTFNPVaO4O824j23SE\u002Ba1f9Nl\u002Bpj/hm0GhAtf6BXs6YbGpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgeV0HeTxz\u002B5snDat2K7zkcqlrEVwDSTkcr6Wjs0593T4CIDI6l31gHEfZEj1vhsul3Cq7rAqneoSPIxbBIp9iC/cw",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "79054fd2e4ed48a1b0197ce5eea32001"
+        "request_id": "667915794cb14108bc4ee1195d857737"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "26f07263349cd231cf24a5adcdbc5a77",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:22 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:39 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "26f07263349cd231cf24a5adcdbc5a77",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e4f36eda-03f7-4932-8037-7086c4129516",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "57a9149e-17f1-413d-aa6f-914b596c1013",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARINBQniUNOURjZSMqEYNaD8K66Zyd2Zbnk9ciyVqYPhqy31M4A8fbx8\u002BLmrK1hgOGSLeOCcDTCNS84/f3/J2JioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgQL\u002BDi32Ohws7FN6C3KJUs5vRvcCHwdaahem36yRcEqwCIQD5lESlCVZryNn903\u002B5KhCzqLKgamqfDnOdw87\u002B4Gg1IQ==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ\u002B5fw1YSJY0ebl8y4UoSPVnOXsenN8H3qFdw1byWJTFNPVaO4O824j23SE\u002Ba1f9Nl\u002Bpj/hm0GhAtf6BXs6YbGpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgeV0HeTxz\u002B5snDat2K7zkcqlrEVwDSTkcr6Wjs0593T4CIDI6l31gHEfZEj1vhsul3Cq7rAqneoSPIxbBIp9iC/cw",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "79054fd2e4ed48a1b0197ce5eea32001"
+        "request_id": "667915794cb14108bc4ee1195d857737"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "bcc1ba8b5a9259c3c1d2eb3e797b3d3b",
         "x-ms-return-client-request-id": "true"
@@ -300,42 +306,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "873",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:26 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:44 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bcc1ba8b5a9259c3c1d2eb3e797b3d3b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f64a7150-a9aa-4e0f-a6f8-b03da07c751d",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b061a7b0-bb53-4c83-b74a-b13a6f15b7d7",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARINBQniUNOURjZSMqEYNaD8K66Zyd2Zbnk9ciyVqYPhqy31M4A8fbx8\u002BLmrK1hgOGSLeOCcDTCNS84/f3/J2JioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgQL\u002BDi32Ohws7FN6C3KJUs5vRvcCHwdaahem36yRcEqwCIQD5lESlCVZryNn903\u002B5KhCzqLKgamqfDnOdw87\u002B4Gg1IQ==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ\u002B5fw1YSJY0ebl8y4UoSPVnOXsenN8H3qFdw1byWJTFNPVaO4O824j23SE\u002Ba1f9Nl\u002Bpj/hm0GhAtf6BXs6YbGpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgeV0HeTxz\u002B5snDat2K7zkcqlrEVwDSTkcr6Wjs0593T4CIDI6l31gHEfZEj1vhsul3Cq7rAqneoSPIxbBIp9iC/cw",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "79054fd2e4ed48a1b0197ce5eea32001"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/2064834413",
+        "request_id": "667915794cb14108bc4ee1195d857737"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2064834413?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "843c5afe0ae472a2ac5d1e83bdd5a67e",
         "x-ms-return-client-request-id": "true"
@@ -344,123 +350,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "1965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:31 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "aea11cfb-83c7-493d-8b31-25722648b7f2",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARINBQniUNOURjZSMqEYNaD8K66Zyd2Zbnk9ciyVqYPhqy31M4A8fbx8\u002BLmrK1hgOGSLeOCcDTCNS84/f3/J2JioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgQL\u002BDi32Ohws7FN6C3KJUs5vRvcCHwdaahem36yRcEqwCIQD5lESlCVZryNn903\u002B5KhCzqLKgamqfDnOdw87\u002B4Gg1IQ==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "79054fd2e4ed48a1b0197ce5eea32001"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "877e6f4282740837ae9764c948f25954",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "879",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:37 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:44 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "843c5afe0ae472a2ac5d1e83bdd5a67e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c84f30d0-d8af-4776-a4b2-0ac8e23d9ee9",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "9b98d737-22df-4e40-8424-a5183372de91",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARINBQniUNOURjZSMqEYNaD8K66Zyd2Zbnk9ciyVqYPhqy31M4A8fbx8\u002BLmrK1hgOGSLeOCcDTCNS84/f3/J2JioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgQL\u002BDi32Ohws7FN6C3KJUs5vRvcCHwdaahem36yRcEqwCIQD5lESlCVZryNn903\u002B5KhCzqLKgamqfDnOdw87\u002B4Gg1IQ==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/2064834413",
-        "request_id": "79054fd2e4ed48a1b0197ce5eea32001"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2064834413?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "73ae69e6d67f8093174f10353b3f9cec",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1970",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:37 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "70abf256-2691-4dca-9822-827c0cdadead",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/4777d90be04f4dde9c29086949642f06",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/2064834413/4777d90be04f4dde9c29086949642f06",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/2064834413/4777d90be04f4dde9c29086949642f06",
-        "x5t": "qvQutq_PoZ_GZ7mBnVl_BuEWutw",
-        "cer": "MIICOzCCAeGgAwIBAgIQU36wKQ9DR3Wn8QRQYnDSVTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTAzNVoXDTIyMDMwNTIzMDAzNVowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARINBQniUNOURjZSMqEYNaD8K66Zyd2Zbnk9ciyVqYPhqy31M4A8fbx8\u002BLmrK1hgOGSLeOCcDTCNS84/f3/J2Jio3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUfagLoHE27arqIeaU6uLXEqyKGiEwHQYDVR0OBBYEFH2oC6BxNu2q6iHmlOri1xKsihohMAoGCCqGSM49BAMCA0gAMEUCIQCrTNQBWFalGc0pmUi78Xvjzh346cL8VGLEpBgjWqk5FgIgb8fuSDlvMmPHkVTwR0oSOJGFJ16iiAmBm7AWmxiB5UM=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2064834413/f74e85a6de6f44318cca804128ab1e86",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/2064834413/f74e85a6de6f44318cca804128ab1e86",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/2064834413/f74e85a6de6f44318cca804128ab1e86",
+        "x5t": "TfbYNZANYSsOeAKrqm0BrjuyqFs",
+        "cer": "MIICOzCCAeGgAwIBAgIQHgXB1dglS1SddbHSnoLQjzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTk0MloXDTIyMDQwODAyMjk0MlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ\u002B5fw1YSJY0ebl8y4UoSPVnOXsenN8H3qFdw1byWJTFNPVaO4O824j23SE\u002Ba1f9Nl\u002Bpj/hm0GhAtf6BXs6YbGpo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUaS69uORNREDc3WuQha5U/yi7IBYwHQYDVR0OBBYEFGkuvbjkTURA3N1rkIWuVP8ouyAWMAoGCCqGSM49BAMCA0gAMEUCIQDT5YOerJsbl5JwxUS0qN1nLkVJ3zQ49Dlgb6wz4Ihc8AIgImQuu9kY4Th8zwCdZXYNIyprmNxHWyabBUQgW6e0U\u002BU=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984635,
-          "exp": 1646521235,
-          "created": 1614985235,
-          "updated": 1614985235,
+          "nbf": 1617848382,
+          "exp": 1649384982,
+          "created": 1617848982,
+          "updated": 1617848982,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/2064834413/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -500,26 +420,169 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985207,
-            "updated": 1614985207
+            "created": 1617848965,
+            "updated": 1617848965
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/2064834413/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2064834413/4777d90be04f4dde9c29086949642f06?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2064834413/f74e85a6de6f44318cca804128ab1e86?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-4c18648962f62e438c91b320acebd35d-97f0074412bb8649-00",
+        "traceparent": "00-899d018fd1b90e40b69a76e6f8efb324-3ffb2a70c070cd48-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "877e6f4282740837ae9764c948f25954",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1371",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:29:50 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "877e6f4282740837ae9764c948f25954",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "8881e620-ab82-47e1-898c-5a33c1d8c715",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2064834413/f74e85a6de6f44318cca804128ab1e86",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/2064834413/f74e85a6de6f44318cca804128ab1e86",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/2064834413/f74e85a6de6f44318cca804128ab1e86",
+        "x5t": "TfbYNZANYSsOeAKrqm0BrjuyqFs",
+        "cer": "MIICOzCCAeGgAwIBAgIQHgXB1dglS1SddbHSnoLQjzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTk0MloXDTIyMDQwODAyMjk0MlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ\u002B5fw1YSJY0ebl8y4UoSPVnOXsenN8H3qFdw1byWJTFNPVaO4O824j23SE\u002Ba1f9Nl\u002Bpj/hm0GhAtf6BXs6YbGpo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUaS69uORNREDc3WuQha5U/yi7IBYwHQYDVR0OBBYEFGkuvbjkTURA3N1rkIWuVP8ouyAWMAoGCCqGSM49BAMCA0gAMEUCIQDT5YOerJsbl5JwxUS0qN1nLkVJ3zQ49Dlgb6wz4Ihc8AIgImQuu9kY4Th8zwCdZXYNIyprmNxHWyabBUQgW6e0U\u002BU=",
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848382,
+          "exp": 1649384982,
+          "created": 1617848982,
+          "updated": 1617848982,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "subject": "CN=default",
+        "issuer": "CN=default",
+        "serialnumber": "1E05C1D5D8254B549D75B1D29E82D08F"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/2064834413/f74e85a6de6f44318cca804128ab1e86?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-899d018fd1b90e40b69a76e6f8efb324-f74283fffecbb24f-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "73ae69e6d67f8093174f10353b3f9cec",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "2203",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:29:50 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "73ae69e6d67f8093174f10353b3f9cec",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ee659903-05b2-41e8-b899-bcbd02cbae6c",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "value": "MIIFMgIBAzCCBO4GCSqGSIb3DQEHAaCCBN8EggTbMIIE1zCCAgAGCSqGSIb3DQEHAaCCAfEEggHtMIIB6TCCAeUGCyqGSIb3DQEMCgECoIIBXjCCAVowHAYKKoZIhvcNAQwBAzAOBAi0iTn0l6m2lQICB9AEggE4rIwaq4Jmcm3T3bVDU2pL/7bfGOdP5m2IOebfafGFR3iZ8qmDkaKtF0x/VLFlwK12iC3a\u002B9auj79eT/oYdC2E11ms9Xji07Yjk7jPUABHsTqI8WK8KxvEvljqDvL\u002BIvW9lyrBrLw4XkmENZnah5CgDivEdIuqwPTe\u002B94po5hsIww3jfxFG6\u002BYC5WkWN2sndgnSwlprsSa5szFd8wZjvdo\u002BEU7r0oBVAzWrRbBhdNEdngDzijx\u002BvdocR4ZLOGstF2EcKaxiqxbyzstbLbqwBT3ReXyhJsV09rc9QkTOMy9aCHaX\u002B8ipX213T9aHaCn6qPvC71KU5JljTE1HKCJy6KIwssEVUJtu0PCPLNmOqPYgFmFFMelTL81u7WI6lQ2I9Yzz/5P2QeE17L04J32UZAq5HqF\u002BGXa5fOoMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAs8GCSqGSIb3DQEHBqCCAsAwggK8AgEAMIICtQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIbilUQSJJvYkCAgfQgIICiHH0oBPYgbAJXQsbHVE99I1ISDysYHtlbdNMj6gN7Qzc9N36ZH8wNxQGXtE7Md7/Aefamwy1T0F5Bp1Z6EQKUtXBDCYEKFHMAwEAR7gLJEZ2OJSEqRwBbM4q/FjEwoEXytIu9PNUbJ9us//wLdJnhFz2tk4fK4Qc\u002Bkib\u002BZ5M\u002BdU3/GV3qu1WNzkOWKImhSfl8EsJ2fUo8EjZ6XlsWO9P0NOvugjVbbwXPLs8AYbV7WlnrFkG6iL2AYpKHl666e9li5k8iibZNPdulelbhQy0YnEVnlWSZgBZIts55c8AtmPcYxkmZb2/8juKm1Ngh9X4MLf9gMnB\u002B0AS3Z9ifad1jSDL6wSW/f6/H7MJK/W002/zj7kuIc\u002BKvwpmRfYPjhlhtPgLXTYlzU1dSDFYZGNfSKTm1wbmBtGjOi6v55U/An\u002BvMPX7dZfrgT3bJxu3Nt7cwoDpH2PZzbueerCQ5/MmhU3CRUDJwWdCBXkz0xA\u002BP5wvxOpl3Yr5x16IRt4lGAGOg0P\u002ByuOuB/JJILxyrqFOZTdAEUnXuuZNooc2PvClZP\u002BW2A3bXpLk\u002BeUnP0RqZKtOdHKX1lHgf9MaBbfrIhWrfqNEip/hVN4VEg27uV5XhyNvMRfHNk4\u002BPOILePJUMzcZGWMjqWavUWF\u002B5nEQC42YNkUTw6q0E54YM0BZvjs092t5kIygIeCDokUxlw3on02gbcvA5g7PBO8Gk385YrovvgCqdjrP6cfiBZxNACDbH9dDIYaOw2oQjHRIH\u002Bfr9lbqwIf5RFINOuIX\u002BFeZfZLIEZaaGFc1a1EJI5y/y\u002BO0q7APFw7F6UVGYWf3QcdMSZGtmp\u002BE8xMhrCcV3Wa1Pm8WFDln40UG4b8MnTA7MB8wBwYFKw4DAhoEFJNSyNAqGejLAx1EUZonH58\u002BE44hBBQKey93oGZPb5Qp453F2\u002BJdX90w1wICB9A=",
+        "contentType": "application/x-pkcs12",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/2064834413/f74e85a6de6f44318cca804128ab1e86",
+        "managed": true,
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848382,
+          "exp": 1649384982,
+          "created": 1617848982,
+          "updated": 1617848982,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "kid": "https://heathskvtest2.vault.azure.net/keys/2064834413/f74e85a6de6f44318cca804128ab1e86"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/2064834413/f74e85a6de6f44318cca804128ab1e86?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-283cf24a50ea2f4e9c7e7f244fe85265-bdcc6a52a06a1745-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "09fc6d2bb5fc7bc72234d54ca6d829ba",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:29:50 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "09fc6d2bb5fc7bc72234d54ca6d829ba",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3ee019a5-9376-4325-9f21-5390647d7b71",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/2064834413/f74e85a6de6f44318cca804128ab1e86?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-283cf24a50ea2f4e9c7e7f244fe85265-bdcc6a52a06a1745-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "09fc6d2bb5fc7bc72234d54ca6d829ba",
         "x-ms-return-client-request-id": "true"
@@ -528,138 +591,38 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1374",
+        "Content-Length": "440",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:51 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "09fc6d2bb5fc7bc72234d54ca6d829ba",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "287bd880-04e5-401f-aec3-2c198ec87436",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2064834413/4777d90be04f4dde9c29086949642f06",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/2064834413/4777d90be04f4dde9c29086949642f06",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/2064834413/4777d90be04f4dde9c29086949642f06",
-        "x5t": "qvQutq_PoZ_GZ7mBnVl_BuEWutw",
-        "cer": "MIICOzCCAeGgAwIBAgIQU36wKQ9DR3Wn8QRQYnDSVTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTAzNVoXDTIyMDMwNTIzMDAzNVowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARINBQniUNOURjZSMqEYNaD8K66Zyd2Zbnk9ciyVqYPhqy31M4A8fbx8\u002BLmrK1hgOGSLeOCcDTCNS84/f3/J2Jio3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUfagLoHE27arqIeaU6uLXEqyKGiEwHQYDVR0OBBYEFH2oC6BxNu2q6iHmlOri1xKsihohMAoGCCqGSM49BAMCA0gAMEUCIQCrTNQBWFalGc0pmUi78Xvjzh346cL8VGLEpBgjWqk5FgIgb8fuSDlvMmPHkVTwR0oSOJGFJ16iiAmBm7AWmxiB5UM=",
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614984635,
-          "exp": 1646521235,
-          "created": 1614985235,
-          "updated": 1614985235,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "subject": "CN=default",
-        "issuer": "CN=default",
-        "serialnumber": "537EB0290F434775A7F104506270D255"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/2064834413/4777d90be04f4dde9c29086949642f06?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-4c18648962f62e438c91b320acebd35d-b2c9850e65756346-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "539cca0333266cfedcfe6f247202cc6e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "2205",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:42 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3588e3de-8e80-4f43-a891-8db311b119de",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "value": "MIIFMgIBAzCCBO4GCSqGSIb3DQEHAaCCBN8EggTbMIIE1zCCAgAGCSqGSIb3DQEHAaCCAfEEggHtMIIB6TCCAeUGCyqGSIb3DQEMCgECoIIBXjCCAVowHAYKKoZIhvcNAQwBAzAOBAhJabO9\u002BreRHQICB9AEggE46r0nnoDElPrm\u002B0ROH1gePygQToXB8Gg7cSrfai3i/w8Pzip6Kh5e2mfOnsy\u002B1LMjFSaAAyxqter2sJ\u002BWFkzEYXtPXtRUmTbKLXQwCA\u002BJZeEL0Nehq3iktMq73bH9Wwo\u002BmiXMcwsqyeA/x90kwqPw//PCuJQTcSHKkZzI3ycjnAgm3eEUOJ/1ykwTN93nZ5C5/jaouNzBj0Tpg92ce9kp\u002B7gcy0gtSMyL4msUchNmLLJvE4eDEB5ze\u002BIVvHt4vQ99MOmE7xjzG5U2l\u002BspvajyZduaUB9IQFxfPSYUwl5r8qFID7BGms2YcsMxpvIVkIY8SOjQT\u002BSwXo8i7XF7AE/eqhxOVddfvr9WWzzFi4LMnAo1dsk/4uP3Kbcpb4vYgy4dsM0OZImifs9kHJLcX0Aep0/m38ecaj3UMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAs8GCSqGSIb3DQEHBqCCAsAwggK8AgEAMIICtQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIplyBysnEqRYCAgfQgIICiLErC5utQmlxMGWhhG5tWLZV5cv/pvK\u002BUNxvlotBJTvvo5dCMPqJ5gDmp5n6HaZtycccaAqjrEGtAK9FN3s5mq7Ic1EDc25cWWkGaEH4kZ52VvIMPPo9zW\u002BKURabLuZ33p14nl5C7ZxzMqvwyDxYGsHEfNUYSK88xVCbxRUsXdWKtsBl/kBYIJy3Pb8\u002BBuXQ0t6K/P68MlmSHo98nuSrIGhflPF\u002B4ZMqO5yh9WOR9Kx0efW3doLbq/k2QhBAMMJKt55YqzShu5XDT\u002BJsm\u002BzCMcbKzb7XWS4a755qSHiqjt2uARHA5rfFn86j7iomIn7GDSZwovKS68Pu3CEb/fNOqgzfp1\u002Bh7LnFtfrXUDeL7j8B0QENkDpdSIhnPWj8r165Po5oZc2CXCmKHfeda30rwGB/eZ3i8r\u002BmIlUIUGyVUj4lzHFUIBXk0alUkCx1\u002BTtx9FVcWI2yofmScwHCSNChhl3wz4SuDbyuJ6KKvL5FMWadxG3FQGd2qLzubxOl4ZHlkqcLrNuQtJYLNu0SEBTI4MrkEBmqJOFEgzTWF3f\u002BFB4RKY4LlPpqZxgrrVevPDwSxcobTazW4xR9JW4uycSqRehlHDzeguA4QrEKRxGKHENe9zZO2NaWBjfraKROuj0/JccoEvXgNkzTKv\u002BG48GVXNsz9KwAWh8nbSz1lKJ4YNjgc21pfgha/md7qALfl3uJP0KY1LK5no9zsROXepy2OusKDDeKlx4fnoAnw7VgJ8ICWNF0keNSaoRkItQgrN1AGDj697lcCU46iiagAcNX28YfjBlbNcC/waSC33IydtsadeagxiSQU2Otxoo4ubXg\u002BbWaPVhLtZUo4rXBMevPWQYpGON8n6YIrDA7MB8wBwYFKw4DAhoEFKH4n4Xsblm6iCn\u002Blfr6CffrC0RdBBSOxpc3mcrKSWTkICphMThqPYltggICB9A=",
-        "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/2064834413/4777d90be04f4dde9c29086949642f06",
-        "managed": true,
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614984635,
-          "exp": 1646521235,
-          "created": 1614985235,
-          "updated": 1614985235,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/2064834413/4777d90be04f4dde9c29086949642f06"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/2064834413/4777d90be04f4dde9c29086949642f06?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-3f965564cb26034a8ff1514897a4d48c-8882f0196925e34d-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "db9d78fb4ff63158a133504b0046da3f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "441",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:42 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1affcbc3-076b-4d73-8b03-151574ec6584",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b80ae981-9aee-4919-9ac6-fc213707e76e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/2064834413/4777d90be04f4dde9c29086949642f06",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/2064834413/f74e85a6de6f44318cca804128ab1e86",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256K",
-          "x": "SDQUJ4lDTlEY2UjKhGDWg_CuumcndmW55PXIslamD4Y",
-          "y": "rLfUzgDx9vHz4uasrWGA4ZIt44JwNMI1Lzj9_f8nYmI"
+          "x": "PuX8NWEiWNHm5fMuFKEj1Zzl7HpzfB96hXcNW8liUxQ",
+          "y": "09Vo7g7zbiPbdIT5rV_02X6mP-GbQaEC1_oFezphsak"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984635,
-          "exp": 1646521235,
-          "created": 1614985235,
-          "updated": 1614985235,
+          "nbf": 1617848382,
+          "exp": 1649384982,
+          "created": 1617848982,
+          "updated": 1617848982,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -668,7 +631,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "238775907"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-256K)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-256K)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2000971188/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2000971188/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-e341c2367295504d8801c6d5114317b2-7c0cf7441b18df47-00",
+        "traceparent": "00-f20ed365affee747b5db1df904a9ab6d-c95986b0c3ce2647-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "9f83463baf5afac6f156e0f7b423941c",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9f83463baf5afac6f156e0f7b423941c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2f98c79c-8b65-4b77-ad1a-2039bd803dfd",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d6384265-aef3-46df-948e-a20dc6998e6a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2000971188/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2000971188/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "220",
         "Content-Type": "application/json",
-        "traceparent": "00-e341c2367295504d8801c6d5114317b2-7c0cf7441b18df47-00",
+        "traceparent": "00-f20ed365affee747b5db1df904a9ab6d-c95986b0c3ce2647-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "9f83463baf5afac6f156e0f7b423941c",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:11 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:43 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending?api-version=7.2\u0026request_id=825b5fad8f6540618bd2fd7a5cba2bdc",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/2000971188/pending?api-version=7.2\u0026request_id=9f6ffcdd450847b4a72a68d0ffd2f6c6",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9f83463baf5afac6f156e0f7b423941c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "51fc269d-44e4-47d0-bf4e-a01f9ae33876",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "49e8c289-2ff6-40be-9d9b-2ff519c4b2b6",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2000971188/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ6g7CgOSUF8aqgQri8r6BN4y2FJtULZqWuWuxIoTutRYqW6P/JWMw0Kpv3axL51WagMN7E0UnAyOAXFMj8AXHNoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgMDJK09T95DozYZ/o2AqldKPICnrqiIq\u002Bn/E5RGiW6VYCIQDhiknmJHvjq0IOC36JFt5PhuE0Ph\u002BghDTRVPi4pnCpHw==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASNuOnXMtlc1O\u002Bs/9kB12dmRR4d\u002BTmHxoDSncrlIrd8G7I9kF7aRwZFu4fxfOEta3eFoEBjqvOuVQ1UGFyN/aFeoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgVOannTSnVZjtgAvkEH2WjH5Sy367FLEYb27ptTNi7OQCIDGw\u002BX1MDmrYvmn7CcefYNjWuZsQfRkIOweemENkLfkD",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "825b5fad8f6540618bd2fd7a5cba2bdc"
+        "request_id": "9f6ffcdd450847b4a72a68d0ffd2f6c6"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2000971188/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "cddc692cd029138a89b0bdc7f0b8d8fb",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:11 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "cddc692cd029138a89b0bdc7f0b8d8fb",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "60cf0ad3-45fc-477f-9abb-ba4093371019",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "e011fc84-92db-4c7c-ae28-57113c9211df",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2000971188/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ6g7CgOSUF8aqgQri8r6BN4y2FJtULZqWuWuxIoTutRYqW6P/JWMw0Kpv3axL51WagMN7E0UnAyOAXFMj8AXHNoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgMDJK09T95DozYZ/o2AqldKPICnrqiIq\u002Bn/E5RGiW6VYCIQDhiknmJHvjq0IOC36JFt5PhuE0Ph\u002BghDTRVPi4pnCpHw==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASNuOnXMtlc1O\u002Bs/9kB12dmRR4d\u002BTmHxoDSncrlIrd8G7I9kF7aRwZFu4fxfOEta3eFoEBjqvOuVQ1UGFyN/aFeoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgVOannTSnVZjtgAvkEH2WjH5Sy367FLEYb27ptTNi7OQCIDGw\u002BX1MDmrYvmn7CcefYNjWuZsQfRkIOweemENkLfkD",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "825b5fad8f6540618bd2fd7a5cba2bdc"
+        "request_id": "9f6ffcdd450847b4a72a68d0ffd2f6c6"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2000971188/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "edaf71b59445742ea5301621b227f714",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:47 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "edaf71b59445742ea5301621b227f714",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "b4cb4834-41c7-4373-b770-fa4351604fbe",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f262531c-ce0d-43d5-83bb-7bba4bf4f423",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2000971188/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ6g7CgOSUF8aqgQri8r6BN4y2FJtULZqWuWuxIoTutRYqW6P/JWMw0Kpv3axL51WagMN7E0UnAyOAXFMj8AXHNoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgMDJK09T95DozYZ/o2AqldKPICnrqiIq\u002Bn/E5RGiW6VYCIQDhiknmJHvjq0IOC36JFt5PhuE0Ph\u002BghDTRVPi4pnCpHw==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASNuOnXMtlc1O\u002Bs/9kB12dmRR4d\u002BTmHxoDSncrlIrd8G7I9kF7aRwZFu4fxfOEta3eFoEBjqvOuVQ1UGFyN/aFeoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgVOannTSnVZjtgAvkEH2WjH5Sy367FLEYb27ptTNi7OQCIDGw\u002BX1MDmrYvmn7CcefYNjWuZsQfRkIOweemENkLfkD",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "825b5fad8f6540618bd2fd7a5cba2bdc"
+        "request_id": "9f6ffcdd450847b4a72a68d0ffd2f6c6"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2000971188/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "56ea0be085716b8bbc6f16aaf2fe0939",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "873",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:21 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "56ea0be085716b8bbc6f16aaf2fe0939",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3dc1b942-1623-402f-96e9-3d87b0e31dd9",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3c1ef94c-8843-44f9-ab21-3b94dade9bca",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2000971188/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ6g7CgOSUF8aqgQri8r6BN4y2FJtULZqWuWuxIoTutRYqW6P/JWMw0Kpv3axL51WagMN7E0UnAyOAXFMj8AXHNoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgMDJK09T95DozYZ/o2AqldKPICnrqiIq\u002Bn/E5RGiW6VYCIQDhiknmJHvjq0IOC36JFt5PhuE0Ph\u002BghDTRVPi4pnCpHw==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASNuOnXMtlc1O\u002Bs/9kB12dmRR4d\u002BTmHxoDSncrlIrd8G7I9kF7aRwZFu4fxfOEta3eFoEBjqvOuVQ1UGFyN/aFeoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgVOannTSnVZjtgAvkEH2WjH5Sy367FLEYb27ptTNi7OQCIDGw\u002BX1MDmrYvmn7CcefYNjWuZsQfRkIOweemENkLfkD",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "825b5fad8f6540618bd2fd7a5cba2bdc"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/2000971188",
+        "request_id": "9f6ffcdd450847b4a72a68d0ffd2f6c6"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2000971188?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "4241e47ea67497d63b6727f8ba686161",
         "x-ms-return-client-request-id": "true"
@@ -256,123 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "1965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f2d838fe-43e0-4a2e-b83f-0fc915a5baea",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ6g7CgOSUF8aqgQri8r6BN4y2FJtULZqWuWuxIoTutRYqW6P/JWMw0Kpv3axL51WagMN7E0UnAyOAXFMj8AXHNoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgMDJK09T95DozYZ/o2AqldKPICnrqiIq\u002Bn/E5RGiW6VYCIQDhiknmJHvjq0IOC36JFt5PhuE0Ph\u002BghDTRVPi4pnCpHw==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "825b5fad8f6540618bd2fd7a5cba2bdc"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "e5e7a9b882cd308ae54331d57e8482a7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "879",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:31 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4241e47ea67497d63b6727f8ba686161",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2cae4d97-790c-4735-a739-65bb6ca562f2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a67360d2-184b-4028-97a3-56879e3a6ddd",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ6g7CgOSUF8aqgQri8r6BN4y2FJtULZqWuWuxIoTutRYqW6P/JWMw0Kpv3axL51WagMN7E0UnAyOAXFMj8AXHNoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgMDJK09T95DozYZ/o2AqldKPICnrqiIq\u002Bn/E5RGiW6VYCIQDhiknmJHvjq0IOC36JFt5PhuE0Ph\u002BghDTRVPi4pnCpHw==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/2000971188",
-        "request_id": "825b5fad8f6540618bd2fd7a5cba2bdc"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2000971188?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "cda3dc27b5e639a034521a095d93b153",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1970",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:31 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "68267d41-99c5-4001-8802-ff580be2b29f",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab",
-        "x5t": "UcXFUXmDF3HjKM33l3FfDHiqNJE",
-        "cer": "MIICPDCCAeGgAwIBAgIQZ1Wkw8xjR/6Coei4j8kN0TAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDAyN1oXDTIyMDMwNTIzMTAyN1owEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ6g7CgOSUF8aqgQri8r6BN4y2FJtULZqWuWuxIoTutRYqW6P/JWMw0Kpv3axL51WagMN7E0UnAyOAXFMj8AXHNo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUw6ubcmjmhv4NJHmP41nEXcMxMjwwHQYDVR0OBBYEFMOrm3Jo5ob\u002BDSR5j\u002BNZxF3DMTI8MAoGCCqGSM49BAMCA0kAMEYCIQDbNQYRjsxy\u002B1AQ4cSfomAY1Zg6FrkQslH7mumkfq5l7gIhAMnr7t3mo0ewM6pZfMF\u002B985KSkCUS8AYNxCU/u2YOLn8",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2000971188/93488a0b43cb4697870a5325409b2ab7",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/2000971188/93488a0b43cb4697870a5325409b2ab7",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/2000971188/93488a0b43cb4697870a5325409b2ab7",
+        "x5t": "RNWhFni4xU9OIdqOssPFJzoeFqQ",
+        "cer": "MIICOzCCAeGgAwIBAgIQBTmW5wZdSuC2UKAxiq6KsjAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjM1MloXDTIyMDQwODAyMzM1MlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASNuOnXMtlc1O\u002Bs/9kB12dmRR4d\u002BTmHxoDSncrlIrd8G7I9kF7aRwZFu4fxfOEta3eFoEBjqvOuVQ1UGFyN/aFeo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUREDqP08EEtLq5fFgwh6GsVcXVkwwHQYDVR0OBBYEFERA6j9PBBLS6uXxYMIehrFXF1ZMMAoGCCqGSM49BAMCA0gAMEUCIC9eXHgslDWDc6h6\u002BblcSfim82swdUe4FsGFT46rkfmsAiEAzdJZleYphAUNEpijUpif1wTtlI91m1E1BynMG04um\u002BM=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985227,
-          "exp": 1646521827,
-          "created": 1614985827,
-          "updated": 1614985827,
+          "nbf": 1617848632,
+          "exp": 1649385232,
+          "created": 1617849232,
+          "updated": 1617849232,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/2000971188/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/2000971188/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -412,26 +330,169 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985811,
-            "updated": 1614985811
+            "created": 1617849223,
+            "updated": 1617849223
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/2000971188/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/2000971188/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2000971188/93488a0b43cb4697870a5325409b2ab7?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-ed05322d804fb047b36d349c7fa28944-87bdf98cf7bda840-00",
+        "traceparent": "00-6814be5e2780be428a9684ce003d2538-6b19beeffcb6d44c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "e5e7a9b882cd308ae54331d57e8482a7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1371",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:33:53 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e5e7a9b882cd308ae54331d57e8482a7",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b9e7202f-0e6f-4124-8162-313c2e675e74",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2000971188/93488a0b43cb4697870a5325409b2ab7",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/2000971188/93488a0b43cb4697870a5325409b2ab7",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/2000971188/93488a0b43cb4697870a5325409b2ab7",
+        "x5t": "RNWhFni4xU9OIdqOssPFJzoeFqQ",
+        "cer": "MIICOzCCAeGgAwIBAgIQBTmW5wZdSuC2UKAxiq6KsjAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjM1MloXDTIyMDQwODAyMzM1MlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASNuOnXMtlc1O\u002Bs/9kB12dmRR4d\u002BTmHxoDSncrlIrd8G7I9kF7aRwZFu4fxfOEta3eFoEBjqvOuVQ1UGFyN/aFeo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUREDqP08EEtLq5fFgwh6GsVcXVkwwHQYDVR0OBBYEFERA6j9PBBLS6uXxYMIehrFXF1ZMMAoGCCqGSM49BAMCA0gAMEUCIC9eXHgslDWDc6h6\u002BblcSfim82swdUe4FsGFT46rkfmsAiEAzdJZleYphAUNEpijUpif1wTtlI91m1E1BynMG04um\u002BM=",
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848632,
+          "exp": 1649385232,
+          "created": 1617849232,
+          "updated": 1617849232,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "subject": "CN=default",
+        "issuer": "CN=default",
+        "serialnumber": "053996E7065D4AE0B650A0318AAE8AB2"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/2000971188/93488a0b43cb4697870a5325409b2ab7?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-6814be5e2780be428a9684ce003d2538-814e35d40e12374e-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "cda3dc27b5e639a034521a095d93b153",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "2203",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:33:53 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "cda3dc27b5e639a034521a095d93b153",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d04336ca-ea1b-48e7-8136-1e3b257adabe",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "value": "MIIFMgIBAzCCBO4GCSqGSIb3DQEHAaCCBN8EggTbMIIE1zCCAgAGCSqGSIb3DQEHAaCCAfEEggHtMIIB6TCCAeUGCyqGSIb3DQEMCgECoIIBXjCCAVowHAYKKoZIhvcNAQwBAzAOBAihx27sCj6Q/AICB9AEggE4hm80BRBwO4FyvnIGgZgZVFf7gMrPietjVf4uEUAJq6Vu5rk0fftPyQ6aTgaNlWLSLH6FRqgN2sLanO3404BveUfy1ldkhV0hE4zqZseF3X4CNFlhAS3cqMndRGNhz1UebhSnMa/gxbf8yytvZItc0c0uBPFB3Uh7izjfh7ehLCVfHlzJSuPhjojS2hqoJoCuDRPHJHKY391pFsK1uTnLHjZLJ5ceQcj1XAbwHxKj8tadTZDiEayxMnvc0IY7sNlCICo4I0J/z4Rv9LwIOX4CTlH8AHEz0Ix9MBe7xKVCfBc1f5Zeij95MrBqjziC3F49kNv0ppO3J4qB0GVT02axXg95ZkYhSsD2dAVI4i3EWJ4pqjArYTjWywA\u002Br5Ol4aaUZ3NC8ydbO3tJ49TnRi6C4GFVVS3bj36zMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAs8GCSqGSIb3DQEHBqCCAsAwggK8AgEAMIICtQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQI\u002Ba9jy1U3vgwCAgfQgIICiNFg8FViGy/1LX\u002BZ/pQxRdYACrhhmHci4lyUyh9GAE22/sj8cI12MTt1rRPa7hvBrqyqCxbZfNCqMhf98\u002BAiK6M/62uG4XGHFaj5bUgQs822AlP4VuOcpn\u002BDWYzMvkBW4TZx5H/Lx04y7xTiEvHrHFfc7xh9aMhGYRYSysnLuAbakoNZnSPQ7sFzmb4VKURzfvChornENwt3gHdxqp8QIZ19gD0XkN1kSITS1M2r8dDA6jCjP\u002BZK\u002B0twK2TR0MfpXBSLHBtrCaJ0c9en6um2imPQRQUl1X/aPPCSLs54RbPplSJSocgw/NmAZwJVhUf2A1rLCFIPEvckPDHqcNk\u002B0DecvbXClsb/sLReG0cJ8twa8zTOHgK9HUiG6ydSASjmERKizNZbyzejTE5BbZMpj78w4gyvtQ\u002BLwoJbnSTKjLNbikNhNPjt6tCwknq4mGUcKQaN8jiTkMaUggdGNn7UdrCP1Dp\u002B7h6rEbYAUUu8qoJ1xZ8RbdvwxfHIppZcaUP1b0\u002BfQ9t3xbGs2TghYRARw0stfObvomiqz4srvhbtE379UZBGg6J40h8tsyG7ltZkvvcSACalo212t62K8d\u002Bz894h6Bj0WccQ3SxzVA18PalPlN6FbAqJ25TgfgdZVf2OBYWg3RYYEDjFrEoFDGJZslZti1fx9YnWMdO0PpwrJLPMo7LHh/p0eS2RpiSoT1NdqWcvkUsCjT5O/BuY7miB4tfprjNlc/AFaaENpzlSv9I540WPtpHNwRoimth8gfNj0GqVSoN5XgTaw24AS5s1qz4174WcX9vH9Q63J\u002Bt48vG5ixkK4KMxWprLpyWOPUYGNhrXn6gk9\u002BV09qfaitk\u002BlmvfTTKXKRfNtTA7MB8wBwYFKw4DAhoEFN1HhNZxMIJgVD\u002BzfBvW5LL5ksxPBBQ//f\u002BcsT\u002Bt\u002Bxu9CWiz24ke1U8NjwICB9A=",
+        "contentType": "application/x-pkcs12",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/2000971188/93488a0b43cb4697870a5325409b2ab7",
+        "managed": true,
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848632,
+          "exp": 1649385232,
+          "created": 1617849232,
+          "updated": 1617849232,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "kid": "https://heathskvtest2.vault.azure.net/keys/2000971188/93488a0b43cb4697870a5325409b2ab7"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/2000971188/93488a0b43cb4697870a5325409b2ab7?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-2d525d4a7a1cd941b8a6d872db522aa0-12a33122b349ee4f-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "49f1b40d2416fb6c5a115c30750119b7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:33:53 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "49f1b40d2416fb6c5a115c30750119b7",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ea44cff9-efd8-4b5d-9b73-a58212903097",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/2000971188/93488a0b43cb4697870a5325409b2ab7?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-2d525d4a7a1cd941b8a6d872db522aa0-12a33122b349ee4f-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "49f1b40d2416fb6c5a115c30750119b7",
         "x-ms-return-client-request-id": "true"
@@ -440,138 +501,38 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1374",
+        "Content-Length": "440",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:31 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "49f1b40d2416fb6c5a115c30750119b7",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0e010806-61e0-4d29-a7cc-8879a896c046",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab",
-        "x5t": "UcXFUXmDF3HjKM33l3FfDHiqNJE",
-        "cer": "MIICPDCCAeGgAwIBAgIQZ1Wkw8xjR/6Coei4j8kN0TAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDAyN1oXDTIyMDMwNTIzMTAyN1owEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQ6g7CgOSUF8aqgQri8r6BN4y2FJtULZqWuWuxIoTutRYqW6P/JWMw0Kpv3axL51WagMN7E0UnAyOAXFMj8AXHNo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUw6ubcmjmhv4NJHmP41nEXcMxMjwwHQYDVR0OBBYEFMOrm3Jo5ob\u002BDSR5j\u002BNZxF3DMTI8MAoGCCqGSM49BAMCA0kAMEYCIQDbNQYRjsxy\u002B1AQ4cSfomAY1Zg6FrkQslH7mumkfq5l7gIhAMnr7t3mo0ewM6pZfMF\u002B985KSkCUS8AYNxCU/u2YOLn8",
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614985227,
-          "exp": 1646521827,
-          "created": 1614985827,
-          "updated": 1614985827,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "subject": "CN=default",
-        "issuer": "CN=default",
-        "serialnumber": "6755A4C3CC6347FE82A1E8B88FC90DD1"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-ed05322d804fb047b36d349c7fa28944-56546f1614451a42-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ddd180e494c5037b08adb07b6780d252",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "2217",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:31 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0abb2083-4a0d-458a-9975-1a52626522e8",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "value": "MIIFOgIBAzCCBPYGCSqGSIb3DQEHAaCCBOcEggTjMIIE3zCCAgAGCSqGSIb3DQEHAaCCAfEEggHtMIIB6TCCAeUGCyqGSIb3DQEMCgECoIIBXjCCAVowHAYKKoZIhvcNAQwBAzAOBAhnuTJcbEUWrQICB9AEggE4PCpEhRRCki9uunP2yiwMDF4V9GuKqPpHgLWTzNOXgddf9J29c7JWaVPZPNblHleZPTfJiEmR1PFkiVt4Dpfajeg2\u002B3lPOxR9MAMMRPJhq3\u002B6lKBpWGu2DnS92amMMgjyDRXiXHv6WvRG6DO3Gu4ffKk3aLI72VcRk7gEP5xW5\u002BBf0WGhVxT\u002BnuD2vZb5A/LLOcKnt7a7wcrpqSN\u002B1wEM3PADCxRccJlpxpkNMRkyS99k41k/wrcfoJE6cc5XZO\u002Bg2ZwS1oEmM4pMzQqKGNlPwT5FIY7lf4DyFGYQU8oaih2QCzT2x1YVA3\u002BujK78HFsYJLesJpfUgrlE/Xx7YYTN/KOLmlhJL104XcUOka3tl8lOeADG3xdhY0LTrwSRy5qU6iRLUz/w7JxizMuhRaLD7e5jqXpLZLM5MXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAtcGCSqGSIb3DQEHBqCCAsgwggLEAgEAMIICvQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIW12dWyEma5cCAgfQgIICkNWjw6B2nLH4VIWRuuDf1Oum/fGfNFTXf6FVwJihcHAgabHVgFRCmGT9qpgVK76gL6cDz71mczg9NGuIzhtUdVP9F10yZr3AFR0JtrDkP6j9CQuV1oA/MznGYpyzi9fd02MqtK83dkYFrHXqOgKWPBfxz3FxxTWWxAH81kuuw\u002BTM2sRV6VoD1bruLKSNUQdrKd9L0rBdSBZZXpiaUVR0BPwV1hGCngHepbx62gElc3D/XKLZt0TvC5mEoWHyE2JHW7PcxGB5dsjGD2MDGddyOovv0f5uJ2acHrGfO/VHZfGnt3zsruNk0jafFpSetI34NmmrgV5F427SOIwNGQub5oZyjAm0Xum3fEX1BSxb7sqgHoEpl\u002BTdtAKW27DPSqBC/kFQ5RFvQIlR5y\u002B/fQUtH\u002BlXSRhMQrs3dozwnnPuT8Tpj/UBtzbTyS96YH3iGek0IPLtTkmYglq62/hgBA6loDSppqjn8k4FugSOV9CEnLsn0EvdgVhfFJ0kobiwCs0MWGlnoRDan20a4IDPNm/SXvL8DKyZ6urZNQyo3RpN/9Lq/6tkgoUm6pqtwzALmUMGdnvWoR3p6Dv3m865/baT3RZ6mAGcDcbQMwkwH69af7qCqExKtnxhe90vAcbj/t55DfOwa97Bo2imr0Q/5eRgr4SfBTw8eMtPRDpysTfz7q2f6ajb\u002BMpA/QhxywTvt\u002B1t\u002B7VNRzVDv8dllsPO6Cob5J1Abgk7\u002BZu9VRiCxaBMEEpIcsto/WgF\u002BfVtMzS4moOwzDlwz6QJlMyO3zmdKldBmV0in2oLI8GLzqZSWA9q4JEuQs7qZGSZGfVC6xBwCb\u002Bvt1wxrOslWjr3/6PfNfCo\u002BgPFIiR3ESlA\u002BiUU6qSy0Iw4MDswHzAHBgUrDgMCGgQU3OHAi6jxaJ2TfjSyobzAp\u002BrzmNkEFOgFCedfmvv4xTyzb5BDodSG4bzwAgIH0A==",
-        "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab",
-        "managed": true,
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614985227,
-          "exp": 1646521827,
-          "created": 1614985827,
-          "updated": 1614985827,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-6b76ed30716ad54ebba26bb2551324c0-d6dbfa58060e4645-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "c9c7de923993039070a772d4586fc433",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "441",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:32 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9790672d-99e7-4a3b-a3dc-c00701d9fd72",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "896150a6-d5a3-4fa4-85ae-76f1a64f2068",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/2000971188/a67d14ef4f5a4d7aad8bd996c0fffdab",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/2000971188/93488a0b43cb4697870a5325409b2ab7",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256K",
-          "x": "OoOwoDklBfGqoEK4vK-gTeMthSbVC2alrlrsSKE7rUU",
-          "y": "ipbo_8lYzDQqm_drEvnVZqAw3sTRScDI4BcUyPwBcc0"
+          "x": "jbjp1zLZXNTvrP_ZAddnZkUeHfk5h8aA0p3K5SK3fBs",
+          "y": "sj2QXtpHBkW7h_F84S1rd4WgQGOq865VDVQYXI39oV4"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985227,
-          "exp": 1646521827,
-          "created": 1614985827,
-          "updated": 1614985827,
+          "nbf": 1617848632,
+          "exp": 1649385232,
+          "created": 1617849232,
+          "updated": 1617849232,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -580,7 +541,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1494748409"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-384).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-384).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/192356644/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-3c854abbe76067419e1f871c101735e6-9d193c23e8e4264b-00",
+        "traceparent": "00-715e5e3eef5be945b77ef22a257dd1d2-28cef92245efa248-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "94704f6e4c234c6ba53d9e7934d9ab83",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:43 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:46 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "94704f6e4c234c6ba53d9e7934d9ab83",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "48e5f875-da54-48f8-8877-96e1ff266c7b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ea3c1897-bea9-4ad3-9c3f-3e25454a5b50",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/192356644/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-3c854abbe76067419e1f871c101735e6-9d193c23e8e4264b-00",
+        "traceparent": "00-715e5e3eef5be945b77ef22a257dd1d2-28cef92245efa248-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "94704f6e4c234c6ba53d9e7934d9ab83",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "840",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:44 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:46 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending?api-version=7.2\u0026request_id=e6d1925c85d6416f94c031e7e2f3d5f7",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/192356644/pending?api-version=7.2\u0026request_id=4a1e3ea326cb4947b35a06d0a5b73ae2",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "94704f6e4c234c6ba53d9e7934d9ab83",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "12762ead-bab8-49a9-97e1-4db479564cfc",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "915feb67-a241-42c7-ba6d-4c9c9a856920",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/192356644/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOxy2RC5BJYkRZfZDyMLy8kJD4sPyzz\u002Bl5YJGXgact06DfYywLpQeGgfKXtWUDgk5TqXzNoE5dwzvU6n7TNqmz1qdpMp1giw5ZlkU4KLCPOiUTsDa5Kifn2fRZArTTitcoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAOnqkz/OTA5TqnWslm5c6rg0eldsdd3A504VhQPw\u002BICj8T0fjxN9qI84tgKjm7XyfQIwG/bDJ6HClMrGUfQ3tdFvZ05vJY7Mg6qOeVvK52OVN82Y4vk8CiWmtu263y8Wa9S3",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4m7sfosHQkHut1mYH14WpJhwrq8qZu9DXz3zwrwyMIzCZucDc8Y2MXOeP8PWf7EjtJ7E90HaR1AZlWiItROFWm4NB8idYxJYKY35qkIp3W88wUMePhu3\u002BnU0Knkl0SnooEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxALXDprc\u002BzQHuI5iGQJPTfcaQUti7zWirgP04Tu9ErIKQUGbjfy7ymn83gfZMDHTlSwIxAIz8\u002BJahk/0ZclFWoZhML9U6JfM900zysk1HKivz\u002BrM1sgrzEBER5A82LQcKPtbS5Q==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e6d1925c85d6416f94c031e7e2f3d5f7"
+        "request_id": "4a1e3ea326cb4947b35a06d0a5b73ae2"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/192356644/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "1a3bc75d3b190ab40c7ca9b3ddaa15c7",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "840",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:44 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:47 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1a3bc75d3b190ab40c7ca9b3ddaa15c7",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "260c93a7-c61d-490b-8f3e-18021fb36b7c",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "61d67700-ec56-4102-8298-1ff0fd29e52d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/192356644/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOxy2RC5BJYkRZfZDyMLy8kJD4sPyzz\u002Bl5YJGXgact06DfYywLpQeGgfKXtWUDgk5TqXzNoE5dwzvU6n7TNqmz1qdpMp1giw5ZlkU4KLCPOiUTsDa5Kifn2fRZArTTitcoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAOnqkz/OTA5TqnWslm5c6rg0eldsdd3A504VhQPw\u002BICj8T0fjxN9qI84tgKjm7XyfQIwG/bDJ6HClMrGUfQ3tdFvZ05vJY7Mg6qOeVvK52OVN82Y4vk8CiWmtu263y8Wa9S3",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4m7sfosHQkHut1mYH14WpJhwrq8qZu9DXz3zwrwyMIzCZucDc8Y2MXOeP8PWf7EjtJ7E90HaR1AZlWiItROFWm4NB8idYxJYKY35qkIp3W88wUMePhu3\u002BnU0Knkl0SnooEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxALXDprc\u002BzQHuI5iGQJPTfcaQUti7zWirgP04Tu9ErIKQUGbjfy7ymn83gfZMDHTlSwIxAIz8\u002BJahk/0ZclFWoZhML9U6JfM900zysk1HKivz\u002BrM1sgrzEBER5A82LQcKPtbS5Q==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e6d1925c85d6416f94c031e7e2f3d5f7"
+        "request_id": "4a1e3ea326cb4947b35a06d0a5b73ae2"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/192356644/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "63bc32a30225e20b8c58f93cdad15462",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "840",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:49 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:52 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "63bc32a30225e20b8c58f93cdad15462",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "b03f5cf6-2123-4b84-bca7-2598bfa7cbad",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "c33d6027-12d1-423b-a6ac-2ff0440506a1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/192356644/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOxy2RC5BJYkRZfZDyMLy8kJD4sPyzz\u002Bl5YJGXgact06DfYywLpQeGgfKXtWUDgk5TqXzNoE5dwzvU6n7TNqmz1qdpMp1giw5ZlkU4KLCPOiUTsDa5Kifn2fRZArTTitcoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAOnqkz/OTA5TqnWslm5c6rg0eldsdd3A504VhQPw\u002BICj8T0fjxN9qI84tgKjm7XyfQIwG/bDJ6HClMrGUfQ3tdFvZ05vJY7Mg6qOeVvK52OVN82Y4vk8CiWmtu263y8Wa9S3",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4m7sfosHQkHut1mYH14WpJhwrq8qZu9DXz3zwrwyMIzCZucDc8Y2MXOeP8PWf7EjtJ7E90HaR1AZlWiItROFWm4NB8idYxJYKY35qkIp3W88wUMePhu3\u002BnU0Knkl0SnooEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxALXDprc\u002BzQHuI5iGQJPTfcaQUti7zWirgP04Tu9ErIKQUGbjfy7ymn83gfZMDHTlSwIxAIz8\u002BJahk/0ZclFWoZhML9U6JfM900zysk1HKivz\u002BrM1sgrzEBER5A82LQcKPtbS5Q==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e6d1925c85d6416f94c031e7e2f3d5f7"
+        "request_id": "4a1e3ea326cb4947b35a06d0a5b73ae2"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/192356644/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "ef4671a1da21320a9b6687a6a2b76ffb",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "840",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:54 GMT",
+        "Date": "Thu, 08 Apr 2021 02:28:57 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ef4671a1da21320a9b6687a6a2b76ffb",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0c2c45cc-631f-4823-8a6f-84fb04139402",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1cdef2d3-1571-48e8-85ff-beacd4bf803c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/192356644/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOxy2RC5BJYkRZfZDyMLy8kJD4sPyzz\u002Bl5YJGXgact06DfYywLpQeGgfKXtWUDgk5TqXzNoE5dwzvU6n7TNqmz1qdpMp1giw5ZlkU4KLCPOiUTsDa5Kifn2fRZArTTitcoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAOnqkz/OTA5TqnWslm5c6rg0eldsdd3A504VhQPw\u002BICj8T0fjxN9qI84tgKjm7XyfQIwG/bDJ6HClMrGUfQ3tdFvZ05vJY7Mg6qOeVvK52OVN82Y4vk8CiWmtu263y8Wa9S3",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4m7sfosHQkHut1mYH14WpJhwrq8qZu9DXz3zwrwyMIzCZucDc8Y2MXOeP8PWf7EjtJ7E90HaR1AZlWiItROFWm4NB8idYxJYKY35qkIp3W88wUMePhu3\u002BnU0Knkl0SnooEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxALXDprc\u002BzQHuI5iGQJPTfcaQUti7zWirgP04Tu9ErIKQUGbjfy7ymn83gfZMDHTlSwIxAIz8\u002BJahk/0ZclFWoZhML9U6JfM900zysk1HKivz\u002BrM1sgrzEBER5A82LQcKPtbS5Q==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e6d1925c85d6416f94c031e7e2f3d5f7"
+        "request_id": "4a1e3ea326cb4947b35a06d0a5b73ae2"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/192356644/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "02d5d628471d5a5ebc588ec142782f3b",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:58:59 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "02d5d628471d5a5ebc588ec142782f3b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f67a4439-9429-48fd-8ee9-f6d54839c75b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "35792fef-5036-49b2-b577-c33f0e8036f0",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/192356644/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOxy2RC5BJYkRZfZDyMLy8kJD4sPyzz\u002Bl5YJGXgact06DfYywLpQeGgfKXtWUDgk5TqXzNoE5dwzvU6n7TNqmz1qdpMp1giw5ZlkU4KLCPOiUTsDa5Kifn2fRZArTTitcoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAOnqkz/OTA5TqnWslm5c6rg0eldsdd3A504VhQPw\u002BICj8T0fjxN9qI84tgKjm7XyfQIwG/bDJ6HClMrGUfQ3tdFvZ05vJY7Mg6qOeVvK52OVN82Y4vk8CiWmtu263y8Wa9S3",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4m7sfosHQkHut1mYH14WpJhwrq8qZu9DXz3zwrwyMIzCZucDc8Y2MXOeP8PWf7EjtJ7E90HaR1AZlWiItROFWm4NB8idYxJYKY35qkIp3W88wUMePhu3\u002BnU0Knkl0SnooEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxALXDprc\u002BzQHuI5iGQJPTfcaQUti7zWirgP04Tu9ErIKQUGbjfy7ymn83gfZMDHTlSwIxAIz8\u002BJahk/0ZclFWoZhML9U6JfM900zysk1HKivz\u002BrM1sgrzEBER5A82LQcKPtbS5Q==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e6d1925c85d6416f94c031e7e2f3d5f7"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/192356644",
+        "request_id": "4a1e3ea326cb4947b35a06d0a5b73ae2"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/192356644?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "6b1246282563c9a62889c8bf7a6440d4",
         "x-ms-return-client-request-id": "true"
@@ -300,211 +305,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "1831",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:04 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "79a9e45f-3536-4c51-bc37-f07dc5872264",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOxy2RC5BJYkRZfZDyMLy8kJD4sPyzz\u002Bl5YJGXgact06DfYywLpQeGgfKXtWUDgk5TqXzNoE5dwzvU6n7TNqmz1qdpMp1giw5ZlkU4KLCPOiUTsDa5Kifn2fRZArTTitcoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAOnqkz/OTA5TqnWslm5c6rg0eldsdd3A504VhQPw\u002BICj8T0fjxN9qI84tgKjm7XyfQIwG/bDJ6HClMrGUfQ3tdFvZ05vJY7Mg6qOeVvK52OVN82Y4vk8CiWmtu263y8Wa9S3",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e6d1925c85d6416f94c031e7e2f3d5f7"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0413fde852fb594413eb33c94c49f022",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "837",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:09 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4895d1eb-1916-4f1c-b4f4-d0aba4b84a4a",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOxy2RC5BJYkRZfZDyMLy8kJD4sPyzz\u002Bl5YJGXgact06DfYywLpQeGgfKXtWUDgk5TqXzNoE5dwzvU6n7TNqmz1qdpMp1giw5ZlkU4KLCPOiUTsDa5Kifn2fRZArTTitcoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAOnqkz/OTA5TqnWslm5c6rg0eldsdd3A504VhQPw\u002BICj8T0fjxN9qI84tgKjm7XyfQIwG/bDJ6HClMrGUfQ3tdFvZ05vJY7Mg6qOeVvK52OVN82Y4vk8CiWmtu263y8Wa9S3",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e6d1925c85d6416f94c031e7e2f3d5f7"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "5c7e4c3603a50297300cd9947f9fe057",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "837",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:14 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "270eb057-680e-4f43-b5f4-36a9a379e6e7",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOxy2RC5BJYkRZfZDyMLy8kJD4sPyzz\u002Bl5YJGXgact06DfYywLpQeGgfKXtWUDgk5TqXzNoE5dwzvU6n7TNqmz1qdpMp1giw5ZlkU4KLCPOiUTsDa5Kifn2fRZArTTitcoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAOnqkz/OTA5TqnWslm5c6rg0eldsdd3A504VhQPw\u002BICj8T0fjxN9qI84tgKjm7XyfQIwG/bDJ6HClMrGUfQ3tdFvZ05vJY7Mg6qOeVvK52OVN82Y4vk8CiWmtu263y8Wa9S3",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e6d1925c85d6416f94c031e7e2f3d5f7"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "44d8b9182b64d63f01b95877f2dc7ddf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "745",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:19 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6b1246282563c9a62889c8bf7a6440d4",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2e7998a5-9156-4aa2-972d-5b13468caf46",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "10232ee1-8391-4e27-8bf4-0957f7852901",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOxy2RC5BJYkRZfZDyMLy8kJD4sPyzz\u002Bl5YJGXgact06DfYywLpQeGgfKXtWUDgk5TqXzNoE5dwzvU6n7TNqmz1qdpMp1giw5ZlkU4KLCPOiUTsDa5Kifn2fRZArTTitcoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAOnqkz/OTA5TqnWslm5c6rg0eldsdd3A504VhQPw\u002BICj8T0fjxN9qI84tgKjm7XyfQIwG/bDJ6HClMrGUfQ3tdFvZ05vJY7Mg6qOeVvK52OVN82Y4vk8CiWmtu263y8Wa9S3",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/192356644",
-        "request_id": "e6d1925c85d6416f94c031e7e2f3d5f7"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "2d88a599e3e6e52f6510d4ef78b0d973",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1836",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:19 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9d3197d7-599e-4f2f-9d8c-e82cddd1dc24",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/b2b25330cf944e16b7a61914be9e285e",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/192356644/b2b25330cf944e16b7a61914be9e285e",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/192356644/b2b25330cf944e16b7a61914be9e285e",
-        "x5t": "7Wqlyw7jubTYV7pfXLsi028wnMM",
-        "cer": "MIIB2zCCAWGgAwIBAgIQZrytFpdlTWyHcF6MeBYH8TAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNDkxN1oXDTIyMDMwNTIyNTkxN1owEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABDsctkQuQSWJEWX2Q8jC8vJCQ\u002BLD8s8/peWCRl4GnLdOg32MsC6UHhoHyl7VlA4JOU6l8zaBOXcM71Op\u002B0zaps9anaTKdYIsOWZZFOCiwjzolE7A2uSon59n0WQK004rXKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFOmFAEVfVPexsHYgGHJb/Z4YOIzuMB0GA1UdDgQWBBTphQBFX1T3sbB2IBhyW/2eGDiM7jAKBggqhkjOPQQDAwNoADBlAjA/wutTgA5nJ4v25DHVCpseimqx4mC17DNHTSF1NOtLcq6N5JxUT0\u002BWF6TJKtbUJ\u002BUCMQDnhkEzosBnRFuPOAb3Picn94DuZo4pQHqMUWBmryTqlqEMtrrVNRQbEAgriPgQ6aQ=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/192356644/8bf94cd8ad784983bc8cc5a3987a55b0",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/192356644/8bf94cd8ad784983bc8cc5a3987a55b0",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/192356644/8bf94cd8ad784983bc8cc5a3987a55b0",
+        "x5t": "PmkB_yE4XtdruijsEYcm8JHBzTg",
+        "cer": "MIIB2zCCAWGgAwIBAgIQTXxLhU6mSzupiBrGdea5IzAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTkwMVoXDTIyMDQwODAyMjkwMVowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABOJu7H6LB0JB7rdZmB9eFqSYcK6vKmbvQ18988K8MjCMwmbnA3PGNjFznj/D1n\u002BxI7SexPdB2kdQGZVoiLUThVpuDQfInWMSWCmN\u002BapCKd1vPMFDHj4bt/p1NCp5JdEp6KN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFFH5FQ6F3R62eJaTwDFJLSQwvaTBMB0GA1UdDgQWBBRR\u002BRUOhd0etniWk8AxSS0kML2kwTAKBggqhkjOPQQDAwNoADBlAjBOrRKXcVsgnGHBZop7IMVn9j6DKCGXScaRIWif5MLurgHczuJchHSU3vayNl9C9jECMQDLWLZoUGLUtAj94lrXDdPNV6vJFW423CBTWZd4iyz9YIpuQg5HGFHAkmQBU3CCuXk=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984557,
-          "exp": 1646521157,
-          "created": 1614985158,
-          "updated": 1614985158,
+          "nbf": 1617848341,
+          "exp": 1649384941,
+          "created": 1617848941,
+          "updated": 1617848941,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/192356644/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -544,166 +375,209 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985124,
-            "updated": 1614985124
+            "created": 1617848927,
+            "updated": 1617848927
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/192356644/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/192356644/b2b25330cf944e16b7a61914be9e285e?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/192356644/8bf94cd8ad784983bc8cc5a3987a55b0?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-8000959faa77204f9a08572c1882b635-7d6a1be20bd36140-00",
+        "traceparent": "00-78facaf3d5da9c43b553661a56a90d89-39fbcbc83dc97349-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "92b0db0bab700bbe0ca85aebab201053",
+        "x-ms-client-request-id": "0413fde852fb594413eb33c94c49f022",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1243",
+        "Content-Length": "1240",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:24 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:07 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0413fde852fb594413eb33c94c49f022",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6029757f-318c-4505-9515-a1ed15f8098f",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f7a43783-930c-4ea8-99a4-fee00f8f6c6b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/192356644/b2b25330cf944e16b7a61914be9e285e",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/192356644/b2b25330cf944e16b7a61914be9e285e",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/192356644/b2b25330cf944e16b7a61914be9e285e",
-        "x5t": "7Wqlyw7jubTYV7pfXLsi028wnMM",
-        "cer": "MIIB2zCCAWGgAwIBAgIQZrytFpdlTWyHcF6MeBYH8TAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNDkxN1oXDTIyMDMwNTIyNTkxN1owEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABDsctkQuQSWJEWX2Q8jC8vJCQ\u002BLD8s8/peWCRl4GnLdOg32MsC6UHhoHyl7VlA4JOU6l8zaBOXcM71Op\u002B0zaps9anaTKdYIsOWZZFOCiwjzolE7A2uSon59n0WQK004rXKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFOmFAEVfVPexsHYgGHJb/Z4YOIzuMB0GA1UdDgQWBBTphQBFX1T3sbB2IBhyW/2eGDiM7jAKBggqhkjOPQQDAwNoADBlAjA/wutTgA5nJ4v25DHVCpseimqx4mC17DNHTSF1NOtLcq6N5JxUT0\u002BWF6TJKtbUJ\u002BUCMQDnhkEzosBnRFuPOAb3Picn94DuZo4pQHqMUWBmryTqlqEMtrrVNRQbEAgriPgQ6aQ=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/192356644/8bf94cd8ad784983bc8cc5a3987a55b0",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/192356644/8bf94cd8ad784983bc8cc5a3987a55b0",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/192356644/8bf94cd8ad784983bc8cc5a3987a55b0",
+        "x5t": "PmkB_yE4XtdruijsEYcm8JHBzTg",
+        "cer": "MIIB2zCCAWGgAwIBAgIQTXxLhU6mSzupiBrGdea5IzAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTkwMVoXDTIyMDQwODAyMjkwMVowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABOJu7H6LB0JB7rdZmB9eFqSYcK6vKmbvQ18988K8MjCMwmbnA3PGNjFznj/D1n\u002BxI7SexPdB2kdQGZVoiLUThVpuDQfInWMSWCmN\u002BapCKd1vPMFDHj4bt/p1NCp5JdEp6KN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFFH5FQ6F3R62eJaTwDFJLSQwvaTBMB0GA1UdDgQWBBRR\u002BRUOhd0etniWk8AxSS0kML2kwTAKBggqhkjOPQQDAwNoADBlAjBOrRKXcVsgnGHBZop7IMVn9j6DKCGXScaRIWif5MLurgHczuJchHSU3vayNl9C9jECMQDLWLZoUGLUtAj94lrXDdPNV6vJFW423CBTWZd4iyz9YIpuQg5HGFHAkmQBU3CCuXk=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984557,
-          "exp": 1646521157,
-          "created": 1614985158,
-          "updated": 1614985158,
+          "nbf": 1617848341,
+          "exp": 1649384941,
+          "created": 1617848941,
+          "updated": 1617848941,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "66BCAD1697654D6C87705E8C781607F1"
+        "serialnumber": "4D7C4B854EA64B3BA9881AC675E6B923"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/192356644/b2b25330cf944e16b7a61914be9e285e?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/192356644/8bf94cd8ad784983bc8cc5a3987a55b0?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-8000959faa77204f9a08572c1882b635-137c3b0da6d3e946-00",
+        "traceparent": "00-78facaf3d5da9c43b553661a56a90d89-ff594166d281f84c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "d9fafa8eb217347189f3de5457505d51",
+        "x-ms-client-request-id": "5c7e4c3603a50297300cd9947f9fe057",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1943",
+        "Content-Length": "1941",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:24 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:07 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5c7e4c3603a50297300cd9947f9fe057",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2c09024d-7fdd-476d-bba0-8ac8bfeb8080",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "496e1c53-757d-4f74-bbef-6f43e41ce3f4",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIEbwIBAzCCBCsGCSqGSIb3DQEHAaCCBBwEggQYMIIEFDCCAZ0GCSqGSIb3DQEHAaCCAY4EggGKMIIBhjCCAYIGCyqGSIb3DQEMCgECoIH8MIH5MBwGCiqGSIb3DQEMAQMwDgQIQGP4pVZLx0ACAgfQBIHYIPUfhv/9ekprZq0r8bnG6yN/hSrk/q4JRc/9gwaTQjvX56lBQGz4am2uITgJtalrq1sCrXU0ggxoIfehCO25mUu6CYvYt25F0wM7guSlRg1KAruFA/sU2KvGClJhTbnj5SorslkS5s/pj5hgu\u002Bv8TkNvycdSD1quzt5R9dfvceENHGc3\u002BqJQxIgFQFvbnWsDTIv1juBAcJrZiHHTZhe/txjsZEZS73orCOIhfX71ftTTzxXhIF/o4oG6B7JVk6MtqFK2joL6MM5rBlhzFqxSqNFwkftKSNCvMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAm8GCSqGSIb3DQEHBqCCAmAwggJcAgEAMIICVQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQI62M33UubXIkCAgfQgIICKICX/9rBMIXLJ6hGQaKMXUlMRT1h/Pt6E09p9G8pNnIi\u002BtrbYypEW2uTw08/j/XIVOkf4DoouOdJ9SzP2InysHjEYBRtxR1wvRIWhxstK\u002BDYjhrejYmIdzxlxSPDnd3Z/xIPBfuP3J30i9SjCjdD3W8bqcG2ZT/pzdIHnLFZFvagExoEXXfuiw6l2viK3c9ISLQFJZDdKA9nd\u002BE94NZO3NydvkVskRTJRnB\u002BQrS4Cc8LZVZPMN9nKt\u002B7BPoUE4ibFzscXMH2eLzaXjRQvjBVwjAJfb\u002B6Yp31WYcNNZedMr8/L/stcejbFi4x3niKyFzEdjL4moCeVBi8VyFlDaJS4q7EJTjF7LPgzFv4PS4BQiU/ibWNknmv32YzamEoQsMNFTO2wEMOmCtl8Bhei4qdvsbNVUe2mxlR9xu2EMAvdXGj9Cex9zIOsj9mVVQI03yjTgsWtkeKWh9pdEZqxWhtw4feeHDD6mKZMXZ\u002BNxaH/BTz2wRqr4qPUKcTSk\u002Bou/Q9S\u002BM/sDSezvz0K79DtWhPhbdsRlEuq3JNgbbZ\u002BPQeUDF4Z9JGjsLqgyIJK0WQJOvTkyEsrnQ9MCWaTYtQM1Mzzku/DhKHqlCwqIw4TLpBRq7e2csPn7p6UHLl2rRgXUTlTr0bowq1tdcNeGdS5fda4vt4K\u002B24xzGL5Gpy6HlsVh\u002BZH6cAF8dq0UdgzTzIL7KKvQGgrSnpZ39zwh8ijgsf0vMFILh8cEIRgTA7MB8wBwYFKw4DAhoEFPCmzSM5hr7ibqoz4roIhvAA80wnBBTLvN5FNVdm75izrd0t\u002BXbNs43S5gICB9A=",
+        "value": "MIIEbwIBAzCCBCsGCSqGSIb3DQEHAaCCBBwEggQYMIIEFDCCAZ0GCSqGSIb3DQEHAaCCAY4EggGKMIIBhjCCAYIGCyqGSIb3DQEMCgECoIH8MIH5MBwGCiqGSIb3DQEMAQMwDgQIRcfY4lznhB4CAgfQBIHY\u002BdgKWSDH1tOGRXVrXxYazLXDhRi3R5j/mmxztp/Q1FUjGaSghchAK3vHCmiZ28\u002B\u002BHbYDwyaqTlQa8mwDvimwe8fgni2Q1oG6UI8Wwdyg/CPdSoTkzwCgk9FrfAfG9Pth4SyCiqClJw1\u002BNpJMUJajZsYFEWm1YmkjChGREB8hSdzcVU/ozHjSnW3MvGWTZSghns1hMNvmC09qTVW675dp0l3pBIUJzeO0HkexPFNuu4X9L9r8t9WMBn7F6cTquHl5JOLy/v38gg3qvVFb6XKq1vId5CE3\u002B93UMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAm8GCSqGSIb3DQEHBqCCAmAwggJcAgEAMIICVQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIgWH7bWoJVvECAgfQgIICKLX7cVqjShQMi9arH26igDdrrs9dWC4Mc1OJNJnEtSBmeHVojoZ3SQYnaY07PQSN2w/metyMtPnnvKN\u002BGtKn\u002BNwcH469MXYnH0YMsYY96a\u002BroTiayBKDWci2GQamm8LoLJeSWbXEBvfPXpSyTkPov7bIuNMYgt39ZnS\u002B26eLkuxSGaa2kQ4yzlmn6cKLvcGVGru056k/VBx311AmAob089/Z6qYDKUf4dtROxDBYgbUZYHeUwwfxwC8wHCpNi39sq\u002BZ21O/4k0Uo4exaWwr98UIjJTHWF2klDY6zNWdFgNrzg7hCJENQyMFRdbf8rWKIpDajkeoQLR/osNlO7xJC7EJCHSFrtk8Gqm/1ZyGZlkCMb9yGhIZV2gMe6FwlsTo5ylGyaLQiQRC8iLWIRo82Eou2bMwpBI44BXjm9PYEW/X1lxOzqcoxBwEG0fvNu/WxRtOB1pnSZM2Ty4z4TiVn\u002Bz/3/jcWIVZpAS19z1CCq4zyvMjqiJth8VRMtZ9H\u002BjiDgMRm2/S4YPITnddzgBrlda5EjpYVMLyMTAzFrXwGhLKHtMPBvlELqju/WOG/CJ\u002BavRSNrWDhTiEVCj7/rT/VU3Sm1s9gv59Hh/VCmKnP54hqdFiJNLFxZ6xfIFJBu7sWRc8/gC5V5UZD4AkCSWQqiS5y\u002B15Kp81mMJYrj1fnlGK4UUeTvSGhBTTQ3C6uYtr1t7a4MYAhnioZGt/iV8WEvfCi\u002BT/3iDhS6DA7MB8wBwYFKw4DAhoEFIgMzDbKF1Vp/\u002BdLf01VkMW1bKEhBBSzEEzRl/3LmF22jDZahbqW8kJsVQICB9A=",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/192356644/b2b25330cf944e16b7a61914be9e285e",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/192356644/8bf94cd8ad784983bc8cc5a3987a55b0",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614984557,
-          "exp": 1646521157,
-          "created": 1614985158,
-          "updated": 1614985158,
+          "nbf": 1617848341,
+          "exp": 1649384941,
+          "created": 1617848941,
+          "updated": 1617848941,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/192356644/b2b25330cf944e16b7a61914be9e285e"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/192356644/8bf94cd8ad784983bc8cc5a3987a55b0"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/192356644/b2b25330cf944e16b7a61914be9e285e?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/192356644/8bf94cd8ad784983bc8cc5a3987a55b0?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-835953ae09b54f4983aaf098bef8ada6-1ef8425b5b7e7747-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "44d8b9182b64d63f01b95877f2dc7ddf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:29:07 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "44d8b9182b64d63f01b95877f2dc7ddf",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "929602bb-b4d8-41b9-84de-ec27cbc3a89d",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/192356644/8bf94cd8ad784983bc8cc5a3987a55b0?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-eb11b3653aba914a88111c0402667b2f-3a128d4d5859f643-00",
+        "traceparent": "00-835953ae09b54f4983aaf098bef8ada6-1ef8425b5b7e7747-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "176ce4dfea2bed6ee77c203d89433a45",
+        "x-ms-client-request-id": "44d8b9182b64d63f01b95877f2dc7ddf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "481",
+        "Content-Length": "480",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:24 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:08 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "44d8b9182b64d63f01b95877f2dc7ddf",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c7053cb7-a3ba-4518-837e-b31e4fb4ee01",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ede673df-2445-48d5-8f14-a20d5e19a287",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/192356644/b2b25330cf944e16b7a61914be9e285e",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/192356644/8bf94cd8ad784983bc8cc5a3987a55b0",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-384",
-          "x": "Oxy2RC5BJYkRZfZDyMLy8kJD4sPyzz-l5YJGXgact06DfYywLpQeGgfKXtWUDgk5",
-          "y": "TqXzNoE5dwzvU6n7TNqmz1qdpMp1giw5ZlkU4KLCPOiUTsDa5Kifn2fRZArTTitc"
+          "x": "4m7sfosHQkHut1mYH14WpJhwrq8qZu9DXz3zwrwyMIzCZucDc8Y2MXOeP8PWf7Ej",
+          "y": "tJ7E90HaR1AZlWiItROFWm4NB8idYxJYKY35qkIp3W88wUMePhu3-nU0Knkl0Sno"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984557,
-          "exp": 1646521157,
-          "created": 1614985158,
-          "updated": 1614985158,
+          "nbf": 1617848341,
+          "exp": 1649384941,
+          "created": 1617848941,
+          "updated": 1617848941,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -712,7 +586,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1905025165"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-384)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-384)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/124091009/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/124091009/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-56ee234dde63ce4d8df2decc4f814126-279b0e300a929245-00",
+        "traceparent": "00-3d28fe23ac11bc43b753663094091e9e-dd45765c6ad16a48-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "55aa8056b38250592e7cb2c842424153",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:18 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "55aa8056b38250592e7cb2c842424153",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "79ea6519-436e-43cc-b4fd-13d4f33e3d85",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "e2a42236-eb4a-48fd-b7eb-50af9564e3ac",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/124091009/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/124091009/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-56ee234dde63ce4d8df2decc4f814126-279b0e300a929245-00",
+        "traceparent": "00-3d28fe23ac11bc43b753663094091e9e-dd45765c6ad16a48-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "55aa8056b38250592e7cb2c842424153",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "836",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:18 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:15 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending?api-version=7.2\u0026request_id=9828582e2da942d3a18be6274d5c8517",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/124091009/pending?api-version=7.2\u0026request_id=639a3091c7c849d5ba887bc3364a99ee",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "55aa8056b38250592e7cb2c842424153",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c28e91d6-a489-4c68-b75b-75622aa31ccb",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "4f24189a-202e-4276-9c27-97d0435456c5",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/124091009/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFfoISNt3piAbEKwatAcP/4RTzg2\u002BgiRC043CW/ygXY5SAR4vLhBOl3hBzaMvzkS04GaRtgqAkGlCkHSQG4fZyJCmHMFbBWG9jfuoHVOQAiNbCvcS7lTYT5o\u002BaBkAlwahoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwSUsXCNJ/pCYstWlfjoHHpWGQ5G2i3HRUhpB7sfqrxbGFHU4XVV5aUQ2/3qwE8UeyAjBhFQZ2U9GrGPwWAASvnhdjRCRsjQBlbvkQ7oVrdIjk4r6NT43v7mhivKjejAxt\u002BGY=",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5LAPe1ev/Vuk3sJHVGs\u002BwkzFQmCiSAE/RYl9XovMzpYdjphr6uAAxIgx6Ug4oolMm\u002BfWh6jD9bWC48F/QMLd63bthFUM4P6398KT7DV2HgH3vHKSkNIwxg/MSfuCdAWUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAM0IVWC4udndooKxUGBAk8wBtODKgDSjiWRb/KYzXF39BsDZSAXE0AVFTuvFndiZLgIwWPwlmzopQhfSO43riFlhROH1xjJsNeqNr\u002BbtvD1AhyLZ4L2xZDBDGG8\u002BCvIoDmgz",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9828582e2da942d3a18be6274d5c8517"
+        "request_id": "639a3091c7c849d5ba887bc3364a99ee"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/124091009/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "9af76fa35bc81ac548275aa4f9186659",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "836",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:18 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9af76fa35bc81ac548275aa4f9186659",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ce5147c7-821e-4b5b-9427-2e6445b81d55",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "94b32e8e-b055-4f4d-b090-135868530591",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/124091009/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFfoISNt3piAbEKwatAcP/4RTzg2\u002BgiRC043CW/ygXY5SAR4vLhBOl3hBzaMvzkS04GaRtgqAkGlCkHSQG4fZyJCmHMFbBWG9jfuoHVOQAiNbCvcS7lTYT5o\u002BaBkAlwahoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwSUsXCNJ/pCYstWlfjoHHpWGQ5G2i3HRUhpB7sfqrxbGFHU4XVV5aUQ2/3qwE8UeyAjBhFQZ2U9GrGPwWAASvnhdjRCRsjQBlbvkQ7oVrdIjk4r6NT43v7mhivKjejAxt\u002BGY=",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5LAPe1ev/Vuk3sJHVGs\u002BwkzFQmCiSAE/RYl9XovMzpYdjphr6uAAxIgx6Ug4oolMm\u002BfWh6jD9bWC48F/QMLd63bthFUM4P6398KT7DV2HgH3vHKSkNIwxg/MSfuCdAWUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAM0IVWC4udndooKxUGBAk8wBtODKgDSjiWRb/KYzXF39BsDZSAXE0AVFTuvFndiZLgIwWPwlmzopQhfSO43riFlhROH1xjJsNeqNr\u002BbtvD1AhyLZ4L2xZDBDGG8\u002BCvIoDmgz",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9828582e2da942d3a18be6274d5c8517"
+        "request_id": "639a3091c7c849d5ba887bc3364a99ee"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/124091009/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "9b1f9ef4c94248437fa6d337afbff0cf",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "836",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:23 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9b1f9ef4c94248437fa6d337afbff0cf",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "26853a74-b404-4c28-9ad1-331cc04eda36",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "668c6c69-7b35-4d6b-9346-8477a217ea8c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/124091009/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFfoISNt3piAbEKwatAcP/4RTzg2\u002BgiRC043CW/ygXY5SAR4vLhBOl3hBzaMvzkS04GaRtgqAkGlCkHSQG4fZyJCmHMFbBWG9jfuoHVOQAiNbCvcS7lTYT5o\u002BaBkAlwahoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwSUsXCNJ/pCYstWlfjoHHpWGQ5G2i3HRUhpB7sfqrxbGFHU4XVV5aUQ2/3qwE8UeyAjBhFQZ2U9GrGPwWAASvnhdjRCRsjQBlbvkQ7oVrdIjk4r6NT43v7mhivKjejAxt\u002BGY=",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5LAPe1ev/Vuk3sJHVGs\u002BwkzFQmCiSAE/RYl9XovMzpYdjphr6uAAxIgx6Ug4oolMm\u002BfWh6jD9bWC48F/QMLd63bthFUM4P6398KT7DV2HgH3vHKSkNIwxg/MSfuCdAWUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAM0IVWC4udndooKxUGBAk8wBtODKgDSjiWRb/KYzXF39BsDZSAXE0AVFTuvFndiZLgIwWPwlmzopQhfSO43riFlhROH1xjJsNeqNr\u002BbtvD1AhyLZ4L2xZDBDGG8\u002BCvIoDmgz",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9828582e2da942d3a18be6274d5c8517"
+        "request_id": "639a3091c7c849d5ba887bc3364a99ee"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/124091009/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "f09c9c87840bfbb8ba900d5a59b45616",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "836",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:29 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f09c9c87840bfbb8ba900d5a59b45616",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e86ba9ec-2149-43a5-af72-77a1b34fa897",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f989c477-c9f2-46ae-ba9f-ee4d5a7ffaab",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/124091009/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFfoISNt3piAbEKwatAcP/4RTzg2\u002BgiRC043CW/ygXY5SAR4vLhBOl3hBzaMvzkS04GaRtgqAkGlCkHSQG4fZyJCmHMFbBWG9jfuoHVOQAiNbCvcS7lTYT5o\u002BaBkAlwahoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwSUsXCNJ/pCYstWlfjoHHpWGQ5G2i3HRUhpB7sfqrxbGFHU4XVV5aUQ2/3qwE8UeyAjBhFQZ2U9GrGPwWAASvnhdjRCRsjQBlbvkQ7oVrdIjk4r6NT43v7mhivKjejAxt\u002BGY=",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5LAPe1ev/Vuk3sJHVGs\u002BwkzFQmCiSAE/RYl9XovMzpYdjphr6uAAxIgx6Ug4oolMm\u002BfWh6jD9bWC48F/QMLd63bthFUM4P6398KT7DV2HgH3vHKSkNIwxg/MSfuCdAWUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAM0IVWC4udndooKxUGBAk8wBtODKgDSjiWRb/KYzXF39BsDZSAXE0AVFTuvFndiZLgIwWPwlmzopQhfSO43riFlhROH1xjJsNeqNr\u002BbtvD1AhyLZ4L2xZDBDGG8\u002BCvIoDmgz",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9828582e2da942d3a18be6274d5c8517"
+        "request_id": "639a3091c7c849d5ba887bc3364a99ee"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/124091009/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "a3d35916a623da102bae1b21888d6a88",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "743",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:34 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a3d35916a623da102bae1b21888d6a88",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0fd217bd-d1ca-4895-8564-533859e2467d",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "cc0beccb-48a7-41e2-8710-7d47baf27e99",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/124091009/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFfoISNt3piAbEKwatAcP/4RTzg2\u002BgiRC043CW/ygXY5SAR4vLhBOl3hBzaMvzkS04GaRtgqAkGlCkHSQG4fZyJCmHMFbBWG9jfuoHVOQAiNbCvcS7lTYT5o\u002BaBkAlwahoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwSUsXCNJ/pCYstWlfjoHHpWGQ5G2i3HRUhpB7sfqrxbGFHU4XVV5aUQ2/3qwE8UeyAjBhFQZ2U9GrGPwWAASvnhdjRCRsjQBlbvkQ7oVrdIjk4r6NT43v7mhivKjejAxt\u002BGY=",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5LAPe1ev/Vuk3sJHVGs\u002BwkzFQmCiSAE/RYl9XovMzpYdjphr6uAAxIgx6Ug4oolMm\u002BfWh6jD9bWC48F/QMLd63bthFUM4P6398KT7DV2HgH3vHKSkNIwxg/MSfuCdAWUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAM0IVWC4udndooKxUGBAk8wBtODKgDSjiWRb/KYzXF39BsDZSAXE0AVFTuvFndiZLgIwWPwlmzopQhfSO43riFlhROH1xjJsNeqNr\u002BbtvD1AhyLZ4L2xZDBDGG8\u002BCvIoDmgz",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9828582e2da942d3a18be6274d5c8517"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/124091009",
+        "request_id": "639a3091c7c849d5ba887bc3364a99ee"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/124091009?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "5c1c8a37767b6f4de524e0b2bbe8efca",
         "x-ms-return-client-request-id": "true"
@@ -300,79 +305,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "745",
+        "Content-Length": "1831",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5c1c8a37767b6f4de524e0b2bbe8efca",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a2bb6687-a2af-415a-8588-0ea3fbe3b8ba",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ec288900-91ac-4c52-9c78-0080b6a393fb",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFfoISNt3piAbEKwatAcP/4RTzg2\u002BgiRC043CW/ygXY5SAR4vLhBOl3hBzaMvzkS04GaRtgqAkGlCkHSQG4fZyJCmHMFbBWG9jfuoHVOQAiNbCvcS7lTYT5o\u002BaBkAlwahoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwSUsXCNJ/pCYstWlfjoHHpWGQ5G2i3HRUhpB7sfqrxbGFHU4XVV5aUQ2/3qwE8UeyAjBhFQZ2U9GrGPwWAASvnhdjRCRsjQBlbvkQ7oVrdIjk4r6NT43v7mhivKjejAxt\u002BGY=",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/124091009",
-        "request_id": "9828582e2da942d3a18be6274d5c8517"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/124091009?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "5621bc4f4cebe1ac8bc2c45c6996732d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1836",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6aed9917-57ec-4f3d-be7b-6466360b24d8",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/124091009/cc633a0f4f9243098c184d3d032c9182",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/124091009/cc633a0f4f9243098c184d3d032c9182",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/124091009/cc633a0f4f9243098c184d3d032c9182",
-        "x5t": "xqnEVQWjDVUSOAeIItUgFE6Jy5s",
-        "cer": "MIIB3DCCAWGgAwIBAgIQK1V1zd92QsWP/IFFb6i5sTAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTkzNloXDTIyMDMwNTIzMDkzNlowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABBX6CEjbd6YgGxCsGrQHD/\u002BEU84NvoIkQtONwlv8oF2OUgEeLy4QTpd4Qc2jL85EtOBmkbYKgJBpQpB0kBuH2ciQphzBWwVhvY37qB1TkAIjWwr3Eu5U2E\u002BaPmgZAJcGoaN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFNu4Cn2TxBmgNIEL2NaNBpyZu\u002BlBMB0GA1UdDgQWBBTbuAp9k8QZoDSBC9jWjQacmbvpQTAKBggqhkjOPQQDAwNpADBmAjEA0JUQaOyDSw7xNHh9E9ry\u002Bp1sz0Opny5DM6B67XTZ4MMfsdYG8tgHGcoZAQpB\u002Bc4HAjEAkV7l\u002B\u002BjaCIqqIDzbcXSoFvOxB\u002BmJz27A/Q/xrqpk3EBdfCPCW5HazAanyPOqdieh",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/124091009/8c80c9bb5ebe40149cc801efb7d062d9",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/124091009/8c80c9bb5ebe40149cc801efb7d062d9",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/124091009/8c80c9bb5ebe40149cc801efb7d062d9",
+        "x5t": "zC52Wik0wsG8eiN6ZGvVF5vzELY",
+        "cer": "MIIB2zCCAWGgAwIBAgIQD0LpOPmSTAe9F26j\u002BT\u002BAjjAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjMzMFoXDTIyMDQwODAyMzMzMFowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABOSwD3tXr/1bpN7CR1RrPsJMxUJgokgBP0WJfV6LzM6WHY6Ya\u002BrgAMSIMelIOKKJTJvn1oeow/W1guPBf0DC3et27YRVDOD\u002Bt/fCk\u002Bw1dh4B97xykpDSMMYPzEn7gnQFlKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFDErjG/lIcnprYr/bbkLsIMyeUB1MB0GA1UdDgQWBBQxK4xv5SHJ6a2K/225C7CDMnlAdTAKBggqhkjOPQQDAwNoADBlAjEAzx\u002BBbB05y1ozdpMXX50hIhoQX8QQDn22Be/Z0IeQBZ/f7/NcFEA3epdtm7Hh2IW1AjAC2eY\u002BgsbfBDkzH5WS11\u002ByM90g79UXQmkWIYIlRycze4Yp5QYsKuFOEKFLzFDhfr8=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985176,
-          "exp": 1646521776,
-          "created": 1614985776,
-          "updated": 1614985776,
+          "nbf": 1617848610,
+          "exp": 1649385210,
+          "created": 1617849210,
+          "updated": 1617849210,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/124091009/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/124091009/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -412,26 +375,79 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985759,
-            "updated": 1614985759
+            "created": 1617849195,
+            "updated": 1617849195
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/124091009/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/124091009/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/124091009/cc633a0f4f9243098c184d3d032c9182?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/124091009/8c80c9bb5ebe40149cc801efb7d062d9?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-1260e97491d0c64eb3a9e53ca5ce058c-8db037fcd0029447-00",
+        "traceparent": "00-0aed51518b855a44bdb11fba3451405e-b80491245726b540-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "5621bc4f4cebe1ac8bc2c45c6996732d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1240",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:33:30 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5621bc4f4cebe1ac8bc2c45c6996732d",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "9a1f1051-cac0-4f58-aa11-1dbfc66ecd12",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "id": "https://heathskvtest2.vault.azure.net/certificates/124091009/8c80c9bb5ebe40149cc801efb7d062d9",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/124091009/8c80c9bb5ebe40149cc801efb7d062d9",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/124091009/8c80c9bb5ebe40149cc801efb7d062d9",
+        "x5t": "zC52Wik0wsG8eiN6ZGvVF5vzELY",
+        "cer": "MIIB2zCCAWGgAwIBAgIQD0LpOPmSTAe9F26j\u002BT\u002BAjjAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjMzMFoXDTIyMDQwODAyMzMzMFowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABOSwD3tXr/1bpN7CR1RrPsJMxUJgokgBP0WJfV6LzM6WHY6Ya\u002BrgAMSIMelIOKKJTJvn1oeow/W1guPBf0DC3et27YRVDOD\u002Bt/fCk\u002Bw1dh4B97xykpDSMMYPzEn7gnQFlKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFDErjG/lIcnprYr/bbkLsIMyeUB1MB0GA1UdDgQWBBQxK4xv5SHJ6a2K/225C7CDMnlAdTAKBggqhkjOPQQDAwNoADBlAjEAzx\u002BBbB05y1ozdpMXX50hIhoQX8QQDn22Be/Z0IeQBZ/f7/NcFEA3epdtm7Hh2IW1AjAC2eY\u002BgsbfBDkzH5WS11\u002ByM90g79UXQmkWIYIlRycze4Yp5QYsKuFOEKFLzFDhfr8=",
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848610,
+          "exp": 1649385210,
+          "created": 1617849210,
+          "updated": 1617849210,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "subject": "CN=default",
+        "issuer": "CN=default",
+        "serialnumber": "0F42E938F9924C07BD176EA3F93F808E"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/124091009/8c80c9bb5ebe40149cc801efb7d062d9?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-0aed51518b855a44bdb11fba3451405e-0ffc5a4b5ef75342-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "ce228425fa98a09b0b63befec65e1e42",
         "x-ms-return-client-request-id": "true"
@@ -440,50 +456,88 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1243",
+        "Content-Length": "1941",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ce228425fa98a09b0b63befec65e1e42",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "592ad83f-fc98-4903-baf1-355cbe67c037",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a8845ea4-e2ea-4742-ad51-e3cffd93d0b2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/124091009/cc633a0f4f9243098c184d3d032c9182",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/124091009/cc633a0f4f9243098c184d3d032c9182",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/124091009/cc633a0f4f9243098c184d3d032c9182",
-        "x5t": "xqnEVQWjDVUSOAeIItUgFE6Jy5s",
-        "cer": "MIIB3DCCAWGgAwIBAgIQK1V1zd92QsWP/IFFb6i5sTAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTkzNloXDTIyMDMwNTIzMDkzNlowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABBX6CEjbd6YgGxCsGrQHD/\u002BEU84NvoIkQtONwlv8oF2OUgEeLy4QTpd4Qc2jL85EtOBmkbYKgJBpQpB0kBuH2ciQphzBWwVhvY37qB1TkAIjWwr3Eu5U2E\u002BaPmgZAJcGoaN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFNu4Cn2TxBmgNIEL2NaNBpyZu\u002BlBMB0GA1UdDgQWBBTbuAp9k8QZoDSBC9jWjQacmbvpQTAKBggqhkjOPQQDAwNpADBmAjEA0JUQaOyDSw7xNHh9E9ry\u002Bp1sz0Opny5DM6B67XTZ4MMfsdYG8tgHGcoZAQpB\u002Bc4HAjEAkV7l\u002B\u002BjaCIqqIDzbcXSoFvOxB\u002BmJz27A/Q/xrqpk3EBdfCPCW5HazAanyPOqdieh",
+        "value": "MIIEbwIBAzCCBCsGCSqGSIb3DQEHAaCCBBwEggQYMIIEFDCCAZ0GCSqGSIb3DQEHAaCCAY4EggGKMIIBhjCCAYIGCyqGSIb3DQEMCgECoIH8MIH5MBwGCiqGSIb3DQEMAQMwDgQIUE8SqLBwpt0CAgfQBIHYceuo8GexnPP9RnBN8VsHB8tQjboQJFXqTa7qYjGDNzGyuwydFjIKZKRiDfsSP5h\u002Bre2/kacaTINsu57JOkpRAaSmW4Wpl03qaTZnpbDFoWzPKejfSxzbqErU47qCdS62MwLJV4B4B0K06O27\u002B0UDmndAHlPNkxnyVUjYQvaRW8Q3QQpT5iz4hL1OPSALmml8z3PqiQJjbebtdg\u002Bq9ZDqeveMEzXJOncvsir7ZqCWL4r\u002B/FyDnoes7129bRDrKfLolbxzyJIegyAJcqhlE29ngUtFrmECKqtSMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAm8GCSqGSIb3DQEHBqCCAmAwggJcAgEAMIICVQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIXXCeNSnqFgQCAgfQgIICKFl69WukKRJJCyqSQCKwiZst45nI8Zyrt8Ivvqop2kydhbXDypELnPyv5Bb3ynAPh/OEx/I5SF23GQLpciahSqZfe\u002BAOP54qyYGMPMp86rp88EMpsTkCTKY\u002BAy8s1ySEah9GfxC1rZAoTVX3K2//2Hdfc4DblxTJ7ZtNMBQkqDGvLMG6RtuRDBb2scY94XR27JyHUxn7/Pe4/NLa6kzSHp7YvZ6nZY22XVcqn7\u002B6K6yhgwRVZW3xaEGdTd03wVy467OM\u002BnANw51T2gI8aLtPofEtFPYXb3/\u002BcomRYYEm2BuR88gCy6sQp3Z\u002BJDq7q\u002BuhvRLl2d6s7JW8qBl4Ioln/N7DXI3YPW4/FdkMFMSICFB6UuQ3POXUZ7lR0O2Sns2vhnkIfeBFCPyvGxb0ktVoaUXOjxr6lk8euZ1Wd0mtBwTQ5thIT6xvmOVpAC3OmIbXy/Ksx1yhIB66vrdfCUg/ZUiPKyag0NpaNo2KWstLMFoc1MuJkhw9V0b1SJcwf6FVB4ZoSedpKJPQpQYclSYmGOFPumvN4J7QLBi0nR8zO1VewsoJ1ZzaipFT9TpLQUmGiW3VZt/ZdoNGV\u002BJoIYlipv71v4AH7twyZqC6F77JbP90Vd4jhIbqc8iszTqoUTDSCd8OXCPuuO5okQE0yReodUGnFeZ8P2WGSHyd3uAcshwnoNUS2rBvrKwTSox/Ojb9bGUubqCEP65EkQNL7\u002Bt1azbAkCbt81qAHDA7MB8wBwYFKw4DAhoEFFvban9SoHlOiqC38ZGj2SxFtfwkBBQDORQdDHX00gRW3e0Qbb35bGZ9wAICB9A=",
+        "contentType": "application/x-pkcs12",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/124091009/8c80c9bb5ebe40149cc801efb7d062d9",
+        "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985176,
-          "exp": 1646521776,
-          "created": 1614985776,
-          "updated": 1614985776,
+          "nbf": 1617848610,
+          "exp": 1649385210,
+          "created": 1617849210,
+          "updated": 1617849210,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "subject": "CN=default",
-        "issuer": "CN=default",
-        "serialnumber": "2B5575CDDF7642C58FFC81456FA8B9B1"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/124091009/8c80c9bb5ebe40149cc801efb7d062d9"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/124091009/cc633a0f4f9243098c184d3d032c9182?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/124091009/8c80c9bb5ebe40149cc801efb7d062d9?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-408608bb14ca1c438fd27d8de88dcb2d-88bfd85e98396d43-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "cbd251bf146beb9dde3bd1b8b2f0064f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:33:30 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "cbd251bf146beb9dde3bd1b8b2f0064f",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6a4b702d-2b8c-4f00-82d6-17a23a5798c5",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/124091009/8c80c9bb5ebe40149cc801efb7d062d9?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-1260e97491d0c64eb3a9e53ca5ce058c-28baa07f99c9db4c-00",
+        "traceparent": "00-408608bb14ca1c438fd27d8de88dcb2d-88bfd85e98396d43-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "cbd251bf146beb9dde3bd1b8b2f0064f",
         "x-ms-return-client-request-id": "true"
@@ -492,86 +546,38 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1955",
+        "Content-Length": "480",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "cbd251bf146beb9dde3bd1b8b2f0064f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "d3a76fc7-0f27-47d9-9333-a28c12fe940f",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "value": "MIIEdwIBAzCCBDMGCSqGSIb3DQEHAaCCBCQEggQgMIIEHDCCAZ0GCSqGSIb3DQEHAaCCAY4EggGKMIIBhjCCAYIGCyqGSIb3DQEMCgECoIH8MIH5MBwGCiqGSIb3DQEMAQMwDgQIt0tQS7tKK5wCAgfQBIHY6XiJDvN/wA\u002BWUUwIDkqQiS0oCbzHaj9JrQPOW3l6lhPOBIOQFKilLprW1A9IGM6lx3mWEqOKG68ya8pah9hGCBuKUh5AE4G6VLx2Sx/xDyhiAZxpXkyPbKBbbTRxOVa6\u002B0wg3iOIUGQVKUfDdJL3Ghakaljf/j53ZQz0lGtH9OWa7kuEcptAqG21q11xIMe1TsSDXqQloH63sO\u002BT6/wj9WpiKwzIFmqPN2JvZvMdi05wwHbchGPS0HUECMXYRCAR\u002BSyS1c8mdWaaIpJCBaFlQR9Su\u002B/nop8lMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAncGCSqGSIb3DQEHBqCCAmgwggJkAgEAMIICXQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIg3euQ/7jX5ACAgfQgIICMEDEL8wRhQC00ECOt5x5kc/zSx4HnTjM99Pm7256EsOe\u002BucpxZvzZFHj0ZCIqIqXCGF0z3j/UCF\u002BqjJCG\u002Bq2gFvDbyZgmw\u002B/tMzwR1wWqGULLoWKGA9Um8jFIHR9EFQ731A2eAGZgIZrAy61VoqtNSqL4b/DALBmldCP8YXzCgLnBhki0z2sYGZd7BEXV5to/e5N1\u002BjmU4Q5qrfH27VjIX2sQ9GKQYsNbImHl5W\u002BU4kgfICXGXvdqPCwgm6ssDY/2LrcHcEZRJgkXKyQtxp7p9MPB1ANAqvEWMyCTm3IyyVsSExFbGleH91Hq0qYTxjEM03AGQ6TSHpIC//xzrQ\u002BBFOIWWgoFIhWw38cdcPQQwyrgA\u002BKCIoRj1uSGElPgydzHL7kb6xkW4vAsoO\u002B1HNN\u002BQ7QwvyXBmeG2lfZLPghvozBbvVbvYreOiZLFm8oULh7inPDNZ\u002BpiW2E1IQFM\u002BX6yI8GJQ2mP00aytpZCHAxd1yTBqwFwNeGw/H7hBu9noSIMc88yoOoYhaUAzAoWW2jwnmVsBNopdsGrR/HeVHa9ROlZ5sAmNPGYYnsR6RkthbR11n\u002B7fy67GxzTg44n/f693TlcqtRnZd2pui3tJJdy9BFJmcmpyzw0SeQby6pXGNOhbNDnrLE3afF9UR8rsc\u002B8Q4gBGIVH4g/cy8THCWhSzJx1MtUJ\u002B27rurcWG2m25kwOKenBQWZSWCuZbgqH2L6M33pVjaLD/I/J\u002Bci90v0OVqPMDswHzAHBgUrDgMCGgQUdUJ9kPhYqSx4SBI2zwSK8QY17VsEFG11BzNYKmCaglJPGy8HAyKnSexbAgIH0A==",
-        "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/124091009/cc633a0f4f9243098c184d3d032c9182",
-        "managed": true,
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614985176,
-          "exp": 1646521776,
-          "created": 1614985776,
-          "updated": 1614985776,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/124091009/cc633a0f4f9243098c184d3d032c9182"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/124091009/cc633a0f4f9243098c184d3d032c9182?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-eaa3783143fd2b42a81133947730071d-cc8cf731f1b2b344-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "378cb2b120c5553221814a878ead1b2c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "481",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f17f7438-ac82-4fc6-b8bc-17cdd3b7a713",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6196129c-ba91-4f07-afa7-7783a49310e3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/124091009/cc633a0f4f9243098c184d3d032c9182",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/124091009/8c80c9bb5ebe40149cc801efb7d062d9",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-384",
-          "x": "FfoISNt3piAbEKwatAcP_4RTzg2-giRC043CW_ygXY5SAR4vLhBOl3hBzaMvzkS0",
-          "y": "4GaRtgqAkGlCkHSQG4fZyJCmHMFbBWG9jfuoHVOQAiNbCvcS7lTYT5o-aBkAlwah"
+          "x": "5LAPe1ev_Vuk3sJHVGs-wkzFQmCiSAE_RYl9XovMzpYdjphr6uAAxIgx6Ug4oolM",
+          "y": "m-fWh6jD9bWC48F_QMLd63bthFUM4P6398KT7DV2HgH3vHKSkNIwxg_MSfuCdAWU"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985176,
-          "exp": 1646521776,
-          "created": 1614985776,
-          "updated": 1614985776,
+          "nbf": 1617848610,
+          "exp": 1649385210,
+          "created": 1617849210,
+          "updated": 1617849210,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -580,7 +586,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "804741761"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-521).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-521).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1561993126/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-a55cec3d3172064c87866a347f195d30-ca471fc2a6c5184d-00",
+        "traceparent": "00-f0b9b411fdfa7b40a2d6623a6239b6d2-c5be66a44f064a4e-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "fc21e100665903f7d8b3a1bc938b4353",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:24 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:08 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "fc21e100665903f7d8b3a1bc938b4353",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6042a8fa-3bd5-45d2-9399-09fcae66e19d",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b671ad79-2224-4a82-9640-14e1721b8179",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1561993126/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-a55cec3d3172064c87866a347f195d30-ca471fc2a6c5184d-00",
+        "traceparent": "00-f0b9b411fdfa7b40a2d6623a6239b6d2-c5be66a44f064a4e-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "fc21e100665903f7d8b3a1bc938b4353",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "937",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:25 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:08 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending?api-version=7.2\u0026request_id=266ba034895e4d9e90fdf9badb8710a4",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1561993126/pending?api-version=7.2\u0026request_id=f59a8871f9e2494caa155f646d050c56",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "fc21e100665903f7d8b3a1bc938b4353",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4083c67a-d769-4989-935d-ca2900631c9d",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f03021c6-58be-4461-83c6-fec1349c1d6f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1561993126/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6\u002Brtn77FAlRZipKjrRiSAGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z\u002Bk2bEo4q40mjXlqDJ/\u002BW\u002BKE4oTSv36RuW0pIJA3BmlwvC3OW/FYkoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBYwJKTvtCJz3qdmqBFKNaP31FAzFxcNmB\u002BirSXGAbNkwFu8chfVd4X4UIExAEaje\u002BdiPY2jRnAJUA5gO0XpZQXPwCQgDUa\u002B2ksi2nX\u002BRnVGnC/69CvcDTfwKMyiTgi/NAwJCADVcPnBELZ5x6caRNioNLNRqswu2JbpP6jTbp92oyFQLcdw==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAaAakBLAUTS0oFoLYzLLIchfadY6mID67wW2u2BIziXsMCcyxV76QiJLnek6jKbNVpmFQAZqGS2oRLrgYlbmbUKtAAtFSxIMMBJtC2GjbwXiO4X74SFMWlbVW7KmLfcz15rwCL4NrT\u002BjsRMCnnqPWfFA855prkhlTjT5XXPhUXMKo3uWoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkF27ks7GuTYGRUp47e6oAI4flvW4IjRQ6BGgmblessTlpG8d8Omhv9TVcX3pHXILLItbM3cn3sFGL40FLjqAItawAJCASYs1HzWPztNvWk5kJYe\u002B/giA7nuED4f21lYybiqG7LkSEuTafRfmfbOjWa9YCiBCjYWi/sGZ976Qh5NMA/cJPDD",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "266ba034895e4d9e90fdf9badb8710a4"
+        "request_id": "f59a8871f9e2494caa155f646d050c56"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1561993126/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "cb962a908a8f0f824968061348179a61",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "937",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:25 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:08 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "cb962a908a8f0f824968061348179a61",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "bddbf8d7-4ee6-4c51-aa42-92f0d649c9d1",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "fa979a6a-8e70-4b47-b2a7-6acc720d587b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1561993126/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6\u002Brtn77FAlRZipKjrRiSAGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z\u002Bk2bEo4q40mjXlqDJ/\u002BW\u002BKE4oTSv36RuW0pIJA3BmlwvC3OW/FYkoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBYwJKTvtCJz3qdmqBFKNaP31FAzFxcNmB\u002BirSXGAbNkwFu8chfVd4X4UIExAEaje\u002BdiPY2jRnAJUA5gO0XpZQXPwCQgDUa\u002B2ksi2nX\u002BRnVGnC/69CvcDTfwKMyiTgi/NAwJCADVcPnBELZ5x6caRNioNLNRqswu2JbpP6jTbp92oyFQLcdw==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAaAakBLAUTS0oFoLYzLLIchfadY6mID67wW2u2BIziXsMCcyxV76QiJLnek6jKbNVpmFQAZqGS2oRLrgYlbmbUKtAAtFSxIMMBJtC2GjbwXiO4X74SFMWlbVW7KmLfcz15rwCL4NrT\u002BjsRMCnnqPWfFA855prkhlTjT5XXPhUXMKo3uWoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkF27ks7GuTYGRUp47e6oAI4flvW4IjRQ6BGgmblessTlpG8d8Omhv9TVcX3pHXILLItbM3cn3sFGL40FLjqAItawAJCASYs1HzWPztNvWk5kJYe\u002B/giA7nuED4f21lYybiqG7LkSEuTafRfmfbOjWa9YCiBCjYWi/sGZ976Qh5NMA/cJPDD",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "266ba034895e4d9e90fdf9badb8710a4"
+        "request_id": "f59a8871f9e2494caa155f646d050c56"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1561993126/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "2e7ec75118db77a623f7df4955b11c38",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "937",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:30 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2e7ec75118db77a623f7df4955b11c38",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a763808c-dc82-41a9-bd0a-67bd066a2f89",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5032498a-0c21-40af-830a-edaa2dc753e3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1561993126/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6\u002Brtn77FAlRZipKjrRiSAGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z\u002Bk2bEo4q40mjXlqDJ/\u002BW\u002BKE4oTSv36RuW0pIJA3BmlwvC3OW/FYkoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBYwJKTvtCJz3qdmqBFKNaP31FAzFxcNmB\u002BirSXGAbNkwFu8chfVd4X4UIExAEaje\u002BdiPY2jRnAJUA5gO0XpZQXPwCQgDUa\u002B2ksi2nX\u002BRnVGnC/69CvcDTfwKMyiTgi/NAwJCADVcPnBELZ5x6caRNioNLNRqswu2JbpP6jTbp92oyFQLcdw==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAaAakBLAUTS0oFoLYzLLIchfadY6mID67wW2u2BIziXsMCcyxV76QiJLnek6jKbNVpmFQAZqGS2oRLrgYlbmbUKtAAtFSxIMMBJtC2GjbwXiO4X74SFMWlbVW7KmLfcz15rwCL4NrT\u002BjsRMCnnqPWfFA855prkhlTjT5XXPhUXMKo3uWoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkF27ks7GuTYGRUp47e6oAI4flvW4IjRQ6BGgmblessTlpG8d8Omhv9TVcX3pHXILLItbM3cn3sFGL40FLjqAItawAJCASYs1HzWPztNvWk5kJYe\u002B/giA7nuED4f21lYybiqG7LkSEuTafRfmfbOjWa9YCiBCjYWi/sGZ976Qh5NMA/cJPDD",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "266ba034895e4d9e90fdf9badb8710a4"
+        "request_id": "f59a8871f9e2494caa155f646d050c56"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1561993126/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "1eba08be187075175f12b3f060e4bac0",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "845",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:35 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1eba08be187075175f12b3f060e4bac0",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "cca9d54a-31fd-407b-9097-dadba2e7e396",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "81a1a4e0-4c26-4702-a889-3ea9caa83530",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1561993126/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6\u002Brtn77FAlRZipKjrRiSAGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z\u002Bk2bEo4q40mjXlqDJ/\u002BW\u002BKE4oTSv36RuW0pIJA3BmlwvC3OW/FYkoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBYwJKTvtCJz3qdmqBFKNaP31FAzFxcNmB\u002BirSXGAbNkwFu8chfVd4X4UIExAEaje\u002BdiPY2jRnAJUA5gO0XpZQXPwCQgDUa\u002B2ksi2nX\u002BRnVGnC/69CvcDTfwKMyiTgi/NAwJCADVcPnBELZ5x6caRNioNLNRqswu2JbpP6jTbp92oyFQLcdw==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAaAakBLAUTS0oFoLYzLLIchfadY6mID67wW2u2BIziXsMCcyxV76QiJLnek6jKbNVpmFQAZqGS2oRLrgYlbmbUKtAAtFSxIMMBJtC2GjbwXiO4X74SFMWlbVW7KmLfcz15rwCL4NrT\u002BjsRMCnnqPWfFA855prkhlTjT5XXPhUXMKo3uWoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkF27ks7GuTYGRUp47e6oAI4flvW4IjRQ6BGgmblessTlpG8d8Omhv9TVcX3pHXILLItbM3cn3sFGL40FLjqAItawAJCASYs1HzWPztNvWk5kJYe\u002B/giA7nuED4f21lYybiqG7LkSEuTafRfmfbOjWa9YCiBCjYWi/sGZ976Qh5NMA/cJPDD",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "266ba034895e4d9e90fdf9badb8710a4"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1561993126",
+        "request_id": "f59a8871f9e2494caa155f646d050c56"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1561993126?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "cc6b3f19150c7777841ea798aa38b997",
         "x-ms-return-client-request-id": "true"
@@ -256,255 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "1936",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:40 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5d81e7c9-5d87-4271-bda2-9152c49d6d23",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6\u002Brtn77FAlRZipKjrRiSAGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z\u002Bk2bEo4q40mjXlqDJ/\u002BW\u002BKE4oTSv36RuW0pIJA3BmlwvC3OW/FYkoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBYwJKTvtCJz3qdmqBFKNaP31FAzFxcNmB\u002BirSXGAbNkwFu8chfVd4X4UIExAEaje\u002BdiPY2jRnAJUA5gO0XpZQXPwCQgDUa\u002B2ksi2nX\u002BRnVGnC/69CvcDTfwKMyiTgi/NAwJCADVcPnBELZ5x6caRNioNLNRqswu2JbpP6jTbp92oyFQLcdw==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "266ba034895e4d9e90fdf9badb8710a4"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "3f54ce4b7c5c39f1b009cec964b5173f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "942",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:46 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a1d044fe-8498-450a-8e57-204c35cdd294",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6\u002Brtn77FAlRZipKjrRiSAGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z\u002Bk2bEo4q40mjXlqDJ/\u002BW\u002BKE4oTSv36RuW0pIJA3BmlwvC3OW/FYkoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBYwJKTvtCJz3qdmqBFKNaP31FAzFxcNmB\u002BirSXGAbNkwFu8chfVd4X4UIExAEaje\u002BdiPY2jRnAJUA5gO0XpZQXPwCQgDUa\u002B2ksi2nX\u002BRnVGnC/69CvcDTfwKMyiTgi/NAwJCADVcPnBELZ5x6caRNioNLNRqswu2JbpP6jTbp92oyFQLcdw==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "266ba034895e4d9e90fdf9badb8710a4"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "15301e3c5046a92b91429a51707ecb27",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "942",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:51 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "48da8e26-e097-4a40-925c-7ddfbb5d363f",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6\u002Brtn77FAlRZipKjrRiSAGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z\u002Bk2bEo4q40mjXlqDJ/\u002BW\u002BKE4oTSv36RuW0pIJA3BmlwvC3OW/FYkoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBYwJKTvtCJz3qdmqBFKNaP31FAzFxcNmB\u002BirSXGAbNkwFu8chfVd4X4UIExAEaje\u002BdiPY2jRnAJUA5gO0XpZQXPwCQgDUa\u002B2ksi2nX\u002BRnVGnC/69CvcDTfwKMyiTgi/NAwJCADVcPnBELZ5x6caRNioNLNRqswu2JbpP6jTbp92oyFQLcdw==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "266ba034895e4d9e90fdf9badb8710a4"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "92a51b587a8f9c644e321c0346ad12ce",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "942",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 22:59:55 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "85558a2a-62f2-477a-9609-3469c5e4dbc2",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6\u002Brtn77FAlRZipKjrRiSAGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z\u002Bk2bEo4q40mjXlqDJ/\u002BW\u002BKE4oTSv36RuW0pIJA3BmlwvC3OW/FYkoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBYwJKTvtCJz3qdmqBFKNaP31FAzFxcNmB\u002BirSXGAbNkwFu8chfVd4X4UIExAEaje\u002BdiPY2jRnAJUA5gO0XpZQXPwCQgDUa\u002B2ksi2nX\u002BRnVGnC/69CvcDTfwKMyiTgi/NAwJCADVcPnBELZ5x6caRNioNLNRqswu2JbpP6jTbp92oyFQLcdw==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "266ba034895e4d9e90fdf9badb8710a4"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "8b5c6807a307fb51a2abae1ae1a0c831",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "851",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:00 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "cc6b3f19150c7777841ea798aa38b997",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3f4945c5-9c76-4751-8357-e26c6c613916",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "c339b50c-e6fd-4d6b-8626-fcaa1ae94a81",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6\u002Brtn77FAlRZipKjrRiSAGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z\u002Bk2bEo4q40mjXlqDJ/\u002BW\u002BKE4oTSv36RuW0pIJA3BmlwvC3OW/FYkoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBYwJKTvtCJz3qdmqBFKNaP31FAzFxcNmB\u002BirSXGAbNkwFu8chfVd4X4UIExAEaje\u002BdiPY2jRnAJUA5gO0XpZQXPwCQgDUa\u002B2ksi2nX\u002BRnVGnC/69CvcDTfwKMyiTgi/NAwJCADVcPnBELZ5x6caRNioNLNRqswu2JbpP6jTbp92oyFQLcdw==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1561993126",
-        "request_id": "266ba034895e4d9e90fdf9badb8710a4"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "4970a73d8410c1afba93c714342762e3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1941",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1f11a0b6-5229-4ff7-8eea-879d6cb6fd45",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/e3867731720b4da499d927814ba39ddc",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1561993126/e3867731720b4da499d927814ba39ddc",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1561993126/e3867731720b4da499d927814ba39ddc",
-        "x5t": "_kM3qSbhLP4v2pbsBPkWim-TfdU",
-        "cer": "MIICJTCCAYegAwIBAgIQTFIe95RlRmylIynTzmkfgzAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNDk1NloXDTIyMDMwNTIyNTk1NlowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6\u002Brtn77FAlRZipKjrRiSAGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z\u002Bk2bEo4q40mjXlqDJ/\u002BW\u002BKE4oTSv36RuW0pIJA3BmlwvC3OW/FYko3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUY95ey4SGPugRw/uuQVE9t4osJEMwHQYDVR0OBBYEFGPeXsuEhj7oEcP7rkFRPbeKLCRDMAoGCCqGSM49BAMEA4GLADCBhwJBM8Nb8pja3WQU9h7JrH3iJJQDOtmpuK4p9VBFxluaZFRDTXtOFyVY1C2\u002Bs5qKpx0\u002BjgkY/Ge/NF5CGHpnUWl6URYCQgFZPbvGYQvRYgmYXVXUFoULvaP/75TnNafzjewd\u002BjW4UdvsqOpYqe/m/k4R/P2e9NIPUSU27M86abkqh6sA4mfk3A==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1561993126/0c673e4c78964f21b9482b35dab4f4cb",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1561993126/0c673e4c78964f21b9482b35dab4f4cb",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1561993126/0c673e4c78964f21b9482b35dab4f4cb",
+        "x5t": "eaYFy4A7G3hw5GnGJpdXQoBM3zQ",
+        "cer": "MIICJTCCAYagAwIBAgIPPVcyrcdHerLkJFzOvCthMAoGCCqGSM49BAMEMBIxEDAOBgNVBAMTB2RlZmF1bHQwHhcNMjEwNDA4MDIxOTE2WhcNMjIwNDA4MDIyOTE2WjASMRAwDgYDVQQDEwdkZWZhdWx0MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBoBqQEsBRNLSgWgtjMsshyF9p1jqYgPrvBba7YEjOJewwJzLFXvpCIkud6TqMps1WmYVABmoZLahEuuBiVuZtQq0AC0VLEgwwEm0LYaNvBeI7hfvhIUxaVtVbsqYt9zPXmvAIvg2tP6OxEwKeeo9Z8UDznmmuSGVONPldc\u002BFRcwqje5ajfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSNni2JhbON4ggk\u002BqdAdmo/fa8L4zAdBgNVHQ4EFgQUjZ4tiYWzjeIIJPqnQHZqP32vC\u002BMwCgYIKoZIzj0EAwQDgYwAMIGIAkIBfxKXSVjy5GtcRtLte7xWsWQ13KJYQAraJkaPrAYGXOY8kXRdo5B66fS5DlHojEFGoOQD6RY4FOLg0FrslB5bCaoCQgEVYlHm9mDb7QcXFqFlzTifJoWcbi48oKQJU3ta/h0e8Ufrvmazn6iZJuN7R69TJuFF1mLssyfUyRMUK/xPBzdNeg==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984596,
-          "exp": 1646521196,
-          "created": 1614985196,
-          "updated": 1614985196,
+          "nbf": 1617848356,
+          "exp": 1649384956,
+          "created": 1617848956,
+          "updated": 1617848956,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1561993126/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -544,166 +330,209 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985165,
-            "updated": 1614985165
+            "created": 1617848949,
+            "updated": 1617848949
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1561993126/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1561993126/e3867731720b4da499d927814ba39ddc?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1561993126/0c673e4c78964f21b9482b35dab4f4cb?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-1bd8bb13da631649b402163ccaeca4b2-e693f34707903c44-00",
+        "traceparent": "00-16312c84a715424ea4c9a5c9d210bc4c-b839a60d2259e24e-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "0849cb2f3f22b51fcaaaefe4cc49baae",
+        "x-ms-client-request-id": "3f54ce4b7c5c39f1b009cec964b5173f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1346",
+        "Content-Length": "1341",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3f54ce4b7c5c39f1b009cec964b5173f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c8260cc7-e6d6-41d6-821d-ff888a3fad16",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bee32e75-e306-45cb-9340-cf81b8cefce8",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1561993126/e3867731720b4da499d927814ba39ddc",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1561993126/e3867731720b4da499d927814ba39ddc",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1561993126/e3867731720b4da499d927814ba39ddc",
-        "x5t": "_kM3qSbhLP4v2pbsBPkWim-TfdU",
-        "cer": "MIICJTCCAYegAwIBAgIQTFIe95RlRmylIynTzmkfgzAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNDk1NloXDTIyMDMwNTIyNTk1NlowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAfb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6\u002Brtn77FAlRZipKjrRiSAGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z\u002Bk2bEo4q40mjXlqDJ/\u002BW\u002BKE4oTSv36RuW0pIJA3BmlwvC3OW/FYko3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUY95ey4SGPugRw/uuQVE9t4osJEMwHQYDVR0OBBYEFGPeXsuEhj7oEcP7rkFRPbeKLCRDMAoGCCqGSM49BAMEA4GLADCBhwJBM8Nb8pja3WQU9h7JrH3iJJQDOtmpuK4p9VBFxluaZFRDTXtOFyVY1C2\u002Bs5qKpx0\u002BjgkY/Ge/NF5CGHpnUWl6URYCQgFZPbvGYQvRYgmYXVXUFoULvaP/75TnNafzjewd\u002BjW4UdvsqOpYqe/m/k4R/P2e9NIPUSU27M86abkqh6sA4mfk3A==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1561993126/0c673e4c78964f21b9482b35dab4f4cb",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1561993126/0c673e4c78964f21b9482b35dab4f4cb",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1561993126/0c673e4c78964f21b9482b35dab4f4cb",
+        "x5t": "eaYFy4A7G3hw5GnGJpdXQoBM3zQ",
+        "cer": "MIICJTCCAYagAwIBAgIPPVcyrcdHerLkJFzOvCthMAoGCCqGSM49BAMEMBIxEDAOBgNVBAMTB2RlZmF1bHQwHhcNMjEwNDA4MDIxOTE2WhcNMjIwNDA4MDIyOTE2WjASMRAwDgYDVQQDEwdkZWZhdWx0MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBoBqQEsBRNLSgWgtjMsshyF9p1jqYgPrvBba7YEjOJewwJzLFXvpCIkud6TqMps1WmYVABmoZLahEuuBiVuZtQq0AC0VLEgwwEm0LYaNvBeI7hfvhIUxaVtVbsqYt9zPXmvAIvg2tP6OxEwKeeo9Z8UDznmmuSGVONPldc\u002BFRcwqje5ajfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSNni2JhbON4ggk\u002BqdAdmo/fa8L4zAdBgNVHQ4EFgQUjZ4tiYWzjeIIJPqnQHZqP32vC\u002BMwCgYIKoZIzj0EAwQDgYwAMIGIAkIBfxKXSVjy5GtcRtLte7xWsWQ13KJYQAraJkaPrAYGXOY8kXRdo5B66fS5DlHojEFGoOQD6RY4FOLg0FrslB5bCaoCQgEVYlHm9mDb7QcXFqFlzTifJoWcbi48oKQJU3ta/h0e8Ufrvmazn6iZJuN7R69TJuFF1mLssyfUyRMUK/xPBzdNeg==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984596,
-          "exp": 1646521196,
-          "created": 1614985196,
-          "updated": 1614985196,
+          "nbf": 1617848356,
+          "exp": 1649384956,
+          "created": 1617848956,
+          "updated": 1617848956,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "4C521EF79465466CA52329D3CE691F83"
+        "serialnumber": "3D5732ADC7477AB2E4245CCEBC2B61"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1561993126/e3867731720b4da499d927814ba39ddc?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1561993126/0c673e4c78964f21b9482b35dab4f4cb?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-1bd8bb13da631649b402163ccaeca4b2-95713193ef24224d-00",
+        "traceparent": "00-16312c84a715424ea4c9a5c9d210bc4c-d722d7a15fa07141-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "9ec5ea69c93d82beb99ad073db3dc67a",
+        "x-ms-client-request-id": "15301e3c5046a92b91429a51707ecb27",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2129",
+        "Content-Length": "2127",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "15301e3c5046a92b91429a51707ecb27",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7c067ca8-bdde-4c1c-8b24-44669c6bde8f",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "94f649fc-0ec2-4a53-8ad0-820f865ccf83",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIE\u002BgIBAzCCBLYGCSqGSIb3DQEHAaCCBKcEggSjMIIEnzCCAdgGCSqGSIb3DQEHAaCCAckEggHFMIIBwTCCAb0GCyqGSIb3DQEMCgECoIIBNjCCATIwHAYKKoZIhvcNAQwBAzAOBAhpAry2sRytjAICB9AEggEQh8yoN8d2cRuoGW/3rpbpHmCOiOlp4AuMjZXt06Z3QpnMNdN6V2blKB5pnsrF\u002B6voc8a2qiweb/mBkI1OOQ6ZYeAsQ9yupBniAmUxG5OCRjcH9aO/3kXmKg9OrojhEhZFbf6AI79uqNWCmXQ2yXVxcMy/V3c0GqOBlK0TYS1tdO2c3IXDC1wHumO59YQ10u3JHjNQz3TPoSj/2xcYfqCgtOIxkPZ32fVVscIrZF5BMApljhO80LhnG7Eng3yBh6csmyRqL7YkgHL4srV5l8\u002BCEk9\u002BMI/I3WTRldfAyAOUCnhDxENS5ysSAV9h\u002BLZG4F7XRgLDqwuoEwXFTUbRvHEzkBwvOk3MqQsAz2y2NM/VqxYxdDATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEEAYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwBvAGYAdAB3AGEAcgBlACAASwBlAHkAIABTAHQAbwByAGEAZwBlACAAUAByAG8AdgBpAGQAZQByMIICvwYJKoZIhvcNAQcGoIICsDCCAqwCAQAwggKlBgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBAzAOBAjHoqNE1OG/sQICB9CAggJ44I7p9yAr2aRjhgDmwCFiPa5x54qFfbA6DGcLXGN8JWx0e9sODmmsQHY0XxVOJzWdwuUKu899zwwb6oFjq5ayphJ75Y83ZtJ546T0RvGP2mHuNTt7fDUVMajinrBpA6dxlB8gwX1TAUmf61PIXD\u002BBDCjq42s2lFAWdkhZ0OGy93OubWdXQ/2qOsCFk6d0s01lKZBvqlZl6q5t8ecPu66sUr7wQQwWDZ86fz06Mm\u002BThVxmGmYOZhb5yqXX82gdlskgZh4lmCJpoMRR/ULHjn3iJ\u002B9MfKm143O1ZJ9XDZiwljnHOCF3NhbVDUovE3S61tbsZM2IvGUj7dqOT13iJLgjm6Qqg\u002ByUsBLs1l1WGowqP7mmqhiIebWIqLPDRdAMnP9Im9s5Sd2XCgfqLokXhjWSp01vXhoCqgCxpo8XLQwG8NEdnBnTrOfWBaSPgqV3TDiyiq40U86HLUPv58or0PzzUt3ojg8Lh0NNLTAdHy8awqdaDKvmxkDhgNRhZUbtTL/1Y6XWTdi6GnpX51rStXyWPVHHRogUOtdNwoFH5nL/K5f5gIIEj/SZ75r36fLPhNfehm0Lc0hubKxMYobr0Y7LtzIzWcYiHGb7g6XIBUi40jVDYjWjxG/Z/E7Fnh3owE/zpUiGrOjK5kIN9RTe/dgXV/c9IC7BhyrAsU8woBmrDD8/7S6z8V1YHxjWpRd2eJmd5fXNz5qf556vzvqHdgHrrQ/v6py8mLQnUivH9QWGt\u002BCu/0pc9ZJtZgkKy7c0XYNyJbxFxwp/FDsqTRtAOjF0Kh82Dxiv\u002B4JFavin\u002B8ev\u002BAGga7YHTgLpyeMs0Ae/D2DuAPmQYMKV55cwOzAfMAcGBSsOAwIaBBTdIWcfLHbmtSGN7cD0YR2ym4bUrAQUkj7QNvtH/MotqUc5CSMeV6J/9XMCAgfQ",
+        "value": "MIIE\u002BgIBAzCCBLYGCSqGSIb3DQEHAaCCBKcEggSjMIIEnzCCAdgGCSqGSIb3DQEHAaCCAckEggHFMIIBwTCCAb0GCyqGSIb3DQEMCgECoIIBNjCCATIwHAYKKoZIhvcNAQwBAzAOBAhKnfE4u4/JSgICB9AEggEQHnbx6E5SvL6xOTfAD/EPkk\u002B8Gq9w0c5ViefqI5pm1CTPllGpwmdphFR9oCI94Y\u002B9gx0IxpL2\u002BcgUZM3Z\u002BN3yoSpIhq0CdiClODFkJOSqC2CL486LIOKvcrhSZ3RUgEXerGwlhu/KzqJ37pNSDH\u002B/h0lmaNSFFEAuELSPFtfAIqqifbHk/W4O80XT8ykFCngIx5pYqWl2Hki6FQo4oqgp\u002BFLv4YmOLpIVDsgZY/xE33u1aLqvmvbe7hU8a3MzpxOf9AgN1aXbtV9YJ60scRsR3hmyl8Lp3YLBMctJpObzOn\u002Bf0kqvxLflYjXPQ1uUf/ffk1ZV9iyJssykxi1741Hv5B9ZAQ1IbY4U5o65n7yHBCUxdDATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEEAYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwBvAGYAdAB3AGEAcgBlACAASwBlAHkAIABTAHQAbwByAGEAZwBlACAAUAByAG8AdgBpAGQAZQByMIICvwYJKoZIhvcNAQcGoIICsDCCAqwCAQAwggKlBgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBAzAOBAi5KXHk3GA1WwICB9CAggJ4zvVH7tR7YVEK/xbGe8AS2a0fWyB6qMVfONiceJemt7nBiES0p4TEyDqJ30BYJsdqq50inikMe1\u002BgdLM\u002BzkXEZHMgW93x1e9c\u002BWgwK1GhNV9wWfhl\u002BrsEko2cR/pITI07TNSd0EiP7KQA5zxatciuC3VYtCTB7ftDttIm4AaA7WDXc6XzFfgX2AfdEHdUokZ/ebssPKYk4O7HGpfAt98D5XKUHdu1J9nkW7AKnfyjtRVm8hrtpDdHfvElxobkqsvZ9BvDYT8xKkc0E8QGUiUlc42PKKGgwEBdYAiS\u002BTBKYIba6msHi0A8eErKAONmiknLTYhiw5Lrbi\u002BChBcWs1CWTDc8tsQ9zxTMRjgt\u002Bsu9xKt5nOYZqiZqX91aMJYyTQ/KJda6qTDwv0pKX/lPkFfnB\u002BzebsTMH4qpiT0BDsYWvwMt9rGSY7/I8jjPyyeD\u002Bd63NVJzmK3CzsG55Ebqb2x0LBSik0QpoNVDf0KQfR/4xv046qHj8ohMBqZesvoJfmC402\u002BWShyxWERuykE3zB78L4qDXa4U4BVuxfm2ZKAmrSGAai/BcLfV1aygk7CPPn8S732qGNo44cXYN9OTxNt1Bl3icmV7vZlzuDEMWNpCaNtQYZ9OatSXayHOOBa1WXLbygBduzF2tKrC1xyVqf6FefxXcU1gtWr/S3SQ06njGpn\u002BEig/hWeNeDYKiOGelSX8r1iJzFnJo8Ho9PCl4b9uw5fxaYXR0G4FfkX72H31uakQwxmnq0n7J8la9lWJnNOIXk6DDam4T8MwZoB0TCAV6ScoV4rbJwqfeTt6kiwnr2LHuru1vnck\u002Bg4vh4r3X6CM0w\u002B1u69zDDUwOzAfMAcGBSsOAwIaBBSU5eol3JyluDa2AqEOhJraMX0x4AQUcik5YSJqD2PiNe5JMQRWablI178CAgfQ",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1561993126/e3867731720b4da499d927814ba39ddc",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1561993126/0c673e4c78964f21b9482b35dab4f4cb",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614984596,
-          "exp": 1646521196,
-          "created": 1614985196,
-          "updated": 1614985196,
+          "nbf": 1617848356,
+          "exp": 1649384956,
+          "created": 1617848956,
+          "updated": 1617848956,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1561993126/e3867731720b4da499d927814ba39ddc"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1561993126/0c673e4c78964f21b9482b35dab4f4cb"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1561993126/e3867731720b4da499d927814ba39ddc?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1561993126/0c673e4c78964f21b9482b35dab4f4cb?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-902dfc76c35c1c42beb180593255788a-e49ea0d908287641-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "92a51b587a8f9c644e321c0346ad12ce",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:29:24 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "92a51b587a8f9c644e321c0346ad12ce",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "0ec3db6a-d56e-4d9a-9393-04157f9a6a1b",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1561993126/0c673e4c78964f21b9482b35dab4f4cb?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-171c68d820e83d4cabacaff663355ba7-d22740f65a33de46-00",
+        "traceparent": "00-902dfc76c35c1c42beb180593255788a-e49ea0d908287641-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "16eaca48c056fe0f88ba7e6695caf471",
+        "x-ms-client-request-id": "92a51b587a8f9c644e321c0346ad12ce",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "530",
+        "Content-Length": "529",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:00:06 GMT",
+        "Date": "Thu, 08 Apr 2021 02:29:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "92a51b587a8f9c644e321c0346ad12ce",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "8ba50585-5643-45fd-8a7e-6e0f7436ee3a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6993fa58-be8c-46fd-a4c4-b945d3b961d8",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1561993126/e3867731720b4da499d927814ba39ddc",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1561993126/0c673e4c78964f21b9482b35dab4f4cb",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-521",
-          "x": "Afb6QbsLRt3cbpv8TVaeb8HlpgqSrOLdmGU0FLJLtFDnESi8zCwZjOzZnH5Z3blmt4ab6-rtn77FAlRZipKjrRiS",
-          "y": "AGKn9ylzoSLh7mjNRC1DOFoSCufRlSOno33Z-k2bEo4q40mjXlqDJ_-W-KE4oTSv36RuW0pIJA3BmlwvC3OW_FYk"
+          "x": "AaAakBLAUTS0oFoLYzLLIchfadY6mID67wW2u2BIziXsMCcyxV76QiJLnek6jKbNVpmFQAZqGS2oRLrgYlbmbUKt",
+          "y": "AAtFSxIMMBJtC2GjbwXiO4X74SFMWlbVW7KmLfcz15rwCL4NrT-jsRMCnnqPWfFA855prkhlTjT5XXPhUXMKo3uW"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984596,
-          "exp": 1646521196,
-          "created": 1614985196,
-          "updated": 1614985196,
+          "nbf": 1617848356,
+          "exp": 1649384956,
+          "created": 1617848956,
+          "updated": 1617848956,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -712,7 +541,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "2135403794"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-521)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignLocalVerifyRemote(application%x-pkcs12,P-521)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/108975857/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/108975857/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-9833abfa7dd9eb40a77da1d88966357c-fe907982bcd0114f-00",
+        "traceparent": "00-aac069e599b4c142a7df6d6207fa6ffd-45f8737bbd53164c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "7fe5a3bf10af8ee58d28c26549f86179",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7fe5a3bf10af8ee58d28c26549f86179",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ce8bc4de-8eef-4aa8-8ba8-c9e383486d9a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ec833533-52bb-4ab7-9f33-633e80071cd2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/108975857/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/108975857/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-9833abfa7dd9eb40a77da1d88966357c-fe907982bcd0114f-00",
+        "traceparent": "00-aac069e599b4c142a7df6d6207fa6ffd-45f8737bbd53164c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "7fe5a3bf10af8ee58d28c26549f86179",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:31 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending?api-version=7.2\u0026request_id=0674911e82cf4366aad7ac3e98873953",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/108975857/pending?api-version=7.2\u0026request_id=a2989c65343b41f18dace1d31dddd3cb",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7fe5a3bf10af8ee58d28c26549f86179",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "cb1f58f9-9586-4c41-acfc-1b81a222b37d",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "43066f10-c544-420b-8cc1-3f1a9fbf591a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/108975857/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGuTYDlw\u002BHY4Fn64fk4LWlB6uy4fL1FshXWd1YhRxR52qdvROOu8n9b\u002B3ryUmHCTd\u002BGjZGzeOmLm2GddZLydd/TuAFkbd52Sj48KV0fHxsDVy6po8c6YHls3txfoMBffsvbp7gNDLGypI1Mxe2sLN3Q42NMKXLv7j0gt\u002Bx/RykOxV\u002BWZoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBHOGniUe3pw18y7o26IIigKJ96e0ZVvt3Comjneelty\u002BMEhakPTguWS2rFMfpMQkWlDsAbevK/NKvs4aWID0TnZwCQgCh0rccoWoIWoDyGGdrqkRx/IZUfaXEpGEKxbZE13dDY\u002BLpN9HccEwm5izZ1N2pFUnvLg1ppVxOuMeVnbSlMQ7oLQ==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAJruz3\u002BkIPy11UnWi7cgl56Xr71RALk/Hem/F0u3lzmK5Kby602PwQbJEgE/qr8tgvc787nZypKEVD5mF2nIIlWDAc1TfPYhWpHuFSX61UWW9Zp9o2iwxSPgJ\u002BAqc2IPDXaleLuIuI8hyXaS0xs/3KTwuXwcn5lpTOLQzwat3MnzXNgzoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB7tghvjtvePO4xP\u002BaCWj9\u002BDmhuRERICuKdj0M5zz9NB9sASr/Nxh4lDafjfLl3nYRSDmBCoSE31Y9WIr6bsjIGOsCQgGxafkm2WqpIImEVdlc1gtpIBSfnlusUUJk1csuiDuLFpEUWwLuBcW2Lb3iqqWBxVXmoFjTBTdliPsmhS8wJlhP6g==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "0674911e82cf4366aad7ac3e98873953"
+        "request_id": "a2989c65343b41f18dace1d31dddd3cb"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/108975857/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "0d2af82508c3224b2a0eaa354de59e4e",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:40 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:31 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0d2af82508c3224b2a0eaa354de59e4e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "502bf966-b29f-436d-8d05-3bc97f93ef15",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1322e92f-84eb-420a-9cf9-23a0b093febe",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/108975857/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGuTYDlw\u002BHY4Fn64fk4LWlB6uy4fL1FshXWd1YhRxR52qdvROOu8n9b\u002B3ryUmHCTd\u002BGjZGzeOmLm2GddZLydd/TuAFkbd52Sj48KV0fHxsDVy6po8c6YHls3txfoMBffsvbp7gNDLGypI1Mxe2sLN3Q42NMKXLv7j0gt\u002Bx/RykOxV\u002BWZoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBHOGniUe3pw18y7o26IIigKJ96e0ZVvt3Comjneelty\u002BMEhakPTguWS2rFMfpMQkWlDsAbevK/NKvs4aWID0TnZwCQgCh0rccoWoIWoDyGGdrqkRx/IZUfaXEpGEKxbZE13dDY\u002BLpN9HccEwm5izZ1N2pFUnvLg1ppVxOuMeVnbSlMQ7oLQ==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAJruz3\u002BkIPy11UnWi7cgl56Xr71RALk/Hem/F0u3lzmK5Kby602PwQbJEgE/qr8tgvc787nZypKEVD5mF2nIIlWDAc1TfPYhWpHuFSX61UWW9Zp9o2iwxSPgJ\u002BAqc2IPDXaleLuIuI8hyXaS0xs/3KTwuXwcn5lpTOLQzwat3MnzXNgzoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB7tghvjtvePO4xP\u002BaCWj9\u002BDmhuRERICuKdj0M5zz9NB9sASr/Nxh4lDafjfLl3nYRSDmBCoSE31Y9WIr6bsjIGOsCQgGxafkm2WqpIImEVdlc1gtpIBSfnlusUUJk1csuiDuLFpEUWwLuBcW2Lb3iqqWBxVXmoFjTBTdliPsmhS8wJlhP6g==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "0674911e82cf4366aad7ac3e98873953"
+        "request_id": "a2989c65343b41f18dace1d31dddd3cb"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/108975857/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "71390fa2348d802ddbb763ff60094b6f",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:44 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "71390fa2348d802ddbb763ff60094b6f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "76510983-54d0-4cc9-8c31-7a0785359220",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "81cc3170-cf51-4354-8742-50f55c0b3cdf",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/108975857/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGuTYDlw\u002BHY4Fn64fk4LWlB6uy4fL1FshXWd1YhRxR52qdvROOu8n9b\u002B3ryUmHCTd\u002BGjZGzeOmLm2GddZLydd/TuAFkbd52Sj48KV0fHxsDVy6po8c6YHls3txfoMBffsvbp7gNDLGypI1Mxe2sLN3Q42NMKXLv7j0gt\u002Bx/RykOxV\u002BWZoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBHOGniUe3pw18y7o26IIigKJ96e0ZVvt3Comjneelty\u002BMEhakPTguWS2rFMfpMQkWlDsAbevK/NKvs4aWID0TnZwCQgCh0rccoWoIWoDyGGdrqkRx/IZUfaXEpGEKxbZE13dDY\u002BLpN9HccEwm5izZ1N2pFUnvLg1ppVxOuMeVnbSlMQ7oLQ==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAJruz3\u002BkIPy11UnWi7cgl56Xr71RALk/Hem/F0u3lzmK5Kby602PwQbJEgE/qr8tgvc787nZypKEVD5mF2nIIlWDAc1TfPYhWpHuFSX61UWW9Zp9o2iwxSPgJ\u002BAqc2IPDXaleLuIuI8hyXaS0xs/3KTwuXwcn5lpTOLQzwat3MnzXNgzoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB7tghvjtvePO4xP\u002BaCWj9\u002BDmhuRERICuKdj0M5zz9NB9sASr/Nxh4lDafjfLl3nYRSDmBCoSE31Y9WIr6bsjIGOsCQgGxafkm2WqpIImEVdlc1gtpIBSfnlusUUJk1csuiDuLFpEUWwLuBcW2Lb3iqqWBxVXmoFjTBTdliPsmhS8wJlhP6g==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "0674911e82cf4366aad7ac3e98873953"
+        "request_id": "a2989c65343b41f18dace1d31dddd3cb"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/108975857/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "9468008e8950b62d57c254a166af41a7",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "847",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:50 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9468008e8950b62d57c254a166af41a7",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "68326c58-2135-4b57-b181-656b5d040078",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "70bcbf8c-0154-44f5-9c2f-5c7cf7c755af",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/108975857/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGuTYDlw\u002BHY4Fn64fk4LWlB6uy4fL1FshXWd1YhRxR52qdvROOu8n9b\u002B3ryUmHCTd\u002BGjZGzeOmLm2GddZLydd/TuAFkbd52Sj48KV0fHxsDVy6po8c6YHls3txfoMBffsvbp7gNDLGypI1Mxe2sLN3Q42NMKXLv7j0gt\u002Bx/RykOxV\u002BWZoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBHOGniUe3pw18y7o26IIigKJ96e0ZVvt3Comjneelty\u002BMEhakPTguWS2rFMfpMQkWlDsAbevK/NKvs4aWID0TnZwCQgCh0rccoWoIWoDyGGdrqkRx/IZUfaXEpGEKxbZE13dDY\u002BLpN9HccEwm5izZ1N2pFUnvLg1ppVxOuMeVnbSlMQ7oLQ==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAJruz3\u002BkIPy11UnWi7cgl56Xr71RALk/Hem/F0u3lzmK5Kby602PwQbJEgE/qr8tgvc787nZypKEVD5mF2nIIlWDAc1TfPYhWpHuFSX61UWW9Zp9o2iwxSPgJ\u002BAqc2IPDXaleLuIuI8hyXaS0xs/3KTwuXwcn5lpTOLQzwat3MnzXNgzoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB7tghvjtvePO4xP\u002BaCWj9\u002BDmhuRERICuKdj0M5zz9NB9sASr/Nxh4lDafjfLl3nYRSDmBCoSE31Y9WIr6bsjIGOsCQgGxafkm2WqpIImEVdlc1gtpIBSfnlusUUJk1csuiDuLFpEUWwLuBcW2Lb3iqqWBxVXmoFjTBTdliPsmhS8wJlhP6g==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "0674911e82cf4366aad7ac3e98873953"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/108975857",
+        "request_id": "a2989c65343b41f18dace1d31dddd3cb"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/108975857?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "3ac27489f0bef0ebcaaa320ca54cc120",
         "x-ms-return-client-request-id": "true"
@@ -256,211 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "1931",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:09:55 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "cf09f64f-f478-4bde-8dcf-1964cfbd535b",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGuTYDlw\u002BHY4Fn64fk4LWlB6uy4fL1FshXWd1YhRxR52qdvROOu8n9b\u002B3ryUmHCTd\u002BGjZGzeOmLm2GddZLydd/TuAFkbd52Sj48KV0fHxsDVy6po8c6YHls3txfoMBffsvbp7gNDLGypI1Mxe2sLN3Q42NMKXLv7j0gt\u002Bx/RykOxV\u002BWZoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBHOGniUe3pw18y7o26IIigKJ96e0ZVvt3Comjneelty\u002BMEhakPTguWS2rFMfpMQkWlDsAbevK/NKvs4aWID0TnZwCQgCh0rccoWoIWoDyGGdrqkRx/IZUfaXEpGEKxbZE13dDY\u002BLpN9HccEwm5izZ1N2pFUnvLg1ppVxOuMeVnbSlMQ7oLQ==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "0674911e82cf4366aad7ac3e98873953"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "4ca63ac2097c19fee18219cadf8b192b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "941",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ceb716c8-56eb-41e5-8e51-37e056471c4c",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGuTYDlw\u002BHY4Fn64fk4LWlB6uy4fL1FshXWd1YhRxR52qdvROOu8n9b\u002B3ryUmHCTd\u002BGjZGzeOmLm2GddZLydd/TuAFkbd52Sj48KV0fHxsDVy6po8c6YHls3txfoMBffsvbp7gNDLGypI1Mxe2sLN3Q42NMKXLv7j0gt\u002Bx/RykOxV\u002BWZoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBHOGniUe3pw18y7o26IIigKJ96e0ZVvt3Comjneelty\u002BMEhakPTguWS2rFMfpMQkWlDsAbevK/NKvs4aWID0TnZwCQgCh0rccoWoIWoDyGGdrqkRx/IZUfaXEpGEKxbZE13dDY\u002BLpN9HccEwm5izZ1N2pFUnvLg1ppVxOuMeVnbSlMQ7oLQ==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "0674911e82cf4366aad7ac3e98873953"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ec75bb7511479eb11477caa55721110b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "941",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9e04634f-2bbf-40c0-89e5-ee43aa8044b9",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGuTYDlw\u002BHY4Fn64fk4LWlB6uy4fL1FshXWd1YhRxR52qdvROOu8n9b\u002B3ryUmHCTd\u002BGjZGzeOmLm2GddZLydd/TuAFkbd52Sj48KV0fHxsDVy6po8c6YHls3txfoMBffsvbp7gNDLGypI1Mxe2sLN3Q42NMKXLv7j0gt\u002Bx/RykOxV\u002BWZoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBHOGniUe3pw18y7o26IIigKJ96e0ZVvt3Comjneelty\u002BMEhakPTguWS2rFMfpMQkWlDsAbevK/NKvs4aWID0TnZwCQgCh0rccoWoIWoDyGGdrqkRx/IZUfaXEpGEKxbZE13dDY\u002BLpN9HccEwm5izZ1N2pFUnvLg1ppVxOuMeVnbSlMQ7oLQ==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "0674911e82cf4366aad7ac3e98873953"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "2bdf3301f4097f2a75a9583cd620113e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "849",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3ac27489f0bef0ebcaaa320ca54cc120",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5d628412-82ab-4af5-9f13-488357dfb1cb",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "0c0c3262-60af-46b9-b044-166795e89406",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGuTYDlw\u002BHY4Fn64fk4LWlB6uy4fL1FshXWd1YhRxR52qdvROOu8n9b\u002B3ryUmHCTd\u002BGjZGzeOmLm2GddZLydd/TuAFkbd52Sj48KV0fHxsDVy6po8c6YHls3txfoMBffsvbp7gNDLGypI1Mxe2sLN3Q42NMKXLv7j0gt\u002Bx/RykOxV\u002BWZoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBHOGniUe3pw18y7o26IIigKJ96e0ZVvt3Comjneelty\u002BMEhakPTguWS2rFMfpMQkWlDsAbevK/NKvs4aWID0TnZwCQgCh0rccoWoIWoDyGGdrqkRx/IZUfaXEpGEKxbZE13dDY\u002BLpN9HccEwm5izZ1N2pFUnvLg1ppVxOuMeVnbSlMQ7oLQ==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/108975857",
-        "request_id": "0674911e82cf4366aad7ac3e98873953"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/108975857?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "e9960690d4d6b1d9890838043f59c2bf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1936",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "d3fae9c8-1443-40d7-b008-dfa011288409",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/af657969080c4844ae255117921086be",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/108975857/af657969080c4844ae255117921086be",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/108975857/af657969080c4844ae255117921086be",
-        "x5t": "pCPI4nH0ytbZhkNvCsv94_55Pg4",
-        "cer": "MIICJTCCAYagAwIBAgIPeao3HL5ANpzg3o4suaSlMAoGCCqGSM49BAMEMBIxEDAOBgNVBAMTB2RlZmF1bHQwHhcNMjEwMzA1MjMwMDA5WhcNMjIwMzA1MjMxMDA5WjASMRAwDgYDVQQDEwdkZWZhdWx0MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAa5NgOXD4djgWfrh\u002BTgtaUHq7Lh8vUWyFdZ3ViFHFHnap29E467yf1v7evJSYcJN34aNkbN46YubYZ11kvJ139O4AWRt3nZKPjwpXR8fGwNXLqmjxzpgeWze3F\u002BgwF9\u002By9unuA0MsbKkjUzF7aws3dDjY0wpcu/uPSC37H9HKQ7FX5ZmjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBRFIT\u002BpQRWfcFLqiVKtgI9UiRselzAdBgNVHQ4EFgQURSE/qUEVn3BS6olSrYCPVIkbHpcwCgYIKoZIzj0EAwQDgYwAMIGIAkIByMxJMsMe\u002BCNbuPrmQGzMdCPpiR9/Jt6klfHUkyNNEt44Nt\u002BWD/fNqwcXgPcKUOvSAks7T/xQv48OOEhjtdrdXAMCQgEb8lAJuAbre1zqZ7gJApVaE4NVbFdI9UdfZ1F6NyMEuB8Ro0tsDxY\u002BqrzDNJjNj2oQv4\u002B32Pzvx5sYaPYYpbP2sw==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/108975857/30eb01caf4db4ea687926cae6a564452",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/108975857/30eb01caf4db4ea687926cae6a564452",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/108975857/30eb01caf4db4ea687926cae6a564452",
+        "x5t": "N7g97L7lhInGSFM_WE3YZfMsGcg",
+        "cer": "MIICJjCCAYegAwIBAgIQENCwutgGQ0aXQdRf4iv58TAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjM0MVoXDTIyMDQwODAyMzM0MVowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAJruz3\u002BkIPy11UnWi7cgl56Xr71RALk/Hem/F0u3lzmK5Kby602PwQbJEgE/qr8tgvc787nZypKEVD5mF2nIIlWDAc1TfPYhWpHuFSX61UWW9Zp9o2iwxSPgJ\u002BAqc2IPDXaleLuIuI8hyXaS0xs/3KTwuXwcn5lpTOLQzwat3MnzXNgzo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUDebYFMSijs8oLtN901I5m3adBOkwHQYDVR0OBBYEFA3m2BTEoo7PKC7TfdNSOZt2nQTpMAoGCCqGSM49BAMEA4GMADCBiAJCAW2XBM9gtbNSRWLl7qlKclpo1jqrkLG4LytKLdNUMS/WITGkNO5sxvtJKutsi8cfSfuy2LC7H7mgRictjlBPcJWUAkIBQGxgLgsEWR8t52n1aVCHCRF9RuuhW\u002BcWeac4Xs2SdH8rHVVxeef/xIxnHSapzXlHuf7plh8OWoJy7O0CAukqss4=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985209,
-          "exp": 1646521809,
-          "created": 1614985809,
-          "updated": 1614985809,
+          "nbf": 1617848621,
+          "exp": 1649385221,
+          "created": 1617849221,
+          "updated": 1617849221,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/108975857/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -500,166 +330,209 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985780,
-            "updated": 1614985780
+            "created": 1617849211,
+            "updated": 1617849211
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/108975857/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/108975857/af657969080c4844ae255117921086be?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/108975857/30eb01caf4db4ea687926cae6a564452?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-66fbf3677320dd4caad45ffef2b10643-b0ebeadf5c9b7547-00",
+        "traceparent": "00-7bf6ec068605414d97183d355fabcc57-923df5d46447ff43-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "acc90d70edac802291f6779db874c7f4",
+        "x-ms-client-request-id": "4ca63ac2097c19fee18219cadf8b192b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1341",
+        "Content-Length": "1340",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4ca63ac2097c19fee18219cadf8b192b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e6c022e4-0a5d-40ac-95f9-3272aa5bd474",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "e2b05a3b-b924-467a-9708-531589885d9f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/108975857/af657969080c4844ae255117921086be",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/108975857/af657969080c4844ae255117921086be",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/108975857/af657969080c4844ae255117921086be",
-        "x5t": "pCPI4nH0ytbZhkNvCsv94_55Pg4",
-        "cer": "MIICJTCCAYagAwIBAgIPeao3HL5ANpzg3o4suaSlMAoGCCqGSM49BAMEMBIxEDAOBgNVBAMTB2RlZmF1bHQwHhcNMjEwMzA1MjMwMDA5WhcNMjIwMzA1MjMxMDA5WjASMRAwDgYDVQQDEwdkZWZhdWx0MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAa5NgOXD4djgWfrh\u002BTgtaUHq7Lh8vUWyFdZ3ViFHFHnap29E467yf1v7evJSYcJN34aNkbN46YubYZ11kvJ139O4AWRt3nZKPjwpXR8fGwNXLqmjxzpgeWze3F\u002BgwF9\u002By9unuA0MsbKkjUzF7aws3dDjY0wpcu/uPSC37H9HKQ7FX5ZmjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBRFIT\u002BpQRWfcFLqiVKtgI9UiRselzAdBgNVHQ4EFgQURSE/qUEVn3BS6olSrYCPVIkbHpcwCgYIKoZIzj0EAwQDgYwAMIGIAkIByMxJMsMe\u002BCNbuPrmQGzMdCPpiR9/Jt6klfHUkyNNEt44Nt\u002BWD/fNqwcXgPcKUOvSAks7T/xQv48OOEhjtdrdXAMCQgEb8lAJuAbre1zqZ7gJApVaE4NVbFdI9UdfZ1F6NyMEuB8Ro0tsDxY\u002BqrzDNJjNj2oQv4\u002B32Pzvx5sYaPYYpbP2sw==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/108975857/30eb01caf4db4ea687926cae6a564452",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/108975857/30eb01caf4db4ea687926cae6a564452",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/108975857/30eb01caf4db4ea687926cae6a564452",
+        "x5t": "N7g97L7lhInGSFM_WE3YZfMsGcg",
+        "cer": "MIICJjCCAYegAwIBAgIQENCwutgGQ0aXQdRf4iv58TAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjM0MVoXDTIyMDQwODAyMzM0MVowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAJruz3\u002BkIPy11UnWi7cgl56Xr71RALk/Hem/F0u3lzmK5Kby602PwQbJEgE/qr8tgvc787nZypKEVD5mF2nIIlWDAc1TfPYhWpHuFSX61UWW9Zp9o2iwxSPgJ\u002BAqc2IPDXaleLuIuI8hyXaS0xs/3KTwuXwcn5lpTOLQzwat3MnzXNgzo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUDebYFMSijs8oLtN901I5m3adBOkwHQYDVR0OBBYEFA3m2BTEoo7PKC7TfdNSOZt2nQTpMAoGCCqGSM49BAMEA4GMADCBiAJCAW2XBM9gtbNSRWLl7qlKclpo1jqrkLG4LytKLdNUMS/WITGkNO5sxvtJKutsi8cfSfuy2LC7H7mgRictjlBPcJWUAkIBQGxgLgsEWR8t52n1aVCHCRF9RuuhW\u002BcWeac4Xs2SdH8rHVVxeef/xIxnHSapzXlHuf7plh8OWoJy7O0CAukqss4=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985209,
-          "exp": 1646521809,
-          "created": 1614985809,
-          "updated": 1614985809,
+          "nbf": 1617848621,
+          "exp": 1649385221,
+          "created": 1617849221,
+          "updated": 1617849221,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "79AA371CBE40369CE0DE8E2CB9A4A5"
+        "serialnumber": "10D0B0BAD80643469741D45FE22BF9F1"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/108975857/af657969080c4844ae255117921086be?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/108975857/30eb01caf4db4ea687926cae6a564452?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-66fbf3677320dd4caad45ffef2b10643-0262910d86092441-00",
+        "traceparent": "00-7bf6ec068605414d97183d355fabcc57-92e8f828d7487244-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "50148b66288b2c355a2da200bc25401c",
+        "x-ms-client-request-id": "ec75bb7511479eb11477caa55721110b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2127",
+        "Content-Length": "2125",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ec75bb7511479eb11477caa55721110b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6c963f13-8190-4a31-b280-9fbb32fcfebd",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "c75e96b0-2ee0-4115-8ed0-2a5618667c80",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIE\u002BgIBAzCCBLYGCSqGSIb3DQEHAaCCBKcEggSjMIIEnzCCAdgGCSqGSIb3DQEHAaCCAckEggHFMIIBwTCCAb0GCyqGSIb3DQEMCgECoIIBNjCCATIwHAYKKoZIhvcNAQwBAzAOBAiY8wk5J/DYNwICB9AEggEQcQ36fBZkQY27csTXSoumOLHcJEP7TTlq/5HN7PxHtduJTB5rrNaQqtAC4IVm6aWpHKvRGC1f/pvuQSR0oTECLDj4KVZRM7Q\u002BHO\u002B4\u002Bg0fp2FiigPOgh/evIyPpt2L8W8qK58eTm5NinnblYw6znRknOaWGGYzn938vD2PqKQe6/UUL4fkss3c/T1o\u002BEHmBTUrp3Oit2edkBJ8ym33JimfXQXcXJml0ogMXL8VZZkG5mxBxcJmJ4zRA5sEjLU4UjhdU\u002BW4Na8O9piKz4Ar\u002BZbp3k5VG7sjYZCCYvn54\u002B9pbv2BgRif4hGKJJqoS5Kg1Wk2qGI92eq0iolEAdQ46x/hHN\u002BbuQwPeG2H14iRLOVP\u002BZAxdDATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEEAYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwBvAGYAdAB3AGEAcgBlACAASwBlAHkAIABTAHQAbwByAGEAZwBlACAAUAByAG8AdgBpAGQAZQByMIICvwYJKoZIhvcNAQcGoIICsDCCAqwCAQAwggKlBgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBAzAOBAhZldIfBZKbWAICB9CAggJ4oeTv5\u002BWNdcaCVY9j\u002BRFtXnxTy5A5eliCY3JZi/1WKl4IJ6m3os3vyNXeOVmzzyGLS9jIdN5ibnXkyUMbbyRiOc6sG/BcRuUsC0QJ9Tr0OTF7fyuJBbJh14Cj/AftZGTO/iU6wPNPXI53mHe17sUkK7N0XkF0NJ0YWJczEk0HNKNt\u002BEwc\u002Bm\u002B/QX0V7mDZmVsZMjZc6sXxh\u002BlgiXu4XZMwkkeI4M4py\u002BwgxUO8lGqSTLSSiey7gxOmk4fYfjZoVhM2OpBn1SyQ5EGHJZzSCp9jTcvwW7UYunN\u002B\u002Bhw\u002B/O3x3wMUCZIMx/wLMrnoJuGOv8kAsFS3qxjt/BweL3GZPF/IXalGUBhbjfnQnJoxHviBc3YlJL3EjBqpYxKKWeVW4ihr7jH8tXsgJQegnuwrJCx1ZxJ9mlpWBo5nKdKG5aZvLn8rl0XCddp7saM//EThVuDB3ZNJBhQOYR5P/v5Y6RRxR2HFJvd11L5G2GIHFaSe9/d8CUPEw9/Y3HajSzAeDKw/QMVjrEP/l0A3HK7kFzW0VzXdBONmWqQtXgZX13dXX4i8MVf8yqv7ECjgBllc0qagyU1F8getbXK2m\u002BD0froTe4bex3jf0Yp5yp6L20NHnx0XdPat7iCKtGMqXKROB7eqy/ch6BldZ1PYuWPVFy4zLNnd9F7wGFn6eIQgIKsThZWDE0l9T7SkAUTaMi4fC2mKSOtpPE1RsBcVyCdESQx6Sz3rGlAbGLe7gNb44QoUMGG48nPV05HFK52Q8VTNPxPpDwbaIxz66xHX3ZQWky9ITQqOd36k7Uj\u002BKxaEBonA4BzQFACjfuayty\u002BndlDtNn8AEpSwHvufJPgwOzAfMAcGBSsOAwIaBBRy8sD00ksTgAAXjMDWZA/8Ms2HbgQUN8No9WPp6dOK9hBSrVo\u002BV08/QLMCAgfQ",
+        "value": "MIIE\u002BgIBAzCCBLYGCSqGSIb3DQEHAaCCBKcEggSjMIIEnzCCAdgGCSqGSIb3DQEHAaCCAckEggHFMIIBwTCCAb0GCyqGSIb3DQEMCgECoIIBNjCCATIwHAYKKoZIhvcNAQwBAzAOBAg7Okf\u002BYsCoKwICB9AEggEQ3yC6WJ/vv2kecn1s\u002BeaxQNRYNHhlf31QQUq38CbTnOOhnifIBE/K7fpwLkMM0t0TOvPdNWQF8MEeFaANYygCMI4s9zAhMK3L03QxY2cWh6XhqI0Az0pOCY2DaPM17hXKEqTTOSsxtnaQIxXGOyrehL6Tze7HkM4bdr42E\u002BCBsipK5pPKIQOa8EyRf2\u002BM\u002BSY0YL5Fi6ZuVdXfvkny5GYP8FLLtS3l\u002BDYCNnFk7hIE6\u002BFuMk7DRM4WPaBF\u002BxfqGGDgPvvvICtrWO0qOJepLRaBLpuY1kWK58eX37DTl7oWnehW1F6nXmPKvULpQAitXO6oymiXpPHiem5HPtTc7fCbrCrm/iQoFfrcaf436hcOajwxdDATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEEAYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwBvAGYAdAB3AGEAcgBlACAASwBlAHkAIABTAHQAbwByAGEAZwBlACAAUAByAG8AdgBpAGQAZQByMIICvwYJKoZIhvcNAQcGoIICsDCCAqwCAQAwggKlBgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBAzAOBAh0AsErxSaa7AICB9CAggJ4i9NEvGNiBq0WDZFh0rHasJvElxg67VNkgTTIpvr\u002BZMCYGOwumDFDeQyw/\u002BWBrFof1q3PNsSdy1gnKIdI14WMV2wjE0uup6oJY5DbeF5YL9Q3Awq\u002BeOxmXrzWeIqgOtF8yC4v7fRHpBcIBjtvaAlgwp5CpUH2l3rgou20X/7cctHvXVDzus9TyqyEwzJsVk\u002BatubzVCdsTBqFdkk9JUS7EUDVw2L2Um2U7cnlIksqgDDqeil/4cXLXMMTpM3PfVD39xl6wi7FGvTg\u002B6jXZGxhFfV3cPN9DoA8AnmVldt/K\u002B9YQHgmEiQFPd4ic2XxtSYsuWeF67mdq/Pjah571qWbOC85kuv4DDn13tEMujksQiy2AjfmstqlYWM38LwvrDLXOkAgBEtVuVvil2/lSECZkHc7YGBeRZIJeJDPYQ1MBoHRzUA8clv4pHXe0cDeY0BNB07jApivJaqvkPY/h11FHOD8oSn1hj99oIfW\u002Bus0icAZ\u002BJBpcpOWboTxLWqPjNrw/RAXnpA/AXQ0p2vkD1weewj4TzEOE9rhIzwSEBkGaNWFc649gUloFdn/SjSW48L451PXAuX6MZIzshsYsJDXB/RtIjpzuxcDdygLabM\u002BoJzAZMhV3OAA0QYKiwrYMt0jwOrrpMLQw31q2hVlCG0U1ydZwBusbCOF1A09pdfZ1zISyIGKTAOy\u002B1B/PGt69heB\u002B3on28JFPK2Dyua3VqLc4URN0a/5ifof19ZkFWJDZCr1IQnM6/PS7NvDbK6\u002B\u002BwZxDA/wM0Gz95YkdB/5jOZIydrGVbq/LaoU959H3jasoQ4JVLrnBJ8oGkukjQYA4JZn4Bcn1\u002B7xODMwOzAfMAcGBSsOAwIaBBRYC2PDIry43Ivm2eOReHsuC9u8fAQUrKqdaG2XaX5iAN3XK7yD6BQnlnkCAgfQ",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/108975857/af657969080c4844ae255117921086be",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/108975857/30eb01caf4db4ea687926cae6a564452",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985209,
-          "exp": 1646521809,
-          "created": 1614985809,
-          "updated": 1614985809,
+          "nbf": 1617848621,
+          "exp": 1649385221,
+          "created": 1617849221,
+          "updated": 1617849221,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/108975857/af657969080c4844ae255117921086be"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/108975857/30eb01caf4db4ea687926cae6a564452"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/108975857/af657969080c4844ae255117921086be?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/108975857/30eb01caf4db4ea687926cae6a564452?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-f301b55ef0424a4ea82792ee29899c19-b97b72e6b086da47-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "2bdf3301f4097f2a75a9583cd620113e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:33:42 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2bdf3301f4097f2a75a9583cd620113e",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b742493d-5213-4a96-890f-1098212e4708",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/108975857/30eb01caf4db4ea687926cae6a564452?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-43b180a8c18f1a48844d71688cb825c2-3ee47791098bf647-00",
+        "traceparent": "00-f301b55ef0424a4ea82792ee29899c19-b97b72e6b086da47-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "c8cb98e76556a292e31557df5d3bf814",
+        "x-ms-client-request-id": "2bdf3301f4097f2a75a9583cd620113e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "529",
+        "Content-Length": "528",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:10:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:33:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2bdf3301f4097f2a75a9583cd620113e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "cc17cde2-b36e-4a67-a037-db6d4cb62975",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "647e554f-1c6c-4e16-9df4-560036242745",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/108975857/af657969080c4844ae255117921086be",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/108975857/30eb01caf4db4ea687926cae6a564452",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-521",
-          "x": "AGuTYDlw-HY4Fn64fk4LWlB6uy4fL1FshXWd1YhRxR52qdvROOu8n9b-3ryUmHCTd-GjZGzeOmLm2GddZLydd_Tu",
-          "y": "AFkbd52Sj48KV0fHxsDVy6po8c6YHls3txfoMBffsvbp7gNDLGypI1Mxe2sLN3Q42NMKXLv7j0gt-x_RykOxV-WZ"
+          "x": "AJruz3-kIPy11UnWi7cgl56Xr71RALk_Hem_F0u3lzmK5Kby602PwQbJEgE_qr8tgvc787nZypKEVD5mF2nIIlWD",
+          "y": "Ac1TfPYhWpHuFSX61UWW9Zp9o2iwxSPgJ-Aqc2IPDXaleLuIuI8hyXaS0xs_3KTwuXwcn5lpTOLQzwat3MnzXNgz"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985209,
-          "exp": 1646521809,
-          "created": 1614985809,
-          "updated": 1614985809,
+          "nbf": 1617848621,
+          "exp": 1649385221,
+          "created": 1617849221,
+          "updated": 1617849221,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -668,7 +541,7 @@
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "445567774"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-256).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-256).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/957650110/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/957650110/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-ff5b9306a8912a45879fd0e3486556f1-a8f4b160c507d441-00",
+        "traceparent": "00-18bfe7f5b978984fa4542a1b4a5a1f8f-3e608d1fd9f86846-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "9af185eae5ad6fc2c43835376816fe56",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:41 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9af185eae5ad6fc2c43835376816fe56",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "67493398-56e6-4998-907d-e0fb1a83d49b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d3099013-b53b-4d53-9106-291feaf2864d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/957650110/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/957650110/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-ff5b9306a8912a45879fd0e3486556f1-a8f4b160c507d441-00",
+        "traceparent": "00-18bfe7f5b978984fa4542a1b4a5a1f8f-3e608d1fd9f86846-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "9af185eae5ad6fc2c43835376816fe56",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:41 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:21 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending?api-version=7.2\u0026request_id=3e9e779b45374c97b64f42eb097064c9",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending?api-version=7.2\u0026request_id=0c9e3bc993af4a01b0f790e492b7f56f",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9af185eae5ad6fc2c43835376816fe56",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1837613d-6a00-41ab-8480-550b4be61893",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "7c2a5221-f636-4db5-914f-49c58f113341",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgYVTBWcegZnwgZGSmgsSYCiwXJO9ZsteXfF9x00b52OFyTLU2n/gNRrFRVk9iAEuVqMSDHR3tZZkErKiZe5J/KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIExsMfWCDwbUJ\u002Bqt804IaiHwlmOVYMjt3tyYfjXfRX5hAiEAxfnwjdVajvKKaVoD7tO1j/lRbgJkbWUPTNG\u002BSrC/ND4=",
+        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8vfvp/BLV48eYkcJw09cdWlBU49xoZ0yEPiQEGnMVn9bLLImGL/x8fmxRChvt/p5z61sXI2\u002Bww8Rv2j6T9p/iKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIERh6gPyCMKUXYc4Or78IwthIwUcME5Dy/28CKRmSNROAiAjXmZtZqXt67cmv0EMmwwDFU/yAVScasARXTZdL2QW8w==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3e9e779b45374c97b64f42eb097064c9"
+        "request_id": "0c9e3bc993af4a01b0f790e492b7f56f"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "2ca0e6ba41e70b5df3c8a97a26cebeb9",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:41 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2ca0e6ba41e70b5df3c8a97a26cebeb9",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3d9aeb7a-9741-4721-9c7b-635685d17718",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ccc33809-85fa-4c55-a1fa-3a7bbf48963e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgYVTBWcegZnwgZGSmgsSYCiwXJO9ZsteXfF9x00b52OFyTLU2n/gNRrFRVk9iAEuVqMSDHR3tZZkErKiZe5J/KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIExsMfWCDwbUJ\u002Bqt804IaiHwlmOVYMjt3tyYfjXfRX5hAiEAxfnwjdVajvKKaVoD7tO1j/lRbgJkbWUPTNG\u002BSrC/ND4=",
+        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8vfvp/BLV48eYkcJw09cdWlBU49xoZ0yEPiQEGnMVn9bLLImGL/x8fmxRChvt/p5z61sXI2\u002Bww8Rv2j6T9p/iKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIERh6gPyCMKUXYc4Or78IwthIwUcME5Dy/28CKRmSNROAiAjXmZtZqXt67cmv0EMmwwDFU/yAVScasARXTZdL2QW8w==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3e9e779b45374c97b64f42eb097064c9"
+        "request_id": "0c9e3bc993af4a01b0f790e492b7f56f"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "0de7fdea1897c8d85faf8921fbabe905",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:46 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:27 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0de7fdea1897c8d85faf8921fbabe905",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0ad72cae-39d2-41f6-941c-86514424755e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "cabbf83b-fbae-4844-a2d5-4b2f75a8a963",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgYVTBWcegZnwgZGSmgsSYCiwXJO9ZsteXfF9x00b52OFyTLU2n/gNRrFRVk9iAEuVqMSDHR3tZZkErKiZe5J/KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIExsMfWCDwbUJ\u002Bqt804IaiHwlmOVYMjt3tyYfjXfRX5hAiEAxfnwjdVajvKKaVoD7tO1j/lRbgJkbWUPTNG\u002BSrC/ND4=",
+        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8vfvp/BLV48eYkcJw09cdWlBU49xoZ0yEPiQEGnMVn9bLLImGL/x8fmxRChvt/p5z61sXI2\u002Bww8Rv2j6T9p/iKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIERh6gPyCMKUXYc4Or78IwthIwUcME5Dy/28CKRmSNROAiAjXmZtZqXt67cmv0EMmwwDFU/yAVScasARXTZdL2QW8w==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3e9e779b45374c97b64f42eb097064c9"
+        "request_id": "0c9e3bc993af4a01b0f790e492b7f56f"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "95973d503e74a9d727e5a7e43b4848f6",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:52 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:31 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "95973d503e74a9d727e5a7e43b4848f6",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "17ee7a07-664e-4eb3-b5db-1beb3662406b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "aa58396d-97d0-4b0b-9a69-784cd767d6ed",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgYVTBWcegZnwgZGSmgsSYCiwXJO9ZsteXfF9x00b52OFyTLU2n/gNRrFRVk9iAEuVqMSDHR3tZZkErKiZe5J/KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIExsMfWCDwbUJ\u002Bqt804IaiHwlmOVYMjt3tyYfjXfRX5hAiEAxfnwjdVajvKKaVoD7tO1j/lRbgJkbWUPTNG\u002BSrC/ND4=",
+        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8vfvp/BLV48eYkcJw09cdWlBU49xoZ0yEPiQEGnMVn9bLLImGL/x8fmxRChvt/p5z61sXI2\u002Bww8Rv2j6T9p/iKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIERh6gPyCMKUXYc4Or78IwthIwUcME5Dy/28CKRmSNROAiAjXmZtZqXt67cmv0EMmwwDFU/yAVScasARXTZdL2QW8w==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3e9e779b45374c97b64f42eb097064c9"
+        "request_id": "0c9e3bc993af4a01b0f790e492b7f56f"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "6a4c7c7af02fa1bf0dd8cc37b83c1047",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:57 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:36 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6a4c7c7af02fa1bf0dd8cc37b83c1047",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f825479a-a48d-4cbc-a4eb-8829e8f0ac9b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "937bc488-3ff4-4978-9fc4-1bceb770fbfb",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgYVTBWcegZnwgZGSmgsSYCiwXJO9ZsteXfF9x00b52OFyTLU2n/gNRrFRVk9iAEuVqMSDHR3tZZkErKiZe5J/KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIExsMfWCDwbUJ\u002Bqt804IaiHwlmOVYMjt3tyYfjXfRX5hAiEAxfnwjdVajvKKaVoD7tO1j/lRbgJkbWUPTNG\u002BSrC/ND4=",
+        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8vfvp/BLV48eYkcJw09cdWlBU49xoZ0yEPiQEGnMVn9bLLImGL/x8fmxRChvt/p5z61sXI2\u002Bww8Rv2j6T9p/iKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIERh6gPyCMKUXYc4Or78IwthIwUcME5Dy/28CKRmSNROAiAjXmZtZqXt67cmv0EMmwwDFU/yAVScasARXTZdL2QW8w==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3e9e779b45374c97b64f42eb097064c9"
+        "request_id": "0c9e3bc993af4a01b0f790e492b7f56f"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "e929a4df2836ac44253ee6b171f48c17",
         "x-ms-return-client-request-id": "true"
@@ -300,42 +306,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "663",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:02 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e929a4df2836ac44253ee6b171f48c17",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "8c8ddabc-97f6-43fc-b398-1ee4ef84b256",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a0bedb44-a865-4a17-aa3e-10b7cad5c95e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgYVTBWcegZnwgZGSmgsSYCiwXJO9ZsteXfF9x00b52OFyTLU2n/gNRrFRVk9iAEuVqMSDHR3tZZkErKiZe5J/KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIExsMfWCDwbUJ\u002Bqt804IaiHwlmOVYMjt3tyYfjXfRX5hAiEAxfnwjdVajvKKaVoD7tO1j/lRbgJkbWUPTNG\u002BSrC/ND4=",
+        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8vfvp/BLV48eYkcJw09cdWlBU49xoZ0yEPiQEGnMVn9bLLImGL/x8fmxRChvt/p5z61sXI2\u002Bww8Rv2j6T9p/iKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIERh6gPyCMKUXYc4Or78IwthIwUcME5Dy/28CKRmSNROAiAjXmZtZqXt67cmv0EMmwwDFU/yAVScasARXTZdL2QW8w==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3e9e779b45374c97b64f42eb097064c9"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/957650110",
+        "request_id": "0c9e3bc993af4a01b0f790e492b7f56f"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/957650110?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "7ea793667e5e5fd67df6889b71a0f1ea",
         "x-ms-return-client-request-id": "true"
@@ -344,123 +350,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "1753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:06 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e6d1d390-f87c-4044-9106-c2983ab1fcc2",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgYVTBWcegZnwgZGSmgsSYCiwXJO9ZsteXfF9x00b52OFyTLU2n/gNRrFRVk9iAEuVqMSDHR3tZZkErKiZe5J/KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIExsMfWCDwbUJ\u002Bqt804IaiHwlmOVYMjt3tyYfjXfRX5hAiEAxfnwjdVajvKKaVoD7tO1j/lRbgJkbWUPTNG\u002BSrC/ND4=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3e9e779b45374c97b64f42eb097064c9"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "97055fd55f1e51bf379f44f00a0d3019",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "665",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:12 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7ea793667e5e5fd67df6889b71a0f1ea",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7cb65b8c-3bc9-4630-b1fe-6fb07e04dfb1",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a4f6f9ff-5054-4ca2-a818-b2717cfe0023",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgYVTBWcegZnwgZGSmgsSYCiwXJO9ZsteXfF9x00b52OFyTLU2n/gNRrFRVk9iAEuVqMSDHR3tZZkErKiZe5J/KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIExsMfWCDwbUJ\u002Bqt804IaiHwlmOVYMjt3tyYfjXfRX5hAiEAxfnwjdVajvKKaVoD7tO1j/lRbgJkbWUPTNG\u002BSrC/ND4=",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/957650110",
-        "request_id": "3e9e779b45374c97b64f42eb097064c9"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/957650110?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "24d0b54c919561e8cdca6b409fa83b85",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1758",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4a010753-cbe1-4fe9-a6c8-353a7e7d0dcd",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/397406fd620e49ba9157a34960b8e08a",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/957650110/397406fd620e49ba9157a34960b8e08a",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/957650110/397406fd620e49ba9157a34960b8e08a",
-        "x5t": "VS5LbAEEZrqDgTZk2vRzQOePMG8",
-        "cer": "MIIBnjCCAUSgAwIBAgIQWywbTMb/QtSCQETRqmj3AzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTYwN1oXDTIyMDMwNTIzMDYwN1owEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIGFUwVnHoGZ8IGRkpoLEmAosFyTvWbLXl3xfcdNG\u002Bdjhcky1Np/4DUaxUVZPYgBLlajEgx0d7WWZBKyomXuSfyjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTc/rQeKauAosFEuLFHO4UKpm0QAjAdBgNVHQ4EFgQU3P60HimrgKLBRLixRzuFCqZtEAIwCgYIKoZIzj0EAwIDSAAwRQIhALIAWkCyg8S5Drm1B26mvhC1\u002BtSHr6AJPlJ9dQ1n0ZnnAiBEVC\u002BrGFZ2SiA7dn36mB7dVDr7B3THRXQNhIOuwBYdhg==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/957650110/a6cf53fb562848df83c961571e3786f3",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/957650110/a6cf53fb562848df83c961571e3786f3",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/957650110/a6cf53fb562848df83c961571e3786f3",
+        "x5t": "0IiEHo5SaJ_49iXLPgpfaILiSdc",
+        "cer": "MIIBnjCCAUSgAwIBAgIQfdgvV5N/RFurIrjttkLgcTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTYzOFoXDTIyMDQwODAyMjYzOFowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPL376fwS1ePHmJHCcNPXHVpQVOPcaGdMhD4kBBpzFZ/WyyyJhi/8fH5sUQob7f6ec\u002BtbFyNvsMPEb9o\u002Bk/af4ijfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBT9Gglds/aP17KuWI1ZBLMXyXCsxTAdBgNVHQ4EFgQU/RoJXbP2j9eyrliNWQSzF8lwrMUwCgYIKoZIzj0EAwIDSAAwRQIhANY767YA8KhmSiBoHxnEg8EDH27PxVwYjliivnAVzRIUAiBbA6Vtto4Pis0zhSucPjF1hI7CjGxuF2YtWYcaG1b4uQ==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984967,
-          "exp": 1646521567,
-          "created": 1614985567,
-          "updated": 1614985567,
+          "nbf": 1617848198,
+          "exp": 1649384798,
+          "created": 1617848798,
+          "updated": 1617848798,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/957650110/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -500,65 +420,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985542,
-            "updated": 1614985542
+            "created": 1617848781,
+            "updated": 1617848781
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/957650110/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/957650110/397406fd620e49ba9157a34960b8e08a?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/957650110/a6cf53fb562848df83c961571e3786f3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-c69fcee4c34c704d8692fdc691a65128-60445b4d9a5b4f46-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "97055fd55f1e51bf379f44f00a0d3019",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:26:47 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "97055fd55f1e51bf379f44f00a0d3019",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d3ce328f-f64d-4a08-bed6-7ba96f531a4c",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/957650110/a6cf53fb562848df83c961571e3786f3?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-f2ef07a59e0ad840891f6c1f318d1c89-5d258e2f4c732d46-00",
+        "traceparent": "00-c69fcee4c34c704d8692fdc691a65128-60445b4d9a5b4f46-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "11dcfb4df4ee07f8d35547bf39e65470",
+        "x-ms-client-request-id": "97055fd55f1e51bf379f44f00a0d3019",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "439",
+        "Content-Length": "438",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:47 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "97055fd55f1e51bf379f44f00a0d3019",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4ee3124e-278f-42b9-9f93-da70a7523202",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "18654eb6-9126-4e31-8d1d-6033937b044e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/957650110/397406fd620e49ba9157a34960b8e08a",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/957650110/a6cf53fb562848df83c961571e3786f3",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256",
-          "x": "gYVTBWcegZnwgZGSmgsSYCiwXJO9ZsteXfF9x00b52M",
-          "y": "hcky1Np_4DUaxUVZPYgBLlajEgx0d7WWZBKyomXuSfw"
+          "x": "8vfvp_BLV48eYkcJw09cdWlBU49xoZ0yEPiQEGnMVn8",
+          "y": "WyyyJhi_8fH5sUQob7f6ec-tbFyNvsMPEb9o-k_af4g"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984967,
-          "exp": 1646521567,
-          "created": 1614985567,
-          "updated": 1614985567,
+          "nbf": 1617848198,
+          "exp": 1649384798,
+          "created": 1617848798,
+          "updated": 1617848798,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -566,19 +527,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/957650110/397406fd620e49ba9157a34960b8e08a/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/957650110/a6cf53fb562848df83c961571e3786f3/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "69",
         "Content-Type": "application/json",
-        "traceparent": "00-f2ef07a59e0ad840891f6c1f318d1c89-3e175e7b3dcf8147-00",
+        "traceparent": "00-c69fcee4c34c704d8692fdc691a65128-14141c408a87e647-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "bc4f6fc5cccf445577a3ca54f37fb28e",
+        "x-ms-client-request-id": "24d0b54c919561e8cdca6b409fa83b85",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -588,128 +549,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "193",
+        "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:47 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "24d0b54c919561e8cdca6b409fa83b85",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2c416f79-463f-4527-b128-51579c768228",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6e7f8442-3add-4cf1-b62b-43dbeb24d840",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/957650110/397406fd620e49ba9157a34960b8e08a",
-        "value": "PJw1yd85l8iFKyeiOGY8oE52_OMQPz0KEHZhSn7F7oYM3J5j347R17ARSPxVzYt6HWaJUuEXGT-K2KQLW00idQ"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/957650110/a6cf53fb562848df83c961571e3786f3",
+        "value": "lUVKAzLpsZ2ADxWwBetxf_CkbU53yrA8lO2yOL0BhVDw3o2XEJNXQAxoH9Pb-ih2xQtxcXYQAraSjPY9ZtSpHA"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/957650110/397406fd620e49ba9157a34960b8e08a?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/957650110/a6cf53fb562848df83c961571e3786f3?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-21e02da744d5094a8f9abcc9a3244a30-ab55b42a735e954a-00",
+        "traceparent": "00-40948c51c4de8145a297a15e36bb12c9-6169a189495c394e-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "0fa3be641e31572abcc85140492927e6",
+        "x-ms-client-request-id": "11dcfb4df4ee07f8d35547bf39e65470",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1163",
+        "Content-Length": "1160",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:47 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "11dcfb4df4ee07f8d35547bf39e65470",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ca7f64a4-dd6a-4d1e-8258-10bf243a2b68",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1b68e216-e735-4ff7-b1f6-8ce9f08817cf",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/957650110/397406fd620e49ba9157a34960b8e08a",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/957650110/397406fd620e49ba9157a34960b8e08a",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/957650110/397406fd620e49ba9157a34960b8e08a",
-        "x5t": "VS5LbAEEZrqDgTZk2vRzQOePMG8",
-        "cer": "MIIBnjCCAUSgAwIBAgIQWywbTMb/QtSCQETRqmj3AzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTYwN1oXDTIyMDMwNTIzMDYwN1owEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIGFUwVnHoGZ8IGRkpoLEmAosFyTvWbLXl3xfcdNG\u002Bdjhcky1Np/4DUaxUVZPYgBLlajEgx0d7WWZBKyomXuSfyjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTc/rQeKauAosFEuLFHO4UKpm0QAjAdBgNVHQ4EFgQU3P60HimrgKLBRLixRzuFCqZtEAIwCgYIKoZIzj0EAwIDSAAwRQIhALIAWkCyg8S5Drm1B26mvhC1\u002BtSHr6AJPlJ9dQ1n0ZnnAiBEVC\u002BrGFZ2SiA7dn36mB7dVDr7B3THRXQNhIOuwBYdhg==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/957650110/a6cf53fb562848df83c961571e3786f3",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/957650110/a6cf53fb562848df83c961571e3786f3",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/957650110/a6cf53fb562848df83c961571e3786f3",
+        "x5t": "0IiEHo5SaJ_49iXLPgpfaILiSdc",
+        "cer": "MIIBnjCCAUSgAwIBAgIQfdgvV5N/RFurIrjttkLgcTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTYzOFoXDTIyMDQwODAyMjYzOFowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPL376fwS1ePHmJHCcNPXHVpQVOPcaGdMhD4kBBpzFZ/WyyyJhi/8fH5sUQob7f6ec\u002BtbFyNvsMPEb9o\u002Bk/af4ijfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBT9Gglds/aP17KuWI1ZBLMXyXCsxTAdBgNVHQ4EFgQU/RoJXbP2j9eyrliNWQSzF8lwrMUwCgYIKoZIzj0EAwIDSAAwRQIhANY767YA8KhmSiBoHxnEg8EDH27PxVwYjliivnAVzRIUAiBbA6Vtto4Pis0zhSucPjF1hI7CjGxuF2YtWYcaG1b4uQ==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984967,
-          "exp": 1646521567,
-          "created": 1614985567,
-          "updated": 1614985567,
+          "nbf": 1617848198,
+          "exp": 1649384798,
+          "created": 1617848798,
+          "updated": 1617848798,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "5B2C1B4CC6FF42D4824044D1AA68F703"
+        "serialnumber": "7DD82F57937F445BAB22B8EDB642E071"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/957650110/397406fd620e49ba9157a34960b8e08a?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/957650110/a6cf53fb562848df83c961571e3786f3?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-21e02da744d5094a8f9abcc9a3244a30-e884fbb24b4da343-00",
+        "traceparent": "00-40948c51c4de8145a297a15e36bb12c9-1db226188134b74b-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "2f7afb757f5880b6a6979a4b29a41354",
+        "x-ms-client-request-id": "bc4f6fc5cccf445577a3ca54f37fb28e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1343",
+        "Content-Length": "1341",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:47 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bc4f6fc5cccf445577a3ca54f37fb28e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f5b47c6d-6028-456c-8c40-749eadf9c61b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "474a9013-9002-4df9-a768-292fe58357e1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIGiAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgHJhAkjQJ3bdG4cXu\n5Ah28eus3R7/1aYRcdAnBqzusy6gCgYIKoZIzj0DAQehRANCAASBhVMFZx6BmfCB\nkZKaCxJgKLBck71my15d8X3HTRvnY4XJMtTaf\u002BA1GsVFWT2IAS5WoxIMdHe1lmQS\nsqJl7kn8oA0wCwYDVR0PMQQDAgCA\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIBnjCCAUSgAwIBAgIQWywbTMb/QtSCQETRqmj3AzAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTYwN1oXDTIyMDMwNTIzMDYwN1ow\nEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIGF\nUwVnHoGZ8IGRkpoLEmAosFyTvWbLXl3xfcdNG\u002Bdjhcky1Np/4DUaxUVZPYgBLlaj\nEgx0d7WWZBKyomXuSfyjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0G\nA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTc/rQeKauA\nosFEuLFHO4UKpm0QAjAdBgNVHQ4EFgQU3P60HimrgKLBRLixRzuFCqZtEAIwCgYI\nKoZIzj0EAwIDSAAwRQIhALIAWkCyg8S5Drm1B26mvhC1\u002BtSHr6AJPlJ9dQ1n0Znn\nAiBEVC\u002BrGFZ2SiA7dn36mB7dVDr7B3THRXQNhIOuwBYdhg==\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIGiAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQghSbbA\u002BcGBeRB7lIP\ndUbOOYQxzqa0Rao2YpFxD6VQqQ2gCgYIKoZIzj0DAQehRANCAATy9\u002B\u002Bn8EtXjx5i\nRwnDT1x1aUFTj3GhnTIQ\u002BJAQacxWf1sssiYYv/Hx\u002BbFEKG\u002B3\u002BnnPrWxcjb7DDxG/\naPpP2n\u002BIoA0wCwYDVR0PMQQDAgCA\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIBnjCCAUSgAwIBAgIQfdgvV5N/RFurIrjttkLgcTAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTYzOFoXDTIyMDQwODAyMjYzOFow\nEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPL3\n76fwS1ePHmJHCcNPXHVpQVOPcaGdMhD4kBBpzFZ/WyyyJhi/8fH5sUQob7f6ec\u002Bt\nbFyNvsMPEb9o\u002Bk/af4ijfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0G\nA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBT9Gglds/aP\n17KuWI1ZBLMXyXCsxTAdBgNVHQ4EFgQU/RoJXbP2j9eyrliNWQSzF8lwrMUwCgYI\nKoZIzj0EAwIDSAAwRQIhANY767YA8KhmSiBoHxnEg8EDH27PxVwYjliivnAVzRIU\nAiBbA6Vtto4Pis0zhSucPjF1hI7CjGxuF2YtWYcaG1b4uQ==\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/957650110/397406fd620e49ba9157a34960b8e08a",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/957650110/a6cf53fb562848df83c961571e3786f3",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614984967,
-          "exp": 1646521567,
-          "created": 1614985567,
-          "updated": 1614985567,
+          "nbf": 1617848198,
+          "exp": 1649384798,
+          "created": 1617848798,
+          "updated": 1617848798,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/957650110/397406fd620e49ba9157a34960b8e08a"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/957650110/a6cf53fb562848df83c961571e3786f3"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "438986769"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-256)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-256)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/685482347/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/685482347/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-5ae1ff6a1e54144e8a42716c16d6c4fb-0e35651f2e706e48-00",
+        "traceparent": "00-3f126878325fdf4fa58f12293d8e6c87-2c11232d5a002c45-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "8063ec19066fe39d273e223d77547ecb",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "8063ec19066fe39d273e223d77547ecb",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f5fff633-dc8d-4a74-aa97-2ac262abb707",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "699e5553-a984-4bd8-9c41-aed41055010e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/685482347/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/685482347/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-5ae1ff6a1e54144e8a42716c16d6c4fb-0e35651f2e706e48-00",
+        "traceparent": "00-3f126878325fdf4fa58f12293d8e6c87-2c11232d5a002c45-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "8063ec19066fe39d273e223d77547ecb",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:44 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/685482347/pending?api-version=7.2\u0026request_id=e53bc1c9b43643ada486d5191e38e8bf",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/685482347/pending?api-version=7.2\u0026request_id=dd7861a2cdd1447492a82471e20c1bf4",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "8063ec19066fe39d273e223d77547ecb",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "d93acad9-f207-49d8-a1a7-d17dcb6c3857",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bd811d33-ca63-463a-99dc-7b9938c1678a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/685482347/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/685482347/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEer46hddHhkvcUABtSwhmztgULayX4YIkZe/PMB4h4gX0T9YVmCwT8E9K2nK6wPXoI8BKBAO5yQYS85xV2lkPMaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIDtu2XZbUsLIJWq7uDl3l0z/EVKpbAPTvgOaqcdkyoVbAiBmbuVYAJhw8C4roA9YBED6Xc/6JRUhmC8y2VcnE2UsOw==",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhl8aalI9BK0W2046PDp2bWhlJPjdsZcbGRtu7geSlU9Bxz2MvKSzcM3I2CpOsZ9XjfdBt16c1330gN/9XENJAqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIQCsF52mPDNHtynItzu7IYkR3Us83\u002Bb3eTB64Esg9XnWrAIgLJ4QwJq58Yf5eUJ6qsgT51VWalIanKmVBWwPVy0LtjM=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e53bc1c9b43643ada486d5191e38e8bf"
+        "request_id": "dd7861a2cdd1447492a82471e20c1bf4"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/685482347/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/685482347/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "135e9f57bc243acdfbad292b290ae3cb",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:44 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "135e9f57bc243acdfbad292b290ae3cb",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3eb3e0ee-28e3-4b84-8845-b294673790b6",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "34716208-0241-4a9a-9d23-4fc4dfb03d90",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/685482347/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/685482347/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEer46hddHhkvcUABtSwhmztgULayX4YIkZe/PMB4h4gX0T9YVmCwT8E9K2nK6wPXoI8BKBAO5yQYS85xV2lkPMaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIDtu2XZbUsLIJWq7uDl3l0z/EVKpbAPTvgOaqcdkyoVbAiBmbuVYAJhw8C4roA9YBED6Xc/6JRUhmC8y2VcnE2UsOw==",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhl8aalI9BK0W2046PDp2bWhlJPjdsZcbGRtu7geSlU9Bxz2MvKSzcM3I2CpOsZ9XjfdBt16c1330gN/9XENJAqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIQCsF52mPDNHtynItzu7IYkR3Us83\u002Bb3eTB64Esg9XnWrAIgLJ4QwJq58Yf5eUJ6qsgT51VWalIanKmVBWwPVy0LtjM=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e53bc1c9b43643ada486d5191e38e8bf"
+        "request_id": "dd7861a2cdd1447492a82471e20c1bf4"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/685482347/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/685482347/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "adb9e379cfda77828965c6bdd2432056",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "adb9e379cfda77828965c6bdd2432056",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f3efa163-bb6a-4e47-ba05-0659a3cf6ef7",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "32dcb3a5-32a7-4155-b41c-4e1f159c8256",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/685482347/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/685482347/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEer46hddHhkvcUABtSwhmztgULayX4YIkZe/PMB4h4gX0T9YVmCwT8E9K2nK6wPXoI8BKBAO5yQYS85xV2lkPMaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIDtu2XZbUsLIJWq7uDl3l0z/EVKpbAPTvgOaqcdkyoVbAiBmbuVYAJhw8C4roA9YBED6Xc/6JRUhmC8y2VcnE2UsOw==",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhl8aalI9BK0W2046PDp2bWhlJPjdsZcbGRtu7geSlU9Bxz2MvKSzcM3I2CpOsZ9XjfdBt16c1330gN/9XENJAqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIQCsF52mPDNHtynItzu7IYkR3Us83\u002Bb3eTB64Esg9XnWrAIgLJ4QwJq58Yf5eUJ6qsgT51VWalIanKmVBWwPVy0LtjM=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e53bc1c9b43643ada486d5191e38e8bf"
+        "request_id": "dd7861a2cdd1447492a82471e20c1bf4"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/685482347/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/685482347/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "e387ab50ed785d471f2984c2dc72ba1c",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "663",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:16 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e387ab50ed785d471f2984c2dc72ba1c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9797f938-b210-4569-a083-165f38718693",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bf2d2d89-8072-49d3-a1a9-9eb5c56ea876",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/685482347/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/685482347/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEer46hddHhkvcUABtSwhmztgULayX4YIkZe/PMB4h4gX0T9YVmCwT8E9K2nK6wPXoI8BKBAO5yQYS85xV2lkPMaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIDtu2XZbUsLIJWq7uDl3l0z/EVKpbAPTvgOaqcdkyoVbAiBmbuVYAJhw8C4roA9YBED6Xc/6JRUhmC8y2VcnE2UsOw==",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhl8aalI9BK0W2046PDp2bWhlJPjdsZcbGRtu7geSlU9Bxz2MvKSzcM3I2CpOsZ9XjfdBt16c1330gN/9XENJAqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIQCsF52mPDNHtynItzu7IYkR3Us83\u002Bb3eTB64Esg9XnWrAIgLJ4QwJq58Yf5eUJ6qsgT51VWalIanKmVBWwPVy0LtjM=",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "e53bc1c9b43643ada486d5191e38e8bf"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/685482347",
+        "request_id": "dd7861a2cdd1447492a82471e20c1bf4"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/685482347/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/685482347?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "93c3575bd19b88f11de78abff50f68b7",
         "x-ms-return-client-request-id": "true"
@@ -256,79 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "665",
+        "Content-Length": "1749",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:21 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "93c3575bd19b88f11de78abff50f68b7",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5e0e37e6-19ea-4d28-a7ed-0c5ec426b7d9",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ebaa3fe7-09fc-40a3-bc76-546c8f7a4b3b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/685482347/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBFzCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEer46hddHhkvcUABtSwhmztgULayX4YIkZe/PMB4h4gX0T9YVmCwT8E9K2nK6wPXoI8BKBAO5yQYS85xV2lkPMaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0cAMEQCIDtu2XZbUsLIJWq7uDl3l0z/EVKpbAPTvgOaqcdkyoVbAiBmbuVYAJhw8C4roA9YBED6Xc/6JRUhmC8y2VcnE2UsOw==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/685482347",
-        "request_id": "e53bc1c9b43643ada486d5191e38e8bf"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/685482347?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "7ddad28dff838c539c5b8db14ac09a17",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1758",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:21 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1dbaab49-cfa7-4eeb-94f8-db0452fea874",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/685482347/0672fe52c2de42abbd50d1208af677ad",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/685482347/0672fe52c2de42abbd50d1208af677ad",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/685482347/0672fe52c2de42abbd50d1208af677ad",
-        "x5t": "mwMJyG5-bbG8jUuNaKz9dbAD5ww",
-        "cer": "MIIBnjCCAUSgAwIBAgIQK6DBXrikQQ2e1v580bVqLjAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDUxOVoXDTIyMDMwNTIzMTUxOVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABHq\u002BOoXXR4ZL3FAAbUsIZs7YFC2sl\u002BGCJGXvzzAeIeIF9E/WFZgsE/BPStpyusD16CPASgQDuckGEvOcVdpZDzGjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTrNSJiozJzhnI/SS9F9KKF4CsOBjAdBgNVHQ4EFgQU6zUiYqMyc4ZyP0kvRfSiheArDgYwCgYIKoZIzj0EAwIDSAAwRQIgQpjDVPdUVOQ\u002BbtDFZNIK\u002Baw4mIi\u002BKAikLKdfuxd2O6QCIQDSpdKSR6duc/wXSvdQk0aOzmL\u002BKAEb3fSNVXoNsG6DsQ==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/685482347/1875c12b59514d4fb174e822c53acdca",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/685482347/1875c12b59514d4fb174e822c53acdca",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/685482347/1875c12b59514d4fb174e822c53acdca",
+        "x5t": "fp80eqr9A4YAp9ovHnIzf73hcHc",
+        "cer": "MIIBnTCCAUSgAwIBAgIQdqnh6A/xQVOVNw86r2HDazAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjU1NFoXDTIyMDQwODAyMzU1NFowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIZfGmpSPQStFttOOjw6dm1oZST43bGXGxkbbu4HkpVPQcc9jLyks3DNyNgqTrGfV433QbdenNd99IDf/VxDSQKjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBS/rlOG9Y8M841QVGcqPcaLfmaNmTAdBgNVHQ4EFgQUv65ThvWPDPONUFRnKj3Gi35mjZkwCgYIKoZIzj0EAwIDRwAwRAIgbZu2LywsgpBV0LxyslzJg9Z/9dW26mdv9xAD5Dgj5zICIH3M8ZgUryebOZMuOIryAxhiLu2taID8daeB4Lpy5/6z",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985519,
-          "exp": 1646522119,
-          "created": 1614986119,
-          "updated": 1614986119,
+          "nbf": 1617848754,
+          "exp": 1649385354,
+          "created": 1617849354,
+          "updated": 1617849354,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/685482347/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/685482347/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -368,65 +330,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614986105,
-            "updated": 1614986105
+            "created": 1617849344,
+            "updated": 1617849344
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/685482347/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/685482347/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/685482347/0672fe52c2de42abbd50d1208af677ad?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/685482347/1875c12b59514d4fb174e822c53acdca?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-c9137e18bcfb5d4b95d8e989ae0c2429-c8a7b4be5fed7d43-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "7ddad28dff838c539c5b8db14ac09a17",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:35:55 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7ddad28dff838c539c5b8db14ac09a17",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "37649063-7dc8-4788-9feb-4d74501e60fa",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/685482347/1875c12b59514d4fb174e822c53acdca?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-644df5cafa49c84e857bb28a9657ae47-2fa0e5f919a3ad42-00",
+        "traceparent": "00-c9137e18bcfb5d4b95d8e989ae0c2429-c8a7b4be5fed7d43-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "7a62a9aa8c807ebbbafec6906388680f",
+        "x-ms-client-request-id": "7ddad28dff838c539c5b8db14ac09a17",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "439",
+        "Content-Length": "438",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:21 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7ddad28dff838c539c5b8db14ac09a17",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9ec7c766-ac59-41db-b23c-ab3eb6cabd8d",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "7f4c3906-4122-4fe1-ae34-cbbed4b5a092",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/685482347/0672fe52c2de42abbd50d1208af677ad",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/685482347/1875c12b59514d4fb174e822c53acdca",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256",
-          "x": "er46hddHhkvcUABtSwhmztgULayX4YIkZe_PMB4h4gU",
-          "y": "9E_WFZgsE_BPStpyusD16CPASgQDuckGEvOcVdpZDzE"
+          "x": "hl8aalI9BK0W2046PDp2bWhlJPjdsZcbGRtu7geSlU8",
+          "y": "Qcc9jLyks3DNyNgqTrGfV433QbdenNd99IDf_VxDSQI"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985519,
-          "exp": 1646522119,
-          "created": 1614986119,
-          "updated": 1614986119,
+          "nbf": 1617848754,
+          "exp": 1649385354,
+          "created": 1617849354,
+          "updated": 1617849354,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -434,19 +437,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/685482347/0672fe52c2de42abbd50d1208af677ad/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/685482347/1875c12b59514d4fb174e822c53acdca/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "69",
         "Content-Type": "application/json",
-        "traceparent": "00-644df5cafa49c84e857bb28a9657ae47-d19581fe794e3c46-00",
+        "traceparent": "00-c9137e18bcfb5d4b95d8e989ae0c2429-ce011027cce3f34d-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "0935cdc03c975b990437f73f43403e5c",
+        "x-ms-client-request-id": "7a62a9aa8c807ebbbafec6906388680f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -456,35 +459,89 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "193",
+        "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:21 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7a62a9aa8c807ebbbafec6906388680f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6fb59038-3c4d-4d91-b477-ff3da0cf4233",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5bd83fef-787d-4921-9e0b-50f4b2bcef4f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/685482347/0672fe52c2de42abbd50d1208af677ad",
-        "value": "fMj0_WWjXQKx5TG_p-wnABNB1mEVt3ZkamGekvlI2i-sOatKZqNy_4mgPGbKDsbZ95NNS0--fiZK3zGcqgmnMQ"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/685482347/1875c12b59514d4fb174e822c53acdca",
+        "value": "vVwx5cMnTHAMOR1FzqdQMcH7lJnsYj06Wh0A9nlo38HA1QmvLyGkVQk8g-i4FmGQQzWw83Pea0ou22JD4k_SWg"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/685482347/0672fe52c2de42abbd50d1208af677ad?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/685482347/1875c12b59514d4fb174e822c53acdca?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-0550992a6a553041aa8b35638ca23554-b65f80f946d38d4b-00",
+        "traceparent": "00-2ed1091c830c5247942fa0f63f08953b-87dc4c85c3dd904b-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "0935cdc03c975b990437f73f43403e5c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1156",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:35:55 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0935cdc03c975b990437f73f43403e5c",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1048ac4a-ac67-4d30-b21b-1d153a457db7",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "id": "https://heathskvtest2.vault.azure.net/certificates/685482347/1875c12b59514d4fb174e822c53acdca",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/685482347/1875c12b59514d4fb174e822c53acdca",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/685482347/1875c12b59514d4fb174e822c53acdca",
+        "x5t": "fp80eqr9A4YAp9ovHnIzf73hcHc",
+        "cer": "MIIBnTCCAUSgAwIBAgIQdqnh6A/xQVOVNw86r2HDazAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjU1NFoXDTIyMDQwODAyMzU1NFowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIZfGmpSPQStFttOOjw6dm1oZST43bGXGxkbbu4HkpVPQcc9jLyks3DNyNgqTrGfV433QbdenNd99IDf/VxDSQKjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBS/rlOG9Y8M841QVGcqPcaLfmaNmTAdBgNVHQ4EFgQUv65ThvWPDPONUFRnKj3Gi35mjZkwCgYIKoZIzj0EAwIDRwAwRAIgbZu2LywsgpBV0LxyslzJg9Z/9dW26mdv9xAD5Dgj5zICIH3M8ZgUryebOZMuOIryAxhiLu2taID8daeB4Lpy5/6z",
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848754,
+          "exp": 1649385354,
+          "created": 1617849354,
+          "updated": 1617849354,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "subject": "CN=default",
+        "issuer": "CN=default",
+        "serialnumber": "76A9E1E80FF1415395370F3AAF61C36B"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/685482347/1875c12b59514d4fb174e822c53acdca?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-2ed1091c830c5247942fa0f63f08953b-4aabdd00bb49ac46-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "4b14724cedac0036175bc38538c22814",
         "x-ms-return-client-request-id": "true"
@@ -493,91 +550,40 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1163",
+        "Content-Length": "1337",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:21 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4b14724cedac0036175bc38538c22814",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a279a7b8-49fb-4349-9e8f-91d9ef75852e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6109f901-2d70-4bd4-9cc5-8531d21c40d8",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/685482347/0672fe52c2de42abbd50d1208af677ad",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/685482347/0672fe52c2de42abbd50d1208af677ad",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/685482347/0672fe52c2de42abbd50d1208af677ad",
-        "x5t": "mwMJyG5-bbG8jUuNaKz9dbAD5ww",
-        "cer": "MIIBnjCCAUSgAwIBAgIQK6DBXrikQQ2e1v580bVqLjAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDUxOVoXDTIyMDMwNTIzMTUxOVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABHq\u002BOoXXR4ZL3FAAbUsIZs7YFC2sl\u002BGCJGXvzzAeIeIF9E/WFZgsE/BPStpyusD16CPASgQDuckGEvOcVdpZDzGjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTrNSJiozJzhnI/SS9F9KKF4CsOBjAdBgNVHQ4EFgQU6zUiYqMyc4ZyP0kvRfSiheArDgYwCgYIKoZIzj0EAwIDSAAwRQIgQpjDVPdUVOQ\u002BbtDFZNIK\u002Baw4mIi\u002BKAikLKdfuxd2O6QCIQDSpdKSR6duc/wXSvdQk0aOzmL\u002BKAEb3fSNVXoNsG6DsQ==",
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614985519,
-          "exp": 1646522119,
-          "created": 1614986119,
-          "updated": 1614986119,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "subject": "CN=default",
-        "issuer": "CN=default",
-        "serialnumber": "2BA0C15EB8A4410D9ED6FE7CD1B56A2E"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/685482347/0672fe52c2de42abbd50d1208af677ad?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-0550992a6a553041aa8b35638ca23554-881b7cadbf85504c-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "7cf07ef2918b6e7f10077649957b3b7a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1343",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:21 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "dc128b7d-930b-4e2e-8899-72380dbcf5f4",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIGiAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgFhnoN9tHJrZK\u002B38X\nvwj\u002Bf8mpGKXvFKEx7eUU9kUXEGGgCgYIKoZIzj0DAQehRANCAAR6vjqF10eGS9xQ\nAG1LCGbO2BQtrJfhgiRl788wHiHiBfRP1hWYLBPwT0racrrA9egjwEoEA7nJBhLz\nnFXaWQ8xoA0wCwYDVR0PMQQDAgCA\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIBnjCCAUSgAwIBAgIQK6DBXrikQQ2e1v580bVqLjAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDUxOVoXDTIyMDMwNTIzMTUxOVow\nEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABHq\u002B\nOoXXR4ZL3FAAbUsIZs7YFC2sl\u002BGCJGXvzzAeIeIF9E/WFZgsE/BPStpyusD16CPA\nSgQDuckGEvOcVdpZDzGjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0G\nA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBTrNSJiozJz\nhnI/SS9F9KKF4CsOBjAdBgNVHQ4EFgQU6zUiYqMyc4ZyP0kvRfSiheArDgYwCgYI\nKoZIzj0EAwIDSAAwRQIgQpjDVPdUVOQ\u002BbtDFZNIK\u002Baw4mIi\u002BKAikLKdfuxd2O6QC\nIQDSpdKSR6duc/wXSvdQk0aOzmL\u002BKAEb3fSNVXoNsG6DsQ==\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIGiAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgFqxJI6lLM6wSaM7N\nDkaNKv2DoXsDatg/NOEERWI36uqgCgYIKoZIzj0DAQehRANCAASGXxpqUj0ErRbb\nTjo8OnZtaGUk\u002BN2xlxsZG27uB5KVT0HHPYy8pLNwzcjYKk6xn1eN90G3XpzXffSA\n3/1cQ0kCoA0wCwYDVR0PMQQDAgCA\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIBnTCCAUSgAwIBAgIQdqnh6A/xQVOVNw86r2HDazAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjU1NFoXDTIyMDQwODAyMzU1NFow\nEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIZf\nGmpSPQStFttOOjw6dm1oZST43bGXGxkbbu4HkpVPQcc9jLyks3DNyNgqTrGfV433\nQbdenNd99IDf/VxDSQKjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0G\nA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBS/rlOG9Y8M\n841QVGcqPcaLfmaNmTAdBgNVHQ4EFgQUv65ThvWPDPONUFRnKj3Gi35mjZkwCgYI\nKoZIzj0EAwIDRwAwRAIgbZu2LywsgpBV0LxyslzJg9Z/9dW26mdv9xAD5Dgj5zIC\nIH3M8ZgUryebOZMuOIryAxhiLu2taID8daeB4Lpy5/6z\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/685482347/0672fe52c2de42abbd50d1208af677ad",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/685482347/1875c12b59514d4fb174e822c53acdca",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985519,
-          "exp": 1646522119,
-          "created": 1614986119,
-          "updated": 1614986119,
+          "nbf": 1617848754,
+          "exp": 1649385354,
+          "created": 1617849354,
+          "updated": 1617849354,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/685482347/0672fe52c2de42abbd50d1208af677ad"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/685482347/1875c12b59514d4fb174e822c53acdca"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1520762287"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-256K).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-256K).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1574850943/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1574850943/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-0c7b569db70ca448b06479cc9ee1735b-14b9a8754a106548-00",
+        "traceparent": "00-c9b7a5feea70724c9ac5b91da66421ad-bad5238dccc64a4f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "d7c9b700b92a59e5f776dac1449e4842",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:40 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "d7c9b700b92a59e5f776dac1449e4842",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2fa0b686-0c49-4969-a3ab-ceaf3b753082",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "336c43f0-92d0-4120-8599-626ff7a82ded",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1574850943/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1574850943/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "222",
         "Content-Type": "application/json",
-        "traceparent": "00-0c7b569db70ca448b06479cc9ee1735b-14b9a8754a106548-00",
+        "traceparent": "00-c9b7a5feea70724c9ac5b91da66421ad-bad5238dccc64a4f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "d7c9b700b92a59e5f776dac1449e4842",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "966",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:41 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:30 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending?api-version=7.2\u0026request_id=22879051763246a7952202c893cebb6f",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1574850943/pending?api-version=7.2\u0026request_id=2607ce9a61f344b0a9e296a98439ff21",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "d7c9b700b92a59e5f776dac1449e4842",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "fe071c8d-1872-4d4f-b1cd-01369e66eec3",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "c016f52f-43fc-408c-b190-6dd0fa787da3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1574850943/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQCl9LhFcG9KYRIPxeYuSPMg7Xn2EM9JhBO01lxinkWNQLrucsyj18BBZupOrb0HyIqBjCUJL6BzmSoQLDkiRNCoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgHzHiipbsHXbDyIyMASCzKy9uMX6xFsjFHTL2bbwWS7oCIAIIEZjOfPYAnphQjuxjxaNqJ7w7ahJt04U5737CV/pH",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASGhQ\u002B\u002B4vpN3BWgvpOB9lRA\u002B09b2IJ2hSadDPUIcWYJCoK9sIPtpgkYk5Qzyxq9crP5FhkvONt4oNZJhYTTQwWUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgQq9MGEIiEvEwV2\u002BNqSRUNGzoWUTqYFUszNQkfb/4QZ0CICHztN45A0zh92hFKH3EkEyyCqpj0ssUWBljvjVoB7iR",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "22879051763246a7952202c893cebb6f"
+        "request_id": "2607ce9a61f344b0a9e296a98439ff21"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1574850943/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "88d16090a81e18a4ac6707d456c573d0",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "966",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:41 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "88d16090a81e18a4ac6707d456c573d0",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e071c128-2051-439c-9c9e-48badb75970c",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "711b3372-3064-4a39-9d25-fb15f889fe49",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1574850943/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQCl9LhFcG9KYRIPxeYuSPMg7Xn2EM9JhBO01lxinkWNQLrucsyj18BBZupOrb0HyIqBjCUJL6BzmSoQLDkiRNCoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgHzHiipbsHXbDyIyMASCzKy9uMX6xFsjFHTL2bbwWS7oCIAIIEZjOfPYAnphQjuxjxaNqJ7w7ahJt04U5737CV/pH",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASGhQ\u002B\u002B4vpN3BWgvpOB9lRA\u002B09b2IJ2hSadDPUIcWYJCoK9sIPtpgkYk5Qzyxq9crP5FhkvONt4oNZJhYTTQwWUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgQq9MGEIiEvEwV2\u002BNqSRUNGzoWUTqYFUszNQkfb/4QZ0CICHztN45A0zh92hFKH3EkEyyCqpj0ssUWBljvjVoB7iR",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "22879051763246a7952202c893cebb6f"
+        "request_id": "2607ce9a61f344b0a9e296a98439ff21"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1574850943/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "33ba269ba0fdb2a8a2ff86b63e5fe312",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "966",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:46 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:36 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "33ba269ba0fdb2a8a2ff86b63e5fe312",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "980b3e01-7dee-4ccf-afa5-e7c8d96eec3a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "c83abe16-bc01-4fe4-b5d0-ef836248196f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1574850943/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQCl9LhFcG9KYRIPxeYuSPMg7Xn2EM9JhBO01lxinkWNQLrucsyj18BBZupOrb0HyIqBjCUJL6BzmSoQLDkiRNCoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgHzHiipbsHXbDyIyMASCzKy9uMX6xFsjFHTL2bbwWS7oCIAIIEZjOfPYAnphQjuxjxaNqJ7w7ahJt04U5737CV/pH",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASGhQ\u002B\u002B4vpN3BWgvpOB9lRA\u002B09b2IJ2hSadDPUIcWYJCoK9sIPtpgkYk5Qzyxq9crP5FhkvONt4oNZJhYTTQwWUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgQq9MGEIiEvEwV2\u002BNqSRUNGzoWUTqYFUszNQkfb/4QZ0CICHztN45A0zh92hFKH3EkEyyCqpj0ssUWBljvjVoB7iR",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "22879051763246a7952202c893cebb6f"
+        "request_id": "2607ce9a61f344b0a9e296a98439ff21"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1574850943/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "f45622fa9161586112b02bc3b1100232",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "966",
+        "Content-Length": "873",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:52 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f45622fa9161586112b02bc3b1100232",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f1cad7f5-16f1-42a3-bed8-23b8fec0c56e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1e7e3b90-4167-40d9-93bd-08dabc368732",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1574850943/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQCl9LhFcG9KYRIPxeYuSPMg7Xn2EM9JhBO01lxinkWNQLrucsyj18BBZupOrb0HyIqBjCUJL6BzmSoQLDkiRNCoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgHzHiipbsHXbDyIyMASCzKy9uMX6xFsjFHTL2bbwWS7oCIAIIEZjOfPYAnphQjuxjxaNqJ7w7ahJt04U5737CV/pH",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASGhQ\u002B\u002B4vpN3BWgvpOB9lRA\u002B09b2IJ2hSadDPUIcWYJCoK9sIPtpgkYk5Qzyxq9crP5FhkvONt4oNZJhYTTQwWUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgQq9MGEIiEvEwV2\u002BNqSRUNGzoWUTqYFUszNQkfb/4QZ0CICHztN45A0zh92hFKH3EkEyyCqpj0ssUWBljvjVoB7iR",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "22879051763246a7952202c893cebb6f"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1574850943",
+        "request_id": "2607ce9a61f344b0a9e296a98439ff21"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1574850943?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "1d260a0214e4f044b81fe61e22edda4c",
         "x-ms-return-client-request-id": "true"
@@ -256,211 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "966",
+        "Content-Length": "1967",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:56 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "64fad47b-de25-48af-8530-7e339fd47d6a",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQCl9LhFcG9KYRIPxeYuSPMg7Xn2EM9JhBO01lxinkWNQLrucsyj18BBZupOrb0HyIqBjCUJL6BzmSoQLDkiRNCoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgHzHiipbsHXbDyIyMASCzKy9uMX6xFsjFHTL2bbwWS7oCIAIIEZjOfPYAnphQjuxjxaNqJ7w7ahJt04U5737CV/pH",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "22879051763246a7952202c893cebb6f"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "34daf5837e6e096ec461204d75e50091",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "966",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2daac9c9-6adb-4118-bc6b-2cddf0e835bf",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQCl9LhFcG9KYRIPxeYuSPMg7Xn2EM9JhBO01lxinkWNQLrucsyj18BBZupOrb0HyIqBjCUJL6BzmSoQLDkiRNCoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgHzHiipbsHXbDyIyMASCzKy9uMX6xFsjFHTL2bbwWS7oCIAIIEZjOfPYAnphQjuxjxaNqJ7w7ahJt04U5737CV/pH",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "22879051763246a7952202c893cebb6f"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "33b353fdc538e52edd663c42ab423524",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "966",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:07 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "caa52af4-6d44-4e97-9b54-8ea2525f35cb",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQCl9LhFcG9KYRIPxeYuSPMg7Xn2EM9JhBO01lxinkWNQLrucsyj18BBZupOrb0HyIqBjCUJL6BzmSoQLDkiRNCoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgHzHiipbsHXbDyIyMASCzKy9uMX6xFsjFHTL2bbwWS7oCIAIIEZjOfPYAnphQjuxjxaNqJ7w7ahJt04U5737CV/pH",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "22879051763246a7952202c893cebb6f"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "bc3fded5ce3683c49b1c5882f3f77bd2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "875",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:12 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1d260a0214e4f044b81fe61e22edda4c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "084a6e82-12e0-4eff-adc6-aaaf27ff4541",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b75543cf-a118-42da-9f15-b0fc5650543d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQCl9LhFcG9KYRIPxeYuSPMg7Xn2EM9JhBO01lxinkWNQLrucsyj18BBZupOrb0HyIqBjCUJL6BzmSoQLDkiRNCoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgHzHiipbsHXbDyIyMASCzKy9uMX6xFsjFHTL2bbwWS7oCIAIIEZjOfPYAnphQjuxjxaNqJ7w7ahJt04U5737CV/pH",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1574850943",
-        "request_id": "22879051763246a7952202c893cebb6f"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1574850943?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "cf21541ea63abe13c6f45607422c5e82",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1972",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "71607c5f-5d9b-453b-88c2-e15ad9db04a2",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/dabfb91f65194ba58a3c4a0854e98e61",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1574850943/dabfb91f65194ba58a3c4a0854e98e61",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1574850943/dabfb91f65194ba58a3c4a0854e98e61",
-        "x5t": "mkwDUFJepca5JOY19JSPQiJbtTo",
-        "cer": "MIICOzCCAeGgAwIBAgIQMCKEgnZiT1mpcqQR5nlToTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTgxMVoXDTIyMDMwNTIzMDgxMVowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQCl9LhFcG9KYRIPxeYuSPMg7Xn2EM9JhBO01lxinkWNQLrucsyj18BBZupOrb0HyIqBjCUJL6BzmSoQLDkiRNCo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUJWwOdi5K2rPgi6uFnOYYEO7oD7wwHQYDVR0OBBYEFCVsDnYuStqz4IurhZzmGBDu6A\u002B8MAoGCCqGSM49BAMCA0gAMEUCIQDSzsn3rP8F9Z/W/iISXmfMUOlAGzcMlFo55/UL8z1TzQIgVv85bh20AP6Lp0z4Ypc6DW4QOzIbzD14SbNrBI7FE0E=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1574850943/7f76c14366c649a29752c2c5a820256c",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1574850943/7f76c14366c649a29752c2c5a820256c",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1574850943/7f76c14366c649a29752c2c5a820256c",
+        "x5t": "slO59utg2W6MmqpzrneVzLJSEaM",
+        "cer": "MIICOjCCAeGgAwIBAgIQSV7gQa4wQ0Sw\u002B9FZZV39izAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTczN1oXDTIyMDQwODAyMjczN1owEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASGhQ\u002B\u002B4vpN3BWgvpOB9lRA\u002B09b2IJ2hSadDPUIcWYJCoK9sIPtpgkYk5Qzyxq9crP5FhkvONt4oNZJhYTTQwWUo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUJCRT4r/k30ZZdW5nPIBAsyVMTocwHQYDVR0OBBYEFCQkU\u002BK/5N9GWXVuZzyAQLMlTE6HMAoGCCqGSM49BAMCA0cAMEQCIAk/t24iqNTxRCQoURRs151QBzJyF8RuYXS\u002BjB9u1KsqAiBZ6SCQKnWrcpZKA5svPkYwdam98GkWVpq2TWliK7mt0A==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985091,
-          "exp": 1646521691,
-          "created": 1614985691,
-          "updated": 1614985691,
+          "nbf": 1617848257,
+          "exp": 1649384857,
+          "created": 1617848857,
+          "updated": 1617848857,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1574850943/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -500,65 +330,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985661,
-            "updated": 1614985661
+            "created": 1617848850,
+            "updated": 1617848850
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1574850943/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1574850943/dabfb91f65194ba58a3c4a0854e98e61?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1574850943/7f76c14366c649a29752c2c5a820256c?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-b028b38841479b49a827bb865a780ce6-ce7c9ea50a8fd244-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "34daf5837e6e096ec461204d75e50091",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:27:45 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "34daf5837e6e096ec461204d75e50091",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3b9c6783-f1b3-439e-8250-bc782ae8be3e",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1574850943/7f76c14366c649a29752c2c5a820256c?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-a280940c8094e345981b4636eb092907-b7a28bc0f09db746-00",
+        "traceparent": "00-b028b38841479b49a827bb865a780ce6-ce7c9ea50a8fd244-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "9677fb2b44a62f5b8e30981c6cabf2e5",
+        "x-ms-client-request-id": "34daf5837e6e096ec461204d75e50091",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "441",
+        "Content-Length": "440",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "34daf5837e6e096ec461204d75e50091",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "bd0b72bd-c2aa-4da7-a4dc-12e1820595db",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "c4e9c187-55e5-44ca-83cf-ad2203739672",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1574850943/dabfb91f65194ba58a3c4a0854e98e61",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1574850943/7f76c14366c649a29752c2c5a820256c",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256K",
-          "x": "ApfS4RXBvSmESD8XmLkjzIO159hDPSYQTtNZcYp5FjU",
-          "y": "Auu5yzKPXwEFm6k6tvQfIioGMJQkvoHOZKhAsOSJE0I"
+          "x": "hoUPvuL6TdwVoL6TgfZUQPtPW9iCdoUmnQz1CHFmCQo",
+          "y": "gr2wg-2mCRiTlDPLGr1ys_kWGS8423ig1kmFhNNDBZQ"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985091,
-          "exp": 1646521691,
-          "created": 1614985691,
-          "updated": 1614985691,
+          "nbf": 1617848257,
+          "exp": 1649384857,
+          "created": 1617848857,
+          "updated": 1617848857,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -566,19 +437,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1574850943/dabfb91f65194ba58a3c4a0854e98e61/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1574850943/7f76c14366c649a29752c2c5a820256c/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "70",
         "Content-Type": "application/json",
-        "traceparent": "00-a280940c8094e345981b4636eb092907-8cfd6bec63b86e42-00",
+        "traceparent": "00-b028b38841479b49a827bb865a780ce6-a94e1747e0c0c44b-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "562469ea66212eeacb80f54177bc416f",
+        "x-ms-client-request-id": "33b353fdc538e52edd663c42ab423524",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -588,128 +459,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "194",
+        "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "33b353fdc538e52edd663c42ab423524",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c679b37f-2fdb-42ca-b15d-d2ac1e9e1a16",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "729718dc-e7d2-4f23-9426-5c3fd0d569d3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1574850943/dabfb91f65194ba58a3c4a0854e98e61",
-        "value": "n1Npw-JQU8vYHQe9yVrYZyXAga-SgqZJVvN1Je4wAQoe-tvutpmkN_3O6y-0c4c3uVqeLVm0oZ0mpHPh5CL47A"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1574850943/7f76c14366c649a29752c2c5a820256c",
+        "value": "khiRdCvBgc6mW7SwonErJKYgoH0sFYnPvuHoGltkU-xADr8wDBrMCYl1QZ2W4mje266nzzJg5XaUpHRuksNn6w"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1574850943/dabfb91f65194ba58a3c4a0854e98e61?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1574850943/7f76c14366c649a29752c2c5a820256c?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-04758fd2a100304aab81aecf7155bf73-62f72ca46377ca4c-00",
+        "traceparent": "00-a701188e9129384ea405dd1dc94628d5-252fcca67d969b4e-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "f756d6bee580d92cf9f1400a0ef7521b",
+        "x-ms-client-request-id": "bc3fded5ce3683c49b1c5882f3f77bd2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1374",
+        "Content-Length": "1371",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bc3fded5ce3683c49b1c5882f3f77bd2",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0a672d59-14af-46f5-82f8-d6cdf1f8bf3a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "fa441c0a-b38f-44e3-89cb-538f3ee890de",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1574850943/dabfb91f65194ba58a3c4a0854e98e61",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1574850943/dabfb91f65194ba58a3c4a0854e98e61",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1574850943/dabfb91f65194ba58a3c4a0854e98e61",
-        "x5t": "mkwDUFJepca5JOY19JSPQiJbtTo",
-        "cer": "MIICOzCCAeGgAwIBAgIQMCKEgnZiT1mpcqQR5nlToTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTgxMVoXDTIyMDMwNTIzMDgxMVowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQCl9LhFcG9KYRIPxeYuSPMg7Xn2EM9JhBO01lxinkWNQLrucsyj18BBZupOrb0HyIqBjCUJL6BzmSoQLDkiRNCo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUJWwOdi5K2rPgi6uFnOYYEO7oD7wwHQYDVR0OBBYEFCVsDnYuStqz4IurhZzmGBDu6A\u002B8MAoGCCqGSM49BAMCA0gAMEUCIQDSzsn3rP8F9Z/W/iISXmfMUOlAGzcMlFo55/UL8z1TzQIgVv85bh20AP6Lp0z4Ypc6DW4QOzIbzD14SbNrBI7FE0E=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1574850943/7f76c14366c649a29752c2c5a820256c",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1574850943/7f76c14366c649a29752c2c5a820256c",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1574850943/7f76c14366c649a29752c2c5a820256c",
+        "x5t": "slO59utg2W6MmqpzrneVzLJSEaM",
+        "cer": "MIICOjCCAeGgAwIBAgIQSV7gQa4wQ0Sw\u002B9FZZV39izAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTczN1oXDTIyMDQwODAyMjczN1owEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASGhQ\u002B\u002B4vpN3BWgvpOB9lRA\u002B09b2IJ2hSadDPUIcWYJCoK9sIPtpgkYk5Qzyxq9crP5FhkvONt4oNZJhYTTQwWUo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUJCRT4r/k30ZZdW5nPIBAsyVMTocwHQYDVR0OBBYEFCQkU\u002BK/5N9GWXVuZzyAQLMlTE6HMAoGCCqGSM49BAMCA0cAMEQCIAk/t24iqNTxRCQoURRs151QBzJyF8RuYXS\u002BjB9u1KsqAiBZ6SCQKnWrcpZKA5svPkYwdam98GkWVpq2TWliK7mt0A==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985091,
-          "exp": 1646521691,
-          "created": 1614985691,
-          "updated": 1614985691,
+          "nbf": 1617848257,
+          "exp": 1649384857,
+          "created": 1617848857,
+          "updated": 1617848857,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "3022848276624F59A972A411E67953A1"
+        "serialnumber": "495EE041AE304344B0FBD159655DFD8B"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1574850943/dabfb91f65194ba58a3c4a0854e98e61?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1574850943/7f76c14366c649a29752c2c5a820256c?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-04758fd2a100304aab81aecf7155bf73-7595402111de374a-00",
+        "traceparent": "00-a701188e9129384ea405dd1dc94628d5-138054c51db0424d-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "d81c71020808c5601148ca254e19b7d1",
+        "x-ms-client-request-id": "cf21541ea63abe13c6f45607422c5e82",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1761",
+        "Content-Length": "1759",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:08:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "cf21541ea63abe13c6f45607422c5e82",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "64d7e9a1-563c-4738-b3f2-9b05e70feb82",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "17756a5a-0bf6-462c-a829-0119d0ac89d2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIIBMgIBADCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA////////////\n/////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6H\nCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ\n1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQRtMGsCAQEE\nIDal3Tk0zwhFeiQAYhM00at\u002BKuXHxP28b3q\u002BpG\u002Bnb1HzoUQDQgAEApfS4RXBvSmE\nSD8XmLkjzIO159hDPSYQTtNZcYp5FjUC67nLMo9fAQWbqTq29B8iKgYwlCS\u002Bgc5k\nqECw5IkTQqANMAsGA1UdDzEEAwIAgA==\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICOzCCAeGgAwIBAgIQMCKEgnZiT1mpcqQR5nlToTAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTgxMVoXDTIyMDMwNTIzMDgxMVow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjO\nPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRB\nBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEI\nqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M\n0DZBQQIBAQNCAAQCl9LhFcG9KYRIPxeYuSPMg7Xn2EM9JhBO01lxinkWNQLrucsy\nj18BBZupOrb0HyIqBjCUJL6BzmSoQLDkiRNCo3wwejAOBgNVHQ8BAf8EBAMCB4Aw\nCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0j\nBBgwFoAUJWwOdi5K2rPgi6uFnOYYEO7oD7wwHQYDVR0OBBYEFCVsDnYuStqz4Iur\nhZzmGBDu6A\u002B8MAoGCCqGSM49BAMCA0gAMEUCIQDSzsn3rP8F9Z/W/iISXmfMUOlA\nGzcMlFo55/UL8z1TzQIgVv85bh20AP6Lp0z4Ypc6DW4QOzIbzD14SbNrBI7FE0E=\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIIBMgIBADCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA////////////\n/////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6H\nCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ\n1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQRtMGsCAQEE\nIHCoroAdE\u002BgasDN8hQY4c5iBN\u002Bou4LGcLMzY9cZ88Zh2oUQDQgAEhoUPvuL6TdwV\noL6TgfZUQPtPW9iCdoUmnQz1CHFmCQqCvbCD7aYJGJOUM8savXKz\u002BRYZLzjbeKDW\nSYWE00MFlKANMAsGA1UdDzEEAwIAgA==\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICOjCCAeGgAwIBAgIQSV7gQa4wQ0Sw\u002B9FZZV39izAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTczN1oXDTIyMDQwODAyMjczN1ow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjO\nPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRB\nBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEI\nqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M\n0DZBQQIBAQNCAASGhQ\u002B\u002B4vpN3BWgvpOB9lRA\u002B09b2IJ2hSadDPUIcWYJCoK9sIPt\npgkYk5Qzyxq9crP5FhkvONt4oNZJhYTTQwWUo3wwejAOBgNVHQ8BAf8EBAMCB4Aw\nCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0j\nBBgwFoAUJCRT4r/k30ZZdW5nPIBAsyVMTocwHQYDVR0OBBYEFCQkU\u002BK/5N9GWXVu\nZzyAQLMlTE6HMAoGCCqGSM49BAMCA0cAMEQCIAk/t24iqNTxRCQoURRs151QBzJy\nF8RuYXS\u002BjB9u1KsqAiBZ6SCQKnWrcpZKA5svPkYwdam98GkWVpq2TWliK7mt0A==\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1574850943/dabfb91f65194ba58a3c4a0854e98e61",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1574850943/7f76c14366c649a29752c2c5a820256c",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985091,
-          "exp": 1646521691,
-          "created": 1614985691,
-          "updated": 1614985691,
+          "nbf": 1617848257,
+          "exp": 1649384857,
+          "created": 1617848857,
+          "updated": 1617848857,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1574850943/dabfb91f65194ba58a3c4a0854e98e61"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1574850943/7f76c14366c649a29752c2c5a820256c"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "777806115"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-256K)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-256K)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/268705199/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-726e1ec9b6ae4f489f23078738bd5d33-f34e3085bdf03849-00",
+        "traceparent": "00-e5aabf6d78898a43bc9843091fce212c-dd7a6381f016d34c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "494a17479a8f5912272d3f3290fbe496",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "494a17479a8f5912272d3f3290fbe496",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6a84783e-4fc9-4482-bcc8-37db4832b84b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "27fff7d0-6bda-4848-8b63-74c34c9b4260",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/268705199/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "222",
         "Content-Type": "application/json",
-        "traceparent": "00-726e1ec9b6ae4f489f23078738bd5d33-f34e3085bdf03849-00",
+        "traceparent": "00-e5aabf6d78898a43bc9843091fce212c-dd7a6381f016d34c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "494a17479a8f5912272d3f3290fbe496",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "968",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:39 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending?api-version=7.2\u0026request_id=a7f38627c5764d64a4bf55417090d5c6",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending?api-version=7.2\u0026request_id=6087c0652a5d4849a669f37c73e8d5a8",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "494a17479a8f5912272d3f3290fbe496",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "8df5524e-2629-4296-9c47-19c5a25c1be0",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1efd85f6-106e-432e-a968-ee7242376575",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6GomixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgVB3y/hqzskSd3D1DlY7XBuYD9ESa64ywr6GQP0n/5fsCIQC4C\u002BkKH4lsMlwYefe\u002Bgu1YDneE0vraDQqclDE50Zd72g==",
+        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQLfroXBxB6PMf7TXTzrjVzZta2cL5YjdzDI319zyzcEelEiJBV8e5WVlKx54bvEfbN1pwxqwUgtH\u002BEKO8Qt2VuoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAPY3Rl7Ls/WKBASss1EIpei85ELSX8i6RRjZiK5ghlvRAiAOJD7uhu0jBE9I1ODf/GRYsg7hI2mb\u002BconSHR43HwLPQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a7f38627c5764d64a4bf55417090d5c6"
+        "request_id": "6087c0652a5d4849a669f37c73e8d5a8"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "dd952163bbbaf02ab28d5910f60a5da7",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "968",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:15 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:39 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "dd952163bbbaf02ab28d5910f60a5da7",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "587ef147-58cf-4a24-9760-c1ee8de7dfc3",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "71142403-5451-46bd-b3c8-a925b6ba7ef7",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6GomixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgVB3y/hqzskSd3D1DlY7XBuYD9ESa64ywr6GQP0n/5fsCIQC4C\u002BkKH4lsMlwYefe\u002Bgu1YDneE0vraDQqclDE50Zd72g==",
+        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQLfroXBxB6PMf7TXTzrjVzZta2cL5YjdzDI319zyzcEelEiJBV8e5WVlKx54bvEfbN1pwxqwUgtH\u002BEKO8Qt2VuoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAPY3Rl7Ls/WKBASss1EIpei85ELSX8i6RRjZiK5ghlvRAiAOJD7uhu0jBE9I1ODf/GRYsg7hI2mb\u002BconSHR43HwLPQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a7f38627c5764d64a4bf55417090d5c6"
+        "request_id": "6087c0652a5d4849a669f37c73e8d5a8"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "5603681bb6825220ffadf81e053b01b0",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "968",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:19 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5603681bb6825220ffadf81e053b01b0",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4c647cff-1020-4f50-9b45-7e9a97631e0a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "db98cee9-5266-4463-8546-26dcfe1ccae4",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6GomixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgVB3y/hqzskSd3D1DlY7XBuYD9ESa64ywr6GQP0n/5fsCIQC4C\u002BkKH4lsMlwYefe\u002Bgu1YDneE0vraDQqclDE50Zd72g==",
+        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQLfroXBxB6PMf7TXTzrjVzZta2cL5YjdzDI319zyzcEelEiJBV8e5WVlKx54bvEfbN1pwxqwUgtH\u002BEKO8Qt2VuoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAPY3Rl7Ls/WKBASss1EIpei85ELSX8i6RRjZiK5ghlvRAiAOJD7uhu0jBE9I1ODf/GRYsg7hI2mb\u002BconSHR43HwLPQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a7f38627c5764d64a4bf55417090d5c6"
+        "request_id": "6087c0652a5d4849a669f37c73e8d5a8"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "6c32136f7c258bf4ec5a97014101621c",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "968",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:24 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6c32136f7c258bf4ec5a97014101621c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f94fb9f7-a91a-45ad-8a71-99a95855ca66",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "2517565a-bf7b-4730-a099-25d0948b0e0c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6GomixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgVB3y/hqzskSd3D1DlY7XBuYD9ESa64ywr6GQP0n/5fsCIQC4C\u002BkKH4lsMlwYefe\u002Bgu1YDneE0vraDQqclDE50Zd72g==",
+        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQLfroXBxB6PMf7TXTzrjVzZta2cL5YjdzDI319zyzcEelEiJBV8e5WVlKx54bvEfbN1pwxqwUgtH\u002BEKO8Qt2VuoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAPY3Rl7Ls/WKBASss1EIpei85ELSX8i6RRjZiK5ghlvRAiAOJD7uhu0jBE9I1ODf/GRYsg7hI2mb\u002BconSHR43HwLPQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a7f38627c5764d64a4bf55417090d5c6"
+        "request_id": "6087c0652a5d4849a669f37c73e8d5a8"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "281797d08ef7ad130142de0cc20cea76",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "968",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:29 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "281797d08ef7ad130142de0cc20cea76",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0c3289eb-4689-4e78-ba33-28bd0798f5e4",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bee1f3aa-bc20-4b1f-a745-df6c48578f1e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6GomixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgVB3y/hqzskSd3D1DlY7XBuYD9ESa64ywr6GQP0n/5fsCIQC4C\u002BkKH4lsMlwYefe\u002Bgu1YDneE0vraDQqclDE50Zd72g==",
+        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQLfroXBxB6PMf7TXTzrjVzZta2cL5YjdzDI319zyzcEelEiJBV8e5WVlKx54bvEfbN1pwxqwUgtH\u002BEKO8Qt2VuoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAPY3Rl7Ls/WKBASss1EIpei85ELSX8i6RRjZiK5ghlvRAiAOJD7uhu0jBE9I1ODf/GRYsg7hI2mb\u002BconSHR43HwLPQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a7f38627c5764d64a4bf55417090d5c6"
+        "request_id": "6087c0652a5d4849a669f37c73e8d5a8"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "e3a1a88bf1d89e81737869281f1e11fd",
         "x-ms-return-client-request-id": "true"
@@ -300,42 +306,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "875",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:35 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e3a1a88bf1d89e81737869281f1e11fd",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a9e02ccf-d5e2-4f1f-90e2-f07669cf715b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6539be98-3320-4855-90a1-75942c5c3e19",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6GomixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgVB3y/hqzskSd3D1DlY7XBuYD9ESa64ywr6GQP0n/5fsCIQC4C\u002BkKH4lsMlwYefe\u002Bgu1YDneE0vraDQqclDE50Zd72g==",
+        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQLfroXBxB6PMf7TXTzrjVzZta2cL5YjdzDI319zyzcEelEiJBV8e5WVlKx54bvEfbN1pwxqwUgtH\u002BEKO8Qt2VuoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAPY3Rl7Ls/WKBASss1EIpei85ELSX8i6RRjZiK5ghlvRAiAOJD7uhu0jBE9I1ODf/GRYsg7hI2mb\u002BconSHR43HwLPQ==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a7f38627c5764d64a4bf55417090d5c6"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/268705199",
+        "request_id": "6087c0652a5d4849a669f37c73e8d5a8"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/268705199?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "6e4edc4bd924e1b900856be39ee7c8e0",
         "x-ms-return-client-request-id": "true"
@@ -344,255 +350,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "1962",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:40 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9edc03dc-a320-4bb0-a1df-a94b260cf3dc",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6GomixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgVB3y/hqzskSd3D1DlY7XBuYD9ESa64ywr6GQP0n/5fsCIQC4C\u002BkKH4lsMlwYefe\u002Bgu1YDneE0vraDQqclDE50Zd72g==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a7f38627c5764d64a4bf55417090d5c6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "9876206f7f60de441578b47f24ea8de3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "969",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:45 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "41349251-5e5f-44cc-a167-e7b6c9803cc5",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6GomixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgVB3y/hqzskSd3D1DlY7XBuYD9ESa64ywr6GQP0n/5fsCIQC4C\u002BkKH4lsMlwYefe\u002Bgu1YDneE0vraDQqclDE50Zd72g==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a7f38627c5764d64a4bf55417090d5c6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "e6c1e0307cbeb252efbfe253859e008b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "969",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:50 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f358d18c-49a7-4228-b6af-be4f36ab116f",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6GomixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgVB3y/hqzskSd3D1DlY7XBuYD9ESa64ywr6GQP0n/5fsCIQC4C\u002BkKH4lsMlwYefe\u002Bgu1YDneE0vraDQqclDE50Zd72g==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a7f38627c5764d64a4bf55417090d5c6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "feb988af78a8cb9d976f58ab2439bc15",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "969",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:55 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "d840870a-ac42-4f5a-941f-117a22629713",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6GomixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgVB3y/hqzskSd3D1DlY7XBuYD9ESa64ywr6GQP0n/5fsCIQC4C\u002BkKH4lsMlwYefe\u002Bgu1YDneE0vraDQqclDE50Zd72g==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a7f38627c5764d64a4bf55417090d5c6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "bdb287f7e125f321cec3a9a09cf05977",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "877",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:17:00 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6e4edc4bd924e1b900856be39ee7c8e0",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "bb13eb19-ad3f-4b39-9a93-e36e4aba79f5",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "34c888ab-9b3d-4532-a73d-25adb3a6e45b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6GomixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgVB3y/hqzskSd3D1DlY7XBuYD9ESa64ywr6GQP0n/5fsCIQC4C\u002BkKH4lsMlwYefe\u002Bgu1YDneE0vraDQqclDE50Zd72g==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/268705199",
-        "request_id": "a7f38627c5764d64a4bf55417090d5c6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "9bd029788f31b83b43f64f4f23a68eb5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1967",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:17:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "15321457-f92a-404e-b58a-d764d040e9f9",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/a270c3ee4e104319a85e9ac836e43d61",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/268705199/a270c3ee4e104319a85e9ac836e43d61",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/268705199/a270c3ee4e104319a85e9ac836e43d61",
-        "x5t": "bL4w7WQmh5gW9roLT37R1Ud_1h8",
-        "cer": "MIICOzCCAeGgAwIBAgIQPNXaZ95jSDaRPz3Cr1tUDzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDY1NloXDTIyMDMwNTIzMTY1NlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6Gomixo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAU3XiTp2Wd0a8\u002BKpzMs2LNj8Eg3E4wHQYDVR0OBBYEFN14k6dlndGvPiqczLNizY/BINxOMAoGCCqGSM49BAMCA0gAMEUCIQCfqJ89JRqBQDW1\u002BFM1VxTOBJ17in4mdzBUcyhJXa32SgIgdm6sEHMyJESL1L8Bl1s0ItqucIzoL8A\u002BtEfoCl9XFJY=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d",
+        "x5t": "qKdjP9UNSMvxCQ8Yikg1XCyt4RY",
+        "cer": "MIICOjCCAeGgAwIBAgIQaoFYz8gzTO2jZF1JiRWzbzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjY1NFoXDTIyMDQwODAyMzY1NFowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQLfroXBxB6PMf7TXTzrjVzZta2cL5YjdzDI319zyzcEelEiJBV8e5WVlKx54bvEfbN1pwxqwUgtH\u002BEKO8Qt2Vuo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUfZWjaF7CeuQdXUfCCuX4m01B2g4wHQYDVR0OBBYEFH2Vo2hewnrkHV1Hwgrl\u002BJtNQdoOMAoGCCqGSM49BAMCA0cAMEQCIBjPOcQI\u002BrWl9Srqfd70VKWgcT\u002BAuy2Z9kmbljhafW5TAiBGw9miP3BcrepVmJ0M4hoAKRZRudCE9hSHtJhVIWZa2w==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985616,
-          "exp": 1646522216,
-          "created": 1614986216,
-          "updated": 1614986216,
+          "nbf": 1617848814,
+          "exp": 1649385414,
+          "created": 1617849414,
+          "updated": 1617849414,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/268705199/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -632,65 +420,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614986175,
-            "updated": 1614986175
+            "created": 1617849399,
+            "updated": 1617849399
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/268705199/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/268705199/a270c3ee4e104319a85e9ac836e43d61?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-7413992b061136489bebebaf0600373e-49a77ef8e685d744-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "9876206f7f60de441578b47f24ea8de3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:36:58 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9876206f7f60de441578b47f24ea8de3",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "222afa52-a945-4361-bc41-8fbce2ff7f32",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-034c919d62723b46b5d21b611946a0fd-d78fca0da172344f-00",
+        "traceparent": "00-7413992b061136489bebebaf0600373e-49a77ef8e685d744-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "fe5ccd0343ebcd6567c52fe4cffc2fa6",
+        "x-ms-client-request-id": "9876206f7f60de441578b47f24ea8de3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "440",
+        "Content-Length": "439",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:17:00 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9876206f7f60de441578b47f24ea8de3",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0bdf884c-fe04-4265-aa8f-d43fae575326",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a94ec5f4-4899-4335-a809-9db9fb8de3d2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/268705199/a270c3ee4e104319a85e9ac836e43d61",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256K",
-          "x": "jPWaVV0_7WYjJkDcemgxP8FMl80e7hV0KaokRzsLnD0",
-          "y": "ZPluAdkeIp1W52tM-Y4jJN9q6CQYxR7FaLv4zoaiaLE"
+          "x": "C366FwcQejzH-0108641c2bWtnC-WI3cwyN9fc8s3BE",
+          "y": "6USIkFXx7lZWUrHnhu8R9s3WnDGrBSC0f4Qo7xC3ZW4"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985616,
-          "exp": 1646522216,
-          "created": 1614986216,
-          "updated": 1614986216,
+          "nbf": 1617848814,
+          "exp": 1649385414,
+          "created": 1617849414,
+          "updated": 1617849414,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -698,19 +527,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/268705199/a270c3ee4e104319a85e9ac836e43d61/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "70",
         "Content-Type": "application/json",
-        "traceparent": "00-034c919d62723b46b5d21b611946a0fd-ea8cd94835fb6b4e-00",
+        "traceparent": "00-7413992b061136489bebebaf0600373e-00cb21469e3b4646-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "fb33e016206967e34cfa7a2f92d2cf27",
+        "x-ms-client-request-id": "e6c1e0307cbeb252efbfe253859e008b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -720,128 +549,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "193",
+        "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:17:00 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e6c1e0307cbeb252efbfe253859e008b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "fdfd0aaf-f5bd-42f3-ae58-65920f9083b3",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ca945e74-8cc1-4ed9-a114-efa8f743f832",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/268705199/a270c3ee4e104319a85e9ac836e43d61",
-        "value": "YPT_flykxEK5Y0ZbMVXpvUwDK3wsaySdFDIZ3S4hSE0SUgpapoXemP-DpQ4tkL1n9AQPZkQEVXl2OGMHt0DsNA"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d",
+        "value": "08HhJuZnNvLhrDgY644dpR9pEkBsVInr11bToxT8HQxcov7L8waa1IVbJKpJCVs5zLD5qhcLS17z8ZQE0pydfQ"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/268705199/a270c3ee4e104319a85e9ac836e43d61?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-e62baf1a7561a7488d624b332eabbf1d-c28a2e7b0e19374f-00",
+        "traceparent": "00-735e0b77a99b814fb521f0a783929eb5-2e54c6071984f74c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "ce9cf3355a94348cc302346b5f56e846",
+        "x-ms-client-request-id": "feb988af78a8cb9d976f58ab2439bc15",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1371",
+        "Content-Length": "1368",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:17:00 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "feb988af78a8cb9d976f58ab2439bc15",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "8752f381-2da4-46d1-8c98-538a48f6c76b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "30ced498-2a30-4650-a19e-c1a16f1e6cec",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/268705199/a270c3ee4e104319a85e9ac836e43d61",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/268705199/a270c3ee4e104319a85e9ac836e43d61",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/268705199/a270c3ee4e104319a85e9ac836e43d61",
-        "x5t": "bL4w7WQmh5gW9roLT37R1Ud_1h8",
-        "cer": "MIICOzCCAeGgAwIBAgIQPNXaZ95jSDaRPz3Cr1tUDzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDY1NloXDTIyMDMwNTIzMTY1NlowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6Gomixo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAU3XiTp2Wd0a8\u002BKpzMs2LNj8Eg3E4wHQYDVR0OBBYEFN14k6dlndGvPiqczLNizY/BINxOMAoGCCqGSM49BAMCA0gAMEUCIQCfqJ89JRqBQDW1\u002BFM1VxTOBJ17in4mdzBUcyhJXa32SgIgdm6sEHMyJESL1L8Bl1s0ItqucIzoL8A\u002BtEfoCl9XFJY=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d",
+        "x5t": "qKdjP9UNSMvxCQ8Yikg1XCyt4RY",
+        "cer": "MIICOjCCAeGgAwIBAgIQaoFYz8gzTO2jZF1JiRWzbzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjY1NFoXDTIyMDQwODAyMzY1NFowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAAQLfroXBxB6PMf7TXTzrjVzZta2cL5YjdzDI319zyzcEelEiJBV8e5WVlKx54bvEfbN1pwxqwUgtH\u002BEKO8Qt2Vuo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUfZWjaF7CeuQdXUfCCuX4m01B2g4wHQYDVR0OBBYEFH2Vo2hewnrkHV1Hwgrl\u002BJtNQdoOMAoGCCqGSM49BAMCA0cAMEQCIBjPOcQI\u002BrWl9Srqfd70VKWgcT\u002BAuy2Z9kmbljhafW5TAiBGw9miP3BcrepVmJ0M4hoAKRZRudCE9hSHtJhVIWZa2w==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985616,
-          "exp": 1646522216,
-          "created": 1614986216,
-          "updated": 1614986216,
+          "nbf": 1617848814,
+          "exp": 1649385414,
+          "created": 1617849414,
+          "updated": 1617849414,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "3CD5DA67DE634836913F3DC2AF5B540F"
+        "serialnumber": "6A8158CFC8334CEDA3645D498915B36F"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/268705199/a270c3ee4e104319a85e9ac836e43d61?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-e62baf1a7561a7488d624b332eabbf1d-52c96efc5bb9be47-00",
+        "traceparent": "00-735e0b77a99b814fb521f0a783929eb5-5b6500ead9c3fa4f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "4238a8c79273e24ce9f4b1f0c8363a94",
+        "x-ms-client-request-id": "bdb287f7e125f321cec3a9a09cf05977",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1759",
+        "Content-Length": "1757",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:17:00 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bdb287f7e125f321cec3a9a09cf05977",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "cd3cc284-bf45-4fdf-a117-c9f383ced1a1",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "efe772df-a17b-4cf5-ab58-7b6d48edd809",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIIBMgIBADCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA////////////\n/////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6H\nCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ\n1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQRtMGsCAQEE\nIPsvstrCRJiUMkSL8kEmir7yjh7nyZhlTlsTYUvbhhfioUQDQgAEjPWaVV0/7WYj\nJkDcemgxP8FMl80e7hV0KaokRzsLnD1k\u002BW4B2R4inVbna0z5jiMk32roJBjFHsVo\nu/jOhqJosaANMAsGA1UdDzEEAwIAgA==\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICOzCCAeGgAwIBAgIQPNXaZ95jSDaRPz3Cr1tUDzAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDY1NloXDTIyMDMwNTIzMTY1Nlow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjO\nPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRB\nBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEI\nqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M\n0DZBQQIBAQNCAASM9ZpVXT/tZiMmQNx6aDE/wUyXzR7uFXQpqiRHOwucPWT5bgHZ\nHiKdVudrTPmOIyTfaugkGMUexWi7\u002BM6Gomixo3wwejAOBgNVHQ8BAf8EBAMCB4Aw\nCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0j\nBBgwFoAU3XiTp2Wd0a8\u002BKpzMs2LNj8Eg3E4wHQYDVR0OBBYEFN14k6dlndGvPiqc\nzLNizY/BINxOMAoGCCqGSM49BAMCA0gAMEUCIQCfqJ89JRqBQDW1\u002BFM1VxTOBJ17\nin4mdzBUcyhJXa32SgIgdm6sEHMyJESL1L8Bl1s0ItqucIzoL8A\u002BtEfoCl9XFJY=\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIIBMgIBADCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA////////////\n/////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6H\nCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ\n1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQRtMGsCAQEE\nINZGmU\u002BUVSymoDuUpvCZroIn8eHXBraA7VPsOvZNx4GtoUQDQgAEC366FwcQejzH\n\u002B0108641c2bWtnC\u002BWI3cwyN9fc8s3BHpRIiQVfHuVlZSseeG7xH2zdacMasFILR/\nhCjvELdlbqANMAsGA1UdDzEEAwIAgA==\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICOjCCAeGgAwIBAgIQaoFYz8gzTO2jZF1JiRWzbzAKBggqhkjOPQQDAjASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjY1NFoXDTIyMDQwODAyMzY1NFow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjO\nPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRB\nBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEI\nqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M\n0DZBQQIBAQNCAAQLfroXBxB6PMf7TXTzrjVzZta2cL5YjdzDI319zyzcEelEiJBV\n8e5WVlKx54bvEfbN1pwxqwUgtH\u002BEKO8Qt2Vuo3wwejAOBgNVHQ8BAf8EBAMCB4Aw\nCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0j\nBBgwFoAUfZWjaF7CeuQdXUfCCuX4m01B2g4wHQYDVR0OBBYEFH2Vo2hewnrkHV1H\nwgrl\u002BJtNQdoOMAoGCCqGSM49BAMCA0cAMEQCIBjPOcQI\u002BrWl9Srqfd70VKWgcT\u002BA\nuy2Z9kmbljhafW5TAiBGw9miP3BcrepVmJ0M4hoAKRZRudCE9hSHtJhVIWZa2w==\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/268705199/a270c3ee4e104319a85e9ac836e43d61",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985616,
-          "exp": 1646522216,
-          "created": 1614986216,
-          "updated": 1614986216,
+          "nbf": 1617848814,
+          "exp": 1649385414,
+          "created": 1617849414,
+          "updated": 1617849414,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/268705199/a270c3ee4e104319a85e9ac836e43d61"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/268705199/78dd7a98d0ae47e78a59b6acdfc7d63d"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1822438453"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-384).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-384).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/186228508/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-f2caf58a28d53e479486e5b795fdf75a-b673cac71be6a647-00",
+        "traceparent": "00-bd5cc2385aad0541b35394b6044cf5c8-656e999a5b4d1c41-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "7f911f4cfd90336c6cd34c16d8e62b38",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:47 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7f911f4cfd90336c6cd34c16d8e62b38",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1f63b99a-7dac-44a1-8676-d3c0df27f319",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "8a79d848-c0d1-44fa-8c96-b0cbf9d98878",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/186228508/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-f2caf58a28d53e479486e5b795fdf75a-b673cac71be6a647-00",
+        "traceparent": "00-bd5cc2385aad0541b35394b6044cf5c8-656e999a5b4d1c41-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "7f911f4cfd90336c6cd34c16d8e62b38",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "840",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:48 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending?api-version=7.2\u0026request_id=78fe41c8bd754f53997481a567afce92",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/186228508/pending?api-version=7.2\u0026request_id=99f7541df2e841e2bb61a6c01fadc974",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7f911f4cfd90336c6cd34c16d8e62b38",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4a3f6cdc-8228-4cee-80d0-ad7e4ed914b7",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d05553a1-24c7-49dd-8e3a-0ea2ccfda3e1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/186228508/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE\u002B00zLuSeiTz2gqI1O0aOJhD/cba\u002B6JL2gVv6259GNMfRaeU\u002BguJXixKIYAVBJoaB1enXR0MLl9VS47x7Nl28S2PzDkEXX5ppxTQW3pCAqrIsE2YqmPK\u002BR97gOv3sDw8IoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwdnYC60N/gKR\u002B\u002Byya7ICCD1iczIRVheNzGEXAAjLzqk/VKNOGTuI4os1YLy0IQCE2AjBoAAZI6/ybtLVYH1Z4fUMI6QdIDFWrOIwX02J3qauIo9X2xKWrq1Kwxi7wMsRQRmY=",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEyzX8etzgibOWvkNrOMLtgCcygHZkZKF4uolm2/KWWDQ4Q0qdsR0\u002BchuGciDlnbjy4xR4ysVf1OBYHRqZktk\u002BqtB1y8d6AU7x6IX4IK1NjCewMLxf1v9f3xRFvitqRoO0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAJ8OrexHQ/AOLELPxdPRIGURST8/TxAf3TU9V9\u002Bnm6yAn0yYpqmqkci0nuWSJBpFYQIxANvE9CMWRDxjrVtOFL53f\u002B725ojW3CbgDI6s2xu9Dlb9bVvqlTxw2L/3EwVEk7pNiQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "78fe41c8bd754f53997481a567afce92"
+        "request_id": "99f7541df2e841e2bb61a6c01fadc974"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/186228508/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "131ab9c34078e6728b87c86c8d66426d",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "840",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:17 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:48 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "131ab9c34078e6728b87c86c8d66426d",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0cfd0ee3-d392-42da-bef3-b1d0cb4f2fec",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "78bb6df7-8d71-4366-8a86-f055bdb0d5ed",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/186228508/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE\u002B00zLuSeiTz2gqI1O0aOJhD/cba\u002B6JL2gVv6259GNMfRaeU\u002BguJXixKIYAVBJoaB1enXR0MLl9VS47x7Nl28S2PzDkEXX5ppxTQW3pCAqrIsE2YqmPK\u002BR97gOv3sDw8IoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwdnYC60N/gKR\u002B\u002Byya7ICCD1iczIRVheNzGEXAAjLzqk/VKNOGTuI4os1YLy0IQCE2AjBoAAZI6/ybtLVYH1Z4fUMI6QdIDFWrOIwX02J3qauIo9X2xKWrq1Kwxi7wMsRQRmY=",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEyzX8etzgibOWvkNrOMLtgCcygHZkZKF4uolm2/KWWDQ4Q0qdsR0\u002BchuGciDlnbjy4xR4ysVf1OBYHRqZktk\u002BqtB1y8d6AU7x6IX4IK1NjCewMLxf1v9f3xRFvitqRoO0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAJ8OrexHQ/AOLELPxdPRIGURST8/TxAf3TU9V9\u002Bnm6yAn0yYpqmqkci0nuWSJBpFYQIxANvE9CMWRDxjrVtOFL53f\u002B725ojW3CbgDI6s2xu9Dlb9bVvqlTxw2L/3EwVEk7pNiQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "78fe41c8bd754f53997481a567afce92"
+        "request_id": "99f7541df2e841e2bb61a6c01fadc974"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/186228508/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "3d147b6e962700138dc8b5f4c3a37d13",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "840",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:23 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:52 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3d147b6e962700138dc8b5f4c3a37d13",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2b81fd92-d249-4513-b89c-b25542a1dda3",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bec0a5e8-e158-4098-93fb-d249e53e59d8",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/186228508/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE\u002B00zLuSeiTz2gqI1O0aOJhD/cba\u002B6JL2gVv6259GNMfRaeU\u002BguJXixKIYAVBJoaB1enXR0MLl9VS47x7Nl28S2PzDkEXX5ppxTQW3pCAqrIsE2YqmPK\u002BR97gOv3sDw8IoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwdnYC60N/gKR\u002B\u002Byya7ICCD1iczIRVheNzGEXAAjLzqk/VKNOGTuI4os1YLy0IQCE2AjBoAAZI6/ybtLVYH1Z4fUMI6QdIDFWrOIwX02J3qauIo9X2xKWrq1Kwxi7wMsRQRmY=",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEyzX8etzgibOWvkNrOMLtgCcygHZkZKF4uolm2/KWWDQ4Q0qdsR0\u002BchuGciDlnbjy4xR4ysVf1OBYHRqZktk\u002BqtB1y8d6AU7x6IX4IK1NjCewMLxf1v9f3xRFvitqRoO0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAJ8OrexHQ/AOLELPxdPRIGURST8/TxAf3TU9V9\u002Bnm6yAn0yYpqmqkci0nuWSJBpFYQIxANvE9CMWRDxjrVtOFL53f\u002B725ojW3CbgDI6s2xu9Dlb9bVvqlTxw2L/3EwVEk7pNiQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "78fe41c8bd754f53997481a567afce92"
+        "request_id": "99f7541df2e841e2bb61a6c01fadc974"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/186228508/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "a26016a859160ca3adaaf4083500a505",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:27 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:57 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a26016a859160ca3adaaf4083500a505",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7acafade-909e-455d-ad5e-5c7e0824267d",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "344ed412-526b-4406-af6a-dafa5305bd37",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/186228508/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE\u002B00zLuSeiTz2gqI1O0aOJhD/cba\u002B6JL2gVv6259GNMfRaeU\u002BguJXixKIYAVBJoaB1enXR0MLl9VS47x7Nl28S2PzDkEXX5ppxTQW3pCAqrIsE2YqmPK\u002BR97gOv3sDw8IoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwdnYC60N/gKR\u002B\u002Byya7ICCD1iczIRVheNzGEXAAjLzqk/VKNOGTuI4os1YLy0IQCE2AjBoAAZI6/ybtLVYH1Z4fUMI6QdIDFWrOIwX02J3qauIo9X2xKWrq1Kwxi7wMsRQRmY=",
+        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEyzX8etzgibOWvkNrOMLtgCcygHZkZKF4uolm2/KWWDQ4Q0qdsR0\u002BchuGciDlnbjy4xR4ysVf1OBYHRqZktk\u002BqtB1y8d6AU7x6IX4IK1NjCewMLxf1v9f3xRFvitqRoO0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAJ8OrexHQ/AOLELPxdPRIGURST8/TxAf3TU9V9\u002Bnm6yAn0yYpqmqkci0nuWSJBpFYQIxANvE9CMWRDxjrVtOFL53f\u002B725ojW3CbgDI6s2xu9Dlb9bVvqlTxw2L/3EwVEk7pNiQ==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "78fe41c8bd754f53997481a567afce92"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/186228508",
+        "request_id": "99f7541df2e841e2bb61a6c01fadc974"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/186228508?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "5ca8df91edd22d10a51986b08b7e23e7",
         "x-ms-return-client-request-id": "true"
@@ -256,255 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "837",
+        "Content-Length": "1833",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:33 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f2c09fcd-65a9-4986-b95f-c6319839a473",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE\u002B00zLuSeiTz2gqI1O0aOJhD/cba\u002B6JL2gVv6259GNMfRaeU\u002BguJXixKIYAVBJoaB1enXR0MLl9VS47x7Nl28S2PzDkEXX5ppxTQW3pCAqrIsE2YqmPK\u002BR97gOv3sDw8IoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwdnYC60N/gKR\u002B\u002Byya7ICCD1iczIRVheNzGEXAAjLzqk/VKNOGTuI4os1YLy0IQCE2AjBoAAZI6/ybtLVYH1Z4fUMI6QdIDFWrOIwX02J3qauIo9X2xKWrq1Kwxi7wMsRQRmY=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "78fe41c8bd754f53997481a567afce92"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "77c3b40a9f061556d808907ca20acb8c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "837",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:38 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "26fdf9e5-b986-4dc0-a327-369cfbd3fafc",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE\u002B00zLuSeiTz2gqI1O0aOJhD/cba\u002B6JL2gVv6259GNMfRaeU\u002BguJXixKIYAVBJoaB1enXR0MLl9VS47x7Nl28S2PzDkEXX5ppxTQW3pCAqrIsE2YqmPK\u002BR97gOv3sDw8IoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwdnYC60N/gKR\u002B\u002Byya7ICCD1iczIRVheNzGEXAAjLzqk/VKNOGTuI4os1YLy0IQCE2AjBoAAZI6/ybtLVYH1Z4fUMI6QdIDFWrOIwX02J3qauIo9X2xKWrq1Kwxi7wMsRQRmY=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "78fe41c8bd754f53997481a567afce92"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "e462af2220fbba410533fcfdd3f3802f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "837",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:43 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7b781412-fbd0-4039-bcb7-a98def666d41",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE\u002B00zLuSeiTz2gqI1O0aOJhD/cba\u002B6JL2gVv6259GNMfRaeU\u002BguJXixKIYAVBJoaB1enXR0MLl9VS47x7Nl28S2PzDkEXX5ppxTQW3pCAqrIsE2YqmPK\u002BR97gOv3sDw8IoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwdnYC60N/gKR\u002B\u002Byya7ICCD1iczIRVheNzGEXAAjLzqk/VKNOGTuI4os1YLy0IQCE2AjBoAAZI6/ybtLVYH1Z4fUMI6QdIDFWrOIwX02J3qauIo9X2xKWrq1Kwxi7wMsRQRmY=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "78fe41c8bd754f53997481a567afce92"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "80fe0c862e3cf1ff889384c95d938a9a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "837",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:48 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f37156a5-03dd-4504-8a56-e0139ab047cb",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE\u002B00zLuSeiTz2gqI1O0aOJhD/cba\u002B6JL2gVv6259GNMfRaeU\u002BguJXixKIYAVBJoaB1enXR0MLl9VS47x7Nl28S2PzDkEXX5ppxTQW3pCAqrIsE2YqmPK\u002BR97gOv3sDw8IoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwdnYC60N/gKR\u002B\u002Byya7ICCD1iczIRVheNzGEXAAjLzqk/VKNOGTuI4os1YLy0IQCE2AjBoAAZI6/ybtLVYH1Z4fUMI6QdIDFWrOIwX02J3qauIo9X2xKWrq1Kwxi7wMsRQRmY=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "78fe41c8bd754f53997481a567afce92"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "db8df94d3f1beaec720971d3a25841e5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "745",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:53 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:57 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5ca8df91edd22d10a51986b08b7e23e7",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c98faf1c-29c9-4be1-ae3f-818a7b9e09f1",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "9c655a99-3f87-4d22-b559-b7218c5b9fcb",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVDCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE\u002B00zLuSeiTz2gqI1O0aOJhD/cba\u002B6JL2gVv6259GNMfRaeU\u002BguJXixKIYAVBJoaB1enXR0MLl9VS47x7Nl28S2PzDkEXX5ppxTQW3pCAqrIsE2YqmPK\u002BR97gOv3sDw8IoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDZwAwZAIwdnYC60N/gKR\u002B\u002Byya7ICCD1iczIRVheNzGEXAAjLzqk/VKNOGTuI4os1YLy0IQCE2AjBoAAZI6/ybtLVYH1Z4fUMI6QdIDFWrOIwX02J3qauIo9X2xKWrq1Kwxi7wMsRQRmY=",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/186228508",
-        "request_id": "78fe41c8bd754f53997481a567afce92"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "95f661884b0cf350b0715b689c785d71",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1838",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:53 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "fc59617e-7b34-4577-babf-18caec10c1ca",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/33244dad099e4add8c6e24170e7118de",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/186228508/33244dad099e4add8c6e24170e7118de",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/186228508/33244dad099e4add8c6e24170e7118de",
-        "x5t": "fOFpcdBgZjs23JOPM7zts1uLpbI",
-        "cer": "MIIB2zCCAWGgAwIBAgIQCyIq1dH1TnWvLGoF5X1IszAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTY1MloXDTIyMDMwNTIzMDY1MlowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABPtNMy7knok89oKiNTtGjiYQ/3G2vuiS9oFb\u002BtufRjTH0WnlPoLiV4sSiGAFQSaGgdXp10dDC5fVUuO8ezZdvEtj8w5BF1\u002BaacU0Ft6QgKqyLBNmKpjyvkfe4Dr97A8PCKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFNwMzCi68HLIwfCihJnRAOq08LPeMB0GA1UdDgQWBBTcDMwouvByyMHwooSZ0QDqtPCz3jAKBggqhkjOPQQDAwNoADBlAjA20VH7DVJbiaIE48US3JkNcHMyCE5TDqmymZNlTYo\u002Bw/eT6EMv8P6OtF2wz1aukQ8CMQCXD8JNFTs0KUvk46uZ/tWZbYUEPWV3YbDqLf531uBJajlS/XMp279keObUlfF\u002BII8=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/186228508/95fed50fb2da49d48c7126886e9ff6b0",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/186228508/95fed50fb2da49d48c7126886e9ff6b0",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/186228508/95fed50fb2da49d48c7126886e9ff6b0",
+        "x5t": "i7Xlbwuj923We5nSR-ZaFJD8ZF0",
+        "cer": "MIIB2jCCAWGgAwIBAgIQLt5a2xQLRSy2QuACavUd2DAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTY1N1oXDTIyMDQwODAyMjY1N1owEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABMs1/Hrc4Imzlr5DazjC7YAnMoB2ZGSheLqJZtvyllg0OENKnbEdPnIbhnIg5Z248uMUeMrFX9TgWB0amZLZPqrQdcvHegFO8eiF\u002BCCtTYwnsDC8X9b/X98URb4rakaDtKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFOEQxFxQRZtfgXkgXRw6Hwb8v5TwMB0GA1UdDgQWBBThEMRcUEWbX4F5IF0cOh8G/L\u002BU8DAKBggqhkjOPQQDAwNnADBkAjAtVGdtISeWEkD4X9WK6QW9If2q\u002B7hYqtYjSwetKHtAV885JOynt0epZS0WkT\u002BkWHACMEkBneE3mmQVfaYhD6tLq2opqaro2tjWRFOsADrlgADh/\u002BjqHLq4J5nuAgmOh0WlJg==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985012,
-          "exp": 1646521612,
-          "created": 1614985612,
-          "updated": 1614985612,
+          "nbf": 1617848217,
+          "exp": 1649384817,
+          "created": 1617848817,
+          "updated": 1617848817,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/186228508/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -544,65 +330,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985578,
-            "updated": 1614985578
+            "created": 1617848808,
+            "updated": 1617848808
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/186228508/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/186228508/33244dad099e4add8c6e24170e7118de?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/186228508/95fed50fb2da49d48c7126886e9ff6b0?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-8511813ba9955742a46cb9c51bde0747-aaaa8198462d1e4d-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "77c3b40a9f061556d808907ca20acb8c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:27:03 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "77c3b40a9f061556d808907ca20acb8c",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "700e4950-5080-4c6e-9dcf-249983ec089a",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/186228508/95fed50fb2da49d48c7126886e9ff6b0?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-7307d43d8b20e74882bd46799f22409a-27314ceda862024a-00",
+        "traceparent": "00-8511813ba9955742a46cb9c51bde0747-aaaa8198462d1e4d-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "d9af62a8a565471320130d33bd2b4f30",
+        "x-ms-client-request-id": "77c3b40a9f061556d808907ca20acb8c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "481",
+        "Content-Length": "480",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:58 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "77c3b40a9f061556d808907ca20acb8c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "19fc39b3-7d24-48eb-a01a-b790134f16b8",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "c6fec83a-ed73-4dc0-bc61-a58fd41bc0dd",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/186228508/33244dad099e4add8c6e24170e7118de",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/186228508/95fed50fb2da49d48c7126886e9ff6b0",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-384",
-          "x": "-00zLuSeiTz2gqI1O0aOJhD_cba-6JL2gVv6259GNMfRaeU-guJXixKIYAVBJoaB",
-          "y": "1enXR0MLl9VS47x7Nl28S2PzDkEXX5ppxTQW3pCAqrIsE2YqmPK-R97gOv3sDw8I"
+          "x": "yzX8etzgibOWvkNrOMLtgCcygHZkZKF4uolm2_KWWDQ4Q0qdsR0-chuGciDlnbjy",
+          "y": "4xR4ysVf1OBYHRqZktk-qtB1y8d6AU7x6IX4IK1NjCewMLxf1v9f3xRFvitqRoO0"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985012,
-          "exp": 1646521612,
-          "created": 1614985612,
-          "updated": 1614985612,
+          "nbf": 1617848217,
+          "exp": 1649384817,
+          "created": 1617848817,
+          "updated": 1617848817,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -610,19 +437,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/186228508/33244dad099e4add8c6e24170e7118de/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/186228508/95fed50fb2da49d48c7126886e9ff6b0/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "90",
         "Content-Type": "application/json",
-        "traceparent": "00-7307d43d8b20e74882bd46799f22409a-cf786a746653fd41-00",
+        "traceparent": "00-8511813ba9955742a46cb9c51bde0747-0404f84b33434146-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "fb409f51f49d028ea9992aaae4844efa",
+        "x-ms-client-request-id": "e462af2220fbba410533fcfdd3f3802f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -632,128 +459,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "235",
+        "Content-Length": "234",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:58 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e462af2220fbba410533fcfdd3f3802f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4b5f4a61-8779-4983-bab3-a82567f2a089",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "c858c002-e079-4e70-8259-af8cee9c60c7",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/186228508/33244dad099e4add8c6e24170e7118de",
-        "value": "x2eT_12VAitxPhP2q0h6vJDUfkUs1fnHyZo_kfI5K1ppf8qF30DWqmvd-n4PQgl-6IrE583Zg4DLFUDLJJaAlY_Ner6HY2LFSTkQHztON_1RpeqUZb2MyGc_PxKwuQm5"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/186228508/95fed50fb2da49d48c7126886e9ff6b0",
+        "value": "NOeYdYxsiu7wWQOO5JQDhpQJkbydcWhns1G9mHz1AEZlZ9VHj_qvSmSrLNsgIAocjCiP12-Y75aRnAFXH07mstqAYsP4GtenLX0WE1s8Tz3KMyoLguCMExeee7uV-w7I"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/186228508/33244dad099e4add8c6e24170e7118de?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/186228508/95fed50fb2da49d48c7126886e9ff6b0?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-0a8cad36b68233468908a39d1afcbd78-eac3c607485ade4c-00",
+        "traceparent": "00-8fccd5a22f042a41a26f3c59e8cc6185-7fbb351938b1a142-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "402affab67a9e37f4daf75f83d1c3684",
+        "x-ms-client-request-id": "80fe0c862e3cf1ff889384c95d938a9a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1243",
+        "Content-Length": "1240",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:58 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "80fe0c862e3cf1ff889384c95d938a9a",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4d38aa78-7a80-456f-bf15-a8d4ae37eed9",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "8278d5b3-4f52-4f3c-a112-4a6cbb182081",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/186228508/33244dad099e4add8c6e24170e7118de",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/186228508/33244dad099e4add8c6e24170e7118de",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/186228508/33244dad099e4add8c6e24170e7118de",
-        "x5t": "fOFpcdBgZjs23JOPM7zts1uLpbI",
-        "cer": "MIIB2zCCAWGgAwIBAgIQCyIq1dH1TnWvLGoF5X1IszAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTY1MloXDTIyMDMwNTIzMDY1MlowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABPtNMy7knok89oKiNTtGjiYQ/3G2vuiS9oFb\u002BtufRjTH0WnlPoLiV4sSiGAFQSaGgdXp10dDC5fVUuO8ezZdvEtj8w5BF1\u002BaacU0Ft6QgKqyLBNmKpjyvkfe4Dr97A8PCKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFNwMzCi68HLIwfCihJnRAOq08LPeMB0GA1UdDgQWBBTcDMwouvByyMHwooSZ0QDqtPCz3jAKBggqhkjOPQQDAwNoADBlAjA20VH7DVJbiaIE48US3JkNcHMyCE5TDqmymZNlTYo\u002Bw/eT6EMv8P6OtF2wz1aukQ8CMQCXD8JNFTs0KUvk46uZ/tWZbYUEPWV3YbDqLf531uBJajlS/XMp279keObUlfF\u002BII8=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/186228508/95fed50fb2da49d48c7126886e9ff6b0",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/186228508/95fed50fb2da49d48c7126886e9ff6b0",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/186228508/95fed50fb2da49d48c7126886e9ff6b0",
+        "x5t": "i7Xlbwuj923We5nSR-ZaFJD8ZF0",
+        "cer": "MIIB2jCCAWGgAwIBAgIQLt5a2xQLRSy2QuACavUd2DAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTY1N1oXDTIyMDQwODAyMjY1N1owEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABMs1/Hrc4Imzlr5DazjC7YAnMoB2ZGSheLqJZtvyllg0OENKnbEdPnIbhnIg5Z248uMUeMrFX9TgWB0amZLZPqrQdcvHegFO8eiF\u002BCCtTYwnsDC8X9b/X98URb4rakaDtKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFOEQxFxQRZtfgXkgXRw6Hwb8v5TwMB0GA1UdDgQWBBThEMRcUEWbX4F5IF0cOh8G/L\u002BU8DAKBggqhkjOPQQDAwNnADBkAjAtVGdtISeWEkD4X9WK6QW9If2q\u002B7hYqtYjSwetKHtAV885JOynt0epZS0WkT\u002BkWHACMEkBneE3mmQVfaYhD6tLq2opqaro2tjWRFOsADrlgADh/\u002BjqHLq4J5nuAgmOh0WlJg==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985012,
-          "exp": 1646521612,
-          "created": 1614985612,
-          "updated": 1614985612,
+          "nbf": 1617848217,
+          "exp": 1649384817,
+          "created": 1617848817,
+          "updated": 1617848817,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "0B222AD5D1F54E75AF2C6A05E57D48B3"
+        "serialnumber": "2EDE5ADB140B452CB642E0026AF51DD8"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/186228508/33244dad099e4add8c6e24170e7118de?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/186228508/95fed50fb2da49d48c7126886e9ff6b0?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-0a8cad36b68233468908a39d1afcbd78-8af465f8c169554d-00",
+        "traceparent": "00-8fccd5a22f042a41a26f3c59e8cc6185-499a6f9afd1de940-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "fd162a216137b3d4d3ac30cb7a69629c",
+        "x-ms-client-request-id": "db8df94d3f1beaec720971d3a25841e5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1487",
+        "Content-Length": "1485",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:58 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "db8df94d3f1beaec720971d3a25841e5",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "77d2a0e3-6c96-4d8e-b5f6-8fcfa36e120f",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1f4aa3ae-5548-41e2-9295-2ab4cb62eb02",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIHOAgEAMBAGByqGSM49AgEGBSuBBAAiBIGnMIGkAgEBBDC152nDSoi7Ne2Ts4Mx\n8ql3A/\u002BK3ox1WGAox7l1Ug0hmPXLmwF8IXD\u002B06a3vgqSq5ygBwYFK4EEACKhZANi\nAAT7TTMu5J6JPPaCojU7Ro4mEP9xtr7okvaBW/rbn0Y0x9Fp5T6C4leLEohgBUEm\nhoHV6ddHQwuX1VLjvHs2XbxLY/MOQRdfmmnFNBbekICqsiwTZiqY8r5H3uA6/ewP\nDwigDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIB2zCCAWGgAwIBAgIQCyIq1dH1TnWvLGoF5X1IszAKBggqhkjOPQQDAzASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTY1MloXDTIyMDMwNTIzMDY1Mlow\nEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABPtNMy7k\nnok89oKiNTtGjiYQ/3G2vuiS9oFb\u002BtufRjTH0WnlPoLiV4sSiGAFQSaGgdXp10dD\nC5fVUuO8ezZdvEtj8w5BF1\u002BaacU0Ft6QgKqyLBNmKpjyvkfe4Dr97A8PCKN8MHow\nDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEG\nCCsGAQUFBwMCMB8GA1UdIwQYMBaAFNwMzCi68HLIwfCihJnRAOq08LPeMB0GA1Ud\nDgQWBBTcDMwouvByyMHwooSZ0QDqtPCz3jAKBggqhkjOPQQDAwNoADBlAjA20VH7\nDVJbiaIE48US3JkNcHMyCE5TDqmymZNlTYo\u002Bw/eT6EMv8P6OtF2wz1aukQ8CMQCX\nD8JNFTs0KUvk46uZ/tWZbYUEPWV3YbDqLf531uBJajlS/XMp279keObUlfF\u002BII8=\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIHOAgEAMBAGByqGSM49AgEGBSuBBAAiBIGnMIGkAgEBBDDASUPCkmDd2PwjA9SO\ngN/OpMI7BaFPp\u002B2djpFtVPT8uR57KystYuVRI15EWWTeHBqgBwYFK4EEACKhZANi\nAATLNfx63OCJs5a\u002BQ2s4wu2AJzKAdmRkoXi6iWbb8pZYNDhDSp2xHT5yG4ZyIOWd\nuPLjFHjKxV/U4FgdGpmS2T6q0HXLx3oBTvHohfggrU2MJ7AwvF/W/1/fFEW\u002BK2pG\ng7SgDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIB2jCCAWGgAwIBAgIQLt5a2xQLRSy2QuACavUd2DAKBggqhkjOPQQDAzASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTY1N1oXDTIyMDQwODAyMjY1N1ow\nEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABMs1/Hrc\n4Imzlr5DazjC7YAnMoB2ZGSheLqJZtvyllg0OENKnbEdPnIbhnIg5Z248uMUeMrF\nX9TgWB0amZLZPqrQdcvHegFO8eiF\u002BCCtTYwnsDC8X9b/X98URb4rakaDtKN8MHow\nDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEG\nCCsGAQUFBwMCMB8GA1UdIwQYMBaAFOEQxFxQRZtfgXkgXRw6Hwb8v5TwMB0GA1Ud\nDgQWBBThEMRcUEWbX4F5IF0cOh8G/L\u002BU8DAKBggqhkjOPQQDAwNnADBkAjAtVGdt\nISeWEkD4X9WK6QW9If2q\u002B7hYqtYjSwetKHtAV885JOynt0epZS0WkT\u002BkWHACMEkB\nneE3mmQVfaYhD6tLq2opqaro2tjWRFOsADrlgADh/\u002BjqHLq4J5nuAgmOh0WlJg==\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/186228508/33244dad099e4add8c6e24170e7118de",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/186228508/95fed50fb2da49d48c7126886e9ff6b0",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985012,
-          "exp": 1646521612,
-          "created": 1614985612,
-          "updated": 1614985612,
+          "nbf": 1617848217,
+          "exp": 1649384817,
+          "created": 1617848817,
+          "updated": 1617848817,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/186228508/33244dad099e4add8c6e24170e7118de"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/186228508/95fed50fb2da49d48c7126886e9ff6b0"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1026254467"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-384)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-384)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2028711033/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2028711033/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-f7491d694049264993768511e726a664-9a0da448365f224d-00",
+        "traceparent": "00-cc4b76a917f2484fabd008fb7727ef44-03ecc4ea11a7e14d-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "451dfa5a228a28183edf4462c445d1ba",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:21 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "451dfa5a228a28183edf4462c445d1ba",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6a2c5b5c-c823-4b5a-940e-74e3ef093b46",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "45de9147-3cb7-4b55-a818-c0a9392ef326",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2028711033/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2028711033/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-f7491d694049264993768511e726a664-9a0da448365f224d-00",
+        "traceparent": "00-cc4b76a917f2484fabd008fb7727ef44-03ecc4ea11a7e14d-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "451dfa5a228a28183edf4462c445d1ba",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:22 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:56 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending?api-version=7.2\u0026request_id=3187a58457374ebab6d63a12983d2f27",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending?api-version=7.2\u0026request_id=0272bf606a2f4a4882949bb0731120aa",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "451dfa5a228a28183edf4462c445d1ba",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "19afcd6d-db1a-4aa8-bfdf-a46477041bda",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bf3fb1c9-e736-481d-965e-10b79a89f8bc",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAESItWNhtv/2a02KtoybBVGcPwNCLnEhNozL0yeUG7vCXHEfRIK8S6z3L9aIsDqxOxAc5J3PVNei4lSs7zZyEkNCCfVuGqVFwnEOBXvCQTnU6vh6cMulVNWymfDs5\u002BxDdooEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAMttHI1jZ5wkPu4tESI2qAQ8LivWj0EyFTCie37aVZH6VMpphXbVJt9NfzkLKHml2wIwQL1vJHyNga4FakUhTlIDfnWqHWIQ\u002BQg6MYf2Sb1Yx60C4j7Fr6RgbPq6ungIcnEg",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEsEthkm\u002B22a2TeXLHMSkhEwSdhFTh8JOzxcXp/wttqhWK7w5DgvtznhKzy5Ind2Zwfi530VVvfwiNfcBNnA8ByegkbMXdHVKuzghBlm8E7RV0WfMdxc0rncNrSWk\u002BYktMoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAN7xz8H/AIOtEnCuD3SYeoy82mO7EKn2d/6/eJNuRY5jIyFQBaIZj2c/kQq28mNgnAIwIiVII1PPoPSYRz5mylHK0MZdS9a22/lU43n2z8cKL55DcBvCkO6WZd6EWutWzwV\u002B",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3187a58457374ebab6d63a12983d2f27"
+        "request_id": "0272bf606a2f4a4882949bb0731120aa"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "3b8a1a3f97f419db21c10cbd4eba3038",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:22 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:56 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3b8a1a3f97f419db21c10cbd4eba3038",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "22e7c1ba-d68c-4909-96be-998bf4a07176",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "0860aacd-3d34-4063-8163-1eccfa5156eb",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAESItWNhtv/2a02KtoybBVGcPwNCLnEhNozL0yeUG7vCXHEfRIK8S6z3L9aIsDqxOxAc5J3PVNei4lSs7zZyEkNCCfVuGqVFwnEOBXvCQTnU6vh6cMulVNWymfDs5\u002BxDdooEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAMttHI1jZ5wkPu4tESI2qAQ8LivWj0EyFTCie37aVZH6VMpphXbVJt9NfzkLKHml2wIwQL1vJHyNga4FakUhTlIDfnWqHWIQ\u002BQg6MYf2Sb1Yx60C4j7Fr6RgbPq6ungIcnEg",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEsEthkm\u002B22a2TeXLHMSkhEwSdhFTh8JOzxcXp/wttqhWK7w5DgvtznhKzy5Ind2Zwfi530VVvfwiNfcBNnA8ByegkbMXdHVKuzghBlm8E7RV0WfMdxc0rncNrSWk\u002BYktMoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAN7xz8H/AIOtEnCuD3SYeoy82mO7EKn2d/6/eJNuRY5jIyFQBaIZj2c/kQq28mNgnAIwIiVII1PPoPSYRz5mylHK0MZdS9a22/lU43n2z8cKL55DcBvCkO6WZd6EWutWzwV\u002B",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3187a58457374ebab6d63a12983d2f27"
+        "request_id": "0272bf606a2f4a4882949bb0731120aa"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "a1374c114cd65ba00a3291338c3713df",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:27 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a1374c114cd65ba00a3291338c3713df",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "bcebad6b-3e5c-4c39-9a56-03959c5fb443",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ddecba58-b19c-4b90-ba97-916c5097b52d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAESItWNhtv/2a02KtoybBVGcPwNCLnEhNozL0yeUG7vCXHEfRIK8S6z3L9aIsDqxOxAc5J3PVNei4lSs7zZyEkNCCfVuGqVFwnEOBXvCQTnU6vh6cMulVNWymfDs5\u002BxDdooEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAMttHI1jZ5wkPu4tESI2qAQ8LivWj0EyFTCie37aVZH6VMpphXbVJt9NfzkLKHml2wIwQL1vJHyNga4FakUhTlIDfnWqHWIQ\u002BQg6MYf2Sb1Yx60C4j7Fr6RgbPq6ungIcnEg",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEsEthkm\u002B22a2TeXLHMSkhEwSdhFTh8JOzxcXp/wttqhWK7w5DgvtznhKzy5Ind2Zwfi530VVvfwiNfcBNnA8ByegkbMXdHVKuzghBlm8E7RV0WfMdxc0rncNrSWk\u002BYktMoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAN7xz8H/AIOtEnCuD3SYeoy82mO7EKn2d/6/eJNuRY5jIyFQBaIZj2c/kQq28mNgnAIwIiVII1PPoPSYRz5mylHK0MZdS9a22/lU43n2z8cKL55DcBvCkO6WZd6EWutWzwV\u002B",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3187a58457374ebab6d63a12983d2f27"
+        "request_id": "0272bf606a2f4a4882949bb0731120aa"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "bccb981adfadc2851e0423c9155ada84",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:31 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bccb981adfadc2851e0423c9155ada84",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ebedfc53-799f-438c-a6a4-82180f8cd1d1",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "0729aaaa-3840-4a21-a21e-6de4da57ff09",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAESItWNhtv/2a02KtoybBVGcPwNCLnEhNozL0yeUG7vCXHEfRIK8S6z3L9aIsDqxOxAc5J3PVNei4lSs7zZyEkNCCfVuGqVFwnEOBXvCQTnU6vh6cMulVNWymfDs5\u002BxDdooEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAMttHI1jZ5wkPu4tESI2qAQ8LivWj0EyFTCie37aVZH6VMpphXbVJt9NfzkLKHml2wIwQL1vJHyNga4FakUhTlIDfnWqHWIQ\u002BQg6MYf2Sb1Yx60C4j7Fr6RgbPq6ungIcnEg",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEsEthkm\u002B22a2TeXLHMSkhEwSdhFTh8JOzxcXp/wttqhWK7w5DgvtznhKzy5Ind2Zwfi530VVvfwiNfcBNnA8ByegkbMXdHVKuzghBlm8E7RV0WfMdxc0rncNrSWk\u002BYktMoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAN7xz8H/AIOtEnCuD3SYeoy82mO7EKn2d/6/eJNuRY5jIyFQBaIZj2c/kQq28mNgnAIwIiVII1PPoPSYRz5mylHK0MZdS9a22/lU43n2z8cKL55DcBvCkO6WZd6EWutWzwV\u002B",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3187a58457374ebab6d63a12983d2f27"
+        "request_id": "0272bf606a2f4a4882949bb0731120aa"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "78510cae2f0df3e4792f30c106a78cea",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:37 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:11 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "78510cae2f0df3e4792f30c106a78cea",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "63be6b58-1f38-4156-85cc-abd4abce337d",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5e5a37e0-7abe-4d80-af38-894c408b3924",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAESItWNhtv/2a02KtoybBVGcPwNCLnEhNozL0yeUG7vCXHEfRIK8S6z3L9aIsDqxOxAc5J3PVNei4lSs7zZyEkNCCfVuGqVFwnEOBXvCQTnU6vh6cMulVNWymfDs5\u002BxDdooEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAMttHI1jZ5wkPu4tESI2qAQ8LivWj0EyFTCie37aVZH6VMpphXbVJt9NfzkLKHml2wIwQL1vJHyNga4FakUhTlIDfnWqHWIQ\u002BQg6MYf2Sb1Yx60C4j7Fr6RgbPq6ungIcnEg",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEsEthkm\u002B22a2TeXLHMSkhEwSdhFTh8JOzxcXp/wttqhWK7w5DgvtznhKzy5Ind2Zwfi530VVvfwiNfcBNnA8ByegkbMXdHVKuzghBlm8E7RV0WfMdxc0rncNrSWk\u002BYktMoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAN7xz8H/AIOtEnCuD3SYeoy82mO7EKn2d/6/eJNuRY5jIyFQBaIZj2c/kQq28mNgnAIwIiVII1PPoPSYRz5mylHK0MZdS9a22/lU43n2z8cKL55DcBvCkO6WZd6EWutWzwV\u002B",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "3187a58457374ebab6d63a12983d2f27"
+        "request_id": "0272bf606a2f4a4882949bb0731120aa"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "b6a22dad73ee318bc67582d228d745af",
         "x-ms-return-client-request-id": "true"
@@ -300,41 +306,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "747",
+        "Content-Length": "745",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b6a22dad73ee318bc67582d228d745af",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "cd05e993-f678-4f17-a542-a16bf76c3282",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "49383f52-561b-437b-a7e7-49e1df5ef780",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAESItWNhtv/2a02KtoybBVGcPwNCLnEhNozL0yeUG7vCXHEfRIK8S6z3L9aIsDqxOxAc5J3PVNei4lSs7zZyEkNCCfVuGqVFwnEOBXvCQTnU6vh6cMulVNWymfDs5\u002BxDdooEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAMttHI1jZ5wkPu4tESI2qAQ8LivWj0EyFTCie37aVZH6VMpphXbVJt9NfzkLKHml2wIwQL1vJHyNga4FakUhTlIDfnWqHWIQ\u002BQg6MYf2Sb1Yx60C4j7Fr6RgbPq6ungIcnEg",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEsEthkm\u002B22a2TeXLHMSkhEwSdhFTh8JOzxcXp/wttqhWK7w5DgvtznhKzy5Ind2Zwfi530VVvfwiNfcBNnA8ByegkbMXdHVKuzghBlm8E7RV0WfMdxc0rncNrSWk\u002BYktMoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAN7xz8H/AIOtEnCuD3SYeoy82mO7EKn2d/6/eJNuRY5jIyFQBaIZj2c/kQq28mNgnAIwIiVII1PPoPSYRz5mylHK0MZdS9a22/lU43n2z8cKL55DcBvCkO6WZd6EWutWzwV\u002B",
         "cancellation_requested": false,
         "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/2028711033",
-        "request_id": "3187a58457374ebab6d63a12983d2f27"
+        "target": "https://heathskvtest2.vault.azure.net/certificates/2028711033",
+        "request_id": "0272bf606a2f4a4882949bb0731120aa"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2028711033?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2028711033?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "7f840d579be5ebd2b3d8437dafc3bc77",
         "x-ms-return-client-request-id": "true"
@@ -343,36 +350,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1843",
+        "Content-Length": "1838",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7f840d579be5ebd2b3d8437dafc3bc77",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5ae8b780-75b5-42a1-bcb3-343d61e205f2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d8a3ac50-90d4-4695-88b6-75b1e45bf276",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2028711033/16955034d741431297939cedac4d2b42",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/2028711033/16955034d741431297939cedac4d2b42",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/2028711033/16955034d741431297939cedac4d2b42",
-        "x5t": "EuuDoY37vu1eJGT71UkUUsXs0O8",
-        "cer": "MIIB2zCCAWGgAwIBAgIQXtQj4LQOQPS9zCYgod7TFDAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDUzOFoXDTIyMDMwNTIzMTUzOFowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABEiLVjYbb/9mtNiraMmwVRnD8DQi5xITaMy9MnlBu7wlxxH0SCvEus9y/WiLA6sTsQHOSdz1TXouJUrO82chJDQgn1bhqlRcJxDgV7wkE51Or4enDLpVTVspnw7OfsQ3aKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFHB9CjFE4Rm1B3Je3FCkhbJWg1ZxMB0GA1UdDgQWBBRwfQoxROEZtQdyXtxQpIWyVoNWcTAKBggqhkjOPQQDAwNoADBlAjAKVGamxc5y/Y4oH/Yg1AXfHzFbJBhVEx8T8fHAUIfpKTsb8S/H0lRm96YNR8FzfJoCMQCXQixDBjWv2rl2tNgmv3Mj1NUbOSTsi9FIMpzrS6RfgJzoyKcUXL4ivDX2LUXOis8=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2028711033/647c8c998f9d4b878a0257c53a6eab8d",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/2028711033/647c8c998f9d4b878a0257c53a6eab8d",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/2028711033/647c8c998f9d4b878a0257c53a6eab8d",
+        "x5t": "UrncC5a-tGaz4-HDjbphjf6pweg",
+        "cer": "MIIB2zCCAWGgAwIBAgIQHp4xlOgdRCGl9UEnBk4ZwzAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjYxMVoXDTIyMDQwODAyMzYxMVowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABLBLYZJvttmtk3lyxzEpIRMEnYRU4fCTs8XF6f8LbaoViu8OQ4L7c54Ss8uSJ3dmcH4ud9FVb38IjX3ATZwPAcnoJGzF3R1Srs4IQZZvBO0VdFnzHcXNK53Da0lpPmJLTKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFCenBwYn/mqwpM6NyrVFqd4PgSFBMB0GA1UdDgQWBBQnpwcGJ/5qsKTOjcq1RaneD4EhQTAKBggqhkjOPQQDAwNoADBlAjBETYrg6L6lvAj84\u002BGgdA9DFdyfCJkpMOUD4uFzqQGM664hkC70OTtjLywD0kHByC4CMQDr2Gq74Y6iqqTE/5xO24DH7hYwAMlrj8c/04HBjZAGGVtPS9erTaCGd5q4MLK0wwA=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985538,
-          "exp": 1646522138,
-          "created": 1614986139,
-          "updated": 1614986139,
+          "nbf": 1617848771,
+          "exp": 1649385371,
+          "created": 1617849371,
+          "updated": 1617849371,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/2028711033/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/2028711033/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -412,26 +420,66 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614986122,
-            "updated": 1614986122
+            "created": 1617849356,
+            "updated": 1617849356
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/2028711033/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/2028711033/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/2028711033/16955034d741431297939cedac4d2b42?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/2028711033/647c8c998f9d4b878a0257c53a6eab8d?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-f577a96c3b66db4db59fb4ea036e330c-3b17a6fce541a94e-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "e81b397724b83b958120b297ac12caa2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:36:16 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e81b397724b83b958120b297ac12caa2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "44156d22-910a-4e5e-9e41-7baf26db31cd",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/2028711033/647c8c998f9d4b878a0257c53a6eab8d?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-903310b73796804e85619e75334dad1c-94fd65ecd5889a41-00",
+        "traceparent": "00-f577a96c3b66db4db59fb4ea036e330c-3b17a6fce541a94e-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "e81b397724b83b958120b297ac12caa2",
         "x-ms-return-client-request-id": "true"
@@ -440,37 +488,38 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "482",
+        "Content-Length": "481",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e81b397724b83b958120b297ac12caa2",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f779ba90-25ca-479f-9833-d46634cc36e2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "503115f9-6ff3-4fa1-b7b4-7502cd0ae13f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/2028711033/16955034d741431297939cedac4d2b42",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/2028711033/647c8c998f9d4b878a0257c53a6eab8d",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-384",
-          "x": "SItWNhtv_2a02KtoybBVGcPwNCLnEhNozL0yeUG7vCXHEfRIK8S6z3L9aIsDqxOx",
-          "y": "Ac5J3PVNei4lSs7zZyEkNCCfVuGqVFwnEOBXvCQTnU6vh6cMulVNWymfDs5-xDdo"
+          "x": "sEthkm-22a2TeXLHMSkhEwSdhFTh8JOzxcXp_wttqhWK7w5DgvtznhKzy5Ind2Zw",
+          "y": "fi530VVvfwiNfcBNnA8ByegkbMXdHVKuzghBlm8E7RV0WfMdxc0rncNrSWk-YktM"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985538,
-          "exp": 1646522138,
-          "created": 1614986139,
-          "updated": 1614986139,
+          "nbf": 1617848771,
+          "exp": 1649385371,
+          "created": 1617849371,
+          "updated": 1617849371,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -478,17 +527,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/2028711033/16955034d741431297939cedac4d2b42/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/2028711033/647c8c998f9d4b878a0257c53a6eab8d/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "90",
         "Content-Type": "application/json",
-        "traceparent": "00-903310b73796804e85619e75334dad1c-953f084d9ba70f4d-00",
+        "traceparent": "00-f577a96c3b66db4db59fb4ea036e330c-6069791b8e3b3b4c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "f86a81e90d2212045ab70215300d8202",
         "x-ms-return-client-request-id": "true"
@@ -500,35 +549,36 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "236",
+        "Content-Length": "235",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f86a81e90d2212045ab70215300d8202",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9d55a248-b926-49a2-9290-c10afb06826a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3422b529-5eba-43ce-a9e2-de9b6da82ffe",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/2028711033/16955034d741431297939cedac4d2b42",
-        "value": "31yduy6YkJMo-z32f2gngcKplAFUngx3kUxSsstpEv2Soyv0UmOQe5yBfNb5Ko6_-ms3K45UoZN6zbz5rOkOvOeSn9JowiLZa5lPMfcdeluTFji9PRWeZDCX7MYrEX5v"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/2028711033/647c8c998f9d4b878a0257c53a6eab8d",
+        "value": "e7eO_NyfTKc4uDHPkbLdCFPxASR3LBOrpUoBITdq2XO68yqFHUz2Z-tnws66mqYIbV_Eny8RK40UvNFIDo0iLHaVfFULfSj7PUalVBzbpBRAEWAQX7gQaFTapj7MxbGQ"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/2028711033/16955034d741431297939cedac4d2b42?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/2028711033/647c8c998f9d4b878a0257c53a6eab8d?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-da5582a95e4a154da0f307dfac2a8719-b51a0b817394924c-00",
+        "traceparent": "00-07cc7e5607d9c743ad302f37479d6f60-bebc49098954a94e-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "ee5b0bb95cbc33f77749fec5e83a3ea1",
         "x-ms-return-client-request-id": "true"
@@ -537,50 +587,51 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1246",
+        "Content-Length": "1243",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ee5b0bb95cbc33f77749fec5e83a3ea1",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2f6cb4ff-7dcb-47d0-a797-dfe4c0ebbb9a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "24fffab1-47df-4536-a0c6-7a775ea63977",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/2028711033/16955034d741431297939cedac4d2b42",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/2028711033/16955034d741431297939cedac4d2b42",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/2028711033/16955034d741431297939cedac4d2b42",
-        "x5t": "EuuDoY37vu1eJGT71UkUUsXs0O8",
-        "cer": "MIIB2zCCAWGgAwIBAgIQXtQj4LQOQPS9zCYgod7TFDAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDUzOFoXDTIyMDMwNTIzMTUzOFowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABEiLVjYbb/9mtNiraMmwVRnD8DQi5xITaMy9MnlBu7wlxxH0SCvEus9y/WiLA6sTsQHOSdz1TXouJUrO82chJDQgn1bhqlRcJxDgV7wkE51Or4enDLpVTVspnw7OfsQ3aKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFHB9CjFE4Rm1B3Je3FCkhbJWg1ZxMB0GA1UdDgQWBBRwfQoxROEZtQdyXtxQpIWyVoNWcTAKBggqhkjOPQQDAwNoADBlAjAKVGamxc5y/Y4oH/Yg1AXfHzFbJBhVEx8T8fHAUIfpKTsb8S/H0lRm96YNR8FzfJoCMQCXQixDBjWv2rl2tNgmv3Mj1NUbOSTsi9FIMpzrS6RfgJzoyKcUXL4ivDX2LUXOis8=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/2028711033/647c8c998f9d4b878a0257c53a6eab8d",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/2028711033/647c8c998f9d4b878a0257c53a6eab8d",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/2028711033/647c8c998f9d4b878a0257c53a6eab8d",
+        "x5t": "UrncC5a-tGaz4-HDjbphjf6pweg",
+        "cer": "MIIB2zCCAWGgAwIBAgIQHp4xlOgdRCGl9UEnBk4ZwzAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjYxMVoXDTIyMDQwODAyMzYxMVowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABLBLYZJvttmtk3lyxzEpIRMEnYRU4fCTs8XF6f8LbaoViu8OQ4L7c54Ss8uSJ3dmcH4ud9FVb38IjX3ATZwPAcnoJGzF3R1Srs4IQZZvBO0VdFnzHcXNK53Da0lpPmJLTKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFCenBwYn/mqwpM6NyrVFqd4PgSFBMB0GA1UdDgQWBBQnpwcGJ/5qsKTOjcq1RaneD4EhQTAKBggqhkjOPQQDAwNoADBlAjBETYrg6L6lvAj84\u002BGgdA9DFdyfCJkpMOUD4uFzqQGM664hkC70OTtjLywD0kHByC4CMQDr2Gq74Y6iqqTE/5xO24DH7hYwAMlrj8c/04HBjZAGGVtPS9erTaCGd5q4MLK0wwA=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985538,
-          "exp": 1646522138,
-          "created": 1614986139,
-          "updated": 1614986139,
+          "nbf": 1617848771,
+          "exp": 1649385371,
+          "created": 1617849371,
+          "updated": 1617849371,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "5ED423E0B40E40F4BDCC2620A1DED314"
+        "serialnumber": "1E9E3194E81D4421A5F54127064E19C3"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/2028711033/16955034d741431297939cedac4d2b42?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/2028711033/647c8c998f9d4b878a0257c53a6eab8d?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-da5582a95e4a154da0f307dfac2a8719-f52ce138d0ed744c-00",
+        "traceparent": "00-07cc7e5607d9c743ad302f37479d6f60-8fe8e38d63b8284d-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "2e93a00ec359695434088d0021800a73",
         "x-ms-return-client-request-id": "true"
@@ -589,39 +640,40 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1489",
+        "Content-Length": "1487",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2e93a00ec359695434088d0021800a73",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a31e625e-5f07-4b28-aee8-901745a93aa1",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "47094b22-e97a-4426-8267-bed7ee1b0670",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIHOAgEAMBAGByqGSM49AgEGBSuBBAAiBIGnMIGkAgEBBDCcWZoOE5afmUG5yyH1\nMaQwswt3tNf6tLiC5kqLpCicE5MFpUV7d6B5DPdameRS/T2gBwYFK4EEACKhZANi\nAARIi1Y2G2//ZrTYq2jJsFUZw/A0IucSE2jMvTJ5Qbu8JccR9EgrxLrPcv1oiwOr\nE7EBzknc9U16LiVKzvNnISQ0IJ9W4apUXCcQ4Fe8JBOdTq\u002BHpwy6VU1bKZ8Ozn7E\nN2igDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIB2zCCAWGgAwIBAgIQXtQj4LQOQPS9zCYgod7TFDAKBggqhkjOPQQDAzASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDUzOFoXDTIyMDMwNTIzMTUzOFow\nEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABEiLVjYb\nb/9mtNiraMmwVRnD8DQi5xITaMy9MnlBu7wlxxH0SCvEus9y/WiLA6sTsQHOSdz1\nTXouJUrO82chJDQgn1bhqlRcJxDgV7wkE51Or4enDLpVTVspnw7OfsQ3aKN8MHow\nDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEG\nCCsGAQUFBwMCMB8GA1UdIwQYMBaAFHB9CjFE4Rm1B3Je3FCkhbJWg1ZxMB0GA1Ud\nDgQWBBRwfQoxROEZtQdyXtxQpIWyVoNWcTAKBggqhkjOPQQDAwNoADBlAjAKVGam\nxc5y/Y4oH/Yg1AXfHzFbJBhVEx8T8fHAUIfpKTsb8S/H0lRm96YNR8FzfJoCMQCX\nQixDBjWv2rl2tNgmv3Mj1NUbOSTsi9FIMpzrS6RfgJzoyKcUXL4ivDX2LUXOis8=\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIHOAgEAMBAGByqGSM49AgEGBSuBBAAiBIGnMIGkAgEBBDD9FCiKiJWSMkyF\u002B\u002BiB\nrlufSOolaV/mAa5rwnmFfN9QhBroJWpFnGM7l8OeiICDGGygBwYFK4EEACKhZANi\nAASwS2GSb7bZrZN5cscxKSETBJ2EVOHwk7PFxen/C22qFYrvDkOC\u002B3OeErPLkid3\nZnB\u002BLnfRVW9/CI19wE2cDwHJ6CRsxd0dUq7OCEGWbwTtFXRZ8x3FzSudw2tJaT5i\nS0ygDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIB2zCCAWGgAwIBAgIQHp4xlOgdRCGl9UEnBk4ZwzAKBggqhkjOPQQDAzASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjYxMVoXDTIyMDQwODAyMzYxMVow\nEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABLBLYZJv\nttmtk3lyxzEpIRMEnYRU4fCTs8XF6f8LbaoViu8OQ4L7c54Ss8uSJ3dmcH4ud9FV\nb38IjX3ATZwPAcnoJGzF3R1Srs4IQZZvBO0VdFnzHcXNK53Da0lpPmJLTKN8MHow\nDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEG\nCCsGAQUFBwMCMB8GA1UdIwQYMBaAFCenBwYn/mqwpM6NyrVFqd4PgSFBMB0GA1Ud\nDgQWBBQnpwcGJ/5qsKTOjcq1RaneD4EhQTAKBggqhkjOPQQDAwNoADBlAjBETYrg\n6L6lvAj84\u002BGgdA9DFdyfCJkpMOUD4uFzqQGM664hkC70OTtjLywD0kHByC4CMQDr\n2Gq74Y6iqqTE/5xO24DH7hYwAMlrj8c/04HBjZAGGVtPS9erTaCGd5q4MLK0wwA=\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/2028711033/16955034d741431297939cedac4d2b42",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/2028711033/647c8c998f9d4b878a0257c53a6eab8d",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985538,
-          "exp": 1646522138,
-          "created": 1614986139,
-          "updated": 1614986139,
+          "nbf": 1617848771,
+          "exp": 1649385371,
+          "created": 1617849371,
+          "updated": 1617849371,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/2028711033/16955034d741431297939cedac4d2b42"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/2028711033/647c8c998f9d4b878a0257c53a6eab8d"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1455960681"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-521).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-521).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1587077666/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-d46ef9d1aee7264b8a9f54178ea60264-b61229368b8ff648-00",
+        "traceparent": "00-30b81804625a1743b570dda271aef824-8a36278e9ccf1844-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "b2ba2b8665484ed36868559efc8b462b",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:58 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b2ba2b8665484ed36868559efc8b462b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3bb636fb-c192-4708-8cd3-5d6efea14945",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "05b53c83-f3d0-4219-9f56-7ab85ab608ea",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1587077666/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-d46ef9d1aee7264b8a9f54178ea60264-b61229368b8ff648-00",
+        "traceparent": "00-30b81804625a1743b570dda271aef824-8a36278e9ccf1844-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "b2ba2b8665484ed36868559efc8b462b",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "937",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:59 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:04 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending?api-version=7.2\u0026request_id=a281845a011d4e9c86d8ffa0c91f0e78",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending?api-version=7.2\u0026request_id=d276d59eb5e14cfdbac3852edeffc725",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b2ba2b8665484ed36868559efc8b462b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7d43f11b-1fe9-4e75-99e2-885ad93b4d72",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5ebafb27-e90f-4c75-b7f3-41bc52c1c59d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtsoAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBZ0gB2J8vBdIbiiVmwxmxyTrsGPCWvjfbmzinph68xXaX04gAQIBBiHxA/Y9f4C3sKtQZ3RI59pda5lWe8Pc0JgACQgDSyERKf/2Fo8SboB/VDxLlVXZY0iqmzUmgYbzKj80GmD6yhnqvluNIUgUOFG7ir4YK1Mwv2Nlnv90uyTz8v21fkg==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEASHmOzV0M6tSK3HlrRJfuOcn82X/O3Ms3xsAnzoQdrVdaZG5SpivmwASobr5D9Tk5wbijoTbWBcS9aBaibOo8yCBAPi/K49sjgsDUEFSNMU\u002BiNg\u002BEyOVG/nGagezZJgkOwfHFGtWoyZNrs1dJcE3TbmX6GckopmMGIC8XMD3EdJ99npBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIAziOjFDThsEMeO/qm4cd44HBuOy0qM07UX/t\u002BtzDGytRfpDkuFHNH9Ym7LzYCtvumikHKxNqPrKYcRHuO7Qw6iBoCQUhpg/WkfezhxnM1qzfKPT8sYr2MoG\u002BirnJn9W4b6qu4VXLnFNz53uzBhJfGG5sn2GN1l7JpdkrtfqYUo7Ju11As",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a281845a011d4e9c86d8ffa0c91f0e78"
+        "request_id": "d276d59eb5e14cfdbac3852edeffc725"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "7debbcba20a72e7512adf1bdd4a6134c",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "937",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:06:59 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7debbcba20a72e7512adf1bdd4a6134c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "8eff917f-733a-47dc-a03b-97ba3efece0b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "17c30c71-15c0-43f7-83e3-6a8ec6052ac9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtsoAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBZ0gB2J8vBdIbiiVmwxmxyTrsGPCWvjfbmzinph68xXaX04gAQIBBiHxA/Y9f4C3sKtQZ3RI59pda5lWe8Pc0JgACQgDSyERKf/2Fo8SboB/VDxLlVXZY0iqmzUmgYbzKj80GmD6yhnqvluNIUgUOFG7ir4YK1Mwv2Nlnv90uyTz8v21fkg==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEASHmOzV0M6tSK3HlrRJfuOcn82X/O3Ms3xsAnzoQdrVdaZG5SpivmwASobr5D9Tk5wbijoTbWBcS9aBaibOo8yCBAPi/K49sjgsDUEFSNMU\u002BiNg\u002BEyOVG/nGagezZJgkOwfHFGtWoyZNrs1dJcE3TbmX6GckopmMGIC8XMD3EdJ99npBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIAziOjFDThsEMeO/qm4cd44HBuOy0qM07UX/t\u002BtzDGytRfpDkuFHNH9Ym7LzYCtvumikHKxNqPrKYcRHuO7Qw6iBoCQUhpg/WkfezhxnM1qzfKPT8sYr2MoG\u002BirnJn9W4b6qu4VXLnFNz53uzBhJfGG5sn2GN1l7JpdkrtfqYUo7Ju11As",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a281845a011d4e9c86d8ffa0c91f0e78"
+        "request_id": "d276d59eb5e14cfdbac3852edeffc725"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "4b314ddbc7d5f88190b48b2d1f99a1eb",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "937",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:09 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4b314ddbc7d5f88190b48b2d1f99a1eb",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5d2f6620-f9f2-4c4b-8351-4b334ad878b2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3c617c2a-ba03-4dac-b456-c0c14e30458f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtsoAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBZ0gB2J8vBdIbiiVmwxmxyTrsGPCWvjfbmzinph68xXaX04gAQIBBiHxA/Y9f4C3sKtQZ3RI59pda5lWe8Pc0JgACQgDSyERKf/2Fo8SboB/VDxLlVXZY0iqmzUmgYbzKj80GmD6yhnqvluNIUgUOFG7ir4YK1Mwv2Nlnv90uyTz8v21fkg==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEASHmOzV0M6tSK3HlrRJfuOcn82X/O3Ms3xsAnzoQdrVdaZG5SpivmwASobr5D9Tk5wbijoTbWBcS9aBaibOo8yCBAPi/K49sjgsDUEFSNMU\u002BiNg\u002BEyOVG/nGagezZJgkOwfHFGtWoyZNrs1dJcE3TbmX6GckopmMGIC8XMD3EdJ99npBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIAziOjFDThsEMeO/qm4cd44HBuOy0qM07UX/t\u002BtzDGytRfpDkuFHNH9Ym7LzYCtvumikHKxNqPrKYcRHuO7Qw6iBoCQUhpg/WkfezhxnM1qzfKPT8sYr2MoG\u002BirnJn9W4b6qu4VXLnFNz53uzBhJfGG5sn2GN1l7JpdkrtfqYUo7Ju11As",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a281845a011d4e9c86d8ffa0c91f0e78"
+        "request_id": "d276d59eb5e14cfdbac3852edeffc725"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "15f3c0df9292657ab58ba09b731579c2",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "937",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "15f3c0df9292657ab58ba09b731579c2",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3c5fcef8-a9ae-4f32-ac78-544338effa32",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "2f1cfbf5-808c-4ba7-9f6b-6ca3a824b0ae",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtsoAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBZ0gB2J8vBdIbiiVmwxmxyTrsGPCWvjfbmzinph68xXaX04gAQIBBiHxA/Y9f4C3sKtQZ3RI59pda5lWe8Pc0JgACQgDSyERKf/2Fo8SboB/VDxLlVXZY0iqmzUmgYbzKj80GmD6yhnqvluNIUgUOFG7ir4YK1Mwv2Nlnv90uyTz8v21fkg==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEASHmOzV0M6tSK3HlrRJfuOcn82X/O3Ms3xsAnzoQdrVdaZG5SpivmwASobr5D9Tk5wbijoTbWBcS9aBaibOo8yCBAPi/K49sjgsDUEFSNMU\u002BiNg\u002BEyOVG/nGagezZJgkOwfHFGtWoyZNrs1dJcE3TbmX6GckopmMGIC8XMD3EdJ99npBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIAziOjFDThsEMeO/qm4cd44HBuOy0qM07UX/t\u002BtzDGytRfpDkuFHNH9Ym7LzYCtvumikHKxNqPrKYcRHuO7Qw6iBoCQUhpg/WkfezhxnM1qzfKPT8sYr2MoG\u002BirnJn9W4b6qu4VXLnFNz53uzBhJfGG5sn2GN1l7JpdkrtfqYUo7Ju11As",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a281845a011d4e9c86d8ffa0c91f0e78"
+        "request_id": "d276d59eb5e14cfdbac3852edeffc725"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "aec20954fb59f3553bf3ecf394480f79",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "937",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:15 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "aec20954fb59f3553bf3ecf394480f79",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3caad752-dd7d-49bd-94af-5f91ef881a49",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a30fc08f-6a36-4a3b-87be-d9553197a14c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtsoAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBZ0gB2J8vBdIbiiVmwxmxyTrsGPCWvjfbmzinph68xXaX04gAQIBBiHxA/Y9f4C3sKtQZ3RI59pda5lWe8Pc0JgACQgDSyERKf/2Fo8SboB/VDxLlVXZY0iqmzUmgYbzKj80GmD6yhnqvluNIUgUOFG7ir4YK1Mwv2Nlnv90uyTz8v21fkg==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEASHmOzV0M6tSK3HlrRJfuOcn82X/O3Ms3xsAnzoQdrVdaZG5SpivmwASobr5D9Tk5wbijoTbWBcS9aBaibOo8yCBAPi/K49sjgsDUEFSNMU\u002BiNg\u002BEyOVG/nGagezZJgkOwfHFGtWoyZNrs1dJcE3TbmX6GckopmMGIC8XMD3EdJ99npBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIAziOjFDThsEMeO/qm4cd44HBuOy0qM07UX/t\u002BtzDGytRfpDkuFHNH9Ym7LzYCtvumikHKxNqPrKYcRHuO7Qw6iBoCQUhpg/WkfezhxnM1qzfKPT8sYr2MoG\u002BirnJn9W4b6qu4VXLnFNz53uzBhJfGG5sn2GN1l7JpdkrtfqYUo7Ju11As",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a281845a011d4e9c86d8ffa0c91f0e78"
+        "request_id": "d276d59eb5e14cfdbac3852edeffc725"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "13de060bfdb248b9d2cb964a26e6847a",
         "x-ms-return-client-request-id": "true"
@@ -300,42 +306,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "845",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:20 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "13de060bfdb248b9d2cb964a26e6847a",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5a958665-ccb7-477b-9e70-9fb32a3bb13d",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f5befe1c-d6c2-478b-b6d7-776b85b1b937",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtsoAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBZ0gB2J8vBdIbiiVmwxmxyTrsGPCWvjfbmzinph68xXaX04gAQIBBiHxA/Y9f4C3sKtQZ3RI59pda5lWe8Pc0JgACQgDSyERKf/2Fo8SboB/VDxLlVXZY0iqmzUmgYbzKj80GmD6yhnqvluNIUgUOFG7ir4YK1Mwv2Nlnv90uyTz8v21fkg==",
+        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEASHmOzV0M6tSK3HlrRJfuOcn82X/O3Ms3xsAnzoQdrVdaZG5SpivmwASobr5D9Tk5wbijoTbWBcS9aBaibOo8yCBAPi/K49sjgsDUEFSNMU\u002BiNg\u002BEyOVG/nGagezZJgkOwfHFGtWoyZNrs1dJcE3TbmX6GckopmMGIC8XMD3EdJ99npBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIAziOjFDThsEMeO/qm4cd44HBuOy0qM07UX/t\u002BtzDGytRfpDkuFHNH9Ym7LzYCtvumikHKxNqPrKYcRHuO7Qw6iBoCQUhpg/WkfezhxnM1qzfKPT8sYr2MoG\u002BirnJn9W4b6qu4VXLnFNz53uzBhJfGG5sn2GN1l7JpdkrtfqYUo7Ju11As",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a281845a011d4e9c86d8ffa0c91f0e78"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1587077666",
+        "request_id": "d276d59eb5e14cfdbac3852edeffc725"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1587077666?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "16d8c93af3d6e4916b00da9fa586d16d",
         "x-ms-return-client-request-id": "true"
@@ -344,167 +350,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "942",
+        "Content-Length": "1938",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:25 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f7762045-2c2a-40b9-ae04-ee151a4e4a60",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtsoAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBZ0gB2J8vBdIbiiVmwxmxyTrsGPCWvjfbmzinph68xXaX04gAQIBBiHxA/Y9f4C3sKtQZ3RI59pda5lWe8Pc0JgACQgDSyERKf/2Fo8SboB/VDxLlVXZY0iqmzUmgYbzKj80GmD6yhnqvluNIUgUOFG7ir4YK1Mwv2Nlnv90uyTz8v21fkg==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a281845a011d4e9c86d8ffa0c91f0e78"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "6d8f277b6537560f4f79db8e640bcc55",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "942",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:30 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "eb074b75-506a-4720-a96c-a6b8b1c321db",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtsoAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBZ0gB2J8vBdIbiiVmwxmxyTrsGPCWvjfbmzinph68xXaX04gAQIBBiHxA/Y9f4C3sKtQZ3RI59pda5lWe8Pc0JgACQgDSyERKf/2Fo8SboB/VDxLlVXZY0iqmzUmgYbzKj80GmD6yhnqvluNIUgUOFG7ir4YK1Mwv2Nlnv90uyTz8v21fkg==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "a281845a011d4e9c86d8ffa0c91f0e78"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "cab9726ff96f18a275faa8b2231aa34b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "851",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:35 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "16d8c93af3d6e4916b00da9fa586d16d",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "04c27bb8-5597-42bc-9330-9b19b10db480",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bd839aac-d138-4200-ae88-6beefda7a0de",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtsoAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBZ0gB2J8vBdIbiiVmwxmxyTrsGPCWvjfbmzinph68xXaX04gAQIBBiHxA/Y9f4C3sKtQZ3RI59pda5lWe8Pc0JgACQgDSyERKf/2Fo8SboB/VDxLlVXZY0iqmzUmgYbzKj80GmD6yhnqvluNIUgUOFG7ir4YK1Mwv2Nlnv90uyTz8v21fkg==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1587077666",
-        "request_id": "a281845a011d4e9c86d8ffa0c91f0e78"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ffce29fa1757d443ba81c65c17037f5f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1943",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:35 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "8585dec2-8d9f-40ee-b119-f5a203c0acfe",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/edc7efd05de54e3192e52eab51a5c430",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1587077666/edc7efd05de54e3192e52eab51a5c430",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1587077666/edc7efd05de54e3192e52eab51a5c430",
-        "x5t": "1uVkfMpHOrc5qs8OEt7jZQD-Qv0",
-        "cer": "MIICJTCCAYegAwIBAgIQHNURT9HoRFOQR/jRmWyyujAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTczMloXDTIyMDMwNTIzMDczMlowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtsoAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0o3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUfuQP0AHfUFIv\u002BtyHedCSJ6ALiSUwHQYDVR0OBBYEFH7kD9AB31BSL/rch3nQkiegC4klMAoGCCqGSM49BAMEA4GLADCBhwJBEW9IsW637\u002B3mW/aZLEt\u002B27RD45Xmpi22/2pre/hruGYCX96ZK1J0ipq/FvGEsmAq78KH5s/3BS2De8420julGtMCQgGpVsJamPLW24SWtn7KuIUkpibuDhKa3STp6yK3HCJuFvTVDrXPFXABGaS0Ma6MPmxhUuvL9dGI3Eg7CN2g0eAyDQ==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1587077666/3cc077abb0dc416fa77cfc7eba283f7f",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1587077666/3cc077abb0dc416fa77cfc7eba283f7f",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1587077666/3cc077abb0dc416fa77cfc7eba283f7f",
+        "x5t": "iLVI2gdwI4ZO2-pJQcubt1KMWdI",
+        "cer": "MIICJjCCAYegAwIBAgIQJbJoihc6RlCkQ39LJ7KhtTAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTcyMFoXDTIyMDQwODAyMjcyMFowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEASHmOzV0M6tSK3HlrRJfuOcn82X/O3Ms3xsAnzoQdrVdaZG5SpivmwASobr5D9Tk5wbijoTbWBcS9aBaibOo8yCBAPi/K49sjgsDUEFSNMU\u002BiNg\u002BEyOVG/nGagezZJgkOwfHFGtWoyZNrs1dJcE3TbmX6GckopmMGIC8XMD3EdJ99npBo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUSfrGSeRRo99PeICKdPhIBVu9cyEwHQYDVR0OBBYEFEn6xknkUaPfT3iAinT4SAVbvXMhMAoGCCqGSM49BAMEA4GMADCBiAJCAT5ldQVr0hi2nFb5O3j78ywGI/c/mJiRleTSaP/zdhVtHGTgeOW99CHFPZuydBzzYfWNqJ\u002B7Y2S0f\u002B4TosjZMlg5AkIBpIW8ikdadvLtsZDqytUZsN\u002BXct1cyPVd3enbv7RO5dZCg3vAWtQmQEjm5JKhQdLDUy4ARRUoQVV91kvKEY7QlHc=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985052,
-          "exp": 1646521652,
-          "created": 1614985652,
-          "updated": 1614985652,
+          "nbf": 1617848240,
+          "exp": 1649384840,
+          "created": 1617848840,
+          "updated": 1617848840,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1587077666/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -544,65 +420,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985620,
-            "updated": 1614985620
+            "created": 1617848824,
+            "updated": 1617848824
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1587077666/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1587077666/edc7efd05de54e3192e52eab51a5c430?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1587077666/3cc077abb0dc416fa77cfc7eba283f7f?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-dc0cf54811de024bbc840ae690080a1f-2be63b7f4e558547-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "6d8f277b6537560f4f79db8e640bcc55",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:27:29 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6d8f277b6537560f4f79db8e640bcc55",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5ae70c00-7db1-4f62-8b42-f68a1d8ca370",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1587077666/3cc077abb0dc416fa77cfc7eba283f7f?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-fec6fcbb3181054e98273f98717d525b-a66b4bf536d76a41-00",
+        "traceparent": "00-dc0cf54811de024bbc840ae690080a1f-2be63b7f4e558547-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "3330853306cd82fd8476f73dbc5c3335",
+        "x-ms-client-request-id": "6d8f277b6537560f4f79db8e640bcc55",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "530",
+        "Content-Length": "529",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:40 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6d8f277b6537560f4f79db8e640bcc55",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7a4064ae-4d55-40a6-9247-8691fee473df",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "841a9191-bd0d-490f-9899-568d082c9adf",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1587077666/edc7efd05de54e3192e52eab51a5c430",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1587077666/3cc077abb0dc416fa77cfc7eba283f7f",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-521",
-          "x": "AY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp_TcDNwBcKmb1ats_wtsoAnevY4OutYKLd3wFPJe7",
-          "y": "AU1foAgPGbcLssQFmFH5_NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0"
+          "x": "ASHmOzV0M6tSK3HlrRJfuOcn82X_O3Ms3xsAnzoQdrVdaZG5SpivmwASobr5D9Tk5wbijoTbWBcS9aBaibOo8yCB",
+          "y": "APi_K49sjgsDUEFSNMU-iNg-EyOVG_nGagezZJgkOwfHFGtWoyZNrs1dJcE3TbmX6GckopmMGIC8XMD3EdJ99npB"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985052,
-          "exp": 1646521652,
-          "created": 1614985652,
-          "updated": 1614985652,
+          "nbf": 1617848240,
+          "exp": 1649384840,
+          "created": 1617848840,
+          "updated": 1617848840,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -610,19 +527,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1587077666/edc7efd05de54e3192e52eab51a5c430/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1587077666/3cc077abb0dc416fa77cfc7eba283f7f/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "112",
         "Content-Type": "application/json",
-        "traceparent": "00-fec6fcbb3181054e98273f98717d525b-b8eced0b4076544c-00",
+        "traceparent": "00-dc0cf54811de024bbc840ae690080a1f-032a2cfb3d296247-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "3b938fd6cd3d58fd2fe410ed32450072",
+        "x-ms-client-request-id": "cab9726ff96f18a275faa8b2231aa34b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -632,128 +549,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "284",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:40 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "cab9726ff96f18a275faa8b2231aa34b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c70aee75-d39a-4a66-8ad9-a522b7264991",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6aca314b-d553-459b-bdbd-b0a23ae6e9ba",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1587077666/edc7efd05de54e3192e52eab51a5c430",
-        "value": "AUhbB4thNC0t9OKGkv8HgsA2ztrgFsdXdDgs2L-SyVld-JiAiWHfWAoioYyPHDpeGaQoM20HOdBE1hy4rJNQGnUqALOCmHlxxtKClXTK2xbi0EkYsYU2AXrqYdao2-RqtAumBqAiD3CqN3WtiWoD_UUJpn-khd6DUG4vkZuwSCpR1gRN"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1587077666/3cc077abb0dc416fa77cfc7eba283f7f",
+        "value": "AL9gJpmhmBi0p2s-E5b9kuaKhrRT9cBhqfKRvAGQkJR_dj6_--VBMauNtND8yUdTXumqAhuGEzbZX7POl0SeKdwoAEmPw54ki8bPkxa1OUhmjLWUsc5qpkMaWm2tOQB7FkFGZLZ1BYITnzDVusvxREOAOzJYO3hiXN53kclNWikbPTPT"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1587077666/edc7efd05de54e3192e52eab51a5c430?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1587077666/3cc077abb0dc416fa77cfc7eba283f7f?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-3600e6e337a4d64e8f4a8c1f466ebf34-4486076823a7ea46-00",
+        "traceparent": "00-d9260764c9fd0649ac19b6ab3c69e8ba-61a849cf0ce1f742-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "9e7f497a6fe9f47e2b4b7ae01f05185d",
+        "x-ms-client-request-id": "ffce29fa1757d443ba81c65c17037f5f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1346",
+        "Content-Length": "1343",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:40 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ffce29fa1757d443ba81c65c17037f5f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0fdae428-5552-449e-9eb2-8df754c9871e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "943bfe2b-ded2-4e80-9406-26a0fcba923a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1587077666/edc7efd05de54e3192e52eab51a5c430",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1587077666/edc7efd05de54e3192e52eab51a5c430",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1587077666/edc7efd05de54e3192e52eab51a5c430",
-        "x5t": "1uVkfMpHOrc5qs8OEt7jZQD-Qv0",
-        "cer": "MIICJTCCAYegAwIBAgIQHNURT9HoRFOQR/jRmWyyujAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTczMloXDTIyMDMwNTIzMDczMlowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9szv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtsoAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVfbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0o3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUfuQP0AHfUFIv\u002BtyHedCSJ6ALiSUwHQYDVR0OBBYEFH7kD9AB31BSL/rch3nQkiegC4klMAoGCCqGSM49BAMEA4GLADCBhwJBEW9IsW637\u002B3mW/aZLEt\u002B27RD45Xmpi22/2pre/hruGYCX96ZK1J0ipq/FvGEsmAq78KH5s/3BS2De8420julGtMCQgGpVsJamPLW24SWtn7KuIUkpibuDhKa3STp6yK3HCJuFvTVDrXPFXABGaS0Ma6MPmxhUuvL9dGI3Eg7CN2g0eAyDQ==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1587077666/3cc077abb0dc416fa77cfc7eba283f7f",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1587077666/3cc077abb0dc416fa77cfc7eba283f7f",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1587077666/3cc077abb0dc416fa77cfc7eba283f7f",
+        "x5t": "iLVI2gdwI4ZO2-pJQcubt1KMWdI",
+        "cer": "MIICJjCCAYegAwIBAgIQJbJoihc6RlCkQ39LJ7KhtTAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTcyMFoXDTIyMDQwODAyMjcyMFowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEASHmOzV0M6tSK3HlrRJfuOcn82X/O3Ms3xsAnzoQdrVdaZG5SpivmwASobr5D9Tk5wbijoTbWBcS9aBaibOo8yCBAPi/K49sjgsDUEFSNMU\u002BiNg\u002BEyOVG/nGagezZJgkOwfHFGtWoyZNrs1dJcE3TbmX6GckopmMGIC8XMD3EdJ99npBo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUSfrGSeRRo99PeICKdPhIBVu9cyEwHQYDVR0OBBYEFEn6xknkUaPfT3iAinT4SAVbvXMhMAoGCCqGSM49BAMEA4GMADCBiAJCAT5ldQVr0hi2nFb5O3j78ywGI/c/mJiRleTSaP/zdhVtHGTgeOW99CHFPZuydBzzYfWNqJ\u002B7Y2S0f\u002B4TosjZMlg5AkIBpIW8ikdadvLtsZDqytUZsN\u002BXct1cyPVd3enbv7RO5dZCg3vAWtQmQEjm5JKhQdLDUy4ARRUoQVV91kvKEY7QlHc=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985052,
-          "exp": 1646521652,
-          "created": 1614985652,
-          "updated": 1614985652,
+          "nbf": 1617848240,
+          "exp": 1649384840,
+          "created": 1617848840,
+          "updated": 1617848840,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "1CD5114FD1E844539047F8D1996CB2BA"
+        "serialnumber": "25B2688A173A4650A4437F4B27B2A1B5"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1587077666/edc7efd05de54e3192e52eab51a5c430?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1587077666/3cc077abb0dc416fa77cfc7eba283f7f?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-3600e6e337a4d64e8f4a8c1f466ebf34-3d0c45f63790a44b-00",
+        "traceparent": "00-d9260764c9fd0649ac19b6ab3c69e8ba-d0a3dc0945ea9d4c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "8886904e436f652187d803e9f610503e",
+        "x-ms-client-request-id": "3330853306cd82fd8476f73dbc5c3335",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1671",
+        "Content-Length": "1669",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:07:40 GMT",
+        "Date": "Thu, 08 Apr 2021 02:27:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3330853306cd82fd8476f73dbc5c3335",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3552aaec-4abe-44d7-961a-ab17e481adab",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d2cfc4de-3f75-4c79-b7ad-4eac475b06cd",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIIBBgIBADAQBgcqhkjOPQIBBgUrgQQAIwSB3zCB3AIBAQRCAdrJ3VLftMw9DeTW\nYU\u002Bj\u002BWnMuLC3cIxOGAK8XfvQ/m8A4ul8VrkyfLitM9lHy5c/GDLA5v4cyqUxGjNC\neMmPgsBDoAcGBSuBBAAjoYGJA4GGAAQBj2zO/zqW9sBZ0v2ZE2Uej0bGBrhRCD1j\nOg4YO1u0AGy7YGn9NwM3AFwqZvVq2z/C2ygCd69jg661got3fAU8l7sBTV\u002BgCA8Z\ntwuyxAWYUfn81NRt17FtbqXUwTcgIvN21V9u6kh04h02xEwapaNJ\u002BmgrCyWPiFEc\nQq\u002B5jyKjR94ayjSgDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICJTCCAYegAwIBAgIQHNURT9HoRFOQR/jRmWyyujAKBggqhkjOPQQDBDASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTczMloXDTIyMDMwNTIzMDczMlow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAY9s\nzv86lvbAWdL9mRNlHo9Gxga4UQg9YzoOGDtbtABsu2Bp/TcDNwBcKmb1ats/wtso\nAnevY4OutYKLd3wFPJe7AU1foAgPGbcLssQFmFH5/NTUbdexbW6l1ME3ICLzdtVf\nbupIdOIdNsRMGqWjSfpoKwslj4hRHEKvuY8io0feGso0o3wwejAOBgNVHQ8BAf8E\nBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw\nHwYDVR0jBBgwFoAUfuQP0AHfUFIv\u002BtyHedCSJ6ALiSUwHQYDVR0OBBYEFH7kD9AB\n31BSL/rch3nQkiegC4klMAoGCCqGSM49BAMEA4GLADCBhwJBEW9IsW637\u002B3mW/aZ\nLEt\u002B27RD45Xmpi22/2pre/hruGYCX96ZK1J0ipq/FvGEsmAq78KH5s/3BS2De842\n0julGtMCQgGpVsJamPLW24SWtn7KuIUkpibuDhKa3STp6yK3HCJuFvTVDrXPFXAB\nGaS0Ma6MPmxhUuvL9dGI3Eg7CN2g0eAyDQ==\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIIBBgIBADAQBgcqhkjOPQIBBgUrgQQAIwSB3zCB3AIBAQRCAMIiCUS1bTHVYQRk\nySE7M8qgaUIlNmzvtX5iSCDr5ZflT4QOdI2PhKPPKhNFOSEYCZtlaMU6rX1oufXP\nvyKZch7hoAcGBSuBBAAjoYGJA4GGAAQBIeY7NXQzq1IrceWtEl\u002B45yfzZf87cyzf\nGwCfOhB2tV1pkblKmK\u002BbABKhuvkP1OTnBuKOhNtYFxL1oFqJs6jzIIEA\u002BL8rj2yO\nCwNQQVI0xT6I2D4TI5Ub\u002BcZqB7NkmCQ7B8cUa1ajJk2uzV0lwTdNuZfoZySimYwY\ngLxcwPcR0n32ekGgDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICJjCCAYegAwIBAgIQJbJoihc6RlCkQ39LJ7KhtTAKBggqhkjOPQQDBDASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTcyMFoXDTIyMDQwODAyMjcyMFow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEASHm\nOzV0M6tSK3HlrRJfuOcn82X/O3Ms3xsAnzoQdrVdaZG5SpivmwASobr5D9Tk5wbi\njoTbWBcS9aBaibOo8yCBAPi/K49sjgsDUEFSNMU\u002BiNg\u002BEyOVG/nGagezZJgkOwfH\nFGtWoyZNrs1dJcE3TbmX6GckopmMGIC8XMD3EdJ99npBo3wwejAOBgNVHQ8BAf8E\nBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw\nHwYDVR0jBBgwFoAUSfrGSeRRo99PeICKdPhIBVu9cyEwHQYDVR0OBBYEFEn6xknk\nUaPfT3iAinT4SAVbvXMhMAoGCCqGSM49BAMEA4GMADCBiAJCAT5ldQVr0hi2nFb5\nO3j78ywGI/c/mJiRleTSaP/zdhVtHGTgeOW99CHFPZuydBzzYfWNqJ\u002B7Y2S0f\u002B4T\nosjZMlg5AkIBpIW8ikdadvLtsZDqytUZsN\u002BXct1cyPVd3enbv7RO5dZCg3vAWtQm\nQEjm5JKhQdLDUy4ARRUoQVV91kvKEY7QlHc=\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1587077666/edc7efd05de54e3192e52eab51a5c430",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1587077666/3cc077abb0dc416fa77cfc7eba283f7f",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985052,
-          "exp": 1646521652,
-          "created": 1614985652,
-          "updated": 1614985652,
+          "nbf": 1617848240,
+          "exp": 1649384840,
+          "created": 1617848840,
+          "updated": 1617848840,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1587077666/edc7efd05de54e3192e52eab51a5c430"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1587077666/3cc077abb0dc416fa77cfc7eba283f7f"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "2070857341"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-521)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pem-file,P-521)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/931375953/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/931375953/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-3f6059643b6d074db992a9d4a89493c8-c22bef8cdf98924d-00",
+        "traceparent": "00-ad3d2f0d214e504e97bbb1548432f63b-ffccc2ae40908f47-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "93b0ecf9d4f9f5849fb3adf11e89598e",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "93b0ecf9d4f9f5849fb3adf11e89598e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e1925473-8d43-4ca3-92d7-b48c36f5fc54",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "2ce6cff0-7550-4b72-a26f-3a4b91864000",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/931375953/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/931375953/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "221",
         "Content-Type": "application/json",
-        "traceparent": "00-3f6059643b6d074db992a9d4a89493c8-c22bef8cdf98924d-00",
+        "traceparent": "00-ad3d2f0d214e504e97bbb1548432f63b-ffccc2ae40908f47-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "93b0ecf9d4f9f5849fb3adf11e89598e",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:43 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:17 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending?api-version=7.2\u0026request_id=76fc088c3ec54f26a062d6948c88fe8e",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending?api-version=7.2\u0026request_id=2da694df23d64a17a97cef4e83483174",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "93b0ecf9d4f9f5849fb3adf11e89598e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9d5de311-e556-4445-b822-7ea027b40394",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "0556cbcf-6df8-4862-9b3e-8d5247a2c573",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAZ7GYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4\u002BoZRBcCZlK\u002BWiqBEwEVJdec/GB409ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMHeU/vP3BY3i\u002Br0uzOjLq3tjSxhlfIv/lPU7x8oibCTe0GoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIArpykQ\u002BkXkJcdbNL2/0IcxKoCTSetOFcjJfXBdBTrxcA2YZWAGk56eqRgL\u002BjttnKRXKSF/Jg4CK6e9yviv6DwPRoCQgCh9e/z8XsBJNAqbGTKUjfBNTXCfs4qzD1flRUj\u002BUif4Udz2bljIppJAWC6dVM\u002BuhUgTXdqmcWFeKBqo2s8gRSjyA==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAQc8E9yh96eyisL2EcP8syIXIjbDX36gfkJNbvAnrLpliYbvpCXqgb8qamvyqFy5J9338BPNxA2BVs8A\u002B9ZI1Kk\u002BAfuLl3tTcVgYXXsIvm1gVCpT98LvLKGDqtZVuWM601ItF5WQIlpBT553YpPkDjxcE5AyE9q\u002BTuXVmylkiyaKl0vloEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB6xU/gYiVGWCjD8L41M8o1U0YEm5dv3WVAc4pyFP9bz5UXQ084/Pr49UP2Jj5w5SN\u002BCG2f1cv3zuE4tl1XJClzVwCQgEA5Jz0ZYHS03q9ZA96LPzOhiNghsbaYpWTZYHcwF9Iq23OJ2KYmDspCJnKFh/w4s5W/Hhzh9XPImVwYmC0rv4mNQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "76fc088c3ec54f26a062d6948c88fe8e"
+        "request_id": "2da694df23d64a17a97cef4e83483174"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "b5b4c09dca6a6bd201c25de534ebef15",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:43 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b5b4c09dca6a6bd201c25de534ebef15",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f030b1f5-c986-4c8d-9c9f-6a7114f94035",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1bca7be2-15ad-4ea3-8f47-84574c306c67",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAZ7GYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4\u002BoZRBcCZlK\u002BWiqBEwEVJdec/GB409ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMHeU/vP3BY3i\u002Br0uzOjLq3tjSxhlfIv/lPU7x8oibCTe0GoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIArpykQ\u002BkXkJcdbNL2/0IcxKoCTSetOFcjJfXBdBTrxcA2YZWAGk56eqRgL\u002BjttnKRXKSF/Jg4CK6e9yviv6DwPRoCQgCh9e/z8XsBJNAqbGTKUjfBNTXCfs4qzD1flRUj\u002BUif4Udz2bljIppJAWC6dVM\u002BuhUgTXdqmcWFeKBqo2s8gRSjyA==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAQc8E9yh96eyisL2EcP8syIXIjbDX36gfkJNbvAnrLpliYbvpCXqgb8qamvyqFy5J9338BPNxA2BVs8A\u002B9ZI1Kk\u002BAfuLl3tTcVgYXXsIvm1gVCpT98LvLKGDqtZVuWM601ItF5WQIlpBT553YpPkDjxcE5AyE9q\u002BTuXVmylkiyaKl0vloEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB6xU/gYiVGWCjD8L41M8o1U0YEm5dv3WVAc4pyFP9bz5UXQ084/Pr49UP2Jj5w5SN\u002BCG2f1cv3zuE4tl1XJClzVwCQgEA5Jz0ZYHS03q9ZA96LPzOhiNghsbaYpWTZYHcwF9Iq23OJ2KYmDspCJnKFh/w4s5W/Hhzh9XPImVwYmC0rv4mNQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "76fc088c3ec54f26a062d6948c88fe8e"
+        "request_id": "2da694df23d64a17a97cef4e83483174"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "5882e77a93ba5c63dd7bf930c6cd79c6",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:48 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5882e77a93ba5c63dd7bf930c6cd79c6",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "83b9db4b-a077-451e-8544-c5f14d7037b0",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "23d174d2-fcd3-4c9d-8a5c-3338653c5f6d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAZ7GYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4\u002BoZRBcCZlK\u002BWiqBEwEVJdec/GB409ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMHeU/vP3BY3i\u002Br0uzOjLq3tjSxhlfIv/lPU7x8oibCTe0GoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIArpykQ\u002BkXkJcdbNL2/0IcxKoCTSetOFcjJfXBdBTrxcA2YZWAGk56eqRgL\u002BjttnKRXKSF/Jg4CK6e9yviv6DwPRoCQgCh9e/z8XsBJNAqbGTKUjfBNTXCfs4qzD1flRUj\u002BUif4Udz2bljIppJAWC6dVM\u002BuhUgTXdqmcWFeKBqo2s8gRSjyA==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAQc8E9yh96eyisL2EcP8syIXIjbDX36gfkJNbvAnrLpliYbvpCXqgb8qamvyqFy5J9338BPNxA2BVs8A\u002B9ZI1Kk\u002BAfuLl3tTcVgYXXsIvm1gVCpT98LvLKGDqtZVuWM601ItF5WQIlpBT553YpPkDjxcE5AyE9q\u002BTuXVmylkiyaKl0vloEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB6xU/gYiVGWCjD8L41M8o1U0YEm5dv3WVAc4pyFP9bz5UXQ084/Pr49UP2Jj5w5SN\u002BCG2f1cv3zuE4tl1XJClzVwCQgEA5Jz0ZYHS03q9ZA96LPzOhiNghsbaYpWTZYHcwF9Iq23OJ2KYmDspCJnKFh/w4s5W/Hhzh9XPImVwYmC0rv4mNQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "76fc088c3ec54f26a062d6948c88fe8e"
+        "request_id": "2da694df23d64a17a97cef4e83483174"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "f56e59b90b8c2fe71a459237779fc0b3",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:53 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f56e59b90b8c2fe71a459237779fc0b3",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c46edf81-6457-46c5-b3c4-29ed6a171432",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "593ac3eb-75aa-4cd8-abd8-e1b49aca1067",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAZ7GYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4\u002BoZRBcCZlK\u002BWiqBEwEVJdec/GB409ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMHeU/vP3BY3i\u002Br0uzOjLq3tjSxhlfIv/lPU7x8oibCTe0GoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIArpykQ\u002BkXkJcdbNL2/0IcxKoCTSetOFcjJfXBdBTrxcA2YZWAGk56eqRgL\u002BjttnKRXKSF/Jg4CK6e9yviv6DwPRoCQgCh9e/z8XsBJNAqbGTKUjfBNTXCfs4qzD1flRUj\u002BUif4Udz2bljIppJAWC6dVM\u002BuhUgTXdqmcWFeKBqo2s8gRSjyA==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAQc8E9yh96eyisL2EcP8syIXIjbDX36gfkJNbvAnrLpliYbvpCXqgb8qamvyqFy5J9338BPNxA2BVs8A\u002B9ZI1Kk\u002BAfuLl3tTcVgYXXsIvm1gVCpT98LvLKGDqtZVuWM601ItF5WQIlpBT553YpPkDjxcE5AyE9q\u002BTuXVmylkiyaKl0vloEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB6xU/gYiVGWCjD8L41M8o1U0YEm5dv3WVAc4pyFP9bz5UXQ084/Pr49UP2Jj5w5SN\u002BCG2f1cv3zuE4tl1XJClzVwCQgEA5Jz0ZYHS03q9ZA96LPzOhiNghsbaYpWTZYHcwF9Iq23OJ2KYmDspCJnKFh/w4s5W/Hhzh9XPImVwYmC0rv4mNQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "76fc088c3ec54f26a062d6948c88fe8e"
+        "request_id": "2da694df23d64a17a97cef4e83483174"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "377797c4000709d35d57d7eed0a2a533",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:58 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:32 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "377797c4000709d35d57d7eed0a2a533",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a44a0705-572a-42f4-b13e-5b5f49c0a560",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "26140038-fd2a-4940-a96f-d04ddad0d6fc",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAZ7GYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4\u002BoZRBcCZlK\u002BWiqBEwEVJdec/GB409ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMHeU/vP3BY3i\u002Br0uzOjLq3tjSxhlfIv/lPU7x8oibCTe0GoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIArpykQ\u002BkXkJcdbNL2/0IcxKoCTSetOFcjJfXBdBTrxcA2YZWAGk56eqRgL\u002BjttnKRXKSF/Jg4CK6e9yviv6DwPRoCQgCh9e/z8XsBJNAqbGTKUjfBNTXCfs4qzD1flRUj\u002BUif4Udz2bljIppJAWC6dVM\u002BuhUgTXdqmcWFeKBqo2s8gRSjyA==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAQc8E9yh96eyisL2EcP8syIXIjbDX36gfkJNbvAnrLpliYbvpCXqgb8qamvyqFy5J9338BPNxA2BVs8A\u002B9ZI1Kk\u002BAfuLl3tTcVgYXXsIvm1gVCpT98LvLKGDqtZVuWM601ItF5WQIlpBT553YpPkDjxcE5AyE9q\u002BTuXVmylkiyaKl0vloEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB6xU/gYiVGWCjD8L41M8o1U0YEm5dv3WVAc4pyFP9bz5UXQ084/Pr49UP2Jj5w5SN\u002BCG2f1cv3zuE4tl1XJClzVwCQgEA5Jz0ZYHS03q9ZA96LPzOhiNghsbaYpWTZYHcwF9Iq23OJ2KYmDspCJnKFh/w4s5W/Hhzh9XPImVwYmC0rv4mNQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "76fc088c3ec54f26a062d6948c88fe8e"
+        "request_id": "2da694df23d64a17a97cef4e83483174"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "da2b9648fa7d6e88ff523d75002be53e",
         "x-ms-return-client-request-id": "true"
@@ -300,42 +306,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "847",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:03 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "da2b9648fa7d6e88ff523d75002be53e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "abb3652e-d814-4c75-a271-096fad566baa",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "74460752-f546-44b6-8af8-a3f3303d5a82",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAZ7GYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4\u002BoZRBcCZlK\u002BWiqBEwEVJdec/GB409ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMHeU/vP3BY3i\u002Br0uzOjLq3tjSxhlfIv/lPU7x8oibCTe0GoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIArpykQ\u002BkXkJcdbNL2/0IcxKoCTSetOFcjJfXBdBTrxcA2YZWAGk56eqRgL\u002BjttnKRXKSF/Jg4CK6e9yviv6DwPRoCQgCh9e/z8XsBJNAqbGTKUjfBNTXCfs4qzD1flRUj\u002BUif4Udz2bljIppJAWC6dVM\u002BuhUgTXdqmcWFeKBqo2s8gRSjyA==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAQc8E9yh96eyisL2EcP8syIXIjbDX36gfkJNbvAnrLpliYbvpCXqgb8qamvyqFy5J9338BPNxA2BVs8A\u002B9ZI1Kk\u002BAfuLl3tTcVgYXXsIvm1gVCpT98LvLKGDqtZVuWM601ItF5WQIlpBT553YpPkDjxcE5AyE9q\u002BTuXVmylkiyaKl0vloEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB6xU/gYiVGWCjD8L41M8o1U0YEm5dv3WVAc4pyFP9bz5UXQ084/Pr49UP2Jj5w5SN\u002BCG2f1cv3zuE4tl1XJClzVwCQgEA5Jz0ZYHS03q9ZA96LPzOhiNghsbaYpWTZYHcwF9Iq23OJ2KYmDspCJnKFh/w4s5W/Hhzh9XPImVwYmC0rv4mNQ==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "76fc088c3ec54f26a062d6948c88fe8e"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/931375953",
+        "request_id": "2da694df23d64a17a97cef4e83483174"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/931375953?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "2e6b46ba4256b8bf8564983434f85e78",
         "x-ms-return-client-request-id": "true"
@@ -344,123 +350,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "1933",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5b6f3faa-7703-4e9c-8fad-c472d62ad704",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAZ7GYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4\u002BoZRBcCZlK\u002BWiqBEwEVJdec/GB409ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMHeU/vP3BY3i\u002Br0uzOjLq3tjSxhlfIv/lPU7x8oibCTe0GoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIArpykQ\u002BkXkJcdbNL2/0IcxKoCTSetOFcjJfXBdBTrxcA2YZWAGk56eqRgL\u002BjttnKRXKSF/Jg4CK6e9yviv6DwPRoCQgCh9e/z8XsBJNAqbGTKUjfBNTXCfs4qzD1flRUj\u002BUif4Udz2bljIppJAWC6dVM\u002BuhUgTXdqmcWFeKBqo2s8gRSjyA==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "76fc088c3ec54f26a062d6948c88fe8e"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "e0ef5ea0e673c9360e0837b4c25e0831",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "849",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2e6b46ba4256b8bf8564983434f85e78",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "af7265cd-3e48-4e5e-8541-e3f96b4c2a18",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5170b446-7fc7-4b3e-9e2c-5064808451ab",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAZ7GYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4\u002BoZRBcCZlK\u002BWiqBEwEVJdec/GB409ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMHeU/vP3BY3i\u002Br0uzOjLq3tjSxhlfIv/lPU7x8oibCTe0GoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIArpykQ\u002BkXkJcdbNL2/0IcxKoCTSetOFcjJfXBdBTrxcA2YZWAGk56eqRgL\u002BjttnKRXKSF/Jg4CK6e9yviv6DwPRoCQgCh9e/z8XsBJNAqbGTKUjfBNTXCfs4qzD1flRUj\u002BUif4Udz2bljIppJAWC6dVM\u002BuhUgTXdqmcWFeKBqo2s8gRSjyA==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/931375953",
-        "request_id": "76fc088c3ec54f26a062d6948c88fe8e"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/931375953?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "8a349972763606ddd773551862543a06",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1938",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:14 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "890cf0e8-7522-479e-9f97-e02fa4488c73",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/b4895763d9dd4b8db6643b339557e8c8",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/931375953/b4895763d9dd4b8db6643b339557e8c8",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/931375953/b4895763d9dd4b8db6643b339557e8c8",
-        "x5t": "JEaJdMxjCOGCx4tBUgx8WC_AFto",
-        "cer": "MIICJTCCAYegAwIBAgIQLrReEXQcThCVHjUl5ueBTzAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDYwOVoXDTIyMDMwNTIzMTYwOVowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAZ7GYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4\u002BoZRBcCZlK\u002BWiqBEwEVJdec/GB409ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMHeU/vP3BY3i\u002Br0uzOjLq3tjSxhlfIv/lPU7x8oibCTe0Go3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUEFb\u002B6szzNxc8cHPV1vdZ35\u002BbzxIwHQYDVR0OBBYEFBBW/urM8zcXPHBz1db3Wd\u002Bfm88SMAoGCCqGSM49BAMEA4GLADCBhwJCARWEHjsvyKs\u002BDwfDAxgXL/sRKRJnCec6/ODXoba2O46UXrqUYTb9HbihgmIBE2gcG/dSnJmCk27ubQs9HuU1CFHcAkEZ85MuVZiMD4dsGKPRAGs7J9Oa63E9x1jHvp5rS8Kw85UsLNZtiU4lfpseZW1VEDfSGUjODLVYq6WzP55Lb/UfbA==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7",
+        "x5t": "dhJp3Z_tINqcRh0obzsP72MO2_s",
+        "cer": "MIICJjCCAYegAwIBAgIQGrn7UqPmSgW/aKzvps5N\u002BjAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjYzM1oXDTIyMDQwODAyMzYzM1owEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAQc8E9yh96eyisL2EcP8syIXIjbDX36gfkJNbvAnrLpliYbvpCXqgb8qamvyqFy5J9338BPNxA2BVs8A\u002B9ZI1Kk\u002BAfuLl3tTcVgYXXsIvm1gVCpT98LvLKGDqtZVuWM601ItF5WQIlpBT553YpPkDjxcE5AyE9q\u002BTuXVmylkiyaKl0vlo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUicrFYubFSP8J\u002BFj9oR4lA5v1pmEwHQYDVR0OBBYEFInKxWLmxUj/CfhY/aEeJQOb9aZhMAoGCCqGSM49BAMEA4GMADCBiAJCAWWXWVI/S1P6a\u002BICBx5qdfDBQGqooE5ZFs0HVwmaUJOLE\u002BJZYWAJihVevxoOStPrG0fDnglRCjiD6H1JllYkZOvJAkIByZ9oC\u002Bv4zd1ROdI9xcCkQhp/ZoDU2calr6on8G1jsRgZXNuf6zG4NIkBwQv03QbMkUnwgBzprlPexFOjxOMPHbc=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985569,
-          "exp": 1646522169,
-          "created": 1614986169,
-          "updated": 1614986169,
+          "nbf": 1617848793,
+          "exp": 1649385393,
+          "created": 1617849393,
+          "updated": 1617849393,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/931375953/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -500,65 +420,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614986143,
-            "updated": 1614986143
+            "created": 1617849377,
+            "updated": 1617849377
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/931375953/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/931375953/b4895763d9dd4b8db6643b339557e8c8?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-3b465e23bc0e3c45811d7a92530c5f9c-f714db81c03d2f4b-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "e0ef5ea0e673c9360e0837b4c25e0831",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:36:37 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e0ef5ea0e673c9360e0837b4c25e0831",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "dbc7c5c4-2f85-4ebe-b758-c248bb205a6c",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-b735d9c2c5c82842bec6b60d83cda1b6-1c6e87cafe06dc48-00",
+        "traceparent": "00-3b465e23bc0e3c45811d7a92530c5f9c-f714db81c03d2f4b-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "a2d5c5f3043cd4ca0fa21f4e0a0af526",
+        "x-ms-client-request-id": "e0ef5ea0e673c9360e0837b4c25e0831",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "529",
+        "Content-Length": "528",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e0ef5ea0e673c9360e0837b4c25e0831",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "12dc3f59-8bea-462a-87a5-48e579061ad8",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f58a946e-2baa-496d-8434-c509bc4155b7",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/931375953/b4895763d9dd4b8db6643b339557e8c8",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-521",
-          "x": "AZ7GYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4-oZRBcCZlK-WiqBEwEVJdec_GB409",
-          "y": "ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMHeU_vP3BY3i-r0uzOjLq3tjSxhlfIv_lPU7x8oibCTe0G"
+          "x": "AQc8E9yh96eyisL2EcP8syIXIjbDX36gfkJNbvAnrLpliYbvpCXqgb8qamvyqFy5J9338BPNxA2BVs8A-9ZI1Kk-",
+          "y": "AfuLl3tTcVgYXXsIvm1gVCpT98LvLKGDqtZVuWM601ItF5WQIlpBT553YpPkDjxcE5AyE9q-TuXVmylkiyaKl0vl"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985569,
-          "exp": 1646522169,
-          "created": 1614986169,
-          "updated": 1614986169,
+          "nbf": 1617848793,
+          "exp": 1649385393,
+          "created": 1617849393,
+          "updated": 1617849393,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -566,19 +527,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/931375953/b4895763d9dd4b8db6643b339557e8c8/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "112",
         "Content-Type": "application/json",
-        "traceparent": "00-b735d9c2c5c82842bec6b60d83cda1b6-b4a3adc8effac64f-00",
+        "traceparent": "00-3b465e23bc0e3c45811d7a92530c5f9c-4e08317517424647-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "9bc1665bd4c4294281e90800901e67ba",
+        "x-ms-client-request-id": "8a349972763606ddd773551862543a06",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -588,128 +549,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "283",
+        "Content-Length": "282",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "8a349972763606ddd773551862543a06",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "71221a29-84b6-4ce1-ab04-accf64ceea13",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5dc48cef-8225-499d-8d60-6d369e7c6a19",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/931375953/b4895763d9dd4b8db6643b339557e8c8",
-        "value": "AFhWq9jzlnaTtOT3-P7iJgNuMPWVoVxvCJnUIWdNEnCs45snpi7Dzkmjo6CYwetxbuWvzU-HfcYTgiMrkatSrP2pAbKyl5Uvld_lIdyZNQ7cF6B0W66IIGY2cDHlXdeG4P0S1FRUoVWhEWux_ORCLJhWI9vwDGCI4W6S0pj4F7JEdlsK"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7",
+        "value": "AYXvOJyB-yp9KPK6zpLvxc9I0j85gutAWWItglZbzic9O_LWTKNRZEhgaMNKI9KEYSKb4bBSUZKZWGriU7LvppVwAD16LoOZQ4f7_B2V214IHvZa6MyKfQAZWS1ql28zEHKEgV1fS0To7laAAl-r7V3BqEpABBJeBEvudh_6_zWioA21"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/931375953/b4895763d9dd4b8db6643b339557e8c8?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-747d977fa0d2e04086e789a72b5cb328-2263bc1ac4770249-00",
+        "traceparent": "00-4e090543bdabef4eb1f577469bcc2893-52ea80df76952542-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "fdc130cd66896df4ce5f7b93578ffbcd",
+        "x-ms-client-request-id": "a2d5c5f3043cd4ca0fa21f4e0a0af526",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1343",
+        "Content-Length": "1340",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a2d5c5f3043cd4ca0fa21f4e0a0af526",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "10369aa1-0177-412b-910c-b2ebdb23a49a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b58f34fd-200e-4026-a4d5-73fa980e6976",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/931375953/b4895763d9dd4b8db6643b339557e8c8",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/931375953/b4895763d9dd4b8db6643b339557e8c8",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/931375953/b4895763d9dd4b8db6643b339557e8c8",
-        "x5t": "JEaJdMxjCOGCx4tBUgx8WC_AFto",
-        "cer": "MIICJTCCAYegAwIBAgIQLrReEXQcThCVHjUl5ueBTzAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDYwOVoXDTIyMDMwNTIzMTYwOVowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAZ7GYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4\u002BoZRBcCZlK\u002BWiqBEwEVJdec/GB409ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMHeU/vP3BY3i\u002Br0uzOjLq3tjSxhlfIv/lPU7x8oibCTe0Go3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUEFb\u002B6szzNxc8cHPV1vdZ35\u002BbzxIwHQYDVR0OBBYEFBBW/urM8zcXPHBz1db3Wd\u002Bfm88SMAoGCCqGSM49BAMEA4GLADCBhwJCARWEHjsvyKs\u002BDwfDAxgXL/sRKRJnCec6/ODXoba2O46UXrqUYTb9HbihgmIBE2gcG/dSnJmCk27ubQs9HuU1CFHcAkEZ85MuVZiMD4dsGKPRAGs7J9Oa63E9x1jHvp5rS8Kw85UsLNZtiU4lfpseZW1VEDfSGUjODLVYq6WzP55Lb/UfbA==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7",
+        "x5t": "dhJp3Z_tINqcRh0obzsP72MO2_s",
+        "cer": "MIICJjCCAYegAwIBAgIQGrn7UqPmSgW/aKzvps5N\u002BjAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjYzM1oXDTIyMDQwODAyMzYzM1owEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAQc8E9yh96eyisL2EcP8syIXIjbDX36gfkJNbvAnrLpliYbvpCXqgb8qamvyqFy5J9338BPNxA2BVs8A\u002B9ZI1Kk\u002BAfuLl3tTcVgYXXsIvm1gVCpT98LvLKGDqtZVuWM601ItF5WQIlpBT553YpPkDjxcE5AyE9q\u002BTuXVmylkiyaKl0vlo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUicrFYubFSP8J\u002BFj9oR4lA5v1pmEwHQYDVR0OBBYEFInKxWLmxUj/CfhY/aEeJQOb9aZhMAoGCCqGSM49BAMEA4GMADCBiAJCAWWXWVI/S1P6a\u002BICBx5qdfDBQGqooE5ZFs0HVwmaUJOLE\u002BJZYWAJihVevxoOStPrG0fDnglRCjiD6H1JllYkZOvJAkIByZ9oC\u002Bv4zd1ROdI9xcCkQhp/ZoDU2calr6on8G1jsRgZXNuf6zG4NIkBwQv03QbMkUnwgBzprlPexFOjxOMPHbc=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985569,
-          "exp": 1646522169,
-          "created": 1614986169,
-          "updated": 1614986169,
+          "nbf": 1617848793,
+          "exp": 1649385393,
+          "created": 1617849393,
+          "updated": 1617849393,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "2EB45E11741C4E10951E3525E6E7814F"
+        "serialnumber": "1AB9FB52A3E64A05BF68ACEFA6CE4DFA"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/931375953/b4895763d9dd4b8db6643b339557e8c8?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-747d977fa0d2e04086e789a72b5cb328-026695a8e6ba4e4a-00",
+        "traceparent": "00-4e090543bdabef4eb1f577469bcc2893-6ef7bf4fd80cc245-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "fbbc2e7d9f921f4283ac2153fbca43f0",
+        "x-ms-client-request-id": "9bc1665bd4c4294281e90800901e67ba",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1669",
+        "Content-Length": "1667",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:16:14 GMT",
+        "Date": "Thu, 08 Apr 2021 02:36:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9bc1665bd4c4294281e90800901e67ba",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "28101f3d-2d4d-41bd-98c9-606e0b1b2e97",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "14b688c7-7307-4f6e-95ce-45c873937057",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "-----BEGIN PRIVATE KEY-----\nMIIBBgIBADAQBgcqhkjOPQIBBgUrgQQAIwSB3zCB3AIBAQRCAFkRJqsNrqav9W7s\ndZJyCbMCpggm/o6Cr7IN4TeABSJw6amIRY6p3NH10DTbMEZCfMJKnycCIEHguOe\u002B\nRoRw9puWoAcGBSuBBAAjoYGJA4GGAAQBnsZhRLjOtbB11\u002BLweh0\u002BBu\u002BYSjSiMXy5\nJXptvZYk3sMHOfaq0\u002BpyMTSOfj6hlEFwJmUr5aKoETARUl15z8YHjT0A2vsTtiKQ\noxlVTHhQdtYvUtIVnLb0eprfK4yPe21u0wd5T\u002B8/cFjeL6vS7M6Mure2NLGGV8i/\n\u002BU9TvHyiJsJN7QagDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICJTCCAYegAwIBAgIQLrReEXQcThCVHjUl5ueBTzAKBggqhkjOPQQDBDASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDYwOVoXDTIyMDMwNTIzMTYwOVow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAZ7G\nYUS4zrWwddfi8HodPgbvmEo0ojF8uSV6bb2WJN7DBzn2qtPqcjE0jn4\u002BoZRBcCZl\nK\u002BWiqBEwEVJdec/GB409ANr7E7YikKMZVUx4UHbWL1LSFZy29Hqa3yuMj3ttbtMH\neU/vP3BY3i\u002Br0uzOjLq3tjSxhlfIv/lPU7x8oibCTe0Go3wwejAOBgNVHQ8BAf8E\nBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw\nHwYDVR0jBBgwFoAUEFb\u002B6szzNxc8cHPV1vdZ35\u002BbzxIwHQYDVR0OBBYEFBBW/urM\n8zcXPHBz1db3Wd\u002Bfm88SMAoGCCqGSM49BAMEA4GLADCBhwJCARWEHjsvyKs\u002BDwfD\nAxgXL/sRKRJnCec6/ODXoba2O46UXrqUYTb9HbihgmIBE2gcG/dSnJmCk27ubQs9\nHuU1CFHcAkEZ85MuVZiMD4dsGKPRAGs7J9Oa63E9x1jHvp5rS8Kw85UsLNZtiU4l\nfpseZW1VEDfSGUjODLVYq6WzP55Lb/UfbA==\n-----END CERTIFICATE-----\n",
+        "value": "-----BEGIN PRIVATE KEY-----\nMIIBBgIBADAQBgcqhkjOPQIBBgUrgQQAIwSB3zCB3AIBAQRCAC0CG5VNgkj3\u002BrFG\n3uAWqRDNVwLv01CeTwHELT0OnS1THeh7V0pQ0wO4WNifDQmaTbURhqGn9xmj7Wf1\n5AD3cRSloAcGBSuBBAAjoYGJA4GGAAQBBzwT3KH3p7KKwvYRw/yzIhciNsNffqB\u002B\nQk1u8CesumWJhu\u002BkJeqBvypqa/KoXLkn3ffwE83EDYFWzwD71kjUqT4B\u002B4uXe1Nx\nWBhdewi\u002BbWBUKlP3wu8soYOq1lW5YzrTUi0XlZAiWkFPnndik\u002BQOPFwTkDIT2r5O\n5dWbKWSLJoqXS\u002BWgDTALBgNVHQ8xBAMCAIA=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIICJjCCAYegAwIBAgIQGrn7UqPmSgW/aKzvps5N\u002BjAKBggqhkjOPQQDBDASMRAw\nDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjYzM1oXDTIyMDQwODAyMzYzM1ow\nEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAQc8\nE9yh96eyisL2EcP8syIXIjbDX36gfkJNbvAnrLpliYbvpCXqgb8qamvyqFy5J933\n8BPNxA2BVs8A\u002B9ZI1Kk\u002BAfuLl3tTcVgYXXsIvm1gVCpT98LvLKGDqtZVuWM601It\nF5WQIlpBT553YpPkDjxcE5AyE9q\u002BTuXVmylkiyaKl0vlo3wwejAOBgNVHQ8BAf8E\nBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw\nHwYDVR0jBBgwFoAUicrFYubFSP8J\u002BFj9oR4lA5v1pmEwHQYDVR0OBBYEFInKxWLm\nxUj/CfhY/aEeJQOb9aZhMAoGCCqGSM49BAMEA4GMADCBiAJCAWWXWVI/S1P6a\u002BIC\nBx5qdfDBQGqooE5ZFs0HVwmaUJOLE\u002BJZYWAJihVevxoOStPrG0fDnglRCjiD6H1J\nllYkZOvJAkIByZ9oC\u002Bv4zd1ROdI9xcCkQhp/ZoDU2calr6on8G1jsRgZXNuf6zG4\nNIkBwQv03QbMkUnwgBzprlPexFOjxOMPHbc=\n-----END CERTIFICATE-----\n",
         "contentType": "application/x-pem-file",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/931375953/b4895763d9dd4b8db6643b339557e8c8",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985569,
-          "exp": 1646522169,
-          "created": 1614986169,
-          "updated": 1614986169,
+          "nbf": 1617848793,
+          "exp": 1649385393,
+          "created": 1617849393,
+          "updated": 1617849393,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/931375953/b4895763d9dd4b8db6643b339557e8c8"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/931375953/a0f9e5b6bc9c479aa04e9dfd275c64b7"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "734109055"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-256).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-256).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/578190564/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/578190564/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-474c965757c31749aa842abf507810ce-35dba4646e27c642-00",
+        "traceparent": "00-941eaf46b23ca947993fbfd39e64425b-9a689c043c111e43-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "831d9b190a238fa42af682b8fe1a26bb",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:24 GMT",
+        "Date": "Thu, 08 Apr 2021 02:24:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "831d9b190a238fa42af682b8fe1a26bb",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1bb9101e-0a0e-4092-b079-d675ce329a2e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "89098c99-81e9-4a90-b73b-78fdbff936e1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/578190564/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/578190564/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-474c965757c31749aa842abf507810ce-35dba4646e27c642-00",
+        "traceparent": "00-941eaf46b23ca947993fbfd39e64425b-9a689c043c111e43-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "831d9b190a238fa42af682b8fe1a26bb",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:24 GMT",
+        "Date": "Thu, 08 Apr 2021 02:24:59 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending?api-version=7.2\u0026request_id=c77b331379de4f0490078f432c9a17ed",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/578190564/pending?api-version=7.2\u0026request_id=5569487e17b74823a1914187e3b72a95",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "831d9b190a238fa42af682b8fe1a26bb",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a0b0cf58-40ce-47d0-b0e4-a6cabbbeae11",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5bb50a8f-62e3-4a24-bdb8-4f91d0a16df9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/578190564/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYbUH654yoa6O350fb\u002BuMa5VSWfjpkKdGZvLeJzsIYNeP1DA4FZGIWjrUnlAftcsW5SNfDBIL808mRa1jAhJl2KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBXePNBAIvzMQtQcDpNUmV4Q7cz/pskqwa67n4RzOzqpAiEAj4kCnZlLmyVRULLes2KKvbCo9L7oFOQ6wKvDZLrkcdY=",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBnpHQdVhf\u002BHvSjq6UrdDLHjGtzfCuK\u002BqW9XfGEKb4pPAzGYu3NNOorJdqdgXBDkVnJNjBhLYI21YoxT1y\u002BbQmaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCICXG63Q3gr58VjcJSHugo8tmfo65X\u002B0O5f\u002BWrA3EulvRAiEA6Ls8MoXnMj72gUuzihNv9gV3ZJURcwJ6Zz4D\u002BWnGvzY=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "c77b331379de4f0490078f432c9a17ed"
+        "request_id": "5569487e17b74823a1914187e3b72a95"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/578190564/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "c395fc924ca95931c4434784cc5a2d1e",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:24 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c395fc924ca95931c4434784cc5a2d1e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2a005f2c-9aaf-4e96-8f28-e79bcd0c6a64",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f4dd7727-a821-4317-ac59-c56788f34c10",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/578190564/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYbUH654yoa6O350fb\u002BuMa5VSWfjpkKdGZvLeJzsIYNeP1DA4FZGIWjrUnlAftcsW5SNfDBIL808mRa1jAhJl2KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBXePNBAIvzMQtQcDpNUmV4Q7cz/pskqwa67n4RzOzqpAiEAj4kCnZlLmyVRULLes2KKvbCo9L7oFOQ6wKvDZLrkcdY=",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBnpHQdVhf\u002BHvSjq6UrdDLHjGtzfCuK\u002BqW9XfGEKb4pPAzGYu3NNOorJdqdgXBDkVnJNjBhLYI21YoxT1y\u002BbQmaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCICXG63Q3gr58VjcJSHugo8tmfo65X\u002B0O5f\u002BWrA3EulvRAiEA6Ls8MoXnMj72gUuzihNv9gV3ZJURcwJ6Zz4D\u002BWnGvzY=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "c77b331379de4f0490078f432c9a17ed"
+        "request_id": "5569487e17b74823a1914187e3b72a95"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/578190564/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "5340dce7fb7a9742aa541e9c71cf7231",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:30 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5340dce7fb7a9742aa541e9c71cf7231",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "bab757ea-7562-4456-85bb-b6a0428a7536",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1538337c-69d5-4ee9-8abe-f46a221ad665",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/578190564/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYbUH654yoa6O350fb\u002BuMa5VSWfjpkKdGZvLeJzsIYNeP1DA4FZGIWjrUnlAftcsW5SNfDBIL808mRa1jAhJl2KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBXePNBAIvzMQtQcDpNUmV4Q7cz/pskqwa67n4RzOzqpAiEAj4kCnZlLmyVRULLes2KKvbCo9L7oFOQ6wKvDZLrkcdY=",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBnpHQdVhf\u002BHvSjq6UrdDLHjGtzfCuK\u002BqW9XfGEKb4pPAzGYu3NNOorJdqdgXBDkVnJNjBhLYI21YoxT1y\u002BbQmaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCICXG63Q3gr58VjcJSHugo8tmfo65X\u002B0O5f\u002BWrA3EulvRAiEA6Ls8MoXnMj72gUuzihNv9gV3ZJURcwJ6Zz4D\u002BWnGvzY=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "c77b331379de4f0490078f432c9a17ed"
+        "request_id": "5569487e17b74823a1914187e3b72a95"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/578190564/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "228167e326e7cd3b69c4bedfc320c2d0",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:35 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:09 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "228167e326e7cd3b69c4bedfc320c2d0",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "90b1ebc6-e5d4-4c2a-884c-9eb1877d652c",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d568dfa8-0d2f-487b-ac6a-8ba8c548ee0e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/578190564/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYbUH654yoa6O350fb\u002BuMa5VSWfjpkKdGZvLeJzsIYNeP1DA4FZGIWjrUnlAftcsW5SNfDBIL808mRa1jAhJl2KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBXePNBAIvzMQtQcDpNUmV4Q7cz/pskqwa67n4RzOzqpAiEAj4kCnZlLmyVRULLes2KKvbCo9L7oFOQ6wKvDZLrkcdY=",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBnpHQdVhf\u002BHvSjq6UrdDLHjGtzfCuK\u002BqW9XfGEKb4pPAzGYu3NNOorJdqdgXBDkVnJNjBhLYI21YoxT1y\u002BbQmaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCICXG63Q3gr58VjcJSHugo8tmfo65X\u002B0O5f\u002BWrA3EulvRAiEA6Ls8MoXnMj72gUuzihNv9gV3ZJURcwJ6Zz4D\u002BWnGvzY=",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "c77b331379de4f0490078f432c9a17ed"
+        "request_id": "5569487e17b74823a1914187e3b72a95"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/578190564/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "21d164c9d2d99740b9fe19552d94e7f5",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "663",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "21d164c9d2d99740b9fe19552d94e7f5",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ed1e6f70-ccd3-46bd-b2d3-e33379c3eb4a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "e283ce66-5fa6-4d69-8e17-9aeaee0f0052",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/578190564/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYbUH654yoa6O350fb\u002BuMa5VSWfjpkKdGZvLeJzsIYNeP1DA4FZGIWjrUnlAftcsW5SNfDBIL808mRa1jAhJl2KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBXePNBAIvzMQtQcDpNUmV4Q7cz/pskqwa67n4RzOzqpAiEAj4kCnZlLmyVRULLes2KKvbCo9L7oFOQ6wKvDZLrkcdY=",
+        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBnpHQdVhf\u002BHvSjq6UrdDLHjGtzfCuK\u002BqW9XfGEKb4pPAzGYu3NNOorJdqdgXBDkVnJNjBhLYI21YoxT1y\u002BbQmaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCICXG63Q3gr58VjcJSHugo8tmfo65X\u002B0O5f\u002BWrA3EulvRAiEA6Ls8MoXnMj72gUuzihNv9gV3ZJURcwJ6Zz4D\u002BWnGvzY=",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "c77b331379de4f0490078f432c9a17ed"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/578190564",
+        "request_id": "5569487e17b74823a1914187e3b72a95"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/578190564?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "65a015d10ad9c037a173e9b63c62d389",
         "x-ms-return-client-request-id": "true"
@@ -300,123 +305,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "1751",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:44 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "574ef975-c820-43ea-a839-3e9e55c06d14",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYbUH654yoa6O350fb\u002BuMa5VSWfjpkKdGZvLeJzsIYNeP1DA4FZGIWjrUnlAftcsW5SNfDBIL808mRa1jAhJl2KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBXePNBAIvzMQtQcDpNUmV4Q7cz/pskqwa67n4RzOzqpAiEAj4kCnZlLmyVRULLes2KKvbCo9L7oFOQ6wKvDZLrkcdY=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "c77b331379de4f0490078f432c9a17ed"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0dd34e9150fe105726ea68e80de59fd5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "665",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:50 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "65a015d10ad9c037a173e9b63c62d389",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7ff95793-4e84-486a-8b83-ca4911f098d8",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a9f62cfc-6a17-4133-9959-ce9cdf6f765c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYbUH654yoa6O350fb\u002BuMa5VSWfjpkKdGZvLeJzsIYNeP1DA4FZGIWjrUnlAftcsW5SNfDBIL808mRa1jAhJl2KBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIBXePNBAIvzMQtQcDpNUmV4Q7cz/pskqwa67n4RzOzqpAiEAj4kCnZlLmyVRULLes2KKvbCo9L7oFOQ6wKvDZLrkcdY=",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/578190564",
-        "request_id": "c77b331379de4f0490078f432c9a17ed"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/578190564?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ad0ec9dc5d80bef62c108066e98a5a56",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1752",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:50 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ae408227-e7ff-4b21-b997-c72bcfaac205",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/578190564/56dd6f0470674960ab7e0f5680337b02",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/578190564/56dd6f0470674960ab7e0f5680337b02",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/578190564/56dd6f0470674960ab7e0f5680337b02",
-        "x5t": "e9GEZg7SECn9KNagxLHepUnMSIU",
-        "cer": "MIIBnTCCAUSgAwIBAgIQM4lQzheaSOSUVwQdfcCU6TAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTM0OVoXDTIyMDMwNTIzMDM0OVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABGG1B\u002BueMqGujt\u002BdH2/rjGuVUln46ZCnRmby3ic7CGDXj9QwOBWRiFo61J5QH7XLFuUjXwwSC/NPJkWtYwISZdijfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQzK7/m9jiZPm8KwcM\u002BKA4NF1osrzAdBgNVHQ4EFgQUMyu/5vY4mT5vCsHDPigODRdaLK8wCgYIKoZIzj0EAwIDRwAwRAIgYIeeVWyQsTyMGWwX2RAg8jQGn\u002Bo9qz/ajsknhLrx1yMCIC0lp1uumCP8JoXTQqNfii4BVQm85DSZTt4C4PQIWW21",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/578190564/1faca2e913c140c7a4eafafd0dc3fe48",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/578190564/1faca2e913c140c7a4eafafd0dc3fe48",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/578190564/1faca2e913c140c7a4eafafd0dc3fe48",
+        "x5t": "kseJ4SAufZT5g70Sd5BumLWur58",
+        "cer": "MIIBnjCCAUSgAwIBAgIQLb\u002B1EwJpTTqhs\u002BszIlczEDAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTUxM1oXDTIyMDQwODAyMjUxM1owEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAZ6R0HVYX/h70o6ulK3Qyx4xrc3wrivqlvV3xhCm\u002BKTwMxmLtzTTqKyXanYFwQ5FZyTYwYS2CNtWKMU9cvm0JmjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBRl2X87PyU5ve5Ex45dIazt1zMTazAdBgNVHQ4EFgQUZdl/Oz8lOb3uRMeOXSGs7dczE2swCgYIKoZIzj0EAwIDSAAwRQIhAPKxmPm5oAyQMLhvAst8hy6uFmbpDnD7bJ6o4F\u002B36YCwAiABnWoueMF6BOTZEM1LzFome6VTX3N9g7ZbcvoYctKXdg==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984829,
-          "exp": 1646521429,
-          "created": 1614985429,
-          "updated": 1614985429,
+          "nbf": 1617848113,
+          "exp": 1649384713,
+          "created": 1617848713,
+          "updated": 1617848713,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/578190564/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/578190564/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -456,65 +375,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985405,
-            "updated": 1614985405
+            "created": 1617848700,
+            "updated": 1617848700
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/578190564/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/578190564/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/578190564/56dd6f0470674960ab7e0f5680337b02?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/578190564/1faca2e913c140c7a4eafafd0dc3fe48?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-b16cb527f85a074f9cf3eef7565336ed-c3a08fb7efec0643-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "0dd34e9150fe105726ea68e80de59fd5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:25:20 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0dd34e9150fe105726ea68e80de59fd5",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "33dcf994-194b-4078-97e9-6b3e235e0c47",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/578190564/1faca2e913c140c7a4eafafd0dc3fe48?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-65309f1371032f49934b0e63af8ad45a-69e306544a7f1d46-00",
+        "traceparent": "00-b16cb527f85a074f9cf3eef7565336ed-c3a08fb7efec0643-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "dec38f2adac081f7bd8f3eeea24eb3bb",
+        "x-ms-client-request-id": "0dd34e9150fe105726ea68e80de59fd5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "439",
+        "Content-Length": "438",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:55 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0dd34e9150fe105726ea68e80de59fd5",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "09a75dce-4ec5-425f-b9d1-f6de410a0e8b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b8fa9c6e-c562-4152-acdc-e83b6e68d9fc",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/578190564/56dd6f0470674960ab7e0f5680337b02",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/578190564/1faca2e913c140c7a4eafafd0dc3fe48",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256",
-          "x": "YbUH654yoa6O350fb-uMa5VSWfjpkKdGZvLeJzsIYNc",
-          "y": "j9QwOBWRiFo61J5QH7XLFuUjXwwSC_NPJkWtYwISZdg"
+          "x": "BnpHQdVhf-HvSjq6UrdDLHjGtzfCuK-qW9XfGEKb4pM",
+          "y": "wMxmLtzTTqKyXanYFwQ5FZyTYwYS2CNtWKMU9cvm0Jk"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984829,
-          "exp": 1646521429,
-          "created": 1614985429,
-          "updated": 1614985429,
+          "nbf": 1617848113,
+          "exp": 1649384713,
+          "created": 1617848713,
+          "updated": 1617848713,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -522,19 +482,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/578190564/56dd6f0470674960ab7e0f5680337b02/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/578190564/1faca2e913c140c7a4eafafd0dc3fe48/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "69",
         "Content-Type": "application/json",
-        "traceparent": "00-65309f1371032f49934b0e63af8ad45a-500388186a2f4442-00",
+        "traceparent": "00-b16cb527f85a074f9cf3eef7565336ed-f302168421665144-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "73d913d3255434095715e0eecff1279c",
+        "x-ms-client-request-id": "ad0ec9dc5d80bef62c108066e98a5a56",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -544,128 +504,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "193",
+        "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:55 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ad0ec9dc5d80bef62c108066e98a5a56",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4d801a22-c74c-4063-90d5-61bfac28ed29",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "cef6a24a-a7d8-47ff-943f-fa80abb7cb13",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/578190564/56dd6f0470674960ab7e0f5680337b02",
-        "value": "lF8m1GUQeUjoYy9UfaPw4SwDadP3J2rczw4vI_NxCFNUnhqdQMTQYL_bJB6hx0dxy25p8cNCUZ2vs4sy76Mz5g"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/578190564/1faca2e913c140c7a4eafafd0dc3fe48",
+        "value": "pxw9lV8khzEzFm17LZvfbpP-V30F6u7bpqDukHh2JYAn64g66gOpp6eFig9Po2Zi8fTgPWT2IvXSRAQ5tWjwJg"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/578190564/56dd6f0470674960ab7e0f5680337b02?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/578190564/1faca2e913c140c7a4eafafd0dc3fe48?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-370e3b45dabed742b77ecf297659867a-f0b6f6b0d2a37241-00",
+        "traceparent": "00-dfd7e7aadcdd914cb447e1d89e42f341-2dd8cfc75179d94f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "7ebe1290c0220214d28df0f01e081bde",
+        "x-ms-client-request-id": "dec38f2adac081f7bd8f3eeea24eb3bb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1159",
+        "Content-Length": "1160",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:55 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "dec38f2adac081f7bd8f3eeea24eb3bb",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5effb404-4074-4c56-aaac-b8c8fa8919a9",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "0682c562-3d26-4ce5-a0ed-a48ba430e76e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/578190564/56dd6f0470674960ab7e0f5680337b02",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/578190564/56dd6f0470674960ab7e0f5680337b02",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/578190564/56dd6f0470674960ab7e0f5680337b02",
-        "x5t": "e9GEZg7SECn9KNagxLHepUnMSIU",
-        "cer": "MIIBnTCCAUSgAwIBAgIQM4lQzheaSOSUVwQdfcCU6TAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTM0OVoXDTIyMDMwNTIzMDM0OVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABGG1B\u002BueMqGujt\u002BdH2/rjGuVUln46ZCnRmby3ic7CGDXj9QwOBWRiFo61J5QH7XLFuUjXwwSC/NPJkWtYwISZdijfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQzK7/m9jiZPm8KwcM\u002BKA4NF1osrzAdBgNVHQ4EFgQUMyu/5vY4mT5vCsHDPigODRdaLK8wCgYIKoZIzj0EAwIDRwAwRAIgYIeeVWyQsTyMGWwX2RAg8jQGn\u002Bo9qz/ajsknhLrx1yMCIC0lp1uumCP8JoXTQqNfii4BVQm85DSZTt4C4PQIWW21",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/578190564/1faca2e913c140c7a4eafafd0dc3fe48",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/578190564/1faca2e913c140c7a4eafafd0dc3fe48",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/578190564/1faca2e913c140c7a4eafafd0dc3fe48",
+        "x5t": "kseJ4SAufZT5g70Sd5BumLWur58",
+        "cer": "MIIBnjCCAUSgAwIBAgIQLb\u002B1EwJpTTqhs\u002BszIlczEDAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTUxM1oXDTIyMDQwODAyMjUxM1owEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAZ6R0HVYX/h70o6ulK3Qyx4xrc3wrivqlvV3xhCm\u002BKTwMxmLtzTTqKyXanYFwQ5FZyTYwYS2CNtWKMU9cvm0JmjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBRl2X87PyU5ve5Ex45dIazt1zMTazAdBgNVHQ4EFgQUZdl/Oz8lOb3uRMeOXSGs7dczE2swCgYIKoZIzj0EAwIDSAAwRQIhAPKxmPm5oAyQMLhvAst8hy6uFmbpDnD7bJ6o4F\u002B36YCwAiABnWoueMF6BOTZEM1LzFome6VTX3N9g7ZbcvoYctKXdg==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984829,
-          "exp": 1646521429,
-          "created": 1614985429,
-          "updated": 1614985429,
+          "nbf": 1617848113,
+          "exp": 1649384713,
+          "created": 1617848713,
+          "updated": 1617848713,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "338950CE179A48E49457041D7DC094E9"
+        "serialnumber": "2DBFB51302694D3AA1B3EB3322573310"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/578190564/56dd6f0470674960ab7e0f5680337b02?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/578190564/1faca2e913c140c7a4eafafd0dc3fe48?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-370e3b45dabed742b77ecf297659867a-11e552bc10222c40-00",
+        "traceparent": "00-dfd7e7aadcdd914cb447e1d89e42f341-30647f52e5ae6e42-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "d592c55ce6b00401868f87abfa08b2cb",
+        "x-ms-client-request-id": "73d913d3255434095715e0eecff1279c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1803",
+        "Content-Length": "1801",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:55 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "73d913d3255434095715e0eecff1279c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "d814d8bf-cc0a-4686-8f5c-8a56cd871099",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "19862f7a-5c33-448a-a1d3-6fbdac9bde82",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIEBwIBAzCCA8MGCSqGSIb3DQEHAaCCA7QEggOwMIIDrDCCAW0GCSqGSIb3DQEHAaCCAV4EggFaMIIBVjCCAVIGCyqGSIb3DQEMCgECoIHMMIHJMBwGCiqGSIb3DQEMAQMwDgQIJiqjfQxMk1ECAgfQBIGot4PLbRSN\u002BBpaH1YeX6GrOrRN2yHBHdQYiC9oisGs38tzjfYzC2sGM3ov2jb4HYrYhglEf2abSzTEaK\u002BcW3z\u002BpsLMYR1IwhdG\u002BtjPi060LoEZ9sbJySb7BXTG\u002BNvWmRKs4iaPjJUTsLWuMXjPEoCwUhN4CGRxbdM2fH7T1yFvxhyMay/AebsLQFc3dNm/FwDVSXEYBiFiv36yTIo\u002BGqTRzGTEvLFX3lBPMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAjcGCSqGSIb3DQEHBqCCAigwggIkAgEAMIICHQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIWPfKG7257ccCAgfQgIIB8DC3dALozpTDqyRLbBy\u002BAIoYYI//CidXEt/wZC3NoS8iLo36aeo05T0kIJwX0qCJOvmbnlizCkPm3K9U7TBxdU1GFbLU1xqIcB3SHRaGILJZ0fPb\u002B7U1r9GJbdICtkDrWZoQ1TbMnXQ8GKveDSs0D9kQVC3L3yaGI4Q2YoSYltkC8QfzdfZ9n\u002BEcGXcj6dkJheM8eqc3tNHy8MneZbYuQVR8gaEz4L2XKRd9gDgsvYxs33\u002BSKxcxWiYsq0tPUQ1OlZs\u002BNzSMJ8Af3sk\u002BcIiqWl1oQhzZA/VGTseWs/jpWUbFSK/CtexhO0R4TGbDti17gZE6ZKQBy3hHy6hCZK3/zc4CWvMSiwyLFDZk46PGgqoHdlTe6Gt8IuraKx0tO4wN7jZA2M4pbr7jyDbDbYMdjKR8alFAxO\u002BKt2CKAP\u002B4/PYxpf3unGydXv5dOwWu/MwZtguM0k969qNCqBF68AOSXvLniKMwPZMJI4vxRoXzQpNjgjSGPyvVu3Kzi/rV/CDDssT5tlZ0fpSiRqJcoojnNV266eXhOVcF4wfPnyIvAaSJXvfcW62PZr8YPeiE/F9bn62noeMwZfKXPAPaOURiAEiPmqs1A1BTGxSx9T6CrdJ2ktWMf3yE9IO5\u002ByYEvt2yehimajbxXLVU27L4uKdNU4AwOzAfMAcGBSsOAwIaBBRxbTzCT0diz0y0NAw1ozwb9V2eOQQUjoLW7\u002Bb13lG6tQEQN0nqKwQ2tvECAgfQ",
+        "value": "MIIEBwIBAzCCA8MGCSqGSIb3DQEHAaCCA7QEggOwMIIDrDCCAW0GCSqGSIb3DQEHAaCCAV4EggFaMIIBVjCCAVIGCyqGSIb3DQEMCgECoIHMMIHJMBwGCiqGSIb3DQEMAQMwDgQIotB6yfO9EvgCAgfQBIGo045/VFLqhE9MJltEQ77t0fzmwwfPCKnHJcpdpxM3RY92NqdmfCRb\u002B3DHPAtn0RtZn0PWW7cawHnvxooa9NYajqiM0xZAm7YhmAHEumUYGskNSShLusJi3hfn0a6rqlbO3OoZIZpAcx2xSeHS6gOlbi2wM/RiAX1AZ/LQk6\u002BDM2uvSnaL5FA2kECTn8IL56bQ402rVi83GKVmbrYIPmLFRrxMKDbWplaVMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAjcGCSqGSIb3DQEHBqCCAigwggIkAgEAMIICHQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIf/qpMBCkWtICAgfQgIIB8CXZW/XSN269k1Jpa7PALQtMB04/mC7WlEFtXR5AWQY0xZ5nUBFXxChK9RlbsGahwDLbuHwm\u002BzJ02dLVy1Ia6JCKX5sU2KFTqrZj9azrjtMSZY1BHHibDieoSrf0MEEcnQmKdE/dTekMFZMolxl8djuC70Qadczjd0clXKE79PsHNSXN3EUmSs1qs6v6hj0Ex8RY18mXAd/eCYZn5p8fLw4n5ryIq0MjqcbuzNPFgiGahJ8Tq1E5I8\u002BT\u002BZF9eAXWDxM\u002BsbE4S4hPVv7CIat8X5qtor\u002BnSO/Z24COzM0iRVQqEZZ6QpzRbbUdJd\u002BKhZx9M9FIT9rKli6vM\u002BI0qxxeB17o74UEOmU\u002BeSpm1mo7mZ\u002BR8c/YLBeOH\u002BKDAftIJBiVxOnb1hBcrsoDN8EFmVtpYDCqiDMckUIekduHdSinMg4N9SRoQD5J7u2zZfI5e\u002BDBfrPJAKE/dAmS0h/\u002Bwbsde1GLK0PZ6r7\u002BdnGAcXDq31DhwujaljHKOBW6FmGmXvWsNXXGhPYLrva9ssDZah8Yd3PX4KBCP1IHrwhvbsx\u002BGqQ7ONJnoCT7kN2Q7EpYoB5JGiNcSFTImenAyqY5c7LTtW5PFjUyNYK4md2rgZOMJ11F1EP5pwxdwWMhgcp/GcSJMWLbjnZoI1U/MyJkSSNbd94wOzAfMAcGBSsOAwIaBBSgXWI6i1sicv6PanLRwAZX5ser4AQUpNYoZardEL7SkPG9FMKIEmPkvr4CAgfQ",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/578190564/56dd6f0470674960ab7e0f5680337b02",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/578190564/1faca2e913c140c7a4eafafd0dc3fe48",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614984829,
-          "exp": 1646521429,
-          "created": 1614985429,
-          "updated": 1614985429,
+          "nbf": 1617848113,
+          "exp": 1649384713,
+          "created": 1617848713,
+          "updated": 1617848713,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/578190564/56dd6f0470674960ab7e0f5680337b02"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/578190564/1faca2e913c140c7a4eafafd0dc3fe48"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "968653164"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-256)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-256)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/169210205/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/169210205/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-f2618d2d74898e408d9f41589f33f513-30d746a25459b54e-00",
+        "traceparent": "00-a2286ad7d7107c4d90d06d5eebdc4b10-ae80d9b8e010ac4f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "1f9da54366ca25c5ed036a734e28b512",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1f9da54366ca25c5ed036a734e28b512",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e7d16d41-4233-4318-90a7-69e9eac270c6",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ad8bb0ab-4491-4032-8022-3dd716ac5bcb",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/169210205/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/169210205/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-f2618d2d74898e408d9f41589f33f513-30d746a25459b54e-00",
+        "traceparent": "00-a2286ad7d7107c4d90d06d5eebdc4b10-ae80d9b8e010ac4f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "1f9da54366ca25c5ed036a734e28b512",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:54 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending?api-version=7.2\u0026request_id=fce7f79f7b19486bb1cafe676359dc95",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/169210205/pending?api-version=7.2\u0026request_id=ade3fd60ebf6429294314803119abf6a",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1f9da54366ca25c5ed036a734e28b512",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "96a76765-658f-4e2c-ab26-67ba47d5f47e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "90963518-063b-4102-9c16-5fe1e7e9e69d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/169210205/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdBJuqhkgSPOtBHLCsk3mDnU4cT84pIrCGZEFBeEPvnowT/ofCI2Bempx5WorJe1PUBOjOh9ftb9haYoZwWTZBqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIHVOa1xvU9IUtcQMqix4pWuAZhTpyal8d6b3uAcgvOdfAiEA4eabCXxFBETksWA7i9\u002B/JkfQ8\u002Bg1h3tNN3YOS2xaFdk=",
+        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKEbh67YlWy3H2PTh66do0hO0\u002BqquQvhFVwLlhci\u002Bw/O9cKvl49cQYEXNhaIKVzlf67QsjzqPfLr0xe7qlFCEdKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCwGjoPkDQefl61eH7/oxPghbI1WA\u002BLauLQjbrcdvSnHgIhAMa/ZYoQGLbiJEXeiVbytkydW6JXyQOabRa7vjiPWY7r",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "fce7f79f7b19486bb1cafe676359dc95"
+        "request_id": "ade3fd60ebf6429294314803119abf6a"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/169210205/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "1d7237e7c13c8e15f867979654c87784",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1d7237e7c13c8e15f867979654c87784",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5ff66226-a463-48b7-b984-c3d88cd9bd4f",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "03704fd2-02d3-48a1-b1cf-7edbeea99997",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/169210205/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdBJuqhkgSPOtBHLCsk3mDnU4cT84pIrCGZEFBeEPvnowT/ofCI2Bempx5WorJe1PUBOjOh9ftb9haYoZwWTZBqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIHVOa1xvU9IUtcQMqix4pWuAZhTpyal8d6b3uAcgvOdfAiEA4eabCXxFBETksWA7i9\u002B/JkfQ8\u002Bg1h3tNN3YOS2xaFdk=",
+        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKEbh67YlWy3H2PTh66do0hO0\u002BqquQvhFVwLlhci\u002Bw/O9cKvl49cQYEXNhaIKVzlf67QsjzqPfLr0xe7qlFCEdKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCwGjoPkDQefl61eH7/oxPghbI1WA\u002BLauLQjbrcdvSnHgIhAMa/ZYoQGLbiJEXeiVbytkydW6JXyQOabRa7vjiPWY7r",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "fce7f79f7b19486bb1cafe676359dc95"
+        "request_id": "ade3fd60ebf6429294314803119abf6a"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/169210205/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "a7272cd22981db889745f1e22b033bae",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "756",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:45 GMT",
+        "Date": "Thu, 08 Apr 2021 02:34:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a7272cd22981db889745f1e22b033bae",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "224dd6ac-22c3-4cca-bb4b-a63ac5365457",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "7261415b-3998-489f-9c4d-ce1985871d29",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/169210205/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdBJuqhkgSPOtBHLCsk3mDnU4cT84pIrCGZEFBeEPvnowT/ofCI2Bempx5WorJe1PUBOjOh9ftb9haYoZwWTZBqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIHVOa1xvU9IUtcQMqix4pWuAZhTpyal8d6b3uAcgvOdfAiEA4eabCXxFBETksWA7i9\u002B/JkfQ8\u002Bg1h3tNN3YOS2xaFdk=",
+        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKEbh67YlWy3H2PTh66do0hO0\u002BqquQvhFVwLlhci\u002Bw/O9cKvl49cQYEXNhaIKVzlf67QsjzqPfLr0xe7qlFCEdKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCwGjoPkDQefl61eH7/oxPghbI1WA\u002BLauLQjbrcdvSnHgIhAMa/ZYoQGLbiJEXeiVbytkydW6JXyQOabRa7vjiPWY7r",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "fce7f79f7b19486bb1cafe676359dc95"
+        "request_id": "ade3fd60ebf6429294314803119abf6a"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/169210205/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "dade57ad830682208f0f2763ce2ed125",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "663",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:50 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "dade57ad830682208f0f2763ce2ed125",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f72d8a4b-ce28-46e1-b5c6-95cb2a681951",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "044d1a03-3f73-4245-ba52-bce284b244fe",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/169210205/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdBJuqhkgSPOtBHLCsk3mDnU4cT84pIrCGZEFBeEPvnowT/ofCI2Bempx5WorJe1PUBOjOh9ftb9haYoZwWTZBqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIHVOa1xvU9IUtcQMqix4pWuAZhTpyal8d6b3uAcgvOdfAiEA4eabCXxFBETksWA7i9\u002B/JkfQ8\u002Bg1h3tNN3YOS2xaFdk=",
+        "csr": "MIIBGTCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKEbh67YlWy3H2PTh66do0hO0\u002BqquQvhFVwLlhci\u002Bw/O9cKvl49cQYEXNhaIKVzlf67QsjzqPfLr0xe7qlFCEdKBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCwGjoPkDQefl61eH7/oxPghbI1WA\u002BLauLQjbrcdvSnHgIhAMa/ZYoQGLbiJEXeiVbytkydW6JXyQOabRa7vjiPWY7r",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "fce7f79f7b19486bb1cafe676359dc95"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/169210205",
+        "request_id": "ade3fd60ebf6429294314803119abf6a"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/169210205?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "22a0e58b0e01bd91af9785f7d03362f4",
         "x-ms-return-client-request-id": "true"
@@ -256,211 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "757",
+        "Content-Length": "1751",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:12:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "cdd3a580-ee0b-4d52-b97f-2567524626bf",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdBJuqhkgSPOtBHLCsk3mDnU4cT84pIrCGZEFBeEPvnowT/ofCI2Bempx5WorJe1PUBOjOh9ftb9haYoZwWTZBqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIHVOa1xvU9IUtcQMqix4pWuAZhTpyal8d6b3uAcgvOdfAiEA4eabCXxFBETksWA7i9\u002B/JkfQ8\u002Bg1h3tNN3YOS2xaFdk=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "fce7f79f7b19486bb1cafe676359dc95"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "fce8e92b9de94f7e0ba5177202250c68",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "757",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "206e4168-2ba2-43b7-9577-99b1e5b52bda",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdBJuqhkgSPOtBHLCsk3mDnU4cT84pIrCGZEFBeEPvnowT/ofCI2Bempx5WorJe1PUBOjOh9ftb9haYoZwWTZBqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIHVOa1xvU9IUtcQMqix4pWuAZhTpyal8d6b3uAcgvOdfAiEA4eabCXxFBETksWA7i9\u002B/JkfQ8\u002Bg1h3tNN3YOS2xaFdk=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "fce7f79f7b19486bb1cafe676359dc95"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "4656cb7319629eadc6202b6efd28b15c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "757",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "17ae7d99-ce5d-41f2-a16c-75dd8069ec34",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdBJuqhkgSPOtBHLCsk3mDnU4cT84pIrCGZEFBeEPvnowT/ofCI2Bempx5WorJe1PUBOjOh9ftb9haYoZwWTZBqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIHVOa1xvU9IUtcQMqix4pWuAZhTpyal8d6b3uAcgvOdfAiEA4eabCXxFBETksWA7i9\u002B/JkfQ8\u002Bg1h3tNN3YOS2xaFdk=",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "fce7f79f7b19486bb1cafe676359dc95"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "e43732acd446ee3b6750165cf71ebb8a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "665",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "22a0e58b0e01bd91af9785f7d03362f4",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a692bb92-aef6-417a-9335-83b2a41bb61c",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "32668c83-2b6d-4632-9c67-4a4872a03bf7",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBGDCBvwIBADASMRAwDgYDVQQDEwdkZWZhdWx0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdBJuqhkgSPOtBHLCsk3mDnU4cT84pIrCGZEFBeEPvnowT/ofCI2Bempx5WorJe1PUBOjOh9ftb9haYoZwWTZBqBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUCIHVOa1xvU9IUtcQMqix4pWuAZhTpyal8d6b3uAcgvOdfAiEA4eabCXxFBETksWA7i9\u002B/JkfQ8\u002Bg1h3tNN3YOS2xaFdk=",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/169210205",
-        "request_id": "fce7f79f7b19486bb1cafe676359dc95"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/169210205?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "04831d8a1cdc12923c4a35c8720f52e2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1756",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "66877a63-bb03-43e3-8077-c7af8729bc40",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c",
-        "x5t": "MTJENBe1p7EttW4ksswYEuV7lbs",
-        "cer": "MIIBnjCCAUSgAwIBAgIQWezj5iQPRDSCUwl\u002BTGIJiDAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDMwNloXDTIyMDMwNTIzMTMwNlowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABHQSbqoZIEjzrQRywrJN5g51OHE/OKSKwhmRBQXhD756ME/6HwiNgXpqceVqKyXtT1ATozofX7W/YWmKGcFk2QajfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBRr79j0eWDvu8posqoLjEpophfL0DAdBgNVHQ4EFgQUa\u002B/Y9Hlg77vKaLKqC4xKaKYXy9AwCgYIKoZIzj0EAwIDSAAwRQIhAK96HqCjULUzYmqoswx/GBDJrTZ6sgNxIkKT8ARXisYlAiBeQSs/xTaelWPJtCEet/whC5SCyfDpFfv\u002BIOXYb1F4Gw==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/169210205/ac24c5ccdf8440108cef3bf86cbcf869",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/169210205/ac24c5ccdf8440108cef3bf86cbcf869",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/169210205/ac24c5ccdf8440108cef3bf86cbcf869",
+        "x5t": "x1qx13out55BXgbFJv93DSwsHNQ",
+        "cer": "MIIBnjCCAUSgAwIBAgIQf0PYyUIyTcObyy1hc9tTzTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjUwMVoXDTIyMDQwODAyMzUwMVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABChG4eu2JVstx9j04eunaNITtPqqrkL4RVcC5YXIvsPzvXCr5ePXEGBFzYWiClc5X\u002Bu0LI86j3y69MXu6pRQhHSjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSPLuA\u002B/G2fgFQQfswUe/2srKvs\u002BDAdBgNVHQ4EFgQUjy7gPvxtn4BUEH7MFHv9rKyr7PgwCgYIKoZIzj0EAwIDSAAwRQIhAJkPHwdx1wlxzmO9aKW0pXlsXFsrlCSH/LWwnPstLFO/AiAp/\u002BOd3hVp\u002BcfnWNbzQZ6eSaiJ/AP5QpkCX9etJFt9Xw==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985386,
-          "exp": 1646521986,
-          "created": 1614985986,
-          "updated": 1614985986,
+          "nbf": 1617848701,
+          "exp": 1649385301,
+          "created": 1617849301,
+          "updated": 1617849301,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/169210205/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -500,65 +330,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985960,
-            "updated": 1614985960
+            "created": 1617849294,
+            "updated": 1617849294
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/169210205/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/169210205/ac24c5ccdf8440108cef3bf86cbcf869?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-7e8016e3afac3f4ea2c0fbcd2ff4e356-69f9cb70edfbe94a-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "fce8e92b9de94f7e0ba5177202250c68",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:35:04 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "fce8e92b9de94f7e0ba5177202250c68",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3e14f023-a518-4d4b-8843-f9624185004c",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/169210205/ac24c5ccdf8440108cef3bf86cbcf869?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-e7cf3c02104ae546807e4810f1903716-9a4159786815074a-00",
+        "traceparent": "00-7e8016e3afac3f4ea2c0fbcd2ff4e356-69f9cb70edfbe94a-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "d0c5baf328ed9f228f68de120251a7a8",
+        "x-ms-client-request-id": "fce8e92b9de94f7e0ba5177202250c68",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "439",
+        "Content-Length": "438",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "fce8e92b9de94f7e0ba5177202250c68",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "26bf8001-34b6-4137-992f-b96fef2d5627",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "fd5bb75c-39d2-48b7-b860-7815cc46dfaf",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/169210205/ac24c5ccdf8440108cef3bf86cbcf869",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256",
-          "x": "dBJuqhkgSPOtBHLCsk3mDnU4cT84pIrCGZEFBeEPvno",
-          "y": "ME_6HwiNgXpqceVqKyXtT1ATozofX7W_YWmKGcFk2QY"
+          "x": "KEbh67YlWy3H2PTh66do0hO0-qquQvhFVwLlhci-w_M",
+          "y": "vXCr5ePXEGBFzYWiClc5X-u0LI86j3y69MXu6pRQhHQ"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985386,
-          "exp": 1646521986,
-          "created": 1614985986,
-          "updated": 1614985986,
+          "nbf": 1617848701,
+          "exp": 1649385301,
+          "created": 1617849301,
+          "updated": 1617849301,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -566,19 +437,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/169210205/ac24c5ccdf8440108cef3bf86cbcf869/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "69",
         "Content-Type": "application/json",
-        "traceparent": "00-e7cf3c02104ae546807e4810f1903716-b4e1a5c16756044a-00",
+        "traceparent": "00-7e8016e3afac3f4ea2c0fbcd2ff4e356-628a64542f97df4c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "e0e4a065ada5907fa025a8fb9f727c57",
+        "x-ms-client-request-id": "4656cb7319629eadc6202b6efd28b15c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -588,128 +459,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "193",
+        "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4656cb7319629eadc6202b6efd28b15c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0430ea02-6cb4-46da-aa1c-b8b71f5ee589",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1fa53ec0-9e61-4c9d-8583-53f4108f778c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c",
-        "value": "N3KpYnjuDsepRqF-JMoaVaOcSi9rKt69E25XECRfDSH9wWbwTPlRwlBImGFXVeq2e5_ygJn-fZ0ROBo0tHXecw"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/169210205/ac24c5ccdf8440108cef3bf86cbcf869",
+        "value": "EGsLYbN_JZFPQTp_7IxU8e3Xs01o7pvd4SdiSS0a4JbifFsjD5srQNZ5g_MXwk44S5cTTr1XuvtaKdv3tpfcXw"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/169210205/ac24c5ccdf8440108cef3bf86cbcf869?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-62c9b05ed4db1740a73fdfdef25c7d65-46fca5ed9ae38f43-00",
+        "traceparent": "00-6eb688c9edd30a42ac70a2e89d03c0b5-a0c985f2e04bdc4a-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "3c6833feeb59629cfae474743d8010eb",
+        "x-ms-client-request-id": "e43732acd446ee3b6750165cf71ebb8a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1163",
+        "Content-Length": "1160",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e43732acd446ee3b6750165cf71ebb8a",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6a69f61b-3bfa-448b-97aa-1a6f19f5b6c6",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "7c75fbaa-5952-416b-9d62-82e25689b0d2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c",
-        "x5t": "MTJENBe1p7EttW4ksswYEuV7lbs",
-        "cer": "MIIBnjCCAUSgAwIBAgIQWezj5iQPRDSCUwl\u002BTGIJiDAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDMwNloXDTIyMDMwNTIzMTMwNlowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABHQSbqoZIEjzrQRywrJN5g51OHE/OKSKwhmRBQXhD756ME/6HwiNgXpqceVqKyXtT1ATozofX7W/YWmKGcFk2QajfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBRr79j0eWDvu8posqoLjEpophfL0DAdBgNVHQ4EFgQUa\u002B/Y9Hlg77vKaLKqC4xKaKYXy9AwCgYIKoZIzj0EAwIDSAAwRQIhAK96HqCjULUzYmqoswx/GBDJrTZ6sgNxIkKT8ARXisYlAiBeQSs/xTaelWPJtCEet/whC5SCyfDpFfv\u002BIOXYb1F4Gw==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/169210205/ac24c5ccdf8440108cef3bf86cbcf869",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/169210205/ac24c5ccdf8440108cef3bf86cbcf869",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/169210205/ac24c5ccdf8440108cef3bf86cbcf869",
+        "x5t": "x1qx13out55BXgbFJv93DSwsHNQ",
+        "cer": "MIIBnjCCAUSgAwIBAgIQf0PYyUIyTcObyy1hc9tTzTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjUwMVoXDTIyMDQwODAyMzUwMVowEjEQMA4GA1UEAxMHZGVmYXVsdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABChG4eu2JVstx9j04eunaNITtPqqrkL4RVcC5YXIvsPzvXCr5ePXEGBFzYWiClc5X\u002Bu0LI86j3y69MXu6pRQhHSjfDB6MA4GA1UdDwEB/wQEAwIHgDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSPLuA\u002B/G2fgFQQfswUe/2srKvs\u002BDAdBgNVHQ4EFgQUjy7gPvxtn4BUEH7MFHv9rKyr7PgwCgYIKoZIzj0EAwIDSAAwRQIhAJkPHwdx1wlxzmO9aKW0pXlsXFsrlCSH/LWwnPstLFO/AiAp/\u002BOd3hVp\u002BcfnWNbzQZ6eSaiJ/AP5QpkCX9etJFt9Xw==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985386,
-          "exp": 1646521986,
-          "created": 1614985986,
-          "updated": 1614985986,
+          "nbf": 1617848701,
+          "exp": 1649385301,
+          "created": 1617849301,
+          "updated": 1617849301,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "59ECE3E6240F44348253097E4C620988"
+        "serialnumber": "7F43D8C942324DC39BCB2D6173DB53CD"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/169210205/ac24c5ccdf8440108cef3bf86cbcf869?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-62c9b05ed4db1740a73fdfdef25c7d65-2fff8f756e2fb041-00",
+        "traceparent": "00-6eb688c9edd30a42ac70a2e89d03c0b5-4878cbbe319a4f4a-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "d1638da3712a453d3a3430c87f26001c",
+        "x-ms-client-request-id": "04831d8a1cdc12923c4a35c8720f52e2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1803",
+        "Content-Length": "1801",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "04831d8a1cdc12923c4a35c8720f52e2",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c3250e60-fc8e-4387-b748-11ca8bd6cc2c",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bf6677a7-969a-4c1d-8302-389f0351b9d8",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIEBwIBAzCCA8MGCSqGSIb3DQEHAaCCA7QEggOwMIIDrDCCAW0GCSqGSIb3DQEHAaCCAV4EggFaMIIBVjCCAVIGCyqGSIb3DQEMCgECoIHMMIHJMBwGCiqGSIb3DQEMAQMwDgQIpEQiTnkq0d0CAgfQBIGo1Jwp2OCTNPwW/Gb56o96yb04rV0WGZk8AGjrElHxQlQOMgzFX/86Occpu1s\u002BZWBr7GyZYVzA7er9rN1T63vD7UxAPbbbOtvhReXrF4VtVVK5x53aNjl3G3MC3RyUuApU1MrJElj7G6ceqDMtJ0QqbnVR5nzRv9A014Vovo61XGatjKwV2mUVc2rmwEZkK0gOXDYnXBoVegkLIq70bs4\u002BoOnmXVDF8lSeMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAjcGCSqGSIb3DQEHBqCCAigwggIkAgEAMIICHQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIatca7pjri5UCAgfQgIIB8IrT1E02x/9jiwzPpTqxuV720V2Ig1hRT0uL7TGIpU7h0T70IlIZvFDYcszs/IgvIqZPd\u002Bz5fqYK\u002B0eP7OheB0pxgh7QFTjqW2zV4Tyi6rhNCFiTffMCcU\u002BL35oaSL3AM6mqcvdijQqC9LKjaaLN3DMyLOLuw7JltkFALA2PtTMsl/IeCfBz6n/tEaaIfZr0aCEpRA9Co/TRym/WSf/Jg9oKYCgwOzlK8KrrwlnA3\u002BKNG5gzHJz8SzBp1rfC\u002BW3TbPdAnKbdR8FwDMmtKOV2zc4xfqwD\u002BzPaZsZb91KeAf7TFNrwaSHAJaCveY3YyWaIYN5GoFCXSC/LaszB9wfVpjSOlJ0KA\u002BWSkGApny2dEtk7cb9fq7FNRMsaDmKI7/pPmKv73M8WKlkI/dsSEtWbAhP1UNtGcIACT/Nbq5vCZZ95iJoRT\u002B0SnEK0sAv0UVUdDJJ6dLpVCfP\u002BJSlFgg3C/HwPYKkXz2Lj0YPZ/\u002B8Jo/NPjxAo1TNZfoTa5PdGWse\u002BTY20T04Pv5LiRiIbWplgzTxGHiGI21mGhGF1MKSPMbzFrncB44jLRfm65ogiQUnIjFcK8c00Duuh4q6wbuzePiAIHUtqmcJgR6vTFdokj/ATndOwH5\u002BrKU8aqTkOHhDNDhzsERTMdVxWhHSDyl7yDVMwOzAfMAcGBSsOAwIaBBTIXP4TnD6Y7A0gEKV3xg67gcHsEAQU7SxfivQ5zNRdD3DxyKP2X5r6OSkCAgfQ",
+        "value": "MIIEBwIBAzCCA8MGCSqGSIb3DQEHAaCCA7QEggOwMIIDrDCCAW0GCSqGSIb3DQEHAaCCAV4EggFaMIIBVjCCAVIGCyqGSIb3DQEMCgECoIHMMIHJMBwGCiqGSIb3DQEMAQMwDgQIUTn2TdBNoXECAgfQBIGo0n7HMXuV1E3JD6kNtRx85QvE4lp4nnnJga23z08C6Nb/dCAhnhM8qe54whc7AtqEx5FFvelcRhu6woKb2JsNWYb1ybG9TpzTY082tBQvO6P3DJGqcz6dJCZOMs5F6wHv6ORGN2IGVAGe8\u002BUiBhDXdBiYxtcAXijNp6b8n069c2nkM\u002BTerbhI0sXJTHRqpj94Lhw0MLQ0rkGt\u002BAKbzvOjilqetwd0/KtOMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAjcGCSqGSIb3DQEHBqCCAigwggIkAgEAMIICHQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIRUi/\u002BzFNtr0CAgfQgIIB8G6FpP118UEF6NkurHY6Po\u002BMFozLZpiJcJf/pt5kNVakL2gzb/CMr0WXvJevbaRX\u002BOpwVUIo9pvLzCFUNN4ChmvFMpE9Ep9GZzNbioKyijtjRQjbbrGs45k/8Dppg21zL\u002B0Y\u002BruDwZIncFGzEcfeEZLfghh5tNgEioe0mPwKgVPfABaVke\u002B93jdvNDTn1MOh/GRbagpY4DknvdBm1JaOx/NM58/dPGPdkkyKoTwR8ApCuKTBbeXCrK\u002BpiYyOemA7wVsp9ZYgrZclXid3hX2kumF0wDZn3Idm3qKmQUr9qmL8ttMYGKxYgBtyxVrWfZq3y\u002BMQVro2Xnd6iwJrh0YoS8UNYX93oe6Sap1IXEeQ71ToblhfUx2ez5ZhdcJwka3IrZl6rXkjNzSBBIhZr\u002BQzz6/zrR/1QliR4QppO4kBRmK/llDmvh5wI6QDl893DXhW72fPIFCh4JX81gjG0Z4Ar2Gxxx0pd8tdHdnHzw3MzrRIe\u002B6ifg2qRdLy9Xda51Gzc/uQBdjRsfFeLiv8d/Px0Mx3Q7x16Nn804/TeGqqovmng44ziYZPiYwN1m8HwHKxeNOk8\u002Btpn6///R8jItojRfiDiOpRmPAwCo4PT7EXcq8iBwB74YQ\u002BxsDQVZZxXXhdZ\u002BiSqHEiJ58HfeXxqU2/K4owOzAfMAcGBSsOAwIaBBRSt2ffvgxT2DGcCuZ6pwDkxKSThQQUQqPdmqW/XbnFRwS8bfQZrS5bEYsCAgfQ",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/169210205/ac24c5ccdf8440108cef3bf86cbcf869",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985386,
-          "exp": 1646521986,
-          "created": 1614985986,
-          "updated": 1614985986,
+          "nbf": 1617848701,
+          "exp": 1649385301,
+          "created": 1617849301,
+          "updated": 1617849301,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/169210205/948e7e5e0d4c4a28ab94a4ec86fa957c"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/169210205/ac24c5ccdf8440108cef3bf86cbcf869"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "213715862"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-256K).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-256K).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/522663450/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/522663450/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-fc22886fe607344db3212fe89a13d648-5787c96a7af83e42-00",
+        "traceparent": "00-091e2df868ae1743a5aaf3f7f18bae9c-7419f1075d759046-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "a4438b5f35bd0453deb45b9721148a2a",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:04 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a4438b5f35bd0453deb45b9721148a2a",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "eda1cbc6-49a5-415a-8221-427ae0839d31",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a5e83089-5395-4fb2-991d-8fd95f830da4",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/522663450/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/522663450/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "220",
         "Content-Type": "application/json",
-        "traceparent": "00-fc22886fe607344db3212fe89a13d648-5787c96a7af83e42-00",
+        "traceparent": "00-091e2df868ae1743a5aaf3f7f18bae9c-7419f1075d759046-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "a4438b5f35bd0453deb45b9721148a2a",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "964",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:04 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending?api-version=7.2\u0026request_id=9156671239c94d9fa96e5b630167cf9d",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/522663450/pending?api-version=7.2\u0026request_id=2f01f6c52a924a379c3ca8c6c3b84c7b",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a4438b5f35bd0453deb45b9721148a2a",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "309c1d04-0e1b-4189-9c9a-7148650107d1",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f91f9a13-a078-4476-8cc1-356bf1e6d7aa",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/522663450/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASt2kJgcR0BRILlPFFDrgyVcB0PnGmKLtMbPnFNJrJfjvF5DtUVN5QQSggiUQE5lhFspONxjVDnsqwxVxnFqQejoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAKzuDeJm/ppTJpjsTbxNSYKtUZCdZc8MVX3V0JS0K1RFAiBA6JUBjepVQDbBAEcmoD2uECe7NIzoKEZkwFQzlloVDA==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARAqrsD3e6U4joOaXIvBv1rrbptIu7NDjM6bsQ6CvUn5hfCCBMy1hZaOKSrKvOGbCNBfF3CnffRVgTTj4LxrQ3koEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgdaiIGBTbZr5SQAlPW/7vWbWIe1KnI/F4S1BBCgS9ZGkCIEwG36KTpa3Wv3E7KtRB2TqbOaqe4Gjm2qWPHVuk6wcI",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9156671239c94d9fa96e5b630167cf9d"
+        "request_id": "2f01f6c52a924a379c3ca8c6c3b84c7b"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/522663450/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "300873289be2833536e086bcf307800f",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "964",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "300873289be2833536e086bcf307800f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3d63b053-0572-4204-9685-9c139f649555",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "2975e1a8-e460-414b-bfb9-cd7dfabac256",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/522663450/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASt2kJgcR0BRILlPFFDrgyVcB0PnGmKLtMbPnFNJrJfjvF5DtUVN5QQSggiUQE5lhFspONxjVDnsqwxVxnFqQejoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAKzuDeJm/ppTJpjsTbxNSYKtUZCdZc8MVX3V0JS0K1RFAiBA6JUBjepVQDbBAEcmoD2uECe7NIzoKEZkwFQzlloVDA==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARAqrsD3e6U4joOaXIvBv1rrbptIu7NDjM6bsQ6CvUn5hfCCBMy1hZaOKSrKvOGbCNBfF3CnffRVgTTj4LxrQ3koEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgdaiIGBTbZr5SQAlPW/7vWbWIe1KnI/F4S1BBCgS9ZGkCIEwG36KTpa3Wv3E7KtRB2TqbOaqe4Gjm2qWPHVuk6wcI",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9156671239c94d9fa96e5b630167cf9d"
+        "request_id": "2f01f6c52a924a379c3ca8c6c3b84c7b"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/522663450/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "38ad560844d9bc5253583777fd05b7d4",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "964",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:10 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "38ad560844d9bc5253583777fd05b7d4",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "d668afc5-9d43-44c5-935e-cccb3a1d5db4",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "96127e32-1ab9-448e-9cd5-9dc5c0feb212",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/522663450/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASt2kJgcR0BRILlPFFDrgyVcB0PnGmKLtMbPnFNJrJfjvF5DtUVN5QQSggiUQE5lhFspONxjVDnsqwxVxnFqQejoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAKzuDeJm/ppTJpjsTbxNSYKtUZCdZc8MVX3V0JS0K1RFAiBA6JUBjepVQDbBAEcmoD2uECe7NIzoKEZkwFQzlloVDA==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARAqrsD3e6U4joOaXIvBv1rrbptIu7NDjM6bsQ6CvUn5hfCCBMy1hZaOKSrKvOGbCNBfF3CnffRVgTTj4LxrQ3koEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgdaiIGBTbZr5SQAlPW/7vWbWIe1KnI/F4S1BBCgS9ZGkCIEwG36KTpa3Wv3E7KtRB2TqbOaqe4Gjm2qWPHVuk6wcI",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9156671239c94d9fa96e5b630167cf9d"
+        "request_id": "2f01f6c52a924a379c3ca8c6c3b84c7b"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/522663450/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "03ff49a4dc57c33755bf6ddcae9710d7",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "871",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:15 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "03ff49a4dc57c33755bf6ddcae9710d7",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7bf234b2-d6e6-4ad2-8f3e-78a909c48ba0",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5a355774-01e8-49cd-b812-b72349d77bfa",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/522663450/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASt2kJgcR0BRILlPFFDrgyVcB0PnGmKLtMbPnFNJrJfjvF5DtUVN5QQSggiUQE5lhFspONxjVDnsqwxVxnFqQejoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAKzuDeJm/ppTJpjsTbxNSYKtUZCdZc8MVX3V0JS0K1RFAiBA6JUBjepVQDbBAEcmoD2uECe7NIzoKEZkwFQzlloVDA==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARAqrsD3e6U4joOaXIvBv1rrbptIu7NDjM6bsQ6CvUn5hfCCBMy1hZaOKSrKvOGbCNBfF3CnffRVgTTj4LxrQ3koEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgdaiIGBTbZr5SQAlPW/7vWbWIe1KnI/F4S1BBCgS9ZGkCIEwG36KTpa3Wv3E7KtRB2TqbOaqe4Gjm2qWPHVuk6wcI",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9156671239c94d9fa96e5b630167cf9d"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/522663450",
+        "request_id": "2f01f6c52a924a379c3ca8c6c3b84c7b"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/522663450?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "cb8f4c345266e351204bdd8a64bd8630",
         "x-ms-return-client-request-id": "true"
@@ -256,211 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "969",
+        "Content-Length": "1960",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:20 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "168f5ac6-b610-455a-a5bc-826afd987e74",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASt2kJgcR0BRILlPFFDrgyVcB0PnGmKLtMbPnFNJrJfjvF5DtUVN5QQSggiUQE5lhFspONxjVDnsqwxVxnFqQejoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAKzuDeJm/ppTJpjsTbxNSYKtUZCdZc8MVX3V0JS0K1RFAiBA6JUBjepVQDbBAEcmoD2uECe7NIzoKEZkwFQzlloVDA==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9156671239c94d9fa96e5b630167cf9d"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "aa18b2287c072cb71eeae319d7750ebb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "969",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "eedf7131-4a58-447a-be89-a02020966940",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASt2kJgcR0BRILlPFFDrgyVcB0PnGmKLtMbPnFNJrJfjvF5DtUVN5QQSggiUQE5lhFspONxjVDnsqwxVxnFqQejoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAKzuDeJm/ppTJpjsTbxNSYKtUZCdZc8MVX3V0JS0K1RFAiBA6JUBjepVQDbBAEcmoD2uECe7NIzoKEZkwFQzlloVDA==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9156671239c94d9fa96e5b630167cf9d"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "b0435f47ec76516df81ce20bfeac5e97",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "969",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:31 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "412ab9d7-7395-4b37-bf2e-50cac1d183b0",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASt2kJgcR0BRILlPFFDrgyVcB0PnGmKLtMbPnFNJrJfjvF5DtUVN5QQSggiUQE5lhFspONxjVDnsqwxVxnFqQejoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAKzuDeJm/ppTJpjsTbxNSYKtUZCdZc8MVX3V0JS0K1RFAiBA6JUBjepVQDbBAEcmoD2uECe7NIzoKEZkwFQzlloVDA==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "9156671239c94d9fa96e5b630167cf9d"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "fcb33c38667eb7d09463ac7c6f370caa",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "877",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:35 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "cb8f4c345266e351204bdd8a64bd8630",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "33477931-4b1a-4cc9-a1c8-c057cafdb24b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d2a782e0-8233-41fc-9375-bd5b327163f5",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASt2kJgcR0BRILlPFFDrgyVcB0PnGmKLtMbPnFNJrJfjvF5DtUVN5QQSggiUQE5lhFspONxjVDnsqwxVxnFqQejoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAKzuDeJm/ppTJpjsTbxNSYKtUZCdZc8MVX3V0JS0K1RFAiBA6JUBjepVQDbBAEcmoD2uECe7NIzoKEZkwFQzlloVDA==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/522663450",
-        "request_id": "9156671239c94d9fa96e5b630167cf9d"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/522663450?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0442213dd57a3cba44c6b1eb99ac2d72",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1965",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "27c6bc4b-e1e0-4de3-9c8a-9c5d59881bd8",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/265ae93f63034a9e96a1a0e7b50c0f96",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/522663450/265ae93f63034a9e96a1a0e7b50c0f96",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/522663450/265ae93f63034a9e96a1a0e7b50c0f96",
-        "x5t": "taOmJdbrPduibciZXQsuA9YUeTM",
-        "cer": "MIICPDCCAeGgAwIBAgIQCA/ZIhVNS7q5FiYStSVLujAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTUzM1oXDTIyMDMwNTIzMDUzM1owEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASt2kJgcR0BRILlPFFDrgyVcB0PnGmKLtMbPnFNJrJfjvF5DtUVN5QQSggiUQE5lhFspONxjVDnsqwxVxnFqQejo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUu4ehfLwFs\u002BZK\u002BAXRDipfyGfvkMYwHQYDVR0OBBYEFLuHoXy8BbPmSvgF0Q4qX8hn75DGMAoGCCqGSM49BAMCA0kAMEYCIQDKeVgpnLypZDYZgUJEUl65sKCGR\u002B1kj6/svkMq\u002Bmy6jAIhAIYuq4yyHCb7U7vTx83rdbXyZ9dRq1lKdrQbaQF/I8mo",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/522663450/98f0109c4bf74a8c9348a17cb35e4f9c",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/522663450/98f0109c4bf74a8c9348a17cb35e4f9c",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/522663450/98f0109c4bf74a8c9348a17cb35e4f9c",
+        "x5t": "zQTqA6bWcZfOcbkIgaPQDCVJD7E",
+        "cer": "MIICOzCCAeGgAwIBAgIQQSU1SEA/Qzq4lUbc2ttZzzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTYxNFoXDTIyMDQwODAyMjYxNFowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARAqrsD3e6U4joOaXIvBv1rrbptIu7NDjM6bsQ6CvUn5hfCCBMy1hZaOKSrKvOGbCNBfF3CnffRVgTTj4LxrQ3ko3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAU3mFvuBK4tG7clMF4E7oFmQs2Yb8wHQYDVR0OBBYEFN5hb7gSuLRu3JTBeBO6BZkLNmG/MAoGCCqGSM49BAMCA0gAMEUCIQDmi4ZRWcpQX4APLL67BlhFF1fJLngcO9DT2bBP3wstIAIgahDbUKUQEzfy/KpdQ5iaKsicDsgHYfsYZ64BaSA7FFo=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984933,
-          "exp": 1646521533,
-          "created": 1614985533,
-          "updated": 1614985533,
+          "nbf": 1617848174,
+          "exp": 1649384774,
+          "created": 1617848774,
+          "updated": 1617848774,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/522663450/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -500,65 +330,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985505,
-            "updated": 1614985505
+            "created": 1617848765,
+            "updated": 1617848765
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/522663450/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/522663450/265ae93f63034a9e96a1a0e7b50c0f96?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/522663450/98f0109c4bf74a8c9348a17cb35e4f9c?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-be12bc8d064ae740a473aeb782afd96a-4c4cb26e20bfe74c-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "aa18b2287c072cb71eeae319d7750ebb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:26:20 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "aa18b2287c072cb71eeae319d7750ebb",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "85c119f6-f905-496f-ad91-0f188c819ada",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/522663450/98f0109c4bf74a8c9348a17cb35e4f9c?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-80f8da9a51fce74583516e8068eab54e-64ca0980cbfd5c41-00",
+        "traceparent": "00-be12bc8d064ae740a473aeb782afd96a-4c4cb26e20bfe74c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "9ae14b8b12c1e13c8f8b1c123ff0e2c1",
+        "x-ms-client-request-id": "aa18b2287c072cb71eeae319d7750ebb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "440",
+        "Content-Length": "439",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:40 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "aa18b2287c072cb71eeae319d7750ebb",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5d298be2-f4ae-4721-a676-8e2477075a1a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "66e42935-6609-427d-9d94-6a11afea26b0",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/522663450/265ae93f63034a9e96a1a0e7b50c0f96",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/522663450/98f0109c4bf74a8c9348a17cb35e4f9c",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256K",
-          "x": "rdpCYHEdAUSC5TxRQ64MlXAdD5xpii7TGz5xTSayX44",
-          "y": "8XkO1RU3lBBKCCJRATmWEWyk43GNUOeyrDFXGcWpB6M"
+          "x": "QKq7A93ulOI6DmlyLwb9a626bSLuzQ4zOm7EOgr1J-Y",
+          "y": "F8IIEzLWFlo4pKsq84ZsI0F8XcKd99FWBNOPgvGtDeQ"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984933,
-          "exp": 1646521533,
-          "created": 1614985533,
-          "updated": 1614985533,
+          "nbf": 1617848174,
+          "exp": 1649384774,
+          "created": 1617848774,
+          "updated": 1617848774,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -566,19 +437,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/522663450/265ae93f63034a9e96a1a0e7b50c0f96/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/522663450/98f0109c4bf74a8c9348a17cb35e4f9c/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "70",
         "Content-Type": "application/json",
-        "traceparent": "00-80f8da9a51fce74583516e8068eab54e-03acbacaa33ae348-00",
+        "traceparent": "00-be12bc8d064ae740a473aeb782afd96a-638dcc5ecb83dd48-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "dcce370f5969621c8277b7b8b4e41de7",
+        "x-ms-client-request-id": "b0435f47ec76516df81ce20bfeac5e97",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -588,128 +459,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "193",
+        "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:40 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b0435f47ec76516df81ce20bfeac5e97",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6610989d-3882-4c95-8d3a-eff3a0c5b93a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "023f2231-380d-4f13-9cc7-e55e1042f582",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/522663450/265ae93f63034a9e96a1a0e7b50c0f96",
-        "value": "hq5D2fsy6uTernBmLFFONG0qsalI5BdRXNIGj_CgTa2xQQrY1I0dsPT21bwuLSvpgPyR4nG6mN0HnJkmEzkzbg"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/522663450/98f0109c4bf74a8c9348a17cb35e4f9c",
+        "value": "0EPaMhHirf9dKe5HGGy2UlsEFI7ZeJaDfrPduPuU80PwxGxqwGNs9_H_KrDKaL4Z9oTT7aPiwQG2E8yWRdUmpg"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/522663450/265ae93f63034a9e96a1a0e7b50c0f96?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/522663450/98f0109c4bf74a8c9348a17cb35e4f9c?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-1db6a714bb8cea47b74e1d22efccfc68-ca1c97aa38c44445-00",
+        "traceparent": "00-3af0b42d35b29445b97b7138272249da-0362904e8fad3948-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "23f13a3571552ae8e46175efb8a7fc54",
+        "x-ms-client-request-id": "fcb33c38667eb7d09463ac7c6f370caa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1371",
+        "Content-Length": "1368",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:41 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "fcb33c38667eb7d09463ac7c6f370caa",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "26b15c90-2569-4297-a5ba-d58f4e918af0",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5f8d5763-81d5-44b5-9e2a-3f425f7dbcfa",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/522663450/265ae93f63034a9e96a1a0e7b50c0f96",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/522663450/265ae93f63034a9e96a1a0e7b50c0f96",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/522663450/265ae93f63034a9e96a1a0e7b50c0f96",
-        "x5t": "taOmJdbrPduibciZXQsuA9YUeTM",
-        "cer": "MIICPDCCAeGgAwIBAgIQCA/ZIhVNS7q5FiYStSVLujAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTUzM1oXDTIyMDMwNTIzMDUzM1owEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASt2kJgcR0BRILlPFFDrgyVcB0PnGmKLtMbPnFNJrJfjvF5DtUVN5QQSggiUQE5lhFspONxjVDnsqwxVxnFqQejo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUu4ehfLwFs\u002BZK\u002BAXRDipfyGfvkMYwHQYDVR0OBBYEFLuHoXy8BbPmSvgF0Q4qX8hn75DGMAoGCCqGSM49BAMCA0kAMEYCIQDKeVgpnLypZDYZgUJEUl65sKCGR\u002B1kj6/svkMq\u002Bmy6jAIhAIYuq4yyHCb7U7vTx83rdbXyZ9dRq1lKdrQbaQF/I8mo",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/522663450/98f0109c4bf74a8c9348a17cb35e4f9c",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/522663450/98f0109c4bf74a8c9348a17cb35e4f9c",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/522663450/98f0109c4bf74a8c9348a17cb35e4f9c",
+        "x5t": "zQTqA6bWcZfOcbkIgaPQDCVJD7E",
+        "cer": "MIICOzCCAeGgAwIBAgIQQSU1SEA/Qzq4lUbc2ttZzzAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTYxNFoXDTIyMDQwODAyMjYxNFowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAARAqrsD3e6U4joOaXIvBv1rrbptIu7NDjM6bsQ6CvUn5hfCCBMy1hZaOKSrKvOGbCNBfF3CnffRVgTTj4LxrQ3ko3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAU3mFvuBK4tG7clMF4E7oFmQs2Yb8wHQYDVR0OBBYEFN5hb7gSuLRu3JTBeBO6BZkLNmG/MAoGCCqGSM49BAMCA0gAMEUCIQDmi4ZRWcpQX4APLL67BlhFF1fJLngcO9DT2bBP3wstIAIgahDbUKUQEzfy/KpdQ5iaKsicDsgHYfsYZ64BaSA7FFo=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984933,
-          "exp": 1646521533,
-          "created": 1614985533,
-          "updated": 1614985533,
+          "nbf": 1617848174,
+          "exp": 1649384774,
+          "created": 1617848774,
+          "updated": 1617848774,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "080FD922154D4BBAB9162612B5254BBA"
+        "serialnumber": "41253548403F433AB89546DCDADB59CF"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/522663450/265ae93f63034a9e96a1a0e7b50c0f96?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/522663450/98f0109c4bf74a8c9348a17cb35e4f9c?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-1db6a714bb8cea47b74e1d22efccfc68-d44cb39e18d9b14b-00",
+        "traceparent": "00-3af0b42d35b29445b97b7138272249da-70feabadf4552949-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "61dbf0e350dd31082f7f184a5a842daa",
+        "x-ms-client-request-id": "0442213dd57a3cba44c6b1eb99ac2d72",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2215",
+        "Content-Length": "2201",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:41 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0442213dd57a3cba44c6b1eb99ac2d72",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4e2149ed-bd32-4b5a-a86c-3e0232fbf63f",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "494fae70-c9c3-417f-919b-515231b943cd",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIFOgIBAzCCBPYGCSqGSIb3DQEHAaCCBOcEggTjMIIE3zCCAgAGCSqGSIb3DQEHAaCCAfEEggHtMIIB6TCCAeUGCyqGSIb3DQEMCgECoIIBXjCCAVowHAYKKoZIhvcNAQwBAzAOBAjCjbdlTRDzNQICB9AEggE4yDK7PMuk5Uboo4xiyc5EfbQygnA9YTMc4SB1QhQqBve0AfWHWNQLd8mGUtFf/v/QW7BKapjaCgHHcQpiTlcBiEuqverC9qXwt\u002BQ4G6CowvcXCJgUifoVUU/WLDjLcikMNnz2I6VdYoGLlXsR\u002BUlRowScxsaGy/KyHpyNnGYnBfj8xQ4EX37qyGVc0UlKHgiqzBp7x57ail5pLiLbVAwbYR0MOsVYlkxU8/YJ3D/SlS\u002BnDZaOUg9N6WXpSawB9BYtiLV5KGgh2qhdis3YDxL1wCGpa8GS5tIANFUXBkG4Pm/Ph0gDxnq53UROWpsB5LvgNxdldcCsb9HbUl1WEtEb/bXYzES\u002Bt1gXihRdJ4Jn79C2FufiDcyqHQ5NWwBY3WVaXPRj\u002B4\u002B0PhJVOhrrsUa7m2lQpwFvyZdkMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAtcGCSqGSIb3DQEHBqCCAsgwggLEAgEAMIICvQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIKUrGAQdwSEsCAgfQgIICkP5kd7zE9SPpNKgPL/nqBAW7xGrsM1Ls3iXVJ7iQ94bfBg3LIkPt9EfKinvjUC1UTqpGuOIhj3CYZo7Is0FRv/vkQ17Ag1DgrEcUCVpj01W4dlPKD/yXzd9t5DnsE0\u002Bqf6D9v2bMoKUYt31blc9C\u002BSRIip78wefI3lF7MD\u002BEftVYp6VxHkpwHY6/MJHQZ3fX1RFIRqQoWymdUSPmp6qC5KGY6eNsXd3XYxBRc9HXH2e7vJeK3Lu1WjSJ0AHjajbDh5BLEg7fL/i7hkqMwHAmEvxiyqQ0mYfFh3jGLDY33F1ytCQUs9zEIT5mdWX1XEU/SiQSW1CU/V1RVbzKa2U2HtM7rUI9dtW4WCetmaME2j21UyYjvFOD2R\u002BEVMars20E6X6wmYL96MjSPvfGMVJMYJ7DP\u002BwUPXZFm2DJy1wFUwK\u002B3aO/YnA8UCXDgankUNiQc1JrEN2UeXv6GCPMgXCX5rIo0LljgHjfg2/l3FrP/UKsAGsc0\u002BsbAVum922NyzqKHLPRKj\u002BK7ZQl5mFS\u002BKUt13FGqwQDuSdU95Sa8zK7rsPgz8TWGNPUuQTicGhRI74HdWu2exmV4BdXWLlLM38ovvmMzJOJV2NbRYSa\u002Bdzbex2q3jxQoX/UzcW9MjbJD3wvGURKaXPX6leasFlvaxKfW7q\u002Bsw9Q4DMzdxlqesAiY\u002B6QCQ0KMO/9lIre/RKu1QZ/W6QJHZUddab6ne4C5ULssu3HfhvVKWwJ7jjJPfCGwx6bXthRQlvLkLgnggEz7EgsU24vam\u002BhmUol1kGQ7OJon3iRv74gmdZx2ZT4A9TWZkeupFhXzDZSKvxyn53pr40hN4BZiM4Dfn7aH6Zyd1I0xRiKCbcC74gueldogBuduG0hMDswHzAHBgUrDgMCGgQUHJztvDXoDdG8Fo3k3YgVqv4g9GcEFAQUC7wWJ/h\u002B1oIsEaJAsX4JEp10AgIH0A==",
+        "value": "MIIFMgIBAzCCBO4GCSqGSIb3DQEHAaCCBN8EggTbMIIE1zCCAgAGCSqGSIb3DQEHAaCCAfEEggHtMIIB6TCCAeUGCyqGSIb3DQEMCgECoIIBXjCCAVowHAYKKoZIhvcNAQwBAzAOBAh7HYHL24pnSAICB9AEggE4VZBteYyOdc0a/eEMMYq6/MZ5zU0o0R6Szaegpmz0O3vuUi02PtMSLqnqYCvde4ItEx3Tiwtgu5hSQqXVab37wMI9GQzq2ZLwH8qPZt5Nb\u002Bq97qRILNLT\u002BIuB/Qe8fCoudqqn0/wz0q2FyrUPX8c0GRccC3Ca/RVRZpzLfqR\u002BZ57dgV51sxpiCt6LncJ70d/SdYolZ7xeYRuWC2BQ/jagG6XFBMmnIcsn1rMU\u002BQkUTh12Cwi/tgmA6ZAGWi/t32A8D3Uva9dDE0cDBnE71W84HZqEcCBsxYqpRIpbuY5qtbEeCOjbwkGNRv1gOdBYmfIIaILzgAzY6ZNzX/n/P/vcrCB2\u002BZuG8RfRlNVjjPfxvTN/rFQzlmsa1\u002BKjUCPNu6xmDkKQ6iT60o\u002B8wWYEtToJpex1EQyg50U6MXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAs8GCSqGSIb3DQEHBqCCAsAwggK8AgEAMIICtQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIm2gao5OM3WcCAgfQgIICiOM2UUB8kWMYYjemE87ZjwUWOIbToCViObWz2LS6hQeTrEU3ZYG0D7ovzVM\u002BBVVEZOfRvxzxftIwPA9cEcjwBgMK4lVvWikJYpn9UKdmhp1YMz\u002BcaeEcU1A5VLAv8txaOsgP/ZPQ3fr7\u002BG15V\u002BeXUHFUrX77dv9/GkjDZfd0F/BvUOprY\u002BdeJ4DF9MWJ1Yrmu7QJBcoRTWU5DXxJ3CxY7cBV81lpkYS3RwedMzEDExo6TE0a7HDhhRr\u002Bfp8W36Mfqa/a1UNuoVLa2Cv7HtxmupGNU0IrcHoa80y/wtAkjpsK\u002BN2Gpcvxl1CpT0\u002Bp0KrwZt2q1Yy69Vf8ykLJXmYK/10E/mvvPLUmjASszuWEYvGhm9gN9Z4u4tYQ1WN8TTy/8RsPt0jV5Z716evytT/Pqi9rLKWUE4qY2WeEph5pg7/WoRdmFaIocKZytRxSLzqeTOwj8h\u002BEdhboEceFg2b25zD8gvUUmyYvmRRE8Zo7sHkviIdASI6sp6xj7rvHVdGriz4JMb840P6h6zHmKcq22leGQg/Fo2vziX\u002BwlSVMX49oMWvFFHw78I2ZGeY7eQ2mI2cVcEd0gUfzB\u002B\u002BBHUr3V/8CmBs29/zKmuMbDOTwicodJ2DWaGkb93miXe\u002B5aeM6PPShnISaFR5HoVkLNKYtmJyRRAZoNpKZdOxFLmVthMZexA5VBkDAIEiH0jfETjoqgs3PsWwcgxflaiSppTNJ/vpvconlQmm\u002B7ifis9ku\u002BD5cSisJig\u002BzdYDFZ3YhdPPY0IRl0e6NpedXXM9p4QS8ZTGeMhg/b3TcZVqHm/2pUjLvxCrYrj47oxE1IoSPzmxEjibJnWujig40FbDhvPH89pcxZYfSUhks1TA7MB8wBwYFKw4DAhoEFM1/2082g\u002BNsEnHmWKl/2SLblHlHBBQYQaRGu1RWoS9Y4VoSVLAP5j9r0gICB9A=",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/522663450/265ae93f63034a9e96a1a0e7b50c0f96",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/522663450/98f0109c4bf74a8c9348a17cb35e4f9c",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614984933,
-          "exp": 1646521533,
-          "created": 1614985533,
-          "updated": 1614985533,
+          "nbf": 1617848174,
+          "exp": 1649384774,
+          "created": 1617848774,
+          "updated": 1617848774,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/522663450/265ae93f63034a9e96a1a0e7b50c0f96"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/522663450/98f0109c4bf74a8c9348a17cb35e4f9c"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "267688335"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-256K)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-256K)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1340240560/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1340240560/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-cdd263941a5cad498cc08abee2ce97b8-9ac29871f5abd24c-00",
+        "traceparent": "00-cacc81c1aa99524d8b82be4439c5f2f7-6c204270b1ea4441-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "86b4c906a82905916fc359c6662ffb20",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:32 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "86b4c906a82905916fc359c6662ffb20",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "eb76090f-ed0f-478d-aef2-4315d06c483a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "33e1eb9a-a1b5-49ea-8777-785729796962",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1340240560/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1340240560/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "220",
         "Content-Type": "application/json",
-        "traceparent": "00-cdd263941a5cad498cc08abee2ce97b8-9ac29871f5abd24c-00",
+        "traceparent": "00-cacc81c1aa99524d8b82be4439c5f2f7-6c204270b1ea4441-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "86b4c906a82905916fc359c6662ffb20",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:33 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending?api-version=7.2\u0026request_id=d87e5c659dca4bd4b6f6900c7db23971",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1340240560/pending?api-version=7.2\u0026request_id=5021c233ab72465ba2e532e5b53717b1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "86b4c906a82905916fc359c6662ffb20",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "e76417a9-a176-4025-b063-9d71a64f7053",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "49166a43-cd47-438b-a829-027f1ffb1487",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1340240560/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATp\u002BiSA5WLRjtOsQMs3kNqPA2DSaXBnZJLCIsvtqBKXl7La/x/s6RRGav6eIn8BCU5ycs9bu8UB2DFzcYn/jkZBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhALLergt86Sd0KbwqA0XRt6NiGigEb0U56S4RcgsSHSCBAiBBmhZzFDsu006uKt0OOzpQ6MLv/MNRDw/XIA0P3EE8jg==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASUyosOHAFBUcUpCE38P\u002BB6rFMTIrWUAXPczk15g\u002BDnqqLdGqGLmsL3AK6H1bwc3\u002BIkRegbgKjl1T4Ejp0mnumSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgdSzfFQFREAC0Dz5EPTi3Uz7HuoNNaxq0donsnKHolmACIB\u002BlGE\u002Bc2CC2aN8zHa\u002BK0xTsy8DV8ZM5J3ElLg1V3lVk",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "d87e5c659dca4bd4b6f6900c7db23971"
+        "request_id": "5021c233ab72465ba2e532e5b53717b1"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1340240560/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "97705883176f89d5a2c0b6d8533f957a",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:39 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:33 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "97705883176f89d5a2c0b6d8533f957a",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "70588cef-02a2-45f7-a7a2-8d3e2c2fddec",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5b3bcb70-997a-4d1f-b268-fe19c274c82a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1340240560/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATp\u002BiSA5WLRjtOsQMs3kNqPA2DSaXBnZJLCIsvtqBKXl7La/x/s6RRGav6eIn8BCU5ycs9bu8UB2DFzcYn/jkZBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhALLergt86Sd0KbwqA0XRt6NiGigEb0U56S4RcgsSHSCBAiBBmhZzFDsu006uKt0OOzpQ6MLv/MNRDw/XIA0P3EE8jg==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASUyosOHAFBUcUpCE38P\u002BB6rFMTIrWUAXPczk15g\u002BDnqqLdGqGLmsL3AK6H1bwc3\u002BIkRegbgKjl1T4Ejp0mnumSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgdSzfFQFREAC0Dz5EPTi3Uz7HuoNNaxq0donsnKHolmACIB\u002BlGE\u002Bc2CC2aN8zHa\u002BK0xTsy8DV8ZM5J3ElLg1V3lVk",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "d87e5c659dca4bd4b6f6900c7db23971"
+        "request_id": "5021c233ab72465ba2e532e5b53717b1"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1340240560/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "bf4f1f0fcb5a1fa01c1000a6e7510d76",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:44 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:38 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bf4f1f0fcb5a1fa01c1000a6e7510d76",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ddf922f3-d376-4455-8d49-08464ea271fe",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5ceea0f0-4401-4520-b763-ab8c2742c4f1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1340240560/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATp\u002BiSA5WLRjtOsQMs3kNqPA2DSaXBnZJLCIsvtqBKXl7La/x/s6RRGav6eIn8BCU5ycs9bu8UB2DFzcYn/jkZBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhALLergt86Sd0KbwqA0XRt6NiGigEb0U56S4RcgsSHSCBAiBBmhZzFDsu006uKt0OOzpQ6MLv/MNRDw/XIA0P3EE8jg==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASUyosOHAFBUcUpCE38P\u002BB6rFMTIrWUAXPczk15g\u002BDnqqLdGqGLmsL3AK6H1bwc3\u002BIkRegbgKjl1T4Ejp0mnumSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgdSzfFQFREAC0Dz5EPTi3Uz7HuoNNaxq0donsnKHolmACIB\u002BlGE\u002Bc2CC2aN8zHa\u002BK0xTsy8DV8ZM5J3ElLg1V3lVk",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "d87e5c659dca4bd4b6f6900c7db23971"
+        "request_id": "5021c233ab72465ba2e532e5b53717b1"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1340240560/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "9c2a5ee7541eef41f32ae468f1b9b22f",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "873",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:49 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9c2a5ee7541eef41f32ae468f1b9b22f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a7b367c3-99dd-479e-9e7d-dd541088dcd2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5d565f43-7989-4eba-83df-488efce7a4b0",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1340240560/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATp\u002BiSA5WLRjtOsQMs3kNqPA2DSaXBnZJLCIsvtqBKXl7La/x/s6RRGav6eIn8BCU5ycs9bu8UB2DFzcYn/jkZBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhALLergt86Sd0KbwqA0XRt6NiGigEb0U56S4RcgsSHSCBAiBBmhZzFDsu006uKt0OOzpQ6MLv/MNRDw/XIA0P3EE8jg==",
+        "csr": "MIIBtTCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASUyosOHAFBUcUpCE38P\u002BB6rFMTIrWUAXPczk15g\u002BDnqqLdGqGLmsL3AK6H1bwc3\u002BIkRegbgKjl1T4Ejp0mnumSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgdSzfFQFREAC0Dz5EPTi3Uz7HuoNNaxq0donsnKHolmACIB\u002BlGE\u002Bc2CC2aN8zHa\u002BK0xTsy8DV8ZM5J3ElLg1V3lVk",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "d87e5c659dca4bd4b6f6900c7db23971"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1340240560",
+        "request_id": "5021c233ab72465ba2e532e5b53717b1"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1340240560?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "47b6df2e3bdfb8c6b8517a5f162ea250",
         "x-ms-return-client-request-id": "true"
@@ -256,167 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "970",
+        "Content-Length": "1965",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5c2bcdfd-00ac-4913-8697-b9e14a9271b1",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATp\u002BiSA5WLRjtOsQMs3kNqPA2DSaXBnZJLCIsvtqBKXl7La/x/s6RRGav6eIn8BCU5ycs9bu8UB2DFzcYn/jkZBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhALLergt86Sd0KbwqA0XRt6NiGigEb0U56S4RcgsSHSCBAiBBmhZzFDsu006uKt0OOzpQ6MLv/MNRDw/XIA0P3EE8jg==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "d87e5c659dca4bd4b6f6900c7db23971"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "f4f140b3f814bb5bde60cb30e7382d63",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "970",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:59 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "17ca91c1-d317-4c3f-b8e9-cf92712856d5",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATp\u002BiSA5WLRjtOsQMs3kNqPA2DSaXBnZJLCIsvtqBKXl7La/x/s6RRGav6eIn8BCU5ycs9bu8UB2DFzcYn/jkZBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhALLergt86Sd0KbwqA0XRt6NiGigEb0U56S4RcgsSHSCBAiBBmhZzFDsu006uKt0OOzpQ6MLv/MNRDw/XIA0P3EE8jg==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "d87e5c659dca4bd4b6f6900c7db23971"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0778d15dc69aab969872e4cdd9e1d8c5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "879",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "47b6df2e3bdfb8c6b8517a5f162ea250",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "b765d269-c5bf-4d54-b67e-1df88ab0f536",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "3627aefe-6a6e-40c6-843c-090325c04a92",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBtjCCAVwCAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATp\u002BiSA5WLRjtOsQMs3kNqPA2DSaXBnZJLCIsvtqBKXl7La/x/s6RRGav6eIn8BCU5ycs9bu8UB2DFzcYn/jkZBoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhALLergt86Sd0KbwqA0XRt6NiGigEb0U56S4RcgsSHSCBAiBBmhZzFDsu006uKt0OOzpQ6MLv/MNRDw/XIA0P3EE8jg==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1340240560",
-        "request_id": "d87e5c659dca4bd4b6f6900c7db23971"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1340240560?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "b1b49387bdc8351a83fb687f6f96d07f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1970",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1d6b5d6c-4b52-40c7-869c-879dc5bee4ab",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1340240560/9d5315cecbaf4b278f17af04d0aee0ef",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1340240560/9d5315cecbaf4b278f17af04d0aee0ef",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1340240560/9d5315cecbaf4b278f17af04d0aee0ef",
-        "x5t": "wh77P_cmxIgy_e4otjRlfxKfqZk",
-        "cer": "MIICOjCCAeGgAwIBAgIQAVeQ7WipRkqG36gMVbLs2zAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDUwNFoXDTIyMDMwNTIzMTUwNFowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATp\u002BiSA5WLRjtOsQMs3kNqPA2DSaXBnZJLCIsvtqBKXl7La/x/s6RRGav6eIn8BCU5ycs9bu8UB2DFzcYn/jkZBo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUMzl70o5uC2edSI0ZSxjV1xjQNjcwHQYDVR0OBBYEFDM5e9KObgtnnUiNGUsY1dcY0DY3MAoGCCqGSM49BAMCA0cAMEQCIEova1V5uguNREvfvD8mwHZY3HWH7nje/YL9PRE9InzJAiAm5WkpSzeJluRKYP6Ou78le7ZKb12ij\u002BK\u002BYSv992n/uw==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1340240560/bed1f5dea9f54c01ae968109a7a23f33",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1340240560/bed1f5dea9f54c01ae968109a7a23f33",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1340240560/bed1f5dea9f54c01ae968109a7a23f33",
+        "x5t": "hJYEhvMJO7W59CNyOqW1TrgHq-Q",
+        "cer": "MIICOzCCAeGgAwIBAgIQBH9Zg9JJT1\u002BuHoAkQlwkeTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjU0M1oXDTIyMDQwODAyMzU0M1owEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASUyosOHAFBUcUpCE38P\u002BB6rFMTIrWUAXPczk15g\u002BDnqqLdGqGLmsL3AK6H1bwc3\u002BIkRegbgKjl1T4Ejp0mnumSo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUd4Cr7hHBBwa5\u002BjoktmdRJxCQJxkwHQYDVR0OBBYEFHeAq\u002B4RwQcGufo6JLZnUScQkCcZMAoGCCqGSM49BAMCA0gAMEUCIGguIhJOMCv7UvCIUJI1zW2w9SXEXpqc7Mro64KzJWXvAiEArfBTSI5t3Owgt6rR\u002B3O/FwRHuTz6lC5W4fa37weitMA=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985504,
-          "exp": 1646522104,
-          "created": 1614986105,
-          "updated": 1614986105,
+          "nbf": 1617848743,
+          "exp": 1649385343,
+          "created": 1617849343,
+          "updated": 1617849343,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1340240560/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1340240560/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -456,65 +330,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614986079,
-            "updated": 1614986079
+            "created": 1617849333,
+            "updated": 1617849333
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1340240560/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1340240560/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1340240560/9d5315cecbaf4b278f17af04d0aee0ef?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1340240560/bed1f5dea9f54c01ae968109a7a23f33?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-da328701449b2f4eb7fb27275adba7b2-18d3fbce46f48042-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "f4f140b3f814bb5bde60cb30e7382d63",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:35:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f4f140b3f814bb5bde60cb30e7382d63",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "c42f050d-d8d4-4b6d-9873-3256ac8885c6",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1340240560/bed1f5dea9f54c01ae968109a7a23f33?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-82d89ca555b34040bbc354365bba3d5c-612f235dcd8fd84a-00",
+        "traceparent": "00-da328701449b2f4eb7fb27275adba7b2-18d3fbce46f48042-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "450117239ab6edb5aa455ba2148ee2fc",
+        "x-ms-client-request-id": "f4f140b3f814bb5bde60cb30e7382d63",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "441",
+        "Content-Length": "440",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f4f140b3f814bb5bde60cb30e7382d63",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "6901e558-f246-4a57-b4db-00cbbc408db4",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "befac293-3fb6-4716-a743-331a4f3dd7f1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1340240560/9d5315cecbaf4b278f17af04d0aee0ef",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1340240560/bed1f5dea9f54c01ae968109a7a23f33",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-256K",
-          "x": "6fokgOVi0Y7TrEDLN5DajwNg0mlwZ2SSwiLL7agSl5c",
-          "y": "str_H-zpFEZq_p4ifwEJTnJyz1u7xQHYMXNxif-ORkE"
+          "x": "lMqLDhwBQVHFKQhN_D_geqxTEyK1lAFz3M5NeYPg56o",
+          "y": "ot0aoYuawvcArofVvBzf4iRF6BuAqOXVPgSOnSae6ZI"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985504,
-          "exp": 1646522104,
-          "created": 1614986105,
-          "updated": 1614986105,
+          "nbf": 1617848743,
+          "exp": 1649385343,
+          "created": 1617849343,
+          "updated": 1617849343,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -522,19 +437,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1340240560/9d5315cecbaf4b278f17af04d0aee0ef/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1340240560/bed1f5dea9f54c01ae968109a7a23f33/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "70",
         "Content-Type": "application/json",
-        "traceparent": "00-82d89ca555b34040bbc354365bba3d5c-9f77882bdcfeb944-00",
+        "traceparent": "00-da328701449b2f4eb7fb27275adba7b2-1c511ce602a3c149-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "53a806877c839f9bb643849f5d173b02",
+        "x-ms-client-request-id": "0778d15dc69aab969872e4cdd9e1d8c5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -544,128 +459,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "194",
+        "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0778d15dc69aab969872e4cdd9e1d8c5",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7108ec09-1248-40f4-b5fc-5f244d027aec",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "d954ad34-1220-46f5-902c-5a208a7b0946",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1340240560/9d5315cecbaf4b278f17af04d0aee0ef",
-        "value": "GMywr0XcwGBXkoGcJJ2pN0uSTgjTAVYGdjzi4qq72lLm4tDRpO8ADSXTTR_xutyACnkuLPirE7JVqkJOa5hnbg"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1340240560/bed1f5dea9f54c01ae968109a7a23f33",
+        "value": "Sf-hSyyGrUqbglHtmN9ByzU2w8w8Q5qFduSuTde0BBW1EScvBjTb2bY2ueF40l9DQm1iU2HHZwMv29wuZLwdUQ"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1340240560/9d5315cecbaf4b278f17af04d0aee0ef?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1340240560/bed1f5dea9f54c01ae968109a7a23f33?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-cf3f00dbf509d740a3ec0fb269c4fa04-a308bacc5dcfe54a-00",
+        "traceparent": "00-5651b05fa00370459c9f0a5d354fba29-d70406ed6d33fa4f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "c1a964a193e0ec0edec70682617821f5",
+        "x-ms-client-request-id": "b1b49387bdc8351a83fb687f6f96d07f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1374",
+        "Content-Length": "1371",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b1b49387bdc8351a83fb687f6f96d07f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1b38fa54-ffc7-4278-b908-75ae714016dc",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ccb1b3cf-d6c5-4679-8bee-7890c41b25a9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1340240560/9d5315cecbaf4b278f17af04d0aee0ef",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1340240560/9d5315cecbaf4b278f17af04d0aee0ef",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1340240560/9d5315cecbaf4b278f17af04d0aee0ef",
-        "x5t": "wh77P_cmxIgy_e4otjRlfxKfqZk",
-        "cer": "MIICOjCCAeGgAwIBAgIQAVeQ7WipRkqG36gMVbLs2zAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDUwNFoXDTIyMDMwNTIzMTUwNFowEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAATp\u002BiSA5WLRjtOsQMs3kNqPA2DSaXBnZJLCIsvtqBKXl7La/x/s6RRGav6eIn8BCU5ycs9bu8UB2DFzcYn/jkZBo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUMzl70o5uC2edSI0ZSxjV1xjQNjcwHQYDVR0OBBYEFDM5e9KObgtnnUiNGUsY1dcY0DY3MAoGCCqGSM49BAMCA0cAMEQCIEova1V5uguNREvfvD8mwHZY3HWH7nje/YL9PRE9InzJAiAm5WkpSzeJluRKYP6Ou78le7ZKb12ij\u002BK\u002BYSv992n/uw==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1340240560/bed1f5dea9f54c01ae968109a7a23f33",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1340240560/bed1f5dea9f54c01ae968109a7a23f33",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1340240560/bed1f5dea9f54c01ae968109a7a23f33",
+        "x5t": "hJYEhvMJO7W59CNyOqW1TrgHq-Q",
+        "cer": "MIICOzCCAeGgAwIBAgIQBH9Zg9JJT1\u002BuHoAkQlwkeTAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjU0M1oXDTIyMDQwODAyMzU0M1owEjEQMA4GA1UEAxMHZGVmYXVsdDCB9TCBrgYHKoZIzj0CATCBogIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wBgQBAAQBBwRBBHm\u002BZn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW\u002BBeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////\u002Buq7c5q9IoDu/0l6M0DZBQQIBAQNCAASUyosOHAFBUcUpCE38P\u002BB6rFMTIrWUAXPczk15g\u002BDnqqLdGqGLmsL3AK6H1bwc3\u002BIkRegbgKjl1T4Ejp0mnumSo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUd4Cr7hHBBwa5\u002BjoktmdRJxCQJxkwHQYDVR0OBBYEFHeAq\u002B4RwQcGufo6JLZnUScQkCcZMAoGCCqGSM49BAMCA0gAMEUCIGguIhJOMCv7UvCIUJI1zW2w9SXEXpqc7Mro64KzJWXvAiEArfBTSI5t3Owgt6rR\u002B3O/FwRHuTz6lC5W4fa37weitMA=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985504,
-          "exp": 1646522104,
-          "created": 1614986105,
-          "updated": 1614986105,
+          "nbf": 1617848743,
+          "exp": 1649385343,
+          "created": 1617849343,
+          "updated": 1617849343,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "015790ED68A9464A86DFA80C55B2ECDB"
+        "serialnumber": "047F5983D2494F5FAE1E8024425C2479"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1340240560/9d5315cecbaf4b278f17af04d0aee0ef?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1340240560/bed1f5dea9f54c01ae968109a7a23f33?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-cf3f00dbf509d740a3ec0fb269c4fa04-16e5d9d14bbc2d4a-00",
+        "traceparent": "00-5651b05fa00370459c9f0a5d354fba29-a38178ba6bc7dd43-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "68f86c197ceda7fc7c618e7216158f93",
+        "x-ms-client-request-id": "450117239ab6edb5aa455ba2148ee2fc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2205",
+        "Content-Length": "2203",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:15:05 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "450117239ab6edb5aa455ba2148ee2fc",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c7fbf3f4-0fba-480b-ac32-f6cdd1127f85",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "4885d050-014c-4c0a-9d89-183b1cca3737",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIFMgIBAzCCBO4GCSqGSIb3DQEHAaCCBN8EggTbMIIE1zCCAgAGCSqGSIb3DQEHAaCCAfEEggHtMIIB6TCCAeUGCyqGSIb3DQEMCgECoIIBXjCCAVowHAYKKoZIhvcNAQwBAzAOBAihhEDHzeAaIAICB9AEggE4MO0kwJEtpL11nSV17z3uNK6gO0uI02ydeAWMgQdbrs18DtGLByk0EbiyIxKVEsDWvyI/ndY9WzxwG1GqBmsPdMbWPh70V4O0cFTIL1KvDJnjpmsL01vMYRpRMMc/RUmPBsNuoKTN02nJ8DPXD34OHSbknvl0/qFq7r/lBmiq/OY37AkGhQrQXLZb/fh1JHTIo5B/hbvOgM1/KQE2JjHUIZifTX1h/DLvtVah1eXVQUgl/9Gho\u002BGdVBM\u002BUB2sDuTARc7q6jyabjTEGKu3VS88M6SgIzDX8qPBsc0Iz/BQ86SYcXFqRNe242GE6IpkRe2ZKBduowwvJR7pSCp1KZ3tTpRp\u002BtDd9hFznPvVxoDdpFw3rpdFZ\u002BYVTFQvUGy6VNv84kl00DRUtD5lJS7RgNdQcC\u002BW33QsgkMbMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAs8GCSqGSIb3DQEHBqCCAsAwggK8AgEAMIICtQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIZX69dD\u002BzFuQCAgfQgIICiGh/i7abHdMHqb9GJ1w6Nwjj5/xOKL88cW7HA6okvR0Sle\u002BbdlDmDnAfKzZe3EHZzQS3i6PpEpgP0IYvQK\u002BImAwKMtNxWX0g3M6nLMEvj0M8ba3WBhNIhbtJlUS71kR8NRgCukV1t2qsxVkq/GmosdA1fRjyTjSGUB7Y73uThvWguVo5GAhN8TUBpdQ8oWczWij5pVGqwjVHmJHGuA\u002BlH3WyVIomLOakeJz6X/Zbz5mzd3xeZ94PigajDynt05zoj7OwNm2alQfTeJFpnkxLY1ibzZncNMNjlvMvllxsktslUw2\u002BEs23Pv\u002B8x6H1uACFJmvJ414kCMelykkbfA2oD1kLIkIa/F99yODvoHln3agj1/hunqYOCI8Qhj1JrOxCbSDHfAj84VWiLTeNQmLUlmhpQVpk0WMSQVwDrgvZNPq30ga1zupvGV6oUraLCYeEEkQu9t5egtQ15eYsk2Qc2XBt\u002BJkRR6OuOwwYCB3fxIh6umajdqAVbDNY/u3dIFTP90bLrdsCWBJqw4hOMfBwpUxILYT1h86K2FSZp\u002BlYrxZwvisR9usTPyhHyU2nOPRdFnJrCHZZbxF6JZE5GxTNxIRqodQ8xvugTlMyIHZ8FBU2i5XVS/ZIx\u002BpUJ0hFibU1OyQq0LgUiRwI7jnFDPXm2Dzf\u002B0C4drdoOcGyDyNXemgjYlF/6cIh6RbG\u002BlDh2PWS\u002Bsv/oIbR2yV8ARGG7uhQGo1ZvxM2Yi6E3kPpBgnU5LesXXAJa9cnAlliEQUQgUmOScCqdBfYSialzAH3rdSoMf5bByL2tbCnuTWV\u002BAC0cmkx10\u002BBZycScrryUQaytWJte1HcynBaAcNKWJHAHYGcJSfrD0bogEBDPDA7MB8wBwYFKw4DAhoEFAM2\u002Bv4PVqCGZ1BrqNG8hEjcHnW\u002BBBRe016eIg1cxlYjVWgCSM3jp4koSAICB9A=",
+        "value": "MIIFMgIBAzCCBO4GCSqGSIb3DQEHAaCCBN8EggTbMIIE1zCCAgAGCSqGSIb3DQEHAaCCAfEEggHtMIIB6TCCAeUGCyqGSIb3DQEMCgECoIIBXjCCAVowHAYKKoZIhvcNAQwBAzAOBAi9uvy2B2MJUwICB9AEggE4qXx4MDQmUQAH4qZ7Z4blmqn219DVXEeou/i9dnijq807LuCd0lUsx8Tg8uRKSkzbrTpa3CND3IIPhd2bbJY2C\u002BbzcdGcv\u002Bgt95HS265Rvgm2tiqpbcZRYkdfczFs6655\u002BvP27NU9jqOkPVvRFi01h36J9DQKAif8o/swjVn8kBJUKbZ5MwNKzW1sTW2T\u002BFHOHZoaQ\u002BcpcexZtRk0uWNVSuEQ6dCdo62AIlj0sHHjz4dkJpa\u002B0yVp45B3w6\u002BZEeJAqyQoCIMQW5Lu/tie0unUsLRo1OLFiVaCg8q896apBMIkMYeIWrh0ykrBt\u002BbonYAKwfDdrHSn43xL3XnAVuHb/\u002BI2L0pLhFbmvwGxPc7YzK1rdPs3gmoa\u002BwQrAs9sHVzM9gQgHpcxTYHCna\u002BdenbKFwbdeECWi0SDMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAs8GCSqGSIb3DQEHBqCCAsAwggK8AgEAMIICtQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIszNzwuh2\u002BLICAgfQgIICiG\u002B4\u002BRl5LWcnu7DfWLzDWxJR6G6wcMBGg1lK6/dV6CQhKuV2s1B8x0K8ZeMGjdjorm/3LWNHhcgEDuPFez3KtUT954pXktdJcRZQxQukPus8kknb2N5XTlhFZPWlFpzmqLOcnmqw/orXtvj6qLGA7a9stpAP\u002B4\u002B\u002BMP7R0ZAcGhln/pLD1CAKBnz0o\u002Bzj89SC1FF4mGIuGqRKyoqy9RYBXyod/vYuCiCsMDRblH5Lo2OL5JI8CUF/Bf5SChgVpYZNIokBY2V0kgk5hl3sBAeYuPDxOms0QOactBZKdf0saQ9JkLJkILKuHR3EDvCh5MnSaP7ILWa/tWrt\u002Blyo/6K6utjYBTr/3SWzebT\u002BI2lVVVNu640rIsv9lp3i2bzdgtcXDPB35xX8ghAxdsJkIiwmBELyBgGd05yHZn0t7F7p4VUopxwAe1fLfnxJlC9nZJX2bAzjy\u002BOdgy/NFiNkYsoKKLEkVRAlcmCBC8SbNdH17ZVVOC1xT9SCznwMBymrQexd6VxUXIHARI2/u5rwWe7mwkMNrxCMcQmhfpF0whVVnaeM5WIa8LLzL2SLN6HGyxDa0XEtt8fLwvHE7o\u002Bnfl5OwJz1CcDQ/Yy5pRCakmg67\u002BcFQ/jwJNSthnCpq/8eAkNy8h14jcIk\u002Bs0B0yd6v2wBSGxWXUJBzydbhoPffMTbUoF3cxwh/1Fz55gA2yGxdfSWBr7Wkjp400dtfRe9LbfH9w8skPjnrrdWuP08M8l1iRoUuSM4EVXJj7vMpeOAIqGQpaRbvjEqA1v3ykXcqzVkE9VnDx3aQ8hPZ\u002BYz1Z9Nvcj1E\u002BBl2ID5pI43AUfoE\u002BPcmVP\u002ByDqUVodal3FOiJ\u002Bf7DFSsH27rNGJaTA7MB8wBwYFKw4DAhoEFKDd16dNO726cDJpXOMxjB7j8eCDBBTwE/aYogrB1nYc6dgvaCHD0QVcCgICB9A=",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1340240560/9d5315cecbaf4b278f17af04d0aee0ef",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1340240560/bed1f5dea9f54c01ae968109a7a23f33",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985504,
-          "exp": 1646522104,
-          "created": 1614986105,
-          "updated": 1614986105,
+          "nbf": 1617848743,
+          "exp": 1649385343,
+          "created": 1617849343,
+          "updated": 1617849343,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1340240560/9d5315cecbaf4b278f17af04d0aee0ef"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1340240560/bed1f5dea9f54c01ae968109a7a23f33"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1298303433"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-384).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-384).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1311055181/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-9f2dd356e481d342b7eb6255242bb9c6-ceac7dc37f4c7f42-00",
+        "traceparent": "00-63b2555de9b10444baeed26a112ae632-295a7f5e97b95341-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "75e4194deac8e65ff1f5689ccf82a899",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:55 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "75e4194deac8e65ff1f5689ccf82a899",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "859c56aa-0b9b-452a-a965-d66e3a60e6eb",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bf24a59d-bfba-4020-b0ca-2035b7a627ee",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1311055181/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-9f2dd356e481d342b7eb6255242bb9c6-ceac7dc37f4c7f42-00",
+        "traceparent": "00-63b2555de9b10444baeed26a112ae632-295a7f5e97b95341-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "75e4194deac8e65ff1f5689ccf82a899",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:56 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:22 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending?api-version=7.2\u0026request_id=008632665cc844e98553bace6d1fb4f0",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1311055181/pending?api-version=7.2\u0026request_id=743d6e1c1b1f458595e1645c981cca55",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "75e4194deac8e65ff1f5689ccf82a899",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "3d22938f-5973-4a6a-a8e5-03899814dc94",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "925514c2-8162-4c11-96e2-71e9068a404f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1311055181/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhKaax59awly1h3JwTQegA3Uz58Nz7oFy7DM78eDxJG46CtJoA/cJm738TceVSP9igszFgzwGTdXXZCmcyT6Wd7mRnaS5t9a2dP/RW8FFWab/xW4gJdyr4ku8hOSckhUpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAPsipwELMhUiOVCKEMpmYrT6YUD5hIkzlKwobosdOViPehRiDg0mbbAlLMRF0RislAIwWuvWy9GmvxvOpDoGR3zyR0siXKQGbtI1o42\u002BusRWNs0zjbQZL2Gn5T4TSjmtEf8f",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt6T8W/VSVXUspLWFo3BsAqPZb\u002BQnDSIJPpgreErg6ow1Z6duab3\u002Bo/pMQQ81KVhQ8boki9nNTGJbX9yWgPvgsmV/kw6ruWn67Wg7mbO47tOFypldhj6S89\u002BHtetSspixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIwR94Gt8J/UBYZXFHJuTWMwcP8Y5\u002BpEiirPPbUOkUDOXUDc2mechLL9St2Xo7S36f6AjEAnAtg3hVTv03LXmtQgcxaALJo9tCd879wjqlnoACdB\u002BRRYaRa4Qywyj1Gsq1nUKt1",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "008632665cc844e98553bace6d1fb4f0"
+        "request_id": "743d6e1c1b1f458595e1645c981cca55"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "db9113a76a502293a56a5fbfcacd239e",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:03:56 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "db9113a76a502293a56a5fbfcacd239e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "de074ca3-3fdc-4949-8915-6a9db46f713c",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "82f17cf7-0e10-4448-ab84-0d8e82319337",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1311055181/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhKaax59awly1h3JwTQegA3Uz58Nz7oFy7DM78eDxJG46CtJoA/cJm738TceVSP9igszFgzwGTdXXZCmcyT6Wd7mRnaS5t9a2dP/RW8FFWab/xW4gJdyr4ku8hOSckhUpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAPsipwELMhUiOVCKEMpmYrT6YUD5hIkzlKwobosdOViPehRiDg0mbbAlLMRF0RislAIwWuvWy9GmvxvOpDoGR3zyR0siXKQGbtI1o42\u002BusRWNs0zjbQZL2Gn5T4TSjmtEf8f",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt6T8W/VSVXUspLWFo3BsAqPZb\u002BQnDSIJPpgreErg6ow1Z6duab3\u002Bo/pMQQ81KVhQ8boki9nNTGJbX9yWgPvgsmV/kw6ruWn67Wg7mbO47tOFypldhj6S89\u002BHtetSspixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIwR94Gt8J/UBYZXFHJuTWMwcP8Y5\u002BpEiirPPbUOkUDOXUDc2mechLL9St2Xo7S36f6AjEAnAtg3hVTv03LXmtQgcxaALJo9tCd879wjqlnoACdB\u002BRRYaRa4Qywyj1Gsq1nUKt1",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "008632665cc844e98553bace6d1fb4f0"
+        "request_id": "743d6e1c1b1f458595e1645c981cca55"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "0070a4b83c73843157b50d1a48de731b",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:02 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:27 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0070a4b83c73843157b50d1a48de731b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "878129ae-e330-4a7b-8fef-6fd1fcbd1173",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "da3e62bf-c700-403c-b6fd-66252422265d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1311055181/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhKaax59awly1h3JwTQegA3Uz58Nz7oFy7DM78eDxJG46CtJoA/cJm738TceVSP9igszFgzwGTdXXZCmcyT6Wd7mRnaS5t9a2dP/RW8FFWab/xW4gJdyr4ku8hOSckhUpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAPsipwELMhUiOVCKEMpmYrT6YUD5hIkzlKwobosdOViPehRiDg0mbbAlLMRF0RislAIwWuvWy9GmvxvOpDoGR3zyR0siXKQGbtI1o42\u002BusRWNs0zjbQZL2Gn5T4TSjmtEf8f",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt6T8W/VSVXUspLWFo3BsAqPZb\u002BQnDSIJPpgreErg6ow1Z6duab3\u002Bo/pMQQ81KVhQ8boki9nNTGJbX9yWgPvgsmV/kw6ruWn67Wg7mbO47tOFypldhj6S89\u002BHtetSspixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIwR94Gt8J/UBYZXFHJuTWMwcP8Y5\u002BpEiirPPbUOkUDOXUDc2mechLL9St2Xo7S36f6AjEAnAtg3hVTv03LXmtQgcxaALJo9tCd879wjqlnoACdB\u002BRRYaRa4Qywyj1Gsq1nUKt1",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "008632665cc844e98553bace6d1fb4f0"
+        "request_id": "743d6e1c1b1f458595e1645c981cca55"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "d3ba78cd09fbe2fc85c2d05d8b9f1c23",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:06 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:32 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "d3ba78cd09fbe2fc85c2d05d8b9f1c23",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c3b9dbf3-f577-4f90-aea9-62c6d0e89c80",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "7abf0d1c-22b2-4df4-a8a2-c67496d0c1bf",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1311055181/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhKaax59awly1h3JwTQegA3Uz58Nz7oFy7DM78eDxJG46CtJoA/cJm738TceVSP9igszFgzwGTdXXZCmcyT6Wd7mRnaS5t9a2dP/RW8FFWab/xW4gJdyr4ku8hOSckhUpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAPsipwELMhUiOVCKEMpmYrT6YUD5hIkzlKwobosdOViPehRiDg0mbbAlLMRF0RislAIwWuvWy9GmvxvOpDoGR3zyR0siXKQGbtI1o42\u002BusRWNs0zjbQZL2Gn5T4TSjmtEf8f",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt6T8W/VSVXUspLWFo3BsAqPZb\u002BQnDSIJPpgreErg6ow1Z6duab3\u002Bo/pMQQ81KVhQ8boki9nNTGJbX9yWgPvgsmV/kw6ruWn67Wg7mbO47tOFypldhj6S89\u002BHtetSspixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIwR94Gt8J/UBYZXFHJuTWMwcP8Y5\u002BpEiirPPbUOkUDOXUDc2mechLL9St2Xo7S36f6AjEAnAtg3hVTv03LXmtQgcxaALJo9tCd879wjqlnoACdB\u002BRRYaRa4Qywyj1Gsq1nUKt1",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "008632665cc844e98553bace6d1fb4f0"
+        "request_id": "743d6e1c1b1f458595e1645c981cca55"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "2be4cad1a7116a26e20c849a5c79dac6",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "745",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:12 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:38 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2be4cad1a7116a26e20c849a5c79dac6",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "053ece9a-7025-40a1-9028-71f01f06cdad",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "650aa084-312e-4df6-a218-fb38562a4142",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1311055181/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhKaax59awly1h3JwTQegA3Uz58Nz7oFy7DM78eDxJG46CtJoA/cJm738TceVSP9igszFgzwGTdXXZCmcyT6Wd7mRnaS5t9a2dP/RW8FFWab/xW4gJdyr4ku8hOSckhUpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAPsipwELMhUiOVCKEMpmYrT6YUD5hIkzlKwobosdOViPehRiDg0mbbAlLMRF0RislAIwWuvWy9GmvxvOpDoGR3zyR0siXKQGbtI1o42\u002BusRWNs0zjbQZL2Gn5T4TSjmtEf8f",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt6T8W/VSVXUspLWFo3BsAqPZb\u002BQnDSIJPpgreErg6ow1Z6duab3\u002Bo/pMQQ81KVhQ8boki9nNTGJbX9yWgPvgsmV/kw6ruWn67Wg7mbO47tOFypldhj6S89\u002BHtetSspixoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIwR94Gt8J/UBYZXFHJuTWMwcP8Y5\u002BpEiirPPbUOkUDOXUDc2mechLL9St2Xo7S36f6AjEAnAtg3hVTv03LXmtQgcxaALJo9tCd879wjqlnoACdB\u002BRRYaRa4Qywyj1Gsq1nUKt1",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "008632665cc844e98553bace6d1fb4f0"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1311055181",
+        "request_id": "743d6e1c1b1f458595e1645c981cca55"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1311055181?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "51f244f74f13afa2a78d7bb16cd3f9b8",
         "x-ms-return-client-request-id": "true"
@@ -300,211 +305,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "838",
+        "Content-Length": "1836",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:17 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9ecb22af-e501-40ff-be90-071205a10611",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhKaax59awly1h3JwTQegA3Uz58Nz7oFy7DM78eDxJG46CtJoA/cJm738TceVSP9igszFgzwGTdXXZCmcyT6Wd7mRnaS5t9a2dP/RW8FFWab/xW4gJdyr4ku8hOSckhUpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAPsipwELMhUiOVCKEMpmYrT6YUD5hIkzlKwobosdOViPehRiDg0mbbAlLMRF0RislAIwWuvWy9GmvxvOpDoGR3zyR0siXKQGbtI1o42\u002BusRWNs0zjbQZL2Gn5T4TSjmtEf8f",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "008632665cc844e98553bace6d1fb4f0"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "7e48e99948f925095250f0ee8562850c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "838",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:22 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9229391b-bde6-487b-9b4c-d54c0eef6338",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhKaax59awly1h3JwTQegA3Uz58Nz7oFy7DM78eDxJG46CtJoA/cJm738TceVSP9igszFgzwGTdXXZCmcyT6Wd7mRnaS5t9a2dP/RW8FFWab/xW4gJdyr4ku8hOSckhUpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAPsipwELMhUiOVCKEMpmYrT6YUD5hIkzlKwobosdOViPehRiDg0mbbAlLMRF0RislAIwWuvWy9GmvxvOpDoGR3zyR0siXKQGbtI1o42\u002BusRWNs0zjbQZL2Gn5T4TSjmtEf8f",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "008632665cc844e98553bace6d1fb4f0"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "466609e7caad8110283583842c74fd0f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "838",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:27 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "50a0f3f3-6e39-4c79-91b0-d58046e2e852",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhKaax59awly1h3JwTQegA3Uz58Nz7oFy7DM78eDxJG46CtJoA/cJm738TceVSP9igszFgzwGTdXXZCmcyT6Wd7mRnaS5t9a2dP/RW8FFWab/xW4gJdyr4ku8hOSckhUpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAPsipwELMhUiOVCKEMpmYrT6YUD5hIkzlKwobosdOViPehRiDg0mbbAlLMRF0RislAIwWuvWy9GmvxvOpDoGR3zyR0siXKQGbtI1o42\u002BusRWNs0zjbQZL2Gn5T4TSjmtEf8f",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "008632665cc844e98553bace6d1fb4f0"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "7300cb135b31afcc3accffc35fb32945",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "747",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:32 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:38 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "51f244f74f13afa2a78d7bb16cd3f9b8",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ccc4eb84-3c96-4b6d-9752-29b0f450b913",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1d558e8a-42b6-431c-adb8-d729bfb46464",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhKaax59awly1h3JwTQegA3Uz58Nz7oFy7DM78eDxJG46CtJoA/cJm738TceVSP9igszFgzwGTdXXZCmcyT6Wd7mRnaS5t9a2dP/RW8FFWab/xW4gJdyr4ku8hOSckhUpoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIxAPsipwELMhUiOVCKEMpmYrT6YUD5hIkzlKwobosdOViPehRiDg0mbbAlLMRF0RislAIwWuvWy9GmvxvOpDoGR3zyR0siXKQGbtI1o42\u002BusRWNs0zjbQZL2Gn5T4TSjmtEf8f",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1311055181",
-        "request_id": "008632665cc844e98553bace6d1fb4f0"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "63c96e07b26ccf0bd9c656c4c484f8dd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1841",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:32 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "09df5b4f-77f6-44c9-90d8-1d06b9553f86",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20",
-        "x5t": "b38RYp8ds45S6aflZS_cweKp1MY",
-        "cer": "MIIB2zCCAWGgAwIBAgIQCJPhm0DNTiOSc1RxogEnzjAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTQzMloXDTIyMDMwNTIzMDQzMlowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABISmmsefWsJctYdycE0HoAN1M\u002BfDc\u002B6BcuwzO/Hg8SRuOgrSaAP3CZu9/E3HlUj/YoLMxYM8Bk3V12QpnMk\u002Blne5kZ2kubfWtnT/0VvBRVmm/8VuICXcq\u002BJLvITknJIVKaN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFDmlhTQw6qGgKPXt/cmZQZTugmYoMB0GA1UdDgQWBBQ5pYU0MOqhoCj17f3JmUGU7oJmKDAKBggqhkjOPQQDAwNoADBlAjBgy3RWomImF6AbFJHL98d6tMtDbAj8/72wws8SFmf2/K6w8ZmjAYnXO15PT9vUJZ4CMQCCLJgLIO082blpLK5KDL7IrqptH22jBjGgAu5AHUQM2nqHR4g\u002BQCABFhR4t1UNOrQ=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1311055181/064531c741344976ac27a29efbadf194",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1311055181/064531c741344976ac27a29efbadf194",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1311055181/064531c741344976ac27a29efbadf194",
+        "x5t": "my6awxgYUforZpsIZ3I0i4XakHI",
+        "cer": "MIIB3DCCAWGgAwIBAgIQI2PVkkzZQ4yzTCkW3/R4jjAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTUzNloXDTIyMDQwODAyMjUzNlowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABLek/Fv1UlV1LKS1haNwbAKj2W/kJw0iCT6YK3hK4OqMNWenbmm9/qP6TEEPNSlYUPG6JIvZzUxiW1/cloD74LJlf5MOq7lp\u002Bu1oO5mzuO7ThcqZXYY\u002BkvPfh7XrUrKYsaN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFNK7cTjPEfTyM6JjvVMavAD\u002Be8QPMB0GA1UdDgQWBBTSu3E4zxH08jOiY71TGrwA/nvEDzAKBggqhkjOPQQDAwNpADBmAjEAtLg1/Ic0VdCmusolM6EdQaqfGNHIKdjd9vV7471FwHPPVlWNyGXkkowXSQ9mntr8AjEAyzvihbw0GYIP0Zyp8/SCZPn1G/eCCsQCWm9s7eE6qWmvuKpEX0nyR0xIoJPccwM9",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984872,
-          "exp": 1646521472,
-          "created": 1614985472,
-          "updated": 1614985472,
+          "nbf": 1617848136,
+          "exp": 1649384736,
+          "created": 1617848736,
+          "updated": 1617848736,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1311055181/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -544,65 +375,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985436,
-            "updated": 1614985436
+            "created": 1617848722,
+            "updated": 1617848722
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1311055181/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1311055181/064531c741344976ac27a29efbadf194?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-feb970497dbee34d90e45e578444673b-5bec1fbd99936742-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "7e48e99948f925095250f0ee8562850c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:25:42 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7e48e99948f925095250f0ee8562850c",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "98e37c30-49bb-4e6b-89b1-3d94015aa1dc",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1311055181/064531c741344976ac27a29efbadf194?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-7896d9e1b9df484ba78a1a4005f50afe-140c8fb79a956d41-00",
+        "traceparent": "00-feb970497dbee34d90e45e578444673b-5bec1fbd99936742-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "b9dbe05212618cda3cb70be0ca4c2274",
+        "x-ms-client-request-id": "7e48e99948f925095250f0ee8562850c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "482",
+        "Content-Length": "481",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:37 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7e48e99948f925095250f0ee8562850c",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "af148652-c29f-4130-a419-cb7b28bf143f",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "94878bc4-9099-49ff-bcd4-d412f985ce65",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1311055181/064531c741344976ac27a29efbadf194",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-384",
-          "x": "hKaax59awly1h3JwTQegA3Uz58Nz7oFy7DM78eDxJG46CtJoA_cJm738TceVSP9i",
-          "y": "gszFgzwGTdXXZCmcyT6Wd7mRnaS5t9a2dP_RW8FFWab_xW4gJdyr4ku8hOSckhUp"
+          "x": "t6T8W_VSVXUspLWFo3BsAqPZb-QnDSIJPpgreErg6ow1Z6duab3-o_pMQQ81KVhQ",
+          "y": "8boki9nNTGJbX9yWgPvgsmV_kw6ruWn67Wg7mbO47tOFypldhj6S89-HtetSspix"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984872,
-          "exp": 1646521472,
-          "created": 1614985472,
-          "updated": 1614985472,
+          "nbf": 1617848136,
+          "exp": 1649384736,
+          "created": 1617848736,
+          "updated": 1617848736,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -610,19 +482,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1311055181/064531c741344976ac27a29efbadf194/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "90",
         "Content-Type": "application/json",
-        "traceparent": "00-7896d9e1b9df484ba78a1a4005f50afe-9100d788f2926348-00",
+        "traceparent": "00-feb970497dbee34d90e45e578444673b-a852047a0f83b148-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "be7d3e0b9aab60a3bf31996b0508eab6",
+        "x-ms-client-request-id": "466609e7caad8110283583842c74fd0f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -632,128 +504,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "236",
+        "Content-Length": "235",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:37 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "466609e7caad8110283583842c74fd0f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ba038e81-4851-4f38-ba79-bd138b3a1ac7",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "0357f11e-fda0-48d6-a25b-fe99a58fd42d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20",
-        "value": "WQnt4Bnk_SZfJaD4Xv5Uks7gFw9o_e8SrafkSgsuwf7wKo17QwY3g7ukGH_CS3sb6yXMX2XbPFcmHic7_Du71CACBkyBaVySM5mWAjurP59Wk52BunmF1YL7tFUoS6ze"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1311055181/064531c741344976ac27a29efbadf194",
+        "value": "N5V_04IAcdfDZwwHFHSZZMbU89CvLv6gxqP-fnImhlfkQaX0lCuxbhmbIneb78ormcdAvFyOV2MYhwCoQ5qbfK50H2Wg1Y0Hr-S3K9BkfgVp8X0F-A1vc5HRQ6z42dtZ"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1311055181/064531c741344976ac27a29efbadf194?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-ccacc9832cc86441a8f63a9084d51498-a0aeb9b63ab33741-00",
+        "traceparent": "00-c951f8843cdf9c498cdea265caca86d6-a9291cd94ddfb64c-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "7e7022d370d7f4e4943d26b4a62a048c",
+        "x-ms-client-request-id": "7300cb135b31afcc3accffc35fb32945",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1246",
+        "Content-Length": "1243",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:37 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7300cb135b31afcc3accffc35fb32945",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2399fc70-0768-4160-9f31-90ca63c2e894",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a80344c6-d125-431d-a203-dbce2c3509f1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20",
-        "x5t": "b38RYp8ds45S6aflZS_cweKp1MY",
-        "cer": "MIIB2zCCAWGgAwIBAgIQCJPhm0DNTiOSc1RxogEnzjAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTQzMloXDTIyMDMwNTIzMDQzMlowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABISmmsefWsJctYdycE0HoAN1M\u002BfDc\u002B6BcuwzO/Hg8SRuOgrSaAP3CZu9/E3HlUj/YoLMxYM8Bk3V12QpnMk\u002Blne5kZ2kubfWtnT/0VvBRVmm/8VuICXcq\u002BJLvITknJIVKaN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFDmlhTQw6qGgKPXt/cmZQZTugmYoMB0GA1UdDgQWBBQ5pYU0MOqhoCj17f3JmUGU7oJmKDAKBggqhkjOPQQDAwNoADBlAjBgy3RWomImF6AbFJHL98d6tMtDbAj8/72wws8SFmf2/K6w8ZmjAYnXO15PT9vUJZ4CMQCCLJgLIO082blpLK5KDL7IrqptH22jBjGgAu5AHUQM2nqHR4g\u002BQCABFhR4t1UNOrQ=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1311055181/064531c741344976ac27a29efbadf194",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1311055181/064531c741344976ac27a29efbadf194",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1311055181/064531c741344976ac27a29efbadf194",
+        "x5t": "my6awxgYUforZpsIZ3I0i4XakHI",
+        "cer": "MIIB3DCCAWGgAwIBAgIQI2PVkkzZQ4yzTCkW3/R4jjAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTUzNloXDTIyMDQwODAyMjUzNlowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABLek/Fv1UlV1LKS1haNwbAKj2W/kJw0iCT6YK3hK4OqMNWenbmm9/qP6TEEPNSlYUPG6JIvZzUxiW1/cloD74LJlf5MOq7lp\u002Bu1oO5mzuO7ThcqZXYY\u002BkvPfh7XrUrKYsaN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFNK7cTjPEfTyM6JjvVMavAD\u002Be8QPMB0GA1UdDgQWBBTSu3E4zxH08jOiY71TGrwA/nvEDzAKBggqhkjOPQQDAwNpADBmAjEAtLg1/Ic0VdCmusolM6EdQaqfGNHIKdjd9vV7471FwHPPVlWNyGXkkowXSQ9mntr8AjEAyzvihbw0GYIP0Zyp8/SCZPn1G/eCCsQCWm9s7eE6qWmvuKpEX0nyR0xIoJPccwM9",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984872,
-          "exp": 1646521472,
-          "created": 1614985472,
-          "updated": 1614985472,
+          "nbf": 1617848136,
+          "exp": 1649384736,
+          "created": 1617848736,
+          "updated": 1617848736,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "0893E19B40CD4E2392735471A20127CE"
+        "serialnumber": "2363D5924CD9438CB34C2916DFF4788E"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1311055181/064531c741344976ac27a29efbadf194?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-ccacc9832cc86441a8f63a9084d51498-99cdd208e51ba849-00",
+        "traceparent": "00-c951f8843cdf9c498cdea265caca86d6-42f113ac16637f41-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "85b8e1a33a07b8313d7bf92f796f8634",
+        "x-ms-client-request-id": "63c96e07b26ccf0bd9c656c4c484f8dd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1945",
+        "Content-Length": "1955",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:37 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "63c96e07b26ccf0bd9c656c4c484f8dd",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0c47afb9-bb10-4f21-821e-cf0c42369815",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "0a0f8523-d569-4160-b322-d32d9b47310c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIEbwIBAzCCBCsGCSqGSIb3DQEHAaCCBBwEggQYMIIEFDCCAZ0GCSqGSIb3DQEHAaCCAY4EggGKMIIBhjCCAYIGCyqGSIb3DQEMCgECoIH8MIH5MBwGCiqGSIb3DQEMAQMwDgQId9WGU/PcTcQCAgfQBIHYaj4by3dJUa2AaQEcdx85ljlOk9BQm/oIyPHh2lCD82OQc4px7p16AfPvkx0LZN9eQVpnsRICXP50zLjmjHHEnpDh9DzzloJuazxa2l8m5DScL/8CK/EA5oQpMk8QqgvLd1qGpnxNBFskejCfgouMxORnLqhnhgyX9D7LEApmHsZgLr1pezU8ltCMMdA4lA\u002B/qnNxkcNJMfOiL56zXzhOxsPf3XrDS57nc/Ef7EY5vNmbYkf3pY76NIogpA6xFWFyw33WWqto6J13aGUTOCxeuAYJqfhjevgtMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAm8GCSqGSIb3DQEHBqCCAmAwggJcAgEAMIICVQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIvYIIjGl/Nl8CAgfQgIICKAdH/MvpHu8y8\u002BB5766UAFbXNXrL3Ee3keixOd7UV6aMXxDrBoJs9bX/q0bC7NZfb9Ck1v\u002B8wWZiPVo2mYxLXISpg9MDxdaDVtiKDpJpljkzfJRMzI9/REh5Hdh0paUSlXrwmVfrATwiaKc5SayG1r1w10sJToxUn2zvqTFJZ/3d90xCPMBwosKxsbQrg4FfB8gyhkDTilhwYmV/kT8NJmeSPELdvHqtIMwmXp3T5Xf89tdr470F6AN5kZEEwgx2nOMki/pe3YunYWdI3cdiU7OY0sFdteSqMtAOj4sduOFm48NgLAFRviStqWPWiPb4k2blL5XSqq66vZfpWlZxxQa61EzUYjGxVHcli7hk20Sftc1NDaqeUocQ1IjK20wPwZhF3YS8pKLeqCMxA8lyV\u002ByIQRskvhvWaelCgmJN\u002B77yfs94pzMXJI4V8xwUi8/EoLcoutmllRj8h3EWGj2qJkEbZvRJP4NtW7gERkf\u002Bny9/0VnMFJ0ngGqg8WyrOegAqmAs9VLrX/0UdPrxTqxt7s\u002BVSDF32hIZHhXfiGuJDJa2DNFH8dgC\u002BtaW6DovhAeLhqoBvv3CuSFng6Lx/y5NaMvHr8ufDVW0bOpk3ST8kloP5xeGjBoKab7Rdn0DWc86AH0Di/afAGKm6Ms7jZyMSkvtGEPwbddJ9xgMS67NGl9gr03oeDJJTBnoBY3WNN3Ib7jAbOK2DKa9Rht81ubInDlSqod8UUAYdTA7MB8wBwYFKw4DAhoEFDh3VJnw5rRBtBl5NB4YfHOknY0GBBQQKmkWjQnenSjc8T1PQbeIwniZiAICB9A=",
+        "value": "MIIEdwIBAzCCBDMGCSqGSIb3DQEHAaCCBCQEggQgMIIEHDCCAZ0GCSqGSIb3DQEHAaCCAY4EggGKMIIBhjCCAYIGCyqGSIb3DQEMCgECoIH8MIH5MBwGCiqGSIb3DQEMAQMwDgQItihQ0LKeN0MCAgfQBIHY/W/elvdda3qgqg7z9StRLAXOXQ/drFbYdiS2Y9PCG5tL338L7wtBF\u002B\u002BaP2O2\u002BM6Mig/N1MRLzP7lU9HU4in7GVQIJURVUNaPgbki5OZXJso9G1YEHgORLS\u002B46Ospb4bPRsnNDPtROlPL5QMouSpGg5CQyeqrERMO8nvbZJx5fRXBGBgqufa3Ipq/2T1/QEcw4RnBkfQx\u002B4EEKyvde0YLGvnaAddBKhwYrE2M9dbdPCgeprtk4aEhi88N5K9hPtvFBIbAbU4sWBYg1famnsHcyWPdRoNOylRfMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAncGCSqGSIb3DQEHBqCCAmgwggJkAgEAMIICXQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIHEpdNGhj88oCAgfQgIICMHDnnUv6DQ4VDatsbXZ7c5TjmrN/N5cnwBuEGqUlGdsu3JdOblQEPnTGvjR7\u002Bw4LC1zgdeG2kL2orNgBaNRt\u002BTa7sgDVo4r/IdhbeKytwz8YqZYawG0DMHvp8A8vBDCKtqsvnX01gTELHL8F\u002BV//wYRTSRegivg3\u002BGGZLMkcWWdRnCkUg48dD/HkhiuFYTd7F\u002ByayU3ZHxx3APP0XxL4EIW07Yq136LUU9TFlmsPLgdMFh4HMTl7jA0kREkl9Klf2i04PYgufLR1fOu4i9kaELhoLqazGfi0dxrUvIiUptdFG\u002BRbOd/2Yp1wtUpo2GFvXJnMWCkbFBJCDV06GRKRHABHEqBlB/EQutpOSf6Wfny\u002BX65KOZSlqgyGyJ1vLtr/5EZ9CLqw41EukY7zsekba4/CiquoDQtX0j8/vdQ5kINK6mue/h5zAgJDnDKtYGih1WZ2yyC2Qtlq9gSXN34eaxLaK7zHqW4pv2BkLwevSiBgou1kEFk3dx14CoaaELb41olxAD8pBNkksf6OwqsnWCQoDGlqJNrdJjrHX0AunPTpuE2fI5k4\u002BXuqkunRvgrA4eZ4yRWRRVtuAgLvdA1us8TYkUqW\u002B\u002BCs0A1PMh6ggSTCWGv8EJtNhSlTkHKg9ujzI6I3an2uyqqCpjFtGm\u002Br/YTn73j\u002B/CHnAGHDd6fGVwG5WedfHbM1B3APZxvKuTkydWOhaQsHFl8ib/WiS2Ij9sIQdjt2On/aif307feUiT5LMDswHzAHBgUrDgMCGgQUCSQkdkZ/18mE0i1GsPhoBviVQJQEFMeSh9qpIqoULF60PLT2/t8wdjxIAgIH0A==",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1311055181/064531c741344976ac27a29efbadf194",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614984872,
-          "exp": 1646521472,
-          "created": 1614985472,
-          "updated": 1614985472,
+          "nbf": 1617848136,
+          "exp": 1649384736,
+          "created": 1617848736,
+          "updated": 1617848736,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1311055181/c6cdffcccab64b6e8a9caf588f8dfc20"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1311055181/064531c741344976ac27a29efbadf194"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "812527273"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-384)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-384)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1701811652/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1701811652/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-26ed7c06c715394586b9ea52c98a552f-73d2fc39dafad047-00",
+        "traceparent": "00-0f3066e17bab33458fd9833da37bebb7-71e76691d289ef4b-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "008c7c9a58500023368f6de1ed07ac65",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:10 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "008c7c9a58500023368f6de1ed07ac65",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "23ee7cb5-5f3a-43ef-909e-ecf3adec2abe",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f823c7ec-cb62-4845-b359-83385ca4667d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1701811652/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1701811652/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-26ed7c06c715394586b9ea52c98a552f-73d2fc39dafad047-00",
+        "traceparent": "00-0f3066e17bab33458fd9833da37bebb7-71e76691d289ef4b-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "008c7c9a58500023368f6de1ed07ac65",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "842",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:11 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:05 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending?api-version=7.2\u0026request_id=5a41ab06565d4814843ffe99443cdef9",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/1701811652/pending?api-version=7.2\u0026request_id=9b4c3bbe41084984b9329af35b97391a",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "008c7c9a58500023368f6de1ed07ac65",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9a0ead3b-861a-43ca-aba8-6a9f9c654668",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f358d2a3-5b73-45e8-ba48-25bcd67c5400",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1701811652/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt3I8elB/jlIVw/fLE4IVrdbsLUG02HNE4Zb6guwnXtl7L5cQg0gmijqauIWkGbNGB/p3DxsYcA\u002Bifo4MzuSTYVTqcEznyTjPM1dn02n64n5bIXZdVGgMDq3svTw0gOaioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMae9CvEAbMfQTZZo4ha1oZuW\u002BzAaP5nj4rbwdJtaOcEIP\u002BW1zgfvIAYIFyvXEmGwAIxAO\u002BdF30bM9zvbmhXgZF\u002BmhDCYD6v0DLXVTW1aNzZjj4r1Q7euw4YDm\u002BIlUY/UNHI7w==",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEzY3puIqaMY7P2Da5nCs21akzE3XV6vtykY\u002Bcaux1VJi30zOteBNKJr1W9CAOWfylHk3AOxQKYLjTBdi3qG9hL4sMeyPmH8AGJCrpRzx06SSVnLwA5sTungDSqSmnuXJEoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIwRG17MY4tJqxeC213Bd8oDLghW4jUmf9ArRGuNAsijdON4mk9YilIucLW9GNqHq75AjEAtcWMAqkek1J\u002BXkjmpLj7zw3vtb2//Qi9BOEjNWwmILIEBcQtgRkAHpJRu72yv8a2",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5a41ab06565d4814843ffe99443cdef9"
+        "request_id": "9b4c3bbe41084984b9329af35b97391a"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1701811652/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "8dc547bb783229feab87bbfbf5503dce",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "842",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:11 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "8dc547bb783229feab87bbfbf5503dce",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a150bbb7-04b3-4270-8369-fb7501ef9caa",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "8e6fde2f-1e4a-411f-ac5a-753a741b8eac",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1701811652/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt3I8elB/jlIVw/fLE4IVrdbsLUG02HNE4Zb6guwnXtl7L5cQg0gmijqauIWkGbNGB/p3DxsYcA\u002Bifo4MzuSTYVTqcEznyTjPM1dn02n64n5bIXZdVGgMDq3svTw0gOaioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMae9CvEAbMfQTZZo4ha1oZuW\u002BzAaP5nj4rbwdJtaOcEIP\u002BW1zgfvIAYIFyvXEmGwAIxAO\u002BdF30bM9zvbmhXgZF\u002BmhDCYD6v0DLXVTW1aNzZjj4r1Q7euw4YDm\u002BIlUY/UNHI7w==",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEzY3puIqaMY7P2Da5nCs21akzE3XV6vtykY\u002Bcaux1VJi30zOteBNKJr1W9CAOWfylHk3AOxQKYLjTBdi3qG9hL4sMeyPmH8AGJCrpRzx06SSVnLwA5sTungDSqSmnuXJEoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIwRG17MY4tJqxeC213Bd8oDLghW4jUmf9ArRGuNAsijdON4mk9YilIucLW9GNqHq75AjEAtcWMAqkek1J\u002BXkjmpLj7zw3vtb2//Qi9BOEjNWwmILIEBcQtgRkAHpJRu72yv8a2",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5a41ab06565d4814843ffe99443cdef9"
+        "request_id": "9b4c3bbe41084984b9329af35b97391a"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1701811652/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "bc5b2ed99897a78d9ffe669ee13048ce",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "842",
+        "Content-Length": "837",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:15 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:11 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bc5b2ed99897a78d9ffe669ee13048ce",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "7b76cd72-8397-4da8-93b7-8242a4975394",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5c3e47a5-d612-49ab-942b-e205b7e458cd",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1701811652/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt3I8elB/jlIVw/fLE4IVrdbsLUG02HNE4Zb6guwnXtl7L5cQg0gmijqauIWkGbNGB/p3DxsYcA\u002Bifo4MzuSTYVTqcEznyTjPM1dn02n64n5bIXZdVGgMDq3svTw0gOaioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMae9CvEAbMfQTZZo4ha1oZuW\u002BzAaP5nj4rbwdJtaOcEIP\u002BW1zgfvIAYIFyvXEmGwAIxAO\u002BdF30bM9zvbmhXgZF\u002BmhDCYD6v0DLXVTW1aNzZjj4r1Q7euw4YDm\u002BIlUY/UNHI7w==",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEzY3puIqaMY7P2Da5nCs21akzE3XV6vtykY\u002Bcaux1VJi30zOteBNKJr1W9CAOWfylHk3AOxQKYLjTBdi3qG9hL4sMeyPmH8AGJCrpRzx06SSVnLwA5sTungDSqSmnuXJEoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIwRG17MY4tJqxeC213Bd8oDLghW4jUmf9ArRGuNAsijdON4mk9YilIucLW9GNqHq75AjEAtcWMAqkek1J\u002BXkjmpLj7zw3vtb2//Qi9BOEjNWwmILIEBcQtgRkAHpJRu72yv8a2",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5a41ab06565d4814843ffe99443cdef9"
+        "request_id": "9b4c3bbe41084984b9329af35b97391a"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1701811652/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "1b7c6f3ead8921917d6254c89d270be5",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "842",
+        "Content-Length": "745",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:21 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1b7c6f3ead8921917d6254c89d270be5",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1d7ce9dc-8686-4aeb-9eb6-a0659e24abd4",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "8adec4d6-a263-48f1-aebe-369d364a935f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1701811652/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt3I8elB/jlIVw/fLE4IVrdbsLUG02HNE4Zb6guwnXtl7L5cQg0gmijqauIWkGbNGB/p3DxsYcA\u002Bifo4MzuSTYVTqcEznyTjPM1dn02n64n5bIXZdVGgMDq3svTw0gOaioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMae9CvEAbMfQTZZo4ha1oZuW\u002BzAaP5nj4rbwdJtaOcEIP\u002BW1zgfvIAYIFyvXEmGwAIxAO\u002BdF30bM9zvbmhXgZF\u002BmhDCYD6v0DLXVTW1aNzZjj4r1Q7euw4YDm\u002BIlUY/UNHI7w==",
+        "csr": "MIIBVTCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEzY3puIqaMY7P2Da5nCs21akzE3XV6vtykY\u002Bcaux1VJi30zOteBNKJr1W9CAOWfylHk3AOxQKYLjTBdi3qG9hL4sMeyPmH8AGJCrpRzx06SSVnLwA5sTungDSqSmnuXJEoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaAAwZQIwRG17MY4tJqxeC213Bd8oDLghW4jUmf9ArRGuNAsijdON4mk9YilIucLW9GNqHq75AjEAtcWMAqkek1J\u002BXkjmpLj7zw3vtb2//Qi9BOEjNWwmILIEBcQtgRkAHpJRu72yv8a2",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5a41ab06565d4814843ffe99443cdef9"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/1701811652",
+        "request_id": "9b4c3bbe41084984b9329af35b97391a"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1701811652?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "bf079f52efab23cdba1eee33115f487a",
         "x-ms-return-client-request-id": "true"
@@ -256,211 +260,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "842",
+        "Content-Length": "1836",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "755d8cdb-03a9-4fde-933b-43bc5f512fc8",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt3I8elB/jlIVw/fLE4IVrdbsLUG02HNE4Zb6guwnXtl7L5cQg0gmijqauIWkGbNGB/p3DxsYcA\u002Bifo4MzuSTYVTqcEznyTjPM1dn02n64n5bIXZdVGgMDq3svTw0gOaioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMae9CvEAbMfQTZZo4ha1oZuW\u002BzAaP5nj4rbwdJtaOcEIP\u002BW1zgfvIAYIFyvXEmGwAIxAO\u002BdF30bM9zvbmhXgZF\u002BmhDCYD6v0DLXVTW1aNzZjj4r1Q7euw4YDm\u002BIlUY/UNHI7w==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5a41ab06565d4814843ffe99443cdef9"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "85bdec3f21d32c459c3a3f3443c40978",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "842",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:31 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4e88cdfd-9e02-4f13-a24e-73c42d2b57f4",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt3I8elB/jlIVw/fLE4IVrdbsLUG02HNE4Zb6guwnXtl7L5cQg0gmijqauIWkGbNGB/p3DxsYcA\u002Bifo4MzuSTYVTqcEznyTjPM1dn02n64n5bIXZdVGgMDq3svTw0gOaioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMae9CvEAbMfQTZZo4ha1oZuW\u002BzAaP5nj4rbwdJtaOcEIP\u002BW1zgfvIAYIFyvXEmGwAIxAO\u002BdF30bM9zvbmhXgZF\u002BmhDCYD6v0DLXVTW1aNzZjj4r1Q7euw4YDm\u002BIlUY/UNHI7w==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5a41ab06565d4814843ffe99443cdef9"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "414b80f389294e23a159606abf5e101e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "842",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2255ea39-de69-4adf-a3ad-ec51ed281121",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt3I8elB/jlIVw/fLE4IVrdbsLUG02HNE4Zb6guwnXtl7L5cQg0gmijqauIWkGbNGB/p3DxsYcA\u002Bifo4MzuSTYVTqcEznyTjPM1dn02n64n5bIXZdVGgMDq3svTw0gOaioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMae9CvEAbMfQTZZo4ha1oZuW\u002BzAaP5nj4rbwdJtaOcEIP\u002BW1zgfvIAYIFyvXEmGwAIxAO\u002BdF30bM9zvbmhXgZF\u002BmhDCYD6v0DLXVTW1aNzZjj4r1Q7euw4YDm\u002BIlUY/UNHI7w==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "5a41ab06565d4814843ffe99443cdef9"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "b189da1a866a30115adb2270b099dff6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "751",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:41 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bf079f52efab23cdba1eee33115f487a",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4d8b1b87-79c8-4a5a-a378-6fcd0fcadbd8",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "554476d3-fc53-483a-9edd-b1577ebe2133",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBVjCB3AIBADASMRAwDgYDVQQDEwdkZWZhdWx0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEt3I8elB/jlIVw/fLE4IVrdbsLUG02HNE4Zb6guwnXtl7L5cQg0gmijqauIWkGbNGB/p3DxsYcA\u002Bifo4MzuSTYVTqcEznyTjPM1dn02n64n5bIXZdVGgMDq3svTw0gOaioEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwMDaQAwZgIxAMae9CvEAbMfQTZZo4ha1oZuW\u002BzAaP5nj4rbwdJtaOcEIP\u002BW1zgfvIAYIFyvXEmGwAIxAO\u002BdF30bM9zvbmhXgZF\u002BmhDCYD6v0DLXVTW1aNzZjj4r1Q7euw4YDm\u002BIlUY/UNHI7w==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/1701811652",
-        "request_id": "5a41ab06565d4814843ffe99443cdef9"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1701811652?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "904076150714b651c86ee37ac0da6c3e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1841",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:41 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "67c05446-e7a5-465b-90dc-7b2ae3f31228",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/0eb9bbc941a140d99b75d567c95103fc",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1701811652/0eb9bbc941a140d99b75d567c95103fc",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1701811652/0eb9bbc941a140d99b75d567c95103fc",
-        "x5t": "p2bPk5y9qjku47MehhVBfKqOrjo",
-        "cer": "MIIB2zCCAWGgAwIBAgIQc9uDPuJ7TGyDk5K/WE0WFDAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDMzN1oXDTIyMDMwNTIzMTMzN1owEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABLdyPHpQf45SFcP3yxOCFa3W7C1BtNhzROGW\u002BoLsJ17Zey\u002BXEINIJoo6mriFpBmzRgf6dw8bGHAPon6ODM7kk2FU6nBM58k4zzNXZ9Np\u002BuJ\u002BWyF2XVRoDA6t7L08NIDmoqN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFLSytpoGXarvhpxrVHXLd0VU2Iu/MB0GA1UdDgQWBBS0sraaBl2q74aca1R1y3dFVNiLvzAKBggqhkjOPQQDAwNoADBlAjEA0jPDn5TyKLX2Xenep2acgz/SGvqYFaq28ZpLCyntUCtTR0lJAJh6DWyhuhIi8HXMAjAN2BXVVNDK7PaANq1EhjJM5QEAKx1AESQB76EGoKujiTC4rXW3PXGUGKSRLLHjJDw=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1701811652/6692246e56be46fbbc32fb6bcd60afdc",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1701811652/6692246e56be46fbbc32fb6bcd60afdc",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1701811652/6692246e56be46fbbc32fb6bcd60afdc",
+        "x5t": "8EK4_qyBqnowTDRJS0zd_ZQCvL4",
+        "cer": "MIIB2zCCAWGgAwIBAgIQKU4q1bQhRmSpFzSOAmx1RzAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjUxMVoXDTIyMDQwODAyMzUxMVowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABM2N6biKmjGOz9g2uZwrNtWpMxN11er7cpGPnGrsdVSYt9MzrXgTSia9VvQgDln8pR5NwDsUCmC40wXYt6hvYS\u002BLDHsj5h/ABiQq6Uc8dOkklZy8AObE7p4A0qkpp7lyRKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFAjU5I2invZBrhBVTFtg/YWn/1rrMB0GA1UdDgQWBBQI1OSNop72Qa4QVUxbYP2Fp/9a6zAKBggqhkjOPQQDAwNoADBlAjBkjWzi4lJbd6XkEs5JedteJIU6DsBXbdlyVj2BMZWQEhoaJD8Hlqmz5bcsaY5fyNwCMQDeAnZAwozhJLl0lkF6/BE\u002BuYzwhWGytKnnH\u002BIC9lljBLFWdvfNfhWmh5lpzwao5RU=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985417,
-          "exp": 1646522017,
-          "created": 1614986017,
-          "updated": 1614986017,
+          "nbf": 1617848711,
+          "exp": 1649385311,
+          "created": 1617849311,
+          "updated": 1617849311,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1701811652/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -500,65 +330,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985991,
-            "updated": 1614985991
+            "created": 1617849305,
+            "updated": 1617849305
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/1701811652/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1701811652/0eb9bbc941a140d99b75d567c95103fc?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1701811652/6692246e56be46fbbc32fb6bcd60afdc?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-5ca2a74eda498545b8cfbd06fdf31bfe-1d26ce28a3915341-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "85bdec3f21d32c459c3a3f3443c40978",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:35:15 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "85bdec3f21d32c459c3a3f3443c40978",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "09f0b8fc-847a-4281-9fc2-c12cec72de3c",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1701811652/6692246e56be46fbbc32fb6bcd60afdc?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-8c292881200fd34e9ba02561c635fdb6-9e339adb8ac52e43-00",
+        "traceparent": "00-5ca2a74eda498545b8cfbd06fdf31bfe-1d26ce28a3915341-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "691a2129583b6c0d6f1be64d66b29e08",
+        "x-ms-client-request-id": "85bdec3f21d32c459c3a3f3443c40978",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "482",
+        "Content-Length": "481",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:41 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "85bdec3f21d32c459c3a3f3443c40978",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "b4807eab-4481-4a5a-9424-6a179ea329ac",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1f14b5c0-bc0e-4e48-be50-51f2e224a962",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/1701811652/0eb9bbc941a140d99b75d567c95103fc",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/1701811652/6692246e56be46fbbc32fb6bcd60afdc",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-384",
-          "x": "t3I8elB_jlIVw_fLE4IVrdbsLUG02HNE4Zb6guwnXtl7L5cQg0gmijqauIWkGbNG",
-          "y": "B_p3DxsYcA-ifo4MzuSTYVTqcEznyTjPM1dn02n64n5bIXZdVGgMDq3svTw0gOai"
+          "x": "zY3puIqaMY7P2Da5nCs21akzE3XV6vtykY-caux1VJi30zOteBNKJr1W9CAOWfyl",
+          "y": "Hk3AOxQKYLjTBdi3qG9hL4sMeyPmH8AGJCrpRzx06SSVnLwA5sTungDSqSmnuXJE"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985417,
-          "exp": 1646522017,
-          "created": 1614986017,
-          "updated": 1614986017,
+          "nbf": 1617848711,
+          "exp": 1649385311,
+          "created": 1617849311,
+          "updated": 1617849311,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -566,19 +437,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/1701811652/0eb9bbc941a140d99b75d567c95103fc/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/1701811652/6692246e56be46fbbc32fb6bcd60afdc/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "90",
         "Content-Type": "application/json",
-        "traceparent": "00-8c292881200fd34e9ba02561c635fdb6-35bd2756e45f9a46-00",
+        "traceparent": "00-5ca2a74eda498545b8cfbd06fdf31bfe-831594478adb9b40-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "49556a797f1d130988d3e8fca3976f7f",
+        "x-ms-client-request-id": "414b80f389294e23a159606abf5e101e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -588,128 +459,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "236",
+        "Content-Length": "235",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:41 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "414b80f389294e23a159606abf5e101e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "980e2f76-d650-4512-8c9a-7bd7815eeb86",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "bac2738f-1613-445e-9fab-d1bd51a4a064",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1701811652/0eb9bbc941a140d99b75d567c95103fc",
-        "value": "mgpvs7i7F_M69UbI1uQarX2FqflnqJtnltQJgqDGbhHCIxXcxDKWcimUjAk_GsITSjcw-U_92DBapIDyRTw-em3_Oh4BfRaZi2-VWLV2QLPoNdScBN2gQ8z_7eRkTwBi"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1701811652/6692246e56be46fbbc32fb6bcd60afdc",
+        "value": "Lmvy14MFfqXfWg-omqaf7inwSnhEJDDlr2wYO17Rgxgp1V2NYevxMd4di0SJFHzY4_8yc3ZSFQhNLYM1fWJNdlmXEUl9bXEViEEh2i-oMAu8nFgRMyiUFvE8mNmZNkwb"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/1701811652/0eb9bbc941a140d99b75d567c95103fc?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/1701811652/6692246e56be46fbbc32fb6bcd60afdc?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-bdd12ad7ffc68e42b0866cef7e30b40d-2384f5686aa38c45-00",
+        "traceparent": "00-33f346de9b8e984eb4fa74e790005c0c-a37229751eef2249-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "8f46e36e767ebdba68d321f820034f16",
+        "x-ms-client-request-id": "b189da1a866a30115adb2270b099dff6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1246",
+        "Content-Length": "1243",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:41 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b189da1a866a30115adb2270b099dff6",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "04c4a7e7-0508-4f33-9da8-7daa28cc605a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "17782ebb-8936-41ae-b488-788a1d47a551",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/1701811652/0eb9bbc941a140d99b75d567c95103fc",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1701811652/0eb9bbc941a140d99b75d567c95103fc",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/1701811652/0eb9bbc941a140d99b75d567c95103fc",
-        "x5t": "p2bPk5y9qjku47MehhVBfKqOrjo",
-        "cer": "MIIB2zCCAWGgAwIBAgIQc9uDPuJ7TGyDk5K/WE0WFDAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDMzN1oXDTIyMDMwNTIzMTMzN1owEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABLdyPHpQf45SFcP3yxOCFa3W7C1BtNhzROGW\u002BoLsJ17Zey\u002BXEINIJoo6mriFpBmzRgf6dw8bGHAPon6ODM7kk2FU6nBM58k4zzNXZ9Np\u002BuJ\u002BWyF2XVRoDA6t7L08NIDmoqN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFLSytpoGXarvhpxrVHXLd0VU2Iu/MB0GA1UdDgQWBBS0sraaBl2q74aca1R1y3dFVNiLvzAKBggqhkjOPQQDAwNoADBlAjEA0jPDn5TyKLX2Xenep2acgz/SGvqYFaq28ZpLCyntUCtTR0lJAJh6DWyhuhIi8HXMAjAN2BXVVNDK7PaANq1EhjJM5QEAKx1AESQB76EGoKujiTC4rXW3PXGUGKSRLLHjJDw=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/1701811652/6692246e56be46fbbc32fb6bcd60afdc",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1701811652/6692246e56be46fbbc32fb6bcd60afdc",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/1701811652/6692246e56be46fbbc32fb6bcd60afdc",
+        "x5t": "8EK4_qyBqnowTDRJS0zd_ZQCvL4",
+        "cer": "MIIB2zCCAWGgAwIBAgIQKU4q1bQhRmSpFzSOAmx1RzAKBggqhkjOPQQDAzASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjUxMVoXDTIyMDQwODAyMzUxMVowEjEQMA4GA1UEAxMHZGVmYXVsdDB2MBAGByqGSM49AgEGBSuBBAAiA2IABM2N6biKmjGOz9g2uZwrNtWpMxN11er7cpGPnGrsdVSYt9MzrXgTSia9VvQgDln8pR5NwDsUCmC40wXYt6hvYS\u002BLDHsj5h/ABiQq6Uc8dOkklZy8AObE7p4A0qkpp7lyRKN8MHowDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFAjU5I2invZBrhBVTFtg/YWn/1rrMB0GA1UdDgQWBBQI1OSNop72Qa4QVUxbYP2Fp/9a6zAKBggqhkjOPQQDAwNoADBlAjBkjWzi4lJbd6XkEs5JedteJIU6DsBXbdlyVj2BMZWQEhoaJD8Hlqmz5bcsaY5fyNwCMQDeAnZAwozhJLl0lkF6/BE\u002BuYzwhWGytKnnH\u002BIC9lljBLFWdvfNfhWmh5lpzwao5RU=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985417,
-          "exp": 1646522017,
-          "created": 1614986017,
-          "updated": 1614986017,
+          "nbf": 1617848711,
+          "exp": 1649385311,
+          "created": 1617849311,
+          "updated": 1617849311,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "73DB833EE27B4C6C839392BF584D1614"
+        "serialnumber": "294E2AD5B4214664A917348E026C7547"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1701811652/0eb9bbc941a140d99b75d567c95103fc?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/1701811652/6692246e56be46fbbc32fb6bcd60afdc?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-bdd12ad7ffc68e42b0866cef7e30b40d-394562c21d7d5a4d-00",
+        "traceparent": "00-33f346de9b8e984eb4fa74e790005c0c-24e80b139f8b4544-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "5600dad02385aa211707e0686f11c9d7",
+        "x-ms-client-request-id": "904076150714b651c86ee37ac0da6c3e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1945",
+        "Content-Length": "1943",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "904076150714b651c86ee37ac0da6c3e",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "09ffa7fd-096d-47c5-bb44-82137a68fb05",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6cdcb443-858e-447c-a6ea-2c90f708e5b5",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIEbwIBAzCCBCsGCSqGSIb3DQEHAaCCBBwEggQYMIIEFDCCAZ0GCSqGSIb3DQEHAaCCAY4EggGKMIIBhjCCAYIGCyqGSIb3DQEMCgECoIH8MIH5MBwGCiqGSIb3DQEMAQMwDgQI54lgcohHK28CAgfQBIHYrCfeWZpayQz4vNbPZiMLHBeyd\u002B4dBVXpF1GkBZEaetV8F/eCsH0d5d7MC8PHTo3Jz4S5IhKZwnMQCcM/1z8eOl1eg\u002BuQ\u002BRYtnWqauR2Wf1Y3arJpFNty1fSB6MxQbDOMxQQnJhvg91PthdhUWL2BRFdvk6JR6RDT5O17WCEsW8s2Bkpkhx\u002B6qCHScJNK1zBKGmADP0JBouHb\u002Bytx9wnOQaMaHktrLs277XK/I1SCFs8gdPooczHStNYbPFRuDC6V3OC7B60DkMLJGG/5bxPNi1aYwDf/iMNyMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAm8GCSqGSIb3DQEHBqCCAmAwggJcAgEAMIICVQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIzGTR2gLujXUCAgfQgIICKB6QkMrQwYeEf8n3YRaUQidBump0YaLh4S4GXeprmh6sknY2NZa/3zn5AXHNW7cu2gUp9XVKMn692pqOvWYFbf04\u002BIo7FoQdPNmoPtoJcTemAKnPxkR/tSlGBQfOwyRqosmEePgjStS2K1lwg4xO7QQx4F1hjK8kc7nOBZE6bDsLxi6kViIhFF7KaynZ9q/FJ32M5jvIIwjvJiflPuIOjGCeoKaIz25Pt/U6lYeALPo\u002BtGGrqXEYxruXGPbu0sp2kp4Q119vjxb0VL9XRlF5QgRIM2x7QDiuTgDgjpBE63tETcI7Z6fLIyw1n2GUycNj56T2pmlc3IMpMXUVUkOi5c4d6DQBOQQlYvMzWfFjsBKQn1Qf7ZIhZe5DChpgz11/LvynBCZhNKLoxGIYsKcFocivUg7ez5Rdi8Ey69VjwJmn0I1sRovRXQvtiDt35RHaLI6uGoqypujW3YcmIn/gGkoIIuUMv1llXPo32unX9hVNaRqMMnadhlpZzdcG6emRsEx4OJLcaAsvEW2J5fa1NiY5xTguwENPwwWxc3nTh7/VuV2vGvOWnaFm730glkUBju/\u002BZBoDMvFO8d1RZNDDzHeIt2vIzJD1hAv5cyDYaRVG59gMcS5ZJLhOPc2dERO7InbFKVW15woRA/lqMVml6l712D8J\u002B\u002Bkx3LyI5bc4VCl8UoxuS/nUiiocx7ShpH2HZtYHffWVQ/N1HvfljVK7m2w3GfQVRERi9zA7MB8wBwYFKw4DAhoEFGEe55Lq6kPPJqSwVXGYRVPmZcY6BBRO8s\u002BJq7ag2KUO1O1jq6ypfpsZlgICB9A=",
+        "value": "MIIEbwIBAzCCBCsGCSqGSIb3DQEHAaCCBBwEggQYMIIEFDCCAZ0GCSqGSIb3DQEHAaCCAY4EggGKMIIBhjCCAYIGCyqGSIb3DQEMCgECoIH8MIH5MBwGCiqGSIb3DQEMAQMwDgQIgO\u002BEqz\u002B7WtQCAgfQBIHY4\u002BOvjmHqFFPb5ODCCguhpSdphkQKtvLDkcTlV9uA3OKc/Qk2KcBSioBHQ/cjeWMrY3XoHRQyYb3f0BroV\u002Bw5Swzx4JRyoi1HAff5fwvJ10bYQ5nJOTFxZGASiw5D5DLrGMAQEbzLVPIvmYMzeVBgNVsExOrTgr66L8wglLn6DALwItwR4VMg/lvQn6Xj7n3s6pGa2gEwI79vGXmgLsrHsj4Hdz8Zq7dVgwhXcqtvWuGyG4geP06fDJSb4R7MpAxpLOF7wHeiaW2bofxCdq59onPiz85Z9f7eMXQwEwYJKoZIhvcNAQkVMQYEBAEAAAAwXQYJKwYBBAGCNxEBMVAeTgBNAGkAYwByAG8AcwBvAGYAdAAgAFMAbwBmAHQAdwBhAHIAZQAgAEsAZQB5ACAAUwB0AG8AcgBhAGcAZQAgAFAAcgBvAHYAaQBkAGUAcjCCAm8GCSqGSIb3DQEHBqCCAmAwggJcAgEAMIICVQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQIuKKTn0jSBRECAgfQgIICKGw9hxvuZtUAETisnF0HDual9j/VT7il68DqxWk6BMwRM1sbduIRd9xyO68KHlVPVxanCOCP8bMjUiYRTRy\u002BpENNpIpeiBCuQ9BUFYS1me/IzpKOAz8EunnRBZk/\u002BjNzIvuF4V83PR/D8OOGzRrshOAYV5ewMU0O6JxUxdgiRSojcH/STzFnHBm8NRJuM4RWfXUxUSItsNpQnAWQhQ9M5Vcn\u002BJfezLl/Rj1L30DhmOJydd\u002BSDbCePSpYoECp8BTDW0PoLwaVs4iichzXav16tI\u002B6VoYa2e8Xq4KhJX5gzXqkOOj0GG2NspQBVTDDPKU/cmzi2ltaX6B5T4v6HCbGSRhU0dn/W\u002B1mlbqIizJmTUVGh8NEUyickXRyoalETrXkhyqI60XR1scmdjN57wt\u002BoloznsKvtn1ytl68kxHlan/Gonfo8FYk6YSPoxDXTEaucnAHmsyogdO9VTlWUFIBPLQUjP/STrsONPrftjV7u1I0370Yjc5uicil2IbAlRBbGq7Pg1nxx57hAsa\u002Bb2hOXHO/BfZx3CXCCXbm0wPXK0LGSz8blQYYMus0b0r7a05Dk3oyp3pJc4SqSO4YbF9ru4Hxo4oxLgKwqFpx\u002B\u002BYyDsy2wNtYj\u002BNA\u002Byqbw\u002B53jsPo9vIK9o\u002BGtrM8dntceZC2J/ZIOgMES2Cud0CGp1j5Awi0fBq0TTtnLUtPAQ6KPl2dZv58Jw8gyS/3cyRxbNpf9T1Ylor6up1kHTA7MB8wBwYFKw4DAhoEFI9c0UTSdek3S1ksUrzsUdpTxyvCBBTTi4se\u002Bvdco12ivz8FLiQEZpmPzgICB9A=",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/1701811652/0eb9bbc941a140d99b75d567c95103fc",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/1701811652/6692246e56be46fbbc32fb6bcd60afdc",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985417,
-          "exp": 1646522017,
-          "created": 1614986017,
-          "updated": 1614986017,
+          "nbf": 1617848711,
+          "exp": 1649385311,
+          "created": 1617849311,
+          "updated": 1617849311,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/1701811652/0eb9bbc941a140d99b75d567c95103fc"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/1701811652/6692246e56be46fbbc32fb6bcd60afdc"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1733345595"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-521).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-521).json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/244092181/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/244092181/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-a7e237e68a326743894b55579db6f513-86f2e099e5e6f940-00",
+        "traceparent": "00-72ea8bce2cc9ef4fa71ccb8d06b32cda-3bb97035972cbb41-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "1266a209d7c3d302b1341f9467dbdc51",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:37 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1266a209d7c3d302b1341f9467dbdc51",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "026348ee-4727-43cd-afb2-5703e048e9ea",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "22ce874d-b3ae-47ae-bb2e-13affd3d949f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/244092181/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/244092181/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-a7e237e68a326743894b55579db6f513-86f2e099e5e6f940-00",
+        "traceparent": "00-72ea8bce2cc9ef4fa71ccb8d06b32cda-3bb97035972cbb41-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "1266a209d7c3d302b1341f9467dbdc51",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "937",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:43 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending?api-version=7.2\u0026request_id=4ebad00f626f44c7a9fec603ae359669",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/244092181/pending?api-version=7.2\u0026request_id=4533a65b44d445ae95c079a62bb9c02e",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1266a209d7c3d302b1341f9467dbdc51",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "4e08c0d4-7f2e-4203-a3ac-220f64e6e749",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "91e29b74-d5aa-4f70-a4bf-077a2246010b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/244092181/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAFgmXRM9uHvhrSQdoTkZctillEi6DoKoM17gDc5jv\u002B712sy/KW5LiBf21dp3OVWtXHQa5Aw8r7mWqLn6rnc1tuCCAURy47r8r91VRc8957k0dGxf8/OKFGbfXD9xk14J4Y3ed6ADRYaRveX2PGJpRUX0AQ7UbMAz7T4nCJHe1XjyIC65oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBgW590tWSqHYsw\u002BrF84tQYR040sOlW3aE24g/MH5s51MHLN1TMulzBR6jtVitJ0KZ4jcqnIAkmJffs7VuncgOZe0CQSqcjYYKYQaw59e86L6sVBcxf4sfsMmn5yuzsV3965oHFgPNnGjPNOq\u002BuWmxc2xKQ/6PiYOSaV7tC8mK/nGOZGvi",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEANvteirpn2yQ8\u002BCEENjWqUkGgdO89744knTzsPJS7YkUupu\u002BxciQf4dYuIchggTqz\u002B0Tnmhh6M576JlmzChAv\u002BriAHywYcxgQ85/Pn/wMmNji2GkocOBr0pQU6aNdDT18JfvMQyDev\u002BMfnTfIkYXyTKUJ34mgXKDvW0ChAbIr4xZ4qbUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB3Asv0DT9Rp25vB/tY8OVqmSFB6TIqyvYJp1hkhdMY7LDq8BkHJBhiMETrNHpb/9chl6A5zRMIkK8CSLuOmKvfm8CQgDAUkspG/9fDOxASmbqDNvVXm0h9T/9iQyT3d\u002BlNFGMgNlbxKDmyPbT829v2GxrhlmANDyY17jw89NUbrZqn\u002B1WcA==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "4ebad00f626f44c7a9fec603ae359669"
+        "request_id": "4533a65b44d445ae95c079a62bb9c02e"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/244092181/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "06c939d5a41ecea1750aed052fadc697",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "937",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "06c939d5a41ecea1750aed052fadc697",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ea94ca7c-3553-4ec9-bb14-3fbbfdc09687",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "00044a4f-b841-44cf-b1e2-ea8bca7b57fe",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/244092181/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAFgmXRM9uHvhrSQdoTkZctillEi6DoKoM17gDc5jv\u002B712sy/KW5LiBf21dp3OVWtXHQa5Aw8r7mWqLn6rnc1tuCCAURy47r8r91VRc8957k0dGxf8/OKFGbfXD9xk14J4Y3ed6ADRYaRveX2PGJpRUX0AQ7UbMAz7T4nCJHe1XjyIC65oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBgW590tWSqHYsw\u002BrF84tQYR040sOlW3aE24g/MH5s51MHLN1TMulzBR6jtVitJ0KZ4jcqnIAkmJffs7VuncgOZe0CQSqcjYYKYQaw59e86L6sVBcxf4sfsMmn5yuzsV3965oHFgPNnGjPNOq\u002BuWmxc2xKQ/6PiYOSaV7tC8mK/nGOZGvi",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEANvteirpn2yQ8\u002BCEENjWqUkGgdO89744knTzsPJS7YkUupu\u002BxciQf4dYuIchggTqz\u002B0Tnmhh6M576JlmzChAv\u002BriAHywYcxgQ85/Pn/wMmNji2GkocOBr0pQU6aNdDT18JfvMQyDev\u002BMfnTfIkYXyTKUJ34mgXKDvW0ChAbIr4xZ4qbUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB3Asv0DT9Rp25vB/tY8OVqmSFB6TIqyvYJp1hkhdMY7LDq8BkHJBhiMETrNHpb/9chl6A5zRMIkK8CSLuOmKvfm8CQgDAUkspG/9fDOxASmbqDNvVXm0h9T/9iQyT3d\u002BlNFGMgNlbxKDmyPbT829v2GxrhlmANDyY17jw89NUbrZqn\u002B1WcA==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "4ebad00f626f44c7a9fec603ae359669"
+        "request_id": "4533a65b44d445ae95c079a62bb9c02e"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/244092181/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "55b10a145c4d2d8c0e98269d3375934f",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "937",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:44 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "55b10a145c4d2d8c0e98269d3375934f",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "01f5ce2d-74de-4589-a33d-b1e5f140937a",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "43bcc884-9110-4b5c-ae6a-5e38c60402ce",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/244092181/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAFgmXRM9uHvhrSQdoTkZctillEi6DoKoM17gDc5jv\u002B712sy/KW5LiBf21dp3OVWtXHQa5Aw8r7mWqLn6rnc1tuCCAURy47r8r91VRc8957k0dGxf8/OKFGbfXD9xk14J4Y3ed6ADRYaRveX2PGJpRUX0AQ7UbMAz7T4nCJHe1XjyIC65oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBgW590tWSqHYsw\u002BrF84tQYR040sOlW3aE24g/MH5s51MHLN1TMulzBR6jtVitJ0KZ4jcqnIAkmJffs7VuncgOZe0CQSqcjYYKYQaw59e86L6sVBcxf4sfsMmn5yuzsV3965oHFgPNnGjPNOq\u002BuWmxc2xKQ/6PiYOSaV7tC8mK/nGOZGvi",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEANvteirpn2yQ8\u002BCEENjWqUkGgdO89744knTzsPJS7YkUupu\u002BxciQf4dYuIchggTqz\u002B0Tnmhh6M576JlmzChAv\u002BriAHywYcxgQ85/Pn/wMmNji2GkocOBr0pQU6aNdDT18JfvMQyDev\u002BMfnTfIkYXyTKUJ34mgXKDvW0ChAbIr4xZ4qbUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB3Asv0DT9Rp25vB/tY8OVqmSFB6TIqyvYJp1hkhdMY7LDq8BkHJBhiMETrNHpb/9chl6A5zRMIkK8CSLuOmKvfm8CQgDAUkspG/9fDOxASmbqDNvVXm0h9T/9iQyT3d\u002BlNFGMgNlbxKDmyPbT829v2GxrhlmANDyY17jw89NUbrZqn\u002B1WcA==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "4ebad00f626f44c7a9fec603ae359669"
+        "request_id": "4533a65b44d445ae95c079a62bb9c02e"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/244092181/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "b8b22cf1531d65f600979db9e9fda304",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "937",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:48 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b8b22cf1531d65f600979db9e9fda304",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "d03fd36c-c4c4-4461-a6b4-111558c92f84",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "2c95be27-9a82-4488-9d1b-c5a5e0e49715",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/244092181/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAFgmXRM9uHvhrSQdoTkZctillEi6DoKoM17gDc5jv\u002B712sy/KW5LiBf21dp3OVWtXHQa5Aw8r7mWqLn6rnc1tuCCAURy47r8r91VRc8957k0dGxf8/OKFGbfXD9xk14J4Y3ed6ADRYaRveX2PGJpRUX0AQ7UbMAz7T4nCJHe1XjyIC65oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBgW590tWSqHYsw\u002BrF84tQYR040sOlW3aE24g/MH5s51MHLN1TMulzBR6jtVitJ0KZ4jcqnIAkmJffs7VuncgOZe0CQSqcjYYKYQaw59e86L6sVBcxf4sfsMmn5yuzsV3965oHFgPNnGjPNOq\u002BuWmxc2xKQ/6PiYOSaV7tC8mK/nGOZGvi",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEANvteirpn2yQ8\u002BCEENjWqUkGgdO89744knTzsPJS7YkUupu\u002BxciQf4dYuIchggTqz\u002B0Tnmhh6M576JlmzChAv\u002BriAHywYcxgQ85/Pn/wMmNji2GkocOBr0pQU6aNdDT18JfvMQyDev\u002BMfnTfIkYXyTKUJ34mgXKDvW0ChAbIr4xZ4qbUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB3Asv0DT9Rp25vB/tY8OVqmSFB6TIqyvYJp1hkhdMY7LDq8BkHJBhiMETrNHpb/9chl6A5zRMIkK8CSLuOmKvfm8CQgDAUkspG/9fDOxASmbqDNvVXm0h9T/9iQyT3d\u002BlNFGMgNlbxKDmyPbT829v2GxrhlmANDyY17jw89NUbrZqn\u002B1WcA==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "4ebad00f626f44c7a9fec603ae359669"
+        "request_id": "4533a65b44d445ae95c079a62bb9c02e"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/244092181/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "5d7f886e87297804ac9bf8867d049bff",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "937",
+        "Content-Length": "847",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:53 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5d7f886e87297804ac9bf8867d049bff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "c1107658-28d6-4565-8605-acfad90818a4",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "5b0fd9f4-5eb9-4323-933e-6357290e9160",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/244092181/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAFgmXRM9uHvhrSQdoTkZctillEi6DoKoM17gDc5jv\u002B712sy/KW5LiBf21dp3OVWtXHQa5Aw8r7mWqLn6rnc1tuCCAURy47r8r91VRc8957k0dGxf8/OKFGbfXD9xk14J4Y3ed6ADRYaRveX2PGJpRUX0AQ7UbMAz7T4nCJHe1XjyIC65oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBgW590tWSqHYsw\u002BrF84tQYR040sOlW3aE24g/MH5s51MHLN1TMulzBR6jtVitJ0KZ4jcqnIAkmJffs7VuncgOZe0CQSqcjYYKYQaw59e86L6sVBcxf4sfsMmn5yuzsV3965oHFgPNnGjPNOq\u002BuWmxc2xKQ/6PiYOSaV7tC8mK/nGOZGvi",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEANvteirpn2yQ8\u002BCEENjWqUkGgdO89744knTzsPJS7YkUupu\u002BxciQf4dYuIchggTqz\u002B0Tnmhh6M576JlmzChAv\u002BriAHywYcxgQ85/Pn/wMmNji2GkocOBr0pQU6aNdDT18JfvMQyDev\u002BMfnTfIkYXyTKUJ34mgXKDvW0ChAbIr4xZ4qbUoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIB3Asv0DT9Rp25vB/tY8OVqmSFB6TIqyvYJp1hkhdMY7LDq8BkHJBhiMETrNHpb/9chl6A5zRMIkK8CSLuOmKvfm8CQgDAUkspG/9fDOxASmbqDNvVXm0h9T/9iQyT3d\u002BlNFGMgNlbxKDmyPbT829v2GxrhlmANDyY17jw89NUbrZqn\u002B1WcA==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "4ebad00f626f44c7a9fec603ae359669"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/244092181",
+        "request_id": "4533a65b44d445ae95c079a62bb9c02e"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/244092181?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "02149e760dfac07a134c54b5bed34410",
         "x-ms-return-client-request-id": "true"
@@ -300,79 +305,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "845",
+        "Content-Length": "1931",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:59 GMT",
+        "Date": "Thu, 08 Apr 2021 02:25:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "02149e760dfac07a134c54b5bed34410",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a4c47439-f2a0-4c47-a0a1-aa434f16e637",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "7cac9566-eb7f-4317-a3b0-3c753ad660e6",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoDCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAFgmXRM9uHvhrSQdoTkZctillEi6DoKoM17gDc5jv\u002B712sy/KW5LiBf21dp3OVWtXHQa5Aw8r7mWqLn6rnc1tuCCAURy47r8r91VRc8957k0dGxf8/OKFGbfXD9xk14J4Y3ed6ADRYaRveX2PGJpRUX0AQ7UbMAz7T4nCJHe1XjyIC65oEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYsAMIGHAkIBgW590tWSqHYsw\u002BrF84tQYR040sOlW3aE24g/MH5s51MHLN1TMulzBR6jtVitJ0KZ4jcqnIAkmJffs7VuncgOZe0CQSqcjYYKYQaw59e86L6sVBcxf4sfsMmn5yuzsV3965oHFgPNnGjPNOq\u002BuWmxc2xKQ/6PiYOSaV7tC8mK/nGOZGvi",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/244092181",
-        "request_id": "4ebad00f626f44c7a9fec603ae359669"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/244092181?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ab2f22f435f56a25283a0b825a70e7fc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1936",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:04:59 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "109744ec-1a5f-49a7-b776-e02932abc617",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/244092181/0f2c3398d9a044e4af053e019bbd7aaa",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/244092181/0f2c3398d9a044e4af053e019bbd7aaa",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/244092181/0f2c3398d9a044e4af053e019bbd7aaa",
-        "x5t": "wlPjlFjG6XTCSExTKGKNZoMlIVM",
-        "cer": "MIICJTCCAYegAwIBAgIQWw8Rg\u002BjhRr\u002BfrfW7W1ysCzAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTQ1N1oXDTIyMDMwNTIzMDQ1N1owEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAFgmXRM9uHvhrSQdoTkZctillEi6DoKoM17gDc5jv\u002B712sy/KW5LiBf21dp3OVWtXHQa5Aw8r7mWqLn6rnc1tuCCAURy47r8r91VRc8957k0dGxf8/OKFGbfXD9xk14J4Y3ed6ADRYaRveX2PGJpRUX0AQ7UbMAz7T4nCJHe1XjyIC65o3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUO7fn0b4J6zY72jT54e0hx15O1TgwHQYDVR0OBBYEFDu359G\u002BCes2O9o0\u002BeHtIcdeTtU4MAoGCCqGSM49BAMEA4GLADCBhwJCAZepfSmATWgseAc99KLhnpL6spemhdY/ARvQKoiOeCvSvGtiuUkhNJOa4wzdmQ\u002BW229hm5qGKD3lzRMhV/7ZFEOsAkELIl2GqF7jB\u002B8XBoq4j6Uf2j\u002BkAyyKd28C\u002BB15yKdJWWLvhQLsE4cVFoWqhsLS5N/VOfw1udJqAJ527Gknne4reQ==",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/244092181/7802acbb444e4c6e9d7c56d788fb91df",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/244092181/7802acbb444e4c6e9d7c56d788fb91df",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/244092181/7802acbb444e4c6e9d7c56d788fb91df",
+        "x5t": "aeGfRi53P5yCN95BuvAdjHBAtas",
+        "cer": "MIICJjCCAYegAwIBAgIQZ4jAyJujTS6n1finQgJbUjAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTU1NloXDTIyMDQwODAyMjU1NlowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEANvteirpn2yQ8\u002BCEENjWqUkGgdO89744knTzsPJS7YkUupu\u002BxciQf4dYuIchggTqz\u002B0Tnmhh6M576JlmzChAv\u002BriAHywYcxgQ85/Pn/wMmNji2GkocOBr0pQU6aNdDT18JfvMQyDev\u002BMfnTfIkYXyTKUJ34mgXKDvW0ChAbIr4xZ4qbUo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUoQaWchD9/AKPUD5zBtqB3YOdaK8wHQYDVR0OBBYEFKEGlnIQ/fwCj1A\u002Bcwbagd2DnWivMAoGCCqGSM49BAMEA4GMADCBiAJCAOqofSeQkysyDy76Zs1s8crpwxr4dgCnXgDDm180tTevcGt5Hr12TNWCWPgocjmlfek6LP0aquntadsmThehHGXdAkIBWMfZGm/Hg6QznzTxRV3a/rAmtNAjScUJxf1wE/LYqzNpLnT\u002BVPewmweKInmPf13uUt\u002BeZmGltDYX0sQXlSzIh5Y=",
         "attributes": {
           "enabled": true,
-          "nbf": 1614984897,
-          "exp": 1646521497,
-          "created": 1614985497,
-          "updated": 1614985497,
+          "nbf": 1617848156,
+          "exp": 1649384756,
+          "created": 1617848757,
+          "updated": 1617848757,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/244092181/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/244092181/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -412,65 +375,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614985479,
-            "updated": 1614985479
+            "created": 1617848744,
+            "updated": 1617848744
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/244092181/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/244092181/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/244092181/0f2c3398d9a044e4af053e019bbd7aaa?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/244092181/7802acbb444e4c6e9d7c56d788fb91df?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-41902ec3b474094fbeb300902970390b-61774b15cd28594f-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "ab2f22f435f56a25283a0b825a70e7fc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:26:03 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ab2f22f435f56a25283a0b825a70e7fc",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "1044a046-0806-4f5a-af8a-8bf9f6e5a715",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/244092181/7802acbb444e4c6e9d7c56d788fb91df?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-1c831aada5e37047a89c1ce456114d45-739a24f9d77a694c-00",
+        "traceparent": "00-41902ec3b474094fbeb300902970390b-61774b15cd28594f-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "4a429efca0e860090dbf4adc324eb9d9",
+        "x-ms-client-request-id": "ab2f22f435f56a25283a0b825a70e7fc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "529",
+        "Content-Length": "528",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:04 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ab2f22f435f56a25283a0b825a70e7fc",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "03ba798a-4d5d-4879-86f6-7ef3b3e4437b",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "dffc0742-1de3-4e6a-980b-adb6784e4201",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/244092181/0f2c3398d9a044e4af053e019bbd7aaa",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/244092181/7802acbb444e4c6e9d7c56d788fb91df",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-521",
-          "x": "AFgmXRM9uHvhrSQdoTkZctillEi6DoKoM17gDc5jv-712sy_KW5LiBf21dp3OVWtXHQa5Aw8r7mWqLn6rnc1tuCC",
-          "y": "AURy47r8r91VRc8957k0dGxf8_OKFGbfXD9xk14J4Y3ed6ADRYaRveX2PGJpRUX0AQ7UbMAz7T4nCJHe1XjyIC65"
+          "x": "ANvteirpn2yQ8-CEENjWqUkGgdO89744knTzsPJS7YkUupu-xciQf4dYuIchggTqz-0Tnmhh6M576JlmzChAv-ri",
+          "y": "AHywYcxgQ85_Pn_wMmNji2GkocOBr0pQU6aNdDT18JfvMQyDev-MfnTfIkYXyTKUJ34mgXKDvW0ChAbIr4xZ4qbU"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614984897,
-          "exp": 1646521497,
-          "created": 1614985497,
-          "updated": 1614985497,
+          "nbf": 1617848156,
+          "exp": 1649384756,
+          "created": 1617848757,
+          "updated": 1617848757,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -478,19 +482,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/244092181/0f2c3398d9a044e4af053e019bbd7aaa/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/244092181/7802acbb444e4c6e9d7c56d788fb91df/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "112",
         "Content-Type": "application/json",
-        "traceparent": "00-1c831aada5e37047a89c1ce456114d45-20ba15ffd7f3f847-00",
+        "traceparent": "00-41902ec3b474094fbeb300902970390b-f3e5e094b2a51f4b-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "5a91e756efd4410978aad9bf01f765a3",
+        "x-ms-client-request-id": "4a429efca0e860090dbf4adc324eb9d9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -500,35 +504,89 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "283",
+        "Content-Length": "282",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:04 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4a429efca0e860090dbf4adc324eb9d9",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "b5b33005-b399-4044-8ab2-1f77720c6bc3",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "f2a1f024-45ab-48a6-9859-952beabd1109",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/244092181/0f2c3398d9a044e4af053e019bbd7aaa",
-        "value": "AEku3MGj3-gDw5dJ1lFGJEbh_HVwsFT5PQSgh_u2FopxCryaFyPDvG3LB1aeIj_Y2AkDQO-uAT8xMWjxuBDg2UF9AQXXy3PWHzzh2dzCHKGfpeRsSdb2uM9IGeVIVHOdOOoqFWuTyRyqMzltGrfhsOyUXm9FSX6U5japyCM4KnZ4OLSu"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/244092181/7802acbb444e4c6e9d7c56d788fb91df",
+        "value": "AGypZ4giVJTYUpX3eqaUNsyTsNB19-T2icz-GsfG6WfvREZuRaBVWvhbaUzNG-1RWI3qs16cSPiaLzBngowRWNSrAJoRDORSMVOYO2tsPvWQQSnL2Id_N-OAjJeqOryip3y8ZBKwb9qz2pdA9tV4Dv6kQJDtxF22VWwMt86CaPExjdi_"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/244092181/0f2c3398d9a044e4af053e019bbd7aaa?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/244092181/7802acbb444e4c6e9d7c56d788fb91df?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-e98f706cb03ece4383729cf70f512110-4c010b79b4517f4f-00",
+        "traceparent": "00-004e4ebb224d1245bf57a3001afd95a2-50c77071cbe20549-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "5a91e756efd4410978aad9bf01f765a3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1340",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:26:04 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5a91e756efd4410978aad9bf01f765a3",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "9772ed8a-4e52-4c19-8c97-c360d950e63e",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "id": "https://heathskvtest2.vault.azure.net/certificates/244092181/7802acbb444e4c6e9d7c56d788fb91df",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/244092181/7802acbb444e4c6e9d7c56d788fb91df",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/244092181/7802acbb444e4c6e9d7c56d788fb91df",
+        "x5t": "aeGfRi53P5yCN95BuvAdjHBAtas",
+        "cer": "MIICJjCCAYegAwIBAgIQZ4jAyJujTS6n1finQgJbUjAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMTU1NloXDTIyMDQwODAyMjU1NlowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEANvteirpn2yQ8\u002BCEENjWqUkGgdO89744knTzsPJS7YkUupu\u002BxciQf4dYuIchggTqz\u002B0Tnmhh6M576JlmzChAv\u002BriAHywYcxgQ85/Pn/wMmNji2GkocOBr0pQU6aNdDT18JfvMQyDev\u002BMfnTfIkYXyTKUJ34mgXKDvW0ChAbIr4xZ4qbUo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUoQaWchD9/AKPUD5zBtqB3YOdaK8wHQYDVR0OBBYEFKEGlnIQ/fwCj1A\u002Bcwbagd2DnWivMAoGCCqGSM49BAMEA4GMADCBiAJCAOqofSeQkysyDy76Zs1s8crpwxr4dgCnXgDDm180tTevcGt5Hr12TNWCWPgocjmlfek6LP0aquntadsmThehHGXdAkIBWMfZGm/Hg6QznzTxRV3a/rAmtNAjScUJxf1wE/LYqzNpLnT\u002BVPewmweKInmPf13uUt\u002BeZmGltDYX0sQXlSzIh5Y=",
+        "attributes": {
+          "enabled": true,
+          "nbf": 1617848156,
+          "exp": 1649384756,
+          "created": 1617848757,
+          "updated": 1617848757,
+          "recoveryLevel": "Recoverable\u002BPurgeable",
+          "recoverableDays": 90
+        },
+        "subject": "CN=default",
+        "issuer": "CN=default",
+        "serialnumber": "6788C0C89BA34D2EA7D5F8A742025B52"
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/244092181/7802acbb444e4c6e9d7c56d788fb91df?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Type": "application/json",
+        "traceparent": "00-004e4ebb224d1245bf57a3001afd95a2-f1f9ce6cb535af42-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "20b95864f990542818cf9d36eb4937da",
         "x-ms-return-client-request-id": "true"
@@ -537,91 +595,40 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1343",
+        "Content-Length": "2125",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:04 GMT",
+        "Date": "Thu, 08 Apr 2021 02:26:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "20b95864f990542818cf9d36eb4937da",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "246f8a06-959f-43d5-b77c-ef89b6c2d865",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "fc4b04b7-4cf8-497b-bd5f-55328437121e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/244092181/0f2c3398d9a044e4af053e019bbd7aaa",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/244092181/0f2c3398d9a044e4af053e019bbd7aaa",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/244092181/0f2c3398d9a044e4af053e019bbd7aaa",
-        "x5t": "wlPjlFjG6XTCSExTKGKNZoMlIVM",
-        "cer": "MIICJTCCAYegAwIBAgIQWw8Rg\u002BjhRr\u002BfrfW7W1ysCzAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIyNTQ1N1oXDTIyMDMwNTIzMDQ1N1owEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAFgmXRM9uHvhrSQdoTkZctillEi6DoKoM17gDc5jv\u002B712sy/KW5LiBf21dp3OVWtXHQa5Aw8r7mWqLn6rnc1tuCCAURy47r8r91VRc8957k0dGxf8/OKFGbfXD9xk14J4Y3ed6ADRYaRveX2PGJpRUX0AQ7UbMAz7T4nCJHe1XjyIC65o3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUO7fn0b4J6zY72jT54e0hx15O1TgwHQYDVR0OBBYEFDu359G\u002BCes2O9o0\u002BeHtIcdeTtU4MAoGCCqGSM49BAMEA4GLADCBhwJCAZepfSmATWgseAc99KLhnpL6spemhdY/ARvQKoiOeCvSvGtiuUkhNJOa4wzdmQ\u002BW229hm5qGKD3lzRMhV/7ZFEOsAkELIl2GqF7jB\u002B8XBoq4j6Uf2j\u002BkAyyKd28C\u002BB15yKdJWWLvhQLsE4cVFoWqhsLS5N/VOfw1udJqAJ527Gknne4reQ==",
-        "attributes": {
-          "enabled": true,
-          "nbf": 1614984897,
-          "exp": 1646521497,
-          "created": 1614985497,
-          "updated": 1614985497,
-          "recoveryLevel": "Recoverable\u002BPurgeable",
-          "recoverableDays": 90
-        },
-        "subject": "CN=default",
-        "issuer": "CN=default",
-        "serialnumber": "5B0F1183E8E146BF9FADF5BB5B5CAC0B"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/244092181/0f2c3398d9a044e4af053e019bbd7aaa?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "traceparent": "00-e98f706cb03ece4383729cf70f512110-3cb93ad54e4af249-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "732c32818dde0c289401d23ec64a5e16",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "2127",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:05:04 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9df70fd3-322f-4f74-a251-41ef2583f78d",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "value": "MIIE\u002BgIBAzCCBLYGCSqGSIb3DQEHAaCCBKcEggSjMIIEnzCCAdgGCSqGSIb3DQEHAaCCAckEggHFMIIBwTCCAb0GCyqGSIb3DQEMCgECoIIBNjCCATIwHAYKKoZIhvcNAQwBAzAOBAiF4Fd6V06JoQICB9AEggEQeLqnnTE8g4dfQ05D46rdNeExDcSgNMwN0l4rt5D8ZAIzQ0if9YgAwK9OzxInjS4p2FrJBX51Z/pGshl6JEdL/wooivT304udJaTdYcEQ\u002BJG6Mb71x\u002Bbck\u002BUPLhcUEh/oMgoRyxs8pi0WRyaMpJn6qMzu00ugpH2LMPBYWjpaKNThgZJLL8OHc5tn4k7hblexhNZr46wstANKdObuyBebbrBpD8wXoeij4aQxi/7ovK569ulwyEQvkj7VL/TGl\u002BSmj1qBoYcRjwwfattgTm3fpFrMhKblgNTG1JT6oKo70I5AQd2j0NA9Bbt62eLsVvdwTotKLBQql8x6L4gE\u002BaSU1xsm5in4zEmxvZfNEdjXw2wxdDATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEEAYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwBvAGYAdAB3AGEAcgBlACAASwBlAHkAIABTAHQAbwByAGEAZwBlACAAUAByAG8AdgBpAGQAZQByMIICvwYJKoZIhvcNAQcGoIICsDCCAqwCAQAwggKlBgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBAzAOBAgZjzh558jZSwICB9CAggJ4kA90SU9c9YrQwJr4zYjNDkDiI2rfB2k0\u002BW4ulrG6elGXoCfmLqhffL7Mds3NUqPrrC2YVYe/wQOWN\u002B8y8MQkFI9Yafgf32tQsW1t/gXh29e69e0gzrqtEEabM8lC3MM52bNLl4lJxsLgAMfds6Qn\u002BOwaBxem6kybgAfRj49coiE/E5YuiTOJF5Ni\u002BO9xmxitBZKoyaVsOO/CTe70ZRZfjtJwyLhmVlr6BUK3HxqyiKhig9\u002Bq/hkAoJVTx8ER25ApX/JOi3epZlmRr3Suupg0OZ1NLuktcAxHABeyx/Yjd/b9aChWcFBklXHVkI4o5x\u002BxouYipFOFblLhnWOmlHdwpdaVueyVEPDQkrqncZHpc7O\u002Bkk4V/9XVbmDaY/eLLtK59EwxFMBJLhZxeKpAkbhmwzOxEbkSybsYx7HZcVDoP\u002BOHlu9NX3bQHX0Y5plbSlFiT8AikQdydCjjt52RTYaZLyKIeOdlDOgK9XniWO3N6uklVs2YmRuNQp99Hj7CwONT7cbpabSSC2WSa/RfNIxeN\u002BYcwithXsQ9L76LmQQZWkWnCEI72YHtDcsOfn3g9jDlW7tX\u002BrPt13nqoQtjQORDaF4JhxtWqhAhWPiGczjxLXQjLoKuu3SHjRmGEPBYFwV8hKI4a4f2yWxcans0khDQgd6/TQ\u002BNZjusdsz2JCOxmWqKlgmyULMFnErQyJgSxwa9MIvV9z3sy4gHbIy6j82T1PTFIq2gpMSpfBTX\u002Bz5Q5pbHtxvwvqiOp70jdQUAbqxoB5eC8NicT9XntAwfnKIevwaiVZ2k4\u002BBEz0DZlrQ2JEPEN4l4vZGbgpS2NRYOZoY54KEdgDe4UIwwOzAfMAcGBSsOAwIaBBTBeEX87YkVkHfIJNq2V/elErEIoQQUbP0\u002B\u002B9LqYnvTKZ3fAJy2GX8nS0cCAgfQ",
+        "value": "MIIE\u002BgIBAzCCBLYGCSqGSIb3DQEHAaCCBKcEggSjMIIEnzCCAdgGCSqGSIb3DQEHAaCCAckEggHFMIIBwTCCAb0GCyqGSIb3DQEMCgECoIIBNjCCATIwHAYKKoZIhvcNAQwBAzAOBAhciWNSyZ3v8wICB9AEggEQuleemkNF/Spm9AtWTvjMtZx0vfxH75QxSqJIq4k04Ohq47UU0yFILmukyNEORmta1YQpCNA5JAELboANf\u002ByQRSp5Baed\u002Bvq2iEKXOw5APfMNOECVYGUVQFI04nFZjG8PAtEBpS8jBQqscTkiLpouBjPRLjpOtyxDcjUH9\u002BzDAQWmene3Zo7/D8rAD1fMgIIXXjvRL9lHRf7ko/IJpLIjHPFl2boiVy9m4Aysgqg1147Vp0aOIQu9LoRWAT21LQVmhFzGVIc6S5eYlhbKC6W7ZBq1eqHiRh3L5xoMe7IWTwRLZTNFyaie\u002BM2hcp3X5I1IP3z8VljOSpOITOLWqBZosanKNLJl8TkjYFk1MFuJEoUxdDATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEEAYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwBvAGYAdAB3AGEAcgBlACAASwBlAHkAIABTAHQAbwByAGEAZwBlACAAUAByAG8AdgBpAGQAZQByMIICvwYJKoZIhvcNAQcGoIICsDCCAqwCAQAwggKlBgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBAzAOBAglILYwcTHoEQICB9CAggJ48V1pwQlLIaZN1d2hEzpCGsFUrg/H22EBR2WyOoVy2CqABxZ1w3Ip90vUMQUgpPKkNcLXhAbbGwKtNExUi9nca3qWHuzH\u002BcwPpgGx\u002Bqd1w6J426aBYxqGICh6iAY222wg5bFHMn6KAXqNXmx8EBp5c/f1yjOQJpGCgdsSnGKuwyUju6a2oJvs043C7KncgrCCLpaTJnRfC82\u002BThfn5q\u002BlVVYH2rENMI4ZAEpjMmW2wnaDlA4MfirJRxMrYauy3XB/DgKnE1ZGOrXFyzKRqhVRy\u002BdQwPgRnBLkGWhJiA3\u002BQbYBJTo6V9DrAC12zKYKpG9TDrnVHp9KUrV\u002B1SzzC8SwYTEbZiqGkb8bS8z6EKDSKTSIOdcQ5EDkXCBGFuqYlCYDyAjukmw3tp0SqPq8oBNAEIlQ5F7FSXwis1C4Lu0jhNGs/kF6S9In74M89e9hRXGeNWybIBAVioyaCUu98AL826yp0NgFbZcoEDLM0xrzvhCEBvIyB4hH84AxOvvEnkkVUc7ESIjBZ\u002Br\u002B33Z3JV2MJxuUbZDYktU/WD7sJ6m5lCZ8ZnXGExA4JMyPgA0s9yBylvUFkmxRY7P9wNqV6WPQuZWjZdSDlyl6TRqkBlQ6zITvE5lz9KMn6QmRbhTO3jXytI4vSu2d18hly7eZtuI2VCQLReTwC49\u002B2C1kGHWJtSJndqAp00S91zlpqIxWZga3yxQcskPs76tEvR/jyF6iO8UWcaBlqtN\u002Bd97IeXRWI/gq22DPu7Cx/\u002B21ywMb8hO\u002BD2HypOnXsMUwtCtUABowb8brW\u002BgnSicJ1PilG9Jpc7348YcBont0zyZdT2DQss7FEdCFhqKLB14wOzAfMAcGBSsOAwIaBBRDyYq8KvGstre78eQUKyqgoCPajgQUR/IjpDWPfHC3yTb8GnU9B8LXcukCAgfQ",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/244092181/0f2c3398d9a044e4af053e019bbd7aaa",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/244092181/7802acbb444e4c6e9d7c56d788fb91df",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614984897,
-          "exp": 1646521497,
-          "created": 1614985497,
-          "updated": 1614985497,
+          "nbf": 1617848156,
+          "exp": 1649384756,
+          "created": 1617848757,
+          "updated": 1617848757,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/244092181/0f2c3398d9a044e4af053e019bbd7aaa"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/244092181/7802acbb444e4c6e9d7c56d788fb91df"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "1041908318"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-521)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/DownloadECDsaCertificateSignRemoteVerifyLocal(application%x-pkcs12,P-521)Async.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/273129278/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "traceparent": "00-04dd20e75f877b4baf3b20e39a1253ea-3059e664e34b574e-00",
+        "traceparent": "00-968c28207b2bb742bf154495e44c1c0f-ac120d691f3f764a-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "f518898c59cb04079988e1bdf7bcbc8b",
         "x-ms-return-client-request-id": "true"
@@ -20,16 +20,17 @@
         "Cache-Control": "no-cache",
         "Content-Length": "87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f518898c59cb04079988e1bdf7bcbc8b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "b478bc83-460e-4c4d-8874-85c3fd4dda58",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "a57dcbf3-88dd-48b3-9e1e-34cfbc025d33",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -40,17 +41,17 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/create?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/273129278/create?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-04dd20e75f877b4baf3b20e39a1253ea-3059e664e34b574e-00",
+        "traceparent": "00-968c28207b2bb742bf154495e44c1c0f-ac120d691f3f764a-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "f518898c59cb04079988e1bdf7bcbc8b",
         "x-ms-return-client-request-id": "true"
@@ -79,43 +80,44 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:16 GMT",
         "Expires": "-1",
-        "Location": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2\u0026request_id=69ccd59910f8454898f6366d3405dda6",
+        "Location": "https://heathskvtest2.vault.azure.net/certificates/273129278/pending?api-version=7.2\u0026request_id=25d4c41050bf4553b634046ddf07e751",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f518898c59cb04079988e1bdf7bcbc8b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5ba04dd1-8b60-4bd5-a27d-437d079b15e1",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ab39a058-3890-473f-9046-ed91f7b99b00",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/273129278/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGLm/IK6AxLo4RmCHtVxfuW0k1WM5WJ2LgTRBG0FN7RKjpCuvd/egg2jAnnIeyWh10xxyz84kkgWHP8ZYefgYkrSAXeDcbanPSJ7FNJ09Bx7uGfaelEzxnDTuXzM4nUyHg/zZGKRwqog6K/BYDLXRtu1b0TpgRPK3PxD9LEsFAcSEhLnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBhgYicZzJWFRWBGw0rMmLsE0XzZ1\u002BaCoHF1JqeKWm3XYT4W6xcMy1HAx3yYrizEeztP01Mf6RK9R9E8zvPWotdWYCQgEMgqJ13LLqAe1L7bi\u002BGTfcs8rF///kAoM0L88LQkHoTH3Uq7MS8SrqkueYan0sXwgi/WHYxwGr3aPW2hR\u002BE7XwwQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
+        "request_id": "25d4c41050bf4553b634046ddf07e751"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/273129278/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "f60cd19aa7b7dc33da7e868c20129237",
         "x-ms-return-client-request-id": "true"
@@ -124,42 +126,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:42 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f60cd19aa7b7dc33da7e868c20129237",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "03249ea1-bcb5-4904-89ed-b076b4889b77",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "b2bc59bb-22f9-455e-95ad-ffc069f5cb64",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/273129278/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGLm/IK6AxLo4RmCHtVxfuW0k1WM5WJ2LgTRBG0FN7RKjpCuvd/egg2jAnnIeyWh10xxyz84kkgWHP8ZYefgYkrSAXeDcbanPSJ7FNJ09Bx7uGfaelEzxnDTuXzM4nUyHg/zZGKRwqog6K/BYDLXRtu1b0TpgRPK3PxD9LEsFAcSEhLnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBhgYicZzJWFRWBGw0rMmLsE0XzZ1\u002BaCoHF1JqeKWm3XYT4W6xcMy1HAx3yYrizEeztP01Mf6RK9R9E8zvPWotdWYCQgEMgqJ13LLqAe1L7bi\u002BGTfcs8rF///kAoM0L88LQkHoTH3Uq7MS8SrqkueYan0sXwgi/WHYxwGr3aPW2hR\u002BE7XwwQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
+        "request_id": "25d4c41050bf4553b634046ddf07e751"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/273129278/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "c26ec978b75a4d54c469ad5e035060af",
         "x-ms-return-client-request-id": "true"
@@ -168,42 +171,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:47 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c26ec978b75a4d54c469ad5e035060af",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0f20aaec-2c9d-40ae-b0cd-c60ef4690815",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "ee54f57a-a47a-4fe7-9fc0-1dbe42c2674b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/273129278/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGLm/IK6AxLo4RmCHtVxfuW0k1WM5WJ2LgTRBG0FN7RKjpCuvd/egg2jAnnIeyWh10xxyz84kkgWHP8ZYefgYkrSAXeDcbanPSJ7FNJ09Bx7uGfaelEzxnDTuXzM4nUyHg/zZGKRwqog6K/BYDLXRtu1b0TpgRPK3PxD9LEsFAcSEhLnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBhgYicZzJWFRWBGw0rMmLsE0XzZ1\u002BaCoHF1JqeKWm3XYT4W6xcMy1HAx3yYrizEeztP01Mf6RK9R9E8zvPWotdWYCQgEMgqJ13LLqAe1L7bi\u002BGTfcs8rF///kAoM0L88LQkHoTH3Uq7MS8SrqkueYan0sXwgi/WHYxwGr3aPW2hR\u002BE7XwwQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
+        "request_id": "25d4c41050bf4553b634046ddf07e751"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/273129278/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "357341154638e486563c1a4cd27ae387",
         "x-ms-return-client-request-id": "true"
@@ -212,42 +216,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:52 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:27 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "357341154638e486563c1a4cd27ae387",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "fea85aec-15f6-4c71-9798-7bc3707a674e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "252e7cfe-6ba9-48f3-981e-9423474b00f6",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/273129278/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGLm/IK6AxLo4RmCHtVxfuW0k1WM5WJ2LgTRBG0FN7RKjpCuvd/egg2jAnnIeyWh10xxyz84kkgWHP8ZYefgYkrSAXeDcbanPSJ7FNJ09Bx7uGfaelEzxnDTuXzM4nUyHg/zZGKRwqog6K/BYDLXRtu1b0TpgRPK3PxD9LEsFAcSEhLnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBhgYicZzJWFRWBGw0rMmLsE0XzZ1\u002BaCoHF1JqeKWm3XYT4W6xcMy1HAx3yYrizEeztP01Mf6RK9R9E8zvPWotdWYCQgEMgqJ13LLqAe1L7bi\u002BGTfcs8rF///kAoM0L88LQkHoTH3Uq7MS8SrqkueYan0sXwgi/WHYxwGr3aPW2hR\u002BE7XwwQ==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
+        "request_id": "25d4c41050bf4553b634046ddf07e751"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/273129278/pending?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "2e45aaf5f94ee2307dbf324efad5d88a",
         "x-ms-return-client-request-id": "true"
@@ -256,42 +261,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "847",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:13:58 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:32 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2e45aaf5f94ee2307dbf324efad5d88a",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "774301c1-ba4d-40f2-9024-c144ba9f718f",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "6fe8c4ec-372f-4dd0-8856-e99de0f9bde9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/273129278/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
+        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGLm/IK6AxLo4RmCHtVxfuW0k1WM5WJ2LgTRBG0FN7RKjpCuvd/egg2jAnnIeyWh10xxyz84kkgWHP8ZYefgYkrSAXeDcbanPSJ7FNJ09Bx7uGfaelEzxnDTuXzM4nUyHg/zZGKRwqog6K/BYDLXRtu1b0TpgRPK3PxD9LEsFAcSEhLnoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIBhgYicZzJWFRWBGw0rMmLsE0XzZ1\u002BaCoHF1JqeKWm3XYT4W6xcMy1HAx3yYrizEeztP01Mf6RK9R9E8zvPWotdWYCQgEMgqJ13LLqAe1L7bi\u002BGTfcs8rF///kAoM0L88LQkHoTH3Uq7MS8SrqkueYan0sXwgi/WHYxwGr3aPW2hR\u002BE7XwwQ==",
         "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
+        "status": "completed",
+        "target": "https://heathskvtest2.vault.azure.net/certificates/273129278",
+        "request_id": "25d4c41050bf4553b634046ddf07e751"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/273129278?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
         "x-ms-client-request-id": "df77d71e5c9f32ff43896c1e9c077a4a",
         "x-ms-return-client-request-id": "true"
@@ -300,387 +305,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "941",
+        "Content-Length": "1931",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:03 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "dce46223-0d48-4ea1-91a5-2ea63f830ffa",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "59682685320a1b601090b8781338ea80",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "941",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:07 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "f894a95f-010d-4ae5-a736-616480ff7892",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "fb2d9063040299e8ab13ebc48c124675",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "941",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "2f22a9ba-ac39-4b49-b9d7-ac8b448262fb",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "d3c8e7447f6cec7f765bce0ea4861e0b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "941",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:18 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0ff3fba2-f922-4def-abb9-d9f6c6ffefc7",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0bbbeb9e7fd981473ecfaef7469c8ffe",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "941",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:23 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "59a6c220-ecb3-4eff-abbd-66d337a626ee",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "2c33424a166fe414104185a635d9f424",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "941",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:28 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "9a061b9c-0f92-482a-8a2d-cbc6b054ac37",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "a026e0f53a56c59b9f47959dd088a5da",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "941",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:33 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "351421d4-58fb-4eba-82c6-96bef62621ab",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
-        "cancellation_requested": false,
-        "status": "inProgress",
-        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "61c4d0ccf152879bd7d7fb98faa14b64",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "849",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:32 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "df77d71e5c9f32ff43896c1e9c077a4a",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "ca01f0a3-21ba-423f-83d9-d0aa4a03335e",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "7100f6c4-a635-40cf-8432-314d4f78f732",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending",
-        "issuer": {
-          "name": "Self"
-        },
-        "csr": "MIIBoTCCAQICAQAwEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwQDgYwAMIGIAkIA05EyFsbcxaOgDWnCzNeG2mWhYeybNqMNa9uWqXZJFCksKcDdfhFwf/pzv0NToi6lQjD5ix8\u002BtfUy37LgH7r\u002BZF0CQgEWVi5SQoZiaN4ZTfC\u002BiDtBhanMtsFTAUhzBTj9K4GOPF7Sr9Pm\u002BIRSHUaJf7p5d5YAM9uC/Y6TUA0hDCukYFSI3A==",
-        "cancellation_requested": false,
-        "status": "completed",
-        "target": "https://heathskeyvault.vault.azure.net/certificates/273129278",
-        "request_id": "69ccd59910f8454898f6366d3405dda6"
-      }
-    },
-    {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "660189daee750fa8a66e8c2781771388",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1936",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:38 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "5aba1582-2253-4ed6-853d-464bc32107fb",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/2cd8ce62a8724995aed6bd98543f4f4d",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/273129278/2cd8ce62a8724995aed6bd98543f4f4d",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/273129278/2cd8ce62a8724995aed6bd98543f4f4d",
-        "x5t": "h5zsD3wtUOrheTpwbe6QvBFaLwU",
-        "cer": "MIICJjCCAYegAwIBAgIQI1HyW\u002B4hTtCqq5kCkjm6bTAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDQzNVoXDTIyMDMwNTIzMTQzNVowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUwvC\u002B8HpvN5sLEpWtjI3j2zsyp9wwHQYDVR0OBBYEFMLwvvB6bzebCxKVrYyN49s7MqfcMAoGCCqGSM49BAMEA4GMADCBiAJCAY6TxOi116U1ltsbl0/Qt9dk3wdRBnaZ7jeVJFtq\u002BHh6Fgm9eUNKRuJT57RPi0V6kPLQ\u002BkeSkEGNKybIIAI7w\u002BeNAkIAk15dr692rvTEnNEE5UGv74Ack2vAlG4zC13Tj7fWlLAEgiwlkZS2EFq7irDUCgpZsfTVulNxuIg4HMqA1S3pE0c=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/273129278/54a4855697d74ae28d58949fa581ae3a",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/273129278/54a4855697d74ae28d58949fa581ae3a",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/273129278/54a4855697d74ae28d58949fa581ae3a",
+        "x5t": "5leHtHWzHHp8Y8bMz3ktO9_FVgE",
+        "cer": "MIICJTCCAYegAwIBAgIQWXcPcM6qTmaWIOVTnMcLmzAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjUzMloXDTIyMDQwODAyMzUzMlowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGLm/IK6AxLo4RmCHtVxfuW0k1WM5WJ2LgTRBG0FN7RKjpCuvd/egg2jAnnIeyWh10xxyz84kkgWHP8ZYefgYkrSAXeDcbanPSJ7FNJ09Bx7uGfaelEzxnDTuXzM4nUyHg/zZGKRwqog6K/BYDLXRtu1b0TpgRPK3PxD9LEsFAcSEhLno3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUV5EN7SHiVIn/YJBUq9zqPvnPiagwHQYDVR0OBBYEFFeRDe0h4lSJ/2CQVKvc6j75z4moMAoGCCqGSM49BAMEA4GLADCBhwJBMS13V9IH8UvuEY30Ym0tqx3524ZV87zqon1muLbhCaNl76g5BPiDV7\u002B8VduTbpF1anVzUki0jYn0dJVmXlDXL60CQgGUU90gGBrBGoLwGwRWUr4Diyz8yJad6xIJXWxl\u002BY97SBMbMss2Fps0HRi6cf7ERT2B/YhpuMwe6NGlTx4sB3zPow==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985475,
-          "exp": 1646522075,
-          "created": 1614986075,
-          "updated": 1614986075,
+          "nbf": 1617848732,
+          "exp": 1649385332,
+          "created": 1617849332,
+          "updated": 1617849332,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "policy": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/policy",
+          "id": "https://heathskvtest2.vault.azure.net/certificates/273129278/policy",
           "key_props": {
             "exportable": true,
             "kty": "EC",
@@ -720,65 +375,106 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1614986022,
-            "updated": 1614986022
+            "created": 1617849317,
+            "updated": 1617849317
           }
         },
         "pending": {
-          "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/pending"
+          "id": "https://heathskvtest2.vault.azure.net/certificates/273129278/pending"
         }
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/273129278/2cd8ce62a8724995aed6bd98543f4f4d?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/273129278/54a4855697d74ae28d58949fa581ae3a?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-238757382acf904eb0934ffe739a8d7d-9e58122343d0c847-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "59682685320a1b601090b8781338ea80",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "87",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 08 Apr 2021 02:35:32 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "59682685320a1b601090b8781338ea80",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "2341e216-6727-4424-9356-0299e0c3bede",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/273129278/54a4855697d74ae28d58949fa581ae3a?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-961a338954052849ba79596d622c2c09-fb7704b1de9e274a-00",
+        "traceparent": "00-238757382acf904eb0934ffe739a8d7d-9e58122343d0c847-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "65daaa9c931403d2449ec97f3f03cbfe",
+        "x-ms-client-request-id": "59682685320a1b601090b8781338ea80",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "529",
+        "Content-Length": "528",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:32 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "59682685320a1b601090b8781338ea80",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "0801c8c9-8d62-42fb-919f-6f830a30a4dd",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "2daf303e-9ca8-40c8-b8f9-1adb35166631",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathskeyvault.vault.azure.net/keys/273129278/2cd8ce62a8724995aed6bd98543f4f4d",
+          "kid": "https://heathskvtest2.vault.azure.net/keys/273129278/54a4855697d74ae28d58949fa581ae3a",
           "kty": "EC",
           "key_ops": [
             "sign",
             "verify"
           ],
           "crv": "P-521",
-          "x": "AIxqftsvW07X-8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK_NNZut1BpTWAY4x7gpHYM-ZX2",
-          "y": "AAVQETPBeqo-KUxVvz7bON1UprR0lBwhCGHSBXnGFeI_VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB-6rS"
+          "x": "AGLm_IK6AxLo4RmCHtVxfuW0k1WM5WJ2LgTRBG0FN7RKjpCuvd_egg2jAnnIeyWh10xxyz84kkgWHP8ZYefgYkrS",
+          "y": "AXeDcbanPSJ7FNJ09Bx7uGfaelEzxnDTuXzM4nUyHg_zZGKRwqog6K_BYDLXRtu1b0TpgRPK3PxD9LEsFAcSEhLn"
         },
         "attributes": {
           "enabled": true,
-          "nbf": 1614985475,
-          "exp": 1646522075,
-          "created": 1614986075,
-          "updated": 1614986075,
+          "nbf": 1617848732,
+          "exp": 1649385332,
+          "created": 1617849332,
+          "updated": 1617849332,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
@@ -786,19 +482,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/keys/273129278/2cd8ce62a8724995aed6bd98543f4f4d/sign?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/keys/273129278/54a4855697d74ae28d58949fa581ae3a/sign?api-version=7.2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "112",
         "Content-Type": "application/json",
-        "traceparent": "00-961a338954052849ba79596d622c2c09-d86ca0bc4b693f46-00",
+        "traceparent": "00-238757382acf904eb0934ffe739a8d7d-2cc82abdcded314d-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Keys/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "46c230fb3e86de6428b5bae465740660",
+        "x-ms-client-request-id": "fb2d9063040299e8ab13ebc48c124675",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -808,128 +504,131 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "283",
+        "Content-Length": "282",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:32 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "fb2d9063040299e8ab13ebc48c124675",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "1c7b7cbd-8258-4a6c-9aba-11c66dd2ba75",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "cdb60c6c-9f00-429e-ab78-632c14c1228d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "kid": "https://heathskeyvault.vault.azure.net/keys/273129278/2cd8ce62a8724995aed6bd98543f4f4d",
-        "value": "AX8XgdDMhkgdMxG3QDuGg6PMN9-Dvze518JIOOSQBqzMi8mGWgQdPzf3DLH8sToMf35eQZ3x5Awzp8Jb4ySLhKgjAZRlIsmfVLzS1qEC72najN5oHF7egYmI-PXlbJn-rI0AEtFFsLSL1ffXwRES4JVnJVULXjdXddtfvZ6Nga-FInp3"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/273129278/54a4855697d74ae28d58949fa581ae3a",
+        "value": "Adzv_DNwEpW3zuDuqcyShJqxFKeZQcI3_yEdLhcF5Hrdmv1wp5A4qfn5rKXzEDcj9R0IbQKs-txW5go7BFD-BPqVAQ6WXKCPOF_NMwVeEuY_Nf_QLuYOxMn1UKqNZa43l66TEbb1179jSGr--ubEmpDQ9EmvWlyGXJBj12ajRXX2PSeB"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/certificates/273129278/2cd8ce62a8724995aed6bd98543f4f4d?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/certificates/273129278/54a4855697d74ae28d58949fa581ae3a?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-e35968bf8e8d5d4e9685477ab901d1e9-69499333c56e374b-00",
+        "traceparent": "00-278a80c5327e90468f901fbfd9653218-ab56bc3a81965b48-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "4ffb72c3e6c74750b7fe22d72529d0a2",
+        "x-ms-client-request-id": "d3c8e7447f6cec7f765bce0ea4861e0b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1343",
+        "Content-Length": "1340",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:32 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "d3c8e7447f6cec7f765bce0ea4861e0b",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "a2444f2b-b62e-4012-9784-5b51f8305667",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "442171cb-2936-42a5-8c2c-d7660d9b7665",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://heathskeyvault.vault.azure.net/certificates/273129278/2cd8ce62a8724995aed6bd98543f4f4d",
-        "kid": "https://heathskeyvault.vault.azure.net/keys/273129278/2cd8ce62a8724995aed6bd98543f4f4d",
-        "sid": "https://heathskeyvault.vault.azure.net/secrets/273129278/2cd8ce62a8724995aed6bd98543f4f4d",
-        "x5t": "h5zsD3wtUOrheTpwbe6QvBFaLwU",
-        "cer": "MIICJjCCAYegAwIBAgIQI1HyW\u002B4hTtCqq5kCkjm6bTAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDMwNTIzMDQzNVoXDTIyMDMwNTIzMTQzNVowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAIxqftsvW07X\u002B8KpIJ1gXsz3D6rzgzve98YpzUBwIoqRUtK2WVqNbE0ICAc50iK/NNZut1BpTWAY4x7gpHYM\u002BZX2AAVQETPBeqo\u002BKUxVvz7bON1UprR0lBwhCGHSBXnGFeI/VZTeLNhGTnOusxhCWwRVJXQ8gDcTW52ECzG8HkLB\u002B6rSo3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUwvC\u002B8HpvN5sLEpWtjI3j2zsyp9wwHQYDVR0OBBYEFMLwvvB6bzebCxKVrYyN49s7MqfcMAoGCCqGSM49BAMEA4GMADCBiAJCAY6TxOi116U1ltsbl0/Qt9dk3wdRBnaZ7jeVJFtq\u002BHh6Fgm9eUNKRuJT57RPi0V6kPLQ\u002BkeSkEGNKybIIAI7w\u002BeNAkIAk15dr692rvTEnNEE5UGv74Ack2vAlG4zC13Tj7fWlLAEgiwlkZS2EFq7irDUCgpZsfTVulNxuIg4HMqA1S3pE0c=",
+        "id": "https://heathskvtest2.vault.azure.net/certificates/273129278/54a4855697d74ae28d58949fa581ae3a",
+        "kid": "https://heathskvtest2.vault.azure.net/keys/273129278/54a4855697d74ae28d58949fa581ae3a",
+        "sid": "https://heathskvtest2.vault.azure.net/secrets/273129278/54a4855697d74ae28d58949fa581ae3a",
+        "x5t": "5leHtHWzHHp8Y8bMz3ktO9_FVgE",
+        "cer": "MIICJTCCAYegAwIBAgIQWXcPcM6qTmaWIOVTnMcLmzAKBggqhkjOPQQDBDASMRAwDgYDVQQDEwdkZWZhdWx0MB4XDTIxMDQwODAyMjUzMloXDTIyMDQwODAyMzUzMlowEjEQMA4GA1UEAxMHZGVmYXVsdDCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAGLm/IK6AxLo4RmCHtVxfuW0k1WM5WJ2LgTRBG0FN7RKjpCuvd/egg2jAnnIeyWh10xxyz84kkgWHP8ZYefgYkrSAXeDcbanPSJ7FNJ09Bx7uGfaelEzxnDTuXzM4nUyHg/zZGKRwqog6K/BYDLXRtu1b0TpgRPK3PxD9LEsFAcSEhLno3wwejAOBgNVHQ8BAf8EBAMCB4AwCQYDVR0TBAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAUV5EN7SHiVIn/YJBUq9zqPvnPiagwHQYDVR0OBBYEFFeRDe0h4lSJ/2CQVKvc6j75z4moMAoGCCqGSM49BAMEA4GLADCBhwJBMS13V9IH8UvuEY30Ym0tqx3524ZV87zqon1muLbhCaNl76g5BPiDV7\u002B8VduTbpF1anVzUki0jYn0dJVmXlDXL60CQgGUU90gGBrBGoLwGwRWUr4Diyz8yJad6xIJXWxl\u002BY97SBMbMss2Fps0HRi6cf7ERT2B/YhpuMwe6NGlTx4sB3zPow==",
         "attributes": {
           "enabled": true,
-          "nbf": 1614985475,
-          "exp": 1646522075,
-          "created": 1614986075,
-          "updated": 1614986075,
+          "nbf": 1617848732,
+          "exp": 1649385332,
+          "created": 1617849332,
+          "updated": 1617849332,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
         "subject": "CN=default",
         "issuer": "CN=default",
-        "serialnumber": "2351F25BEE214ED0AAAB99029239BA6D"
+        "serialnumber": "59770F70CEAA4E669620E5539CC70B9B"
       }
     },
     {
-      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/273129278/2cd8ce62a8724995aed6bd98543f4f4d?api-version=7.2",
+      "RequestUri": "https://heathskvtest2.vault.azure.net/secrets/273129278/54a4855697d74ae28d58949fa581ae3a?api-version=7.2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Type": "application/json",
-        "traceparent": "00-e35968bf8e8d5d4e9685477ab901d1e9-e7c0bda2be87dc43-00",
+        "traceparent": "00-278a80c5327e90468f901fbfd9653218-c430d6d210d1b74b-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210305.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-Security.KeyVault.Certificates/4.2.0-alpha.20210407.1",
+          "(.NET 5.0.4; Microsoft Windows 10.0.19042)"
         ],
-        "x-ms-client-request-id": "502b8ea2ccb55d0146fc3c5fd8ee9ed0",
+        "x-ms-client-request-id": "0bbbeb9e7fd981473ecfaef7469c8ffe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2127",
+        "Content-Length": "2125",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Mar 2021 23:14:38 GMT",
+        "Date": "Thu, 08 Apr 2021 02:35:32 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0bbbeb9e7fd981473ecfaef7469c8ffe",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.191.0",
-        "x-ms-request-id": "46940b1d-214f-4477-bfd6-9d81650511d8",
+        "x-ms-keyvault-service-version": "1.2.236.0",
+        "x-ms-request-id": "fd0c9e9c-6e14-4e3f-bca8-4b9adc6670f1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "MIIE\u002BgIBAzCCBLYGCSqGSIb3DQEHAaCCBKcEggSjMIIEnzCCAdgGCSqGSIb3DQEHAaCCAckEggHFMIIBwTCCAb0GCyqGSIb3DQEMCgECoIIBNjCCATIwHAYKKoZIhvcNAQwBAzAOBAhIo5D7\u002B3EdqwICB9AEggEQhd2zxtXaL5wkup0Jttj3bXbQQfdsBghKWstHW1DxdcYp77SZZo78bbhcPQ9VpgVW2IYu1semys2WnoOjeTbfCnw1SOhCR2HYDuxf2N/NjMQEQLxkmnMqowh4Uk0KJE6KCT38wUUO7e34NGR6vvB7gk1iLlx8rlGk8hBX46CHNapKzL9fOwXlDa\u002B\u002BM3UeHbE2urEaztPsBFGk2o/fWw97U5\u002Bzh33NryWEAc4SujUX6cEElJWU2pysOy9rmWBahmvFtqqqCblpd92BQmg1LX9mW8D1KsCHKEu\u002BFGNu8lC6u79HRIEk0CUDxXIIn466FUsy4VW7fbZFvid/uqz5tyuaIlH8WLsRo9gaq/HkFkJ/wyQxdDATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEEAYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwBvAGYAdAB3AGEAcgBlACAASwBlAHkAIABTAHQAbwByAGEAZwBlACAAUAByAG8AdgBpAGQAZQByMIICvwYJKoZIhvcNAQcGoIICsDCCAqwCAQAwggKlBgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBAzAOBAgDFvBP44pU1AICB9CAggJ4dTDzvyS1//UAHdu5jOSANlTrSCxowFSHAfYIY99eXOXGthtbhN5K\u002BJ7my2HauH1JtLPY7dZuaqJeGB7iXZLkYjrfdCOcJ\u002BPa5Yr/c7YUKcjI5DDv9PLGfz7d7PVfVE9hpdDKVWCqouXc5/0HnlSQAt7/b7y4/Y/bEVGofXexg7JsuonmeoIMtHxXwv8WXmharJ805HPrPoYSdqkHhPdX723ygfwSh2I5jRz2\u002BQObtHgsaVetzxAj0igpnKzG7762fkiJGUpSzfhyb975To3uWIzNMM3vJIHvvCvqiKPsFdQfAEebemD\u002B/rK6\u002B7bzq2uHfN7rQlkFGEmauCXrcwcyCdusamVn\u002BjCxmYWY3awopr//hkd6PHtY1YAbi0pNjCHUKzTh\u002BioPMLO4GjRZgC5Sw8jaq0i8V0j7oBmtHmVaJ\u002BQSzp12q6RQZ6l8fRbKYoFciOMWco4d9Y\u002Btgz40\u002BAGEDU4mq7V0DLDVZvdhhWRm5YnewDYvsLiw7cccLlVzQbvmJpCE3cw5iEJrpE1wRIThPqjIy1iJsxPOv4umxpu/1kXfBD\u002BgB/\u002BTWP3JLIh971kXgbaqbxMaJgYMQ7dvfUKYKdgioekJc7\u002BT0UTOz\u002BY/ArwxQ8q9/i4qlpEtJSZwpr0EHDWFDsR0H6TdJAdy1D0gI\u002BododzXl7d1memJ\u002BzBpwcNTHKwpPBHeNzPLMpCWABEjLy9ZzYJhSrm761ff2/WuXCKD2xJ2/klkovgDV6D6wgea4HAvT59rO4gm/144daDhT4lFIwpb3LjuymAwSQ6NMDLbe0SqN93ytFPn3LFABanCW\u002BwD/BPhDev8Ed1ipb3q2WRCG9ED2E8wOzAfMAcGBSsOAwIaBBTkzj/yIIKdrUVWVLsW63wSwvJ9XQQUtbCKww4/c6WEbh44Dw777PBnAl0CAgfQ",
+        "value": "MIIE\u002BgIBAzCCBLYGCSqGSIb3DQEHAaCCBKcEggSjMIIEnzCCAdgGCSqGSIb3DQEHAaCCAckEggHFMIIBwTCCAb0GCyqGSIb3DQEMCgECoIIBNjCCATIwHAYKKoZIhvcNAQwBAzAOBAiuIlaUN5ImGQICB9AEggEQAktispB4nHSYg5eWloU\u002BPoGPKEd/SUIxSLqhcH7723a4xLMGSkLG5be0vcltdwS/vn72GZqmZ8NeO7sRecrty5gZx7kNL6VDo569XdSrbcGc\u002B\u002Bm0at7iCV80LanRcu3IF15VyC\u002BSorNXcFec2zSDJih3/AIj6M4AV7z\u002BerZswMEjG1KA/jCrA7NyIa\u002BHLB2ihMURvA\u002BBJ2O2gSJHA2UZcWNyU1/P93roMFfwDLs5bxX3MZKB9mk1DUo80QvKW4vWS9EjY1wCPXmeFtuFOaK1P6ongtW2hWueaE0hNoZzB7TWZ5ryDdup3PWT\u002BIMmYvbF\u002B2sV3ZSgEI/Kp3343SykihNvVbcbbzdT6jclR4HisOoxdDATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEEAYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwBvAGYAdAB3AGEAcgBlACAASwBlAHkAIABTAHQAbwByAGEAZwBlACAAUAByAG8AdgBpAGQAZQByMIICvwYJKoZIhvcNAQcGoIICsDCCAqwCAQAwggKlBgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBAzAOBAjD\u002BcDnL5OK1QICB9CAggJ49EUNNLz9zy2nAz/LMebFblwKKhgzF1xqtJ678vQAGTxlb60zJsFYdfLuSnQ/zrwujtzQcajfqFkAnsjborrx015T8JTV4Haj9w61hy\u002Br6W45dv3\u002B2KHsrZyc/FRlZIsxuZyTaP1zLhSeDMKL/3HnxEotw4Y0YvUGW\u002BWf9i4jfk\u002BIOetsijtoiraFg5aziRVdgbVI0OaKe5wi2ssQ7z9Lkk0rVDDLdTy16U3qrnRfkPflpRJUVmKIakjudBHn1PQ2hO\u002BMqGEK\u002BVFRNN/nMl4ZUjAGm4SZVLn0Z4F0gwR0P4EGhMTej50OmMfxaGu1/PQe80ojle5W\u002BQNbzTF\u002BCjTqfIb5HIFagocXR6lcmTNlt6sjcls2fkIDi\u002BLQIo9uU5eevFoPbpUsVVHmhZl4\u002BOi6u4L46xTfpiwZYtKrwuXZ7QMnpg6cBKP50e6JVvO5gm3if62sj9nqJGtBFlM5JIcMVKR06oQ/ShSo3zUuqpn1PuD4V9V0XzsrrJbtfbiJX9CW0Xd76FrAGf0xvHEoYkBcfyuMMSB9pjRdmsxoJPrm5QiXKwaq4B1964NvIPmQTYRdrLOXbHPfwBkR0TUhY0AOpvWQYBSkJY1WRx5RVMzKTRNgtLj5/A5RTW56MfCoiFVrxr0N4LKFnus80eKl5JKNYnaYslVgUjh5Ysd4PIE/x1t3MYnIB8QUsD1GQAKmCjAW13htoglD54gmm1/xKrvxGezjfSQQF6JTmYaUc2uUa82iF53/H1JDC/1pNeL\u002BIjuopEvaOPBDT87Iv5CCA0Jftmi4sO8anR4VDwLiWnQksH8D/FR8B\u002B9m3IGwr4e78xKYaFUZ1Vnq9a0wOzAfMAcGBSsOAwIaBBSRcIsxsQc1sYAaYon3ht/gWyAV0gQUNdC4IkQjbuPmzrOtlwSlG69tO0ICAgfQ",
         "contentType": "application/x-pkcs12",
-        "id": "https://heathskeyvault.vault.azure.net/secrets/273129278/2cd8ce62a8724995aed6bd98543f4f4d",
+        "id": "https://heathskvtest2.vault.azure.net/secrets/273129278/54a4855697d74ae28d58949fa581ae3a",
         "managed": true,
         "attributes": {
           "enabled": true,
-          "nbf": 1614985475,
-          "exp": 1646522075,
-          "created": 1614986075,
-          "updated": 1614986075,
+          "nbf": 1617848732,
+          "exp": 1649385332,
+          "created": 1617849332,
+          "updated": 1617849332,
           "recoveryLevel": "Recoverable\u002BPurgeable",
           "recoverableDays": 90
         },
-        "kid": "https://heathskeyvault.vault.azure.net/keys/273129278/2cd8ce62a8724995aed6bd98543f4f4d"
+        "kid": "https://heathskvtest2.vault.azure.net/keys/273129278/54a4855697d74ae28d58949fa581ae3a"
       }
     }
   ],
   "Variables": {
-    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "AZURE_KEYVAULT_URL": "https://heathskvtest2.vault.azure.net/",
     "RandomSeed": "747393426"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/JsonStream.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/JsonStream.cs
@@ -29,7 +29,7 @@ namespace Azure.Security.KeyVault.Tests
 
         public void Dispose() => _buffer.Dispose();
 
-        public override string ToString() => Encoding.UTF8.GetString(_buffer.GetBuffer(), 0, (int)_buffer.Length);
+        public override string ToString() => Encoding.UTF8.GetString(_buffer.ToArray(), 0, (int)_buffer.Length);
 
         public void WriteObject(IJsonSerializable @object, JsonWriterOptions options = default)
         {


### PR DESCRIPTION
DownloadECDsaCertificateSignLocalVerifyRemote started failing on linux because of #20204 and we found some related ordering issues in tests when run locally.
