### PR TITLE
Add ubuntu 18.04 agent VM DNS workaround to CI tests

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -43,6 +43,7 @@ jobs:
       - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
         parameters:
           AgentImage: $(OSVmImage)
+      - template: /eng/common/pipelines/templates/steps/bypass-local-dns.yml
       - ${{ each step in parameters.TestSetupSteps }}:
         - ${{ each pair in step }}:
             ${{ pair.key }}: ${{ pair.value }}


### PR DESCRIPTION
This adds a workaround to our CI tests for this issue: https://github.com/actions/virtual-environments/issues/798. We already run this in live tests, but not in CI.