### PR TITLE
Enable retain run template.

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -73,6 +73,7 @@ stages:
                         PackageRepository: Nuget
                         ReleaseSha: $(Build.SourceVersion)
                         RepoId: Azure/azure-sdk-for-net
+                    - template: /eng/common/pipelines/steps/retain-run.yml
 
           - ${{if ne(artifact.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage


### PR DESCRIPTION
This uses the retain run template to retain pipeline runs for 12 months if a pipeline has been approved for release (and completes the tag job).