### PR TITLE
Fix broken documentation link.

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/README.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/README.md
@@ -150,6 +150,6 @@ For more information see the [Code of Conduct FAQ][code_of_conduct_faq] or conta
 [digital_twins_client]: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
 [digital_twins_documentation]: https://docs.microsoft.com/azure/digital-twins/
 [iot_cli_extension]: https://github.com/Azure/azure-iot-cli-extension/releases
-[iot_cli_doc]: https://docs.microsoft.com/en-us/cli/azure/azure-cli-reference-for-iot
+[iot_cli_doc]: https://docs.microsoft.com/cli/azure/azure-cli-reference-for-iot
 [http_status_code]: https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netcore-3.1
 [adt_nuget]: https://www.nuget.org/packages/Azure.DigitalTwins.Core

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/README.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/README.md
@@ -149,8 +149,7 @@ For more information see the [Code of Conduct FAQ][code_of_conduct_faq] or conta
 [token_credential]: https://docs.microsoft.com/dotnet/api/azure.core.tokencredential?view=azure-dotnet
 [digital_twins_client]: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
 [digital_twins_documentation]: https://docs.microsoft.com/azure/digital-twins/
-[azure_cli]: https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest
 [iot_cli_extension]: https://github.com/Azure/azure-iot-cli-extension/releases
-[iot_cli_doc]: https://docs.microsoft.com/cli/azure/ext/azure-iot/dt?view=azure-cli-latest
+[iot_cli_doc]: https://docs.microsoft.com/en-us/cli/azure/azure-cli-reference-for-iot
 [http_status_code]: https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netcore-3.1
 [adt_nuget]: https://www.nuget.org/packages/Azure.DigitalTwins.Core


### PR DESCRIPTION
In the [latest build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=831814&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=bdeefc16-b669-5ebd-ad94-a2c19ade53b0), the documentation verification step failed due to a broken link.

