### PR TITLE
ServiceBusReceivedMessage internal constructor wraps body for consistency

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -310,7 +310,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             if ((amqpMessage.BodyType & SectionFlag.Data) != 0 && amqpMessage.DataBody != null)
             {
-                annotatedMessage = new AmqpAnnotatedMessage(AmqpMessageBody.FromData(Body.FromDataSegments(amqpMessage.DataBody)));
+                annotatedMessage = new AmqpAnnotatedMessage(AmqpMessageBody.FromData(MessageBody.FromDataSegments(amqpMessage.DataBody)));
             }
             else if ((amqpMessage.BodyType & SectionFlag.AmqpValue) != 0 && amqpMessage.ValueBody?.Value != null)
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageExtensions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageExtensions.cs
@@ -103,7 +103,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         {
             if (message.Body.TryGetData(out IEnumerable<ReadOnlyMemory<byte>> dataBody))
             {
-                return BinaryData.FromBytes(Body.FromReadOnlyMemorySegments(dataBody));
+                return BinaryData.FromBytes(MessageBody.FromReadOnlyMemorySegments(dataBody));
             }
             throw new NotSupportedException($"{message.Body.BodyType} cannot be retrieved using the {nameof(ServiceBusMessage.Body)} property." +
                 $"Use {nameof(ServiceBusMessage.GetRawAmqpMessage)} to access the underlying Amqp Message object.");

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -44,7 +44,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="body">The payload of the message in bytes.</param>
         public ServiceBusMessage(ReadOnlyMemory<byte> body)
         {
-            AmqpMessageBody amqpBody = new AmqpMessageBody(Amqp.Body.FromReadOnlyMemorySegment(body));
+            AmqpMessageBody amqpBody = new AmqpMessageBody(MessageBody.FromReadOnlyMemorySegment(body));
             AmqpMessage = new AmqpAnnotatedMessage(amqpBody);
         }
 
@@ -68,7 +68,7 @@ namespace Azure.Messaging.ServiceBus
                 throw new NotSupportedException($"{receivedMessage.AmqpMessage.Body.BodyType} is not a supported message body type.");
             }
 
-            AmqpMessageBody body = new AmqpMessageBody(Amqp.Body.FromReadOnlyMemorySegments(dataBody));
+            AmqpMessageBody body = new AmqpMessageBody(MessageBody.FromReadOnlyMemorySegments(dataBody));
             AmqpMessage = new AmqpAnnotatedMessage(body);
 
             // copy properties
@@ -140,7 +140,7 @@ namespace Azure.Messaging.ServiceBus
             get => AmqpMessage.GetBody();
             set
             {
-                AmqpMessage.Body = new AmqpMessageBody(Amqp.Body.FromReadOnlyMemorySegment(value));
+                AmqpMessage.Body = new AmqpMessageBody(MessageBody.FromReadOnlyMemorySegment(value));
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
@@ -26,7 +26,7 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <param name="body">The payload of the message represented as bytes.</param>
         internal ServiceBusReceivedMessage(ReadOnlyMemory<byte> body)
-            : this(new AmqpAnnotatedMessage(new AmqpMessageBody(new ReadOnlyMemory<byte>[] { body })))
+            : this(new AmqpAnnotatedMessage(new AmqpMessageBody(Amqp.Body.FromReadOnlyMemorySegments(new ReadOnlyMemory<byte>[] { body }))))
         {
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
@@ -26,7 +26,7 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <param name="body">The payload of the message represented as bytes.</param>
         internal ServiceBusReceivedMessage(ReadOnlyMemory<byte> body)
-            : this(new AmqpAnnotatedMessage(new AmqpMessageBody(Amqp.Body.FromReadOnlyMemorySegments(new ReadOnlyMemory<byte>[] { body }))))
+            : this(new AmqpAnnotatedMessage(new AmqpMessageBody(MessageBody.FromReadOnlyMemorySegments(new ReadOnlyMemory<byte>[] { body }))))
         {
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/MessageBodyTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/MessageBodyTests.cs
@@ -11,22 +11,22 @@ using NUnit.Framework;
 namespace Azure.Messaging.ServiceBus.Tests.Amqp
 {
     /// <summary>
-    ///   The suite of tests for the <see cref="Body" />
+    ///   The suite of tests for the <see cref="MessageBody" />
     ///   class.
     /// </summary>
     ///
     [TestFixture]
-    public class BodyTests
+    public class MessageBodyTests
     {
         [Test]
         public void ManagesSingleReadOnlyMemoryWithoutCopying()
         {
             ReadOnlyMemory<byte> singleReadOnlyMemory = new byte[] { 1, 2, 3 };
 
-            var message = new AmqpMessageBody(Body.FromReadOnlyMemorySegment(singleReadOnlyMemory));
+            var message = new AmqpMessageBody(MessageBody.FromReadOnlyMemorySegment(singleReadOnlyMemory));
 
             message.TryGetData(out var body);
-            ReadOnlyMemory<byte> fromReadOnlyMemorySegments = Body.FromReadOnlyMemorySegments(body);
+            ReadOnlyMemory<byte> fromReadOnlyMemorySegments = MessageBody.FromReadOnlyMemorySegments(body);
 
             Assert.IsTrue(singleReadOnlyMemory.Equals(fromReadOnlyMemorySegments));
         }
@@ -37,14 +37,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             ReadOnlyMemory<byte> firstSegment = new byte[] { 1, 2, 3 };
             ReadOnlyMemory<byte> secondSegment = new byte[] { 4, 5, 6 };
 
-            var message = new AmqpMessageBody(Body.FromReadOnlyMemorySegments(new[]{ firstSegment, secondSegment }));
+            var message = new AmqpMessageBody(MessageBody.FromReadOnlyMemorySegments(new[]{ firstSegment, secondSegment }));
 
             message.TryGetData(out var body);
             var firstSegmentBeforeConversion = body.ElementAt(0);
             var secondSegmentBeforeConversion = body.ElementAt(1);
 
-            ReadOnlyMemory<byte> fromReadOnlyMemorySegments = Body.FromReadOnlyMemorySegments(body);
-            ReadOnlyMemory<byte> convertedASecondTime = Body.FromReadOnlyMemorySegments(body);
+            ReadOnlyMemory<byte> fromReadOnlyMemorySegments = MessageBody.FromReadOnlyMemorySegments(body);
+            ReadOnlyMemory<byte> convertedASecondTime = MessageBody.FromReadOnlyMemorySegments(body);
 
             var firstSegmentAfterConversion = body.ElementAt(0);
             var secondSegmentAfterConversion = body.ElementAt(1);
@@ -65,7 +65,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             byte[] firstSegment = new byte[] {1, 2, 3};
             byte[]  secondSegment = new byte[] { 4, 5, 6 };
 
-            var message = new AmqpMessageBody(Body.FromDataSegments(new[]
+            var message = new AmqpMessageBody(MessageBody.FromDataSegments(new[]
             {
                 new Data {Value = new ArraySegment<byte>(firstSegment) }, new Data {Value = new ArraySegment<byte>(secondSegment) }
             }));
@@ -74,8 +74,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             var firstSegmentBeforeConversion = body.ElementAt(0);
             var secondSegmentBeforeConversion = body.ElementAt(1);
 
-            ReadOnlyMemory<byte> fromReadOnlyMemorySegments = Body.FromReadOnlyMemorySegments(body);
-            ReadOnlyMemory<byte> convertedASecondTime = Body.FromReadOnlyMemorySegments(body);
+            ReadOnlyMemory<byte> fromReadOnlyMemorySegments = MessageBody.FromReadOnlyMemorySegments(body);
+            ReadOnlyMemory<byte> convertedASecondTime = MessageBody.FromReadOnlyMemorySegments(body);
 
             var firstSegmentAfterConversion = body.ElementAt(0);
             var secondSegmentAfterConversion = body.ElementAt(1);


### PR DESCRIPTION
# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
