### PR TITLE
[CODEOWNERS] Add Quantum

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -472,6 +472,9 @@ sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/            @tmsupp
 # ServiceLabel: %PostgreSQL %Service Attention
 /sdk/postgresql/Microsoft.Azure.Management.PostgreSQL/            @sunilagarwal @lfittl-msft @sr-msft @niklarin
 
+# ServiceLabel: %Quantum %Service Attention
+/sdk/quantum/Azure.Quantum.Jobs/           @xfield
+
 # ServiceLabel: %Recovery Services Backup %Service Attention
 /sdk/recoveryservices-backup/Microsoft.Azure.Management.RecoveryServices.Backup/           @pvrk
 


### PR DESCRIPTION
# Summary

The focus of these changes is to add the Quantum SDK and service attention contact to the CODEOWNERS.