### PR TITLE
Add location overrides to smoke test matrix

### DIFF
--- a/eng/pipelines/templates/jobs/smoke-tests.yml
+++ b/eng/pipelines/templates/jobs/smoke-tests.yml
@@ -52,6 +52,7 @@ jobs:
           TestTargetFramework: netcoreapp2.1
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: "westus"
         Linux (AzureCloud Canary):
           Pool: Azure Pipelines
           OSVmImage: "ubuntu-18.04"
@@ -65,48 +66,56 @@ jobs:
           TestTargetFramework: netcoreapp2.1
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: "westus"
         Windows_NetFramework (AzureCloud):
           Pool: Azure Pipelines
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: "westus"
         MacOs (AzureCloud):
           Pool: Azure Pipelines
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: "westus"
         Windows_Net50 (AzureCloud):
           Pool: Azure Pipelines
           OSVmImage: "windows-2019"
           TestTargetFramework: net5.0
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: "westus"
         Windows_NetCoreApp (AzureUSGovernment):
           Pool: Azure Pipelines
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(azureUSGovernmentArmParameters)
+          Location: "usgovarizona"
         Windows_NetFramework (AzureUSGovernment):
           Pool: Azure Pipelines
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(azureUSGovernmentArmParameters)
+          Location: "usgovarizona"
         Windows_NetCoreApp (AzureChinaCloud):
           Pool: Azure Pipelines
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           ArmTemplateParameters: $(azureChinaCloudArmParameters)
+          Location: "chinaeast2"
         Windows_NetFramework (AzureChinaCloud):
           Pool: Azure Pipelines
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           ArmTemplateParameters: $(azureChinaCloudArmParameters)
+          Location: "chinaeast2"
 
     variables:
       azureCloudArmParameters: "@{ storageEndpointSuffix = 'core.windows.net'; azureCloud = 'AzureCloud'; }"
@@ -162,6 +171,7 @@ jobs:
           ServiceDirectory: '$(Build.SourcesDirectory)/common/SmokeTests/'
           SubscriptionConfiguration: $(SubscriptionConfiguration)
           ArmTemplateParameters: $(ArmTemplateParameters)
+          Location: $(Location)
 
       - pwsh: dotnet run -p .\common\SmokeTests\SmokeTest\SmokeTest.csproj --framework $(TestTargetFramework)
         displayName: "Run Smoke Tests"


### PR DESCRIPTION
We are frequently seeing capacity and reliability issues for the `usgovvirginia` region regarding the iothub dependency of the smoke tests. This attempts to mitigate this issue by changing our region when AzureUSGovernment is the target environment in the smoke tests.

```
"statusMessage": {
  "status": "Failed",
  "error": {
  "code": "500019",
  "message": "Capacity is not available, retry later. If you contact a support representative please include this correlation identifier: f6c34c3a-e94d-4bdc-8657-34711e422b87, timestamp: 2021-03-06 19:15:08Z, errorcode: IH500019."
}
```