### PR TITLE
Fix title for EH processor sample

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/README.md
@@ -5,7 +5,7 @@ languages:
 products:
 - azure
 - azure-event-hubs
-name: Samples for the Azure.Messaging.EventHubs client library
+name: Samples for the Azure.Messaging.EventHubs.Processor client library
 description: Samples for the Azure.Messaging.EventHubs.Processor client library
 ---
 


### PR DESCRIPTION
When looking for Event Hubs samples using this [search query](https://docs.microsoft.com/en-us/samples/browse/?filter-products=hubs&products=azure-event-hubs&languages=csharp), found that the ones for the processor and the EH client, both have the same title. Fixing that here.

![image](https://user-images.githubusercontent.com/16890566/114134721-09778200-98bd-11eb-8bd1-45fad5f2edde.png)
