### PR TITLE
ServiceBusProcessor received message buffer management

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -203,6 +203,7 @@ namespace Azure.Messaging.ServiceBus
         public virtual bool IsProcessing { get { throw null; } }
         public virtual System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } }
         public virtual int MaxConcurrentCalls { get { throw null; } }
+        public virtual bool PoolMessageBodies { get { throw null; } }
         public virtual int PrefetchCount { get { throw null; } }
         public virtual Azure.Messaging.ServiceBus.ServiceBusReceiveMode ReceiveMode { get { throw null; } }
         public event System.Func<Azure.Messaging.ServiceBus.ProcessErrorEventArgs, System.Threading.Tasks.Task> ProcessErrorAsync { add { } remove { } }
@@ -226,6 +227,7 @@ namespace Azure.Messaging.ServiceBus
         public bool AutoCompleteMessages { get { throw null; } set { } }
         public System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } set { } }
         public int MaxConcurrentCalls { get { throw null; } set { } }
+        public bool PoolMessageBodies { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusReceiveMode ReceiveMode { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -377,6 +379,7 @@ namespace Azure.Messaging.ServiceBus
         public virtual System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } }
         public virtual int MaxConcurrentCallsPerSession { get { throw null; } }
         public virtual int MaxConcurrentSessions { get { throw null; } }
+        public virtual bool PoolMessageBodies { get { throw null; } }
         public virtual int PrefetchCount { get { throw null; } }
         public virtual Azure.Messaging.ServiceBus.ServiceBusReceiveMode ReceiveMode { get { throw null; } }
         public virtual System.TimeSpan? SessionIdleTimeout { get { throw null; } }
@@ -406,6 +409,7 @@ namespace Azure.Messaging.ServiceBus
         public System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } set { } }
         public int MaxConcurrentCallsPerSession { get { throw null; } set { } }
         public int MaxConcurrentSessions { get { throw null; } set { } }
+        public bool PoolMessageBodies { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusReceiveMode ReceiveMode { get { throw null; } set { } }
         public System.TimeSpan? SessionIdleTimeout { get { throw null; } set { } }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -139,6 +139,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="identifier">The identifier for the sender.</param>
         /// <param name="sessionId">The session ID to receive messages for.</param>
         /// <param name="isSessionReceiver">Whether or not this is a sessionful receiver link.</param>
+        /// <param name="poolReceivedMessageBodies">Whether or not the messages bodies use pooled byte arrays underneath in case of binary data. When this option is enabled the receiver needs to
+        /// dispose the received messages by using the <see cref="ServiceBusReceivedMessageExtensions.CreateBodyScope"/> extension.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the
         /// open link operation. Only applicable for session receivers.</param>
         ///
@@ -151,6 +153,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             string identifier,
             string sessionId,
             bool isSessionReceiver,
+            bool poolReceivedMessageBodies,
             CancellationToken cancellationToken)
         {
             Argument.AssertNotDisposed(_closed, nameof(AmqpClient));
@@ -165,6 +168,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 identifier,
                 sessionId,
                 isSessionReceiver,
+                poolReceivedMessageBodies,
                 cancellationToken
             );
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -301,7 +301,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             return amqpMessage;
         }
 
-        public static ServiceBusReceivedMessage AmqpMessageToSBMessage(AmqpMessage amqpMessage, bool isPeeked = false)
+        public static ServiceBusReceivedMessage AmqpMessageToSBMessage(AmqpMessage amqpMessage, bool poolReceivedMessageBodies = false, bool isPeeked = false)
         {
             Argument.AssertNotNull(amqpMessage, nameof(amqpMessage));
             AmqpAnnotatedMessage annotatedMessage;
@@ -310,7 +310,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             if ((amqpMessage.BodyType & SectionFlag.Data) != 0 && amqpMessage.DataBody != null)
             {
-                annotatedMessage = new AmqpAnnotatedMessage(AmqpMessageBody.FromData(MessageBody.FromDataSegments(amqpMessage.DataBody)));
+                annotatedMessage = new AmqpAnnotatedMessage(AmqpMessageBody.FromData(MessageBody.FromDataSegments(amqpMessage.DataBody, poolReceivedMessageBodies)));
             }
             else if ((amqpMessage.BodyType & SectionFlag.AmqpValue) != 0 && amqpMessage.ValueBody?.Value != null)
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportClient.cs
@@ -55,6 +55,7 @@ namespace Azure.Messaging.ServiceBus.Core
             string identifier,
             string sessionId,
             bool isSessionReceiver,
+            bool poolReceivedMessageBodies,
             CancellationToken cancellationToken);
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusConnection.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusConnection.cs
@@ -240,6 +240,7 @@ namespace Azure.Messaging.ServiceBus
             string identifier,
             string sessionId,
             bool isSessionReceiver,
+            bool poolReceivedMessageBodies,
             CancellationToken cancellationToken) =>
                 _innerClient.CreateReceiver(
                     entityPath,
@@ -249,6 +250,7 @@ namespace Azure.Messaging.ServiceBus
                     identifier,
                     sessionId,
                     isSessionReceiver,
+                    poolReceivedMessageBodies,
                     cancellationToken);
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessageExtensions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessageExtensions.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Messaging.ServiceBus.Amqp;
+
+namespace Azure.Messaging.ServiceBus
+{
+    internal static class ServiceBusReceivedMessageExtensions
+    {
+        public static BodyScope CreateBodyScope(this ServiceBusReceivedMessage message)
+        {
+            // necessary to get the body early because it could be replaced by the user
+            if (message.AmqpMessage.Body.TryGetData(out var bodyData) &&
+                bodyData is MessageBody body)
+            {
+                return new BodyScope(body);
+            }
+
+            return default;
+        }
+
+        internal readonly struct BodyScope : IDisposable
+        {
+            private readonly MessageBody _body;
+            public BodyScope(MessageBody body)
+            {
+                _body = body;
+            }
+
+            public void Dispose()
+            {
+                _body?.Release();
+            }
+        }
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
+using Azure.Messaging.ServiceBus.Amqp;
 using Azure.Messaging.ServiceBus.Diagnostics;
 using Azure.Messaging.ServiceBus.Plugins;
 
@@ -41,6 +42,7 @@ namespace Azure.Messaging.ServiceBus
             {
                 ReceiveMode = ProcessorOptions.ReceiveMode,
                 PrefetchCount = ProcessorOptions.PrefetchCount,
+                PoolMessageBodies = true
             };
             _maxReceiveWaitTime = ProcessorOptions.MaxReceiveWaitTime;
             _plugins = plugins;
@@ -87,6 +89,8 @@ namespace Azure.Messaging.ServiceBus
                     {
                         continue;
                     }
+
+                    using var bodyScope = message.CreateBodyScope();
                     await ProcessOneMessageWithinScopeAsync(
                         message,
                         DiagnosticProperty.ProcessMessageActivityName,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -42,7 +42,7 @@ namespace Azure.Messaging.ServiceBus
             {
                 ReceiveMode = ProcessorOptions.ReceiveMode,
                 PrefetchCount = ProcessorOptions.PrefetchCount,
-                PoolMessageBodies = true
+                PoolMessageBodies = ProcessorOptions.PoolMessageBodies,
             };
             _maxReceiveWaitTime = ProcessorOptions.MaxReceiveWaitTime;
             _plugins = plugins;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -126,6 +126,17 @@ namespace Azure.Messaging.ServiceBus
         public virtual bool AutoCompleteMessages { get; }
 
         /// <summary>
+        /// Gets or sets whether the messages bodies use pooled byte arrays underneath in case of binary data.
+        /// When this option is enabled <see cref="ServiceBusReceivedMessage"/> cannot be safely kept for longer than the
+        /// lifetime of the scope of the <see cref="ServiceBusProcessor.ProcessMessageAsync"/> or
+        /// the <see cref="ServiceBusProcessor.ProcessSessionMessageAsync"/> event handler delegate.
+        /// The default value is false.
+        /// </summary>
+        ///
+        /// <value>true to pool message bodies; otherwise, false.</value>
+        public virtual bool PoolMessageBodies { get; }
+
+        /// <summary>
         /// Gets the maximum duration within which the lock will be renewed automatically. This
         /// value should be greater than the longest message lock duration; for example, the LockDuration Property.
         /// </summary>
@@ -224,6 +235,7 @@ namespace Azure.Messaging.ServiceBus
                 maxAcceptSessions);
 
             AutoCompleteMessages = Options.AutoCompleteMessages;
+            PoolMessageBodies = Options.PoolMessageBodies;
 
             EntityPath = entityPath;
             IsSessionProcessor = isSessionEntity;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -128,8 +128,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Gets or sets whether the messages bodies use pooled byte arrays underneath in case of binary data.
         /// When this option is enabled <see cref="ServiceBusReceivedMessage"/> cannot be safely kept for longer than the
-        /// lifetime of the scope of the <see cref="ServiceBusProcessor.ProcessMessageAsync"/> or
-        /// the <see cref="ServiceBusProcessor.ProcessSessionMessageAsync"/> event handler delegate.
+        /// lifetime of the scope of the <see cref="ServiceBusProcessor.ProcessMessageAsync"/> event handler delegate.
         /// The default value is false.
         /// </summary>
         ///

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
@@ -53,6 +53,17 @@ namespace Azure.Messaging.ServiceBus
         public bool AutoCompleteMessages { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets whether the messages bodies use pooled byte arrays underneath in case of binary data.
+        /// When this option is enabled <see cref="ServiceBusReceivedMessage"/> cannot be safely kept for longer than the
+        /// lifetime of the scope of the <see cref="ServiceBusProcessor.ProcessMessageAsync"/> or
+        /// the <see cref="ServiceBusProcessor.ProcessSessionMessageAsync"/> event handler delegate.
+        /// The default value is false.
+        /// </summary>
+        ///
+        /// <value>true to pool message bodies; otherwise, false.</value>
+        public bool PoolMessageBodies { get; set; }
+
+        /// <summary>
         /// Gets or sets the maximum duration within which the lock will be renewed automatically. This
         /// value should be greater than the longest message lock duration; for example, the LockDuration Property.
         /// </summary>
@@ -163,6 +174,7 @@ namespace Azure.Messaging.ServiceBus
                 MaxAutoLockRenewalDuration = MaxAutoLockRenewalDuration,
                 MaxReceiveWaitTime = MaxReceiveWaitTime,
                 MaxConcurrentCalls = MaxConcurrentCalls,
+                PoolMessageBodies = PoolMessageBodies,
             };
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
@@ -55,8 +55,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Gets or sets whether the messages bodies use pooled byte arrays underneath in case of binary data.
         /// When this option is enabled <see cref="ServiceBusReceivedMessage"/> cannot be safely kept for longer than the
-        /// lifetime of the scope of the <see cref="ServiceBusProcessor.ProcessMessageAsync"/> or
-        /// the <see cref="ServiceBusProcessor.ProcessSessionMessageAsync"/> event handler delegate.
+        /// lifetime of the scope of the <see cref="ServiceBusProcessor.ProcessMessageAsync"/> event handler delegate.
         /// The default value is false.
         /// </summary>
         ///

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -52,6 +52,9 @@ namespace Azure.Messaging.ServiceBus
         /// <inheritdoc cref="ServiceBusProcessor.AutoCompleteMessages"/>
         public virtual bool AutoCompleteMessages => InnerProcessor.AutoCompleteMessages;
 
+        /// <inheritdoc cref="ServiceBusProcessor.PoolMessageBodies"/>
+        public virtual bool PoolMessageBodies => InnerProcessor.PoolMessageBodies;
+
         /// <summary>
         ///   Indicates whether or not this <see cref="ServiceBusSessionProcessor"/> has been closed.
         /// </summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessorOptions.cs
@@ -148,6 +148,17 @@ namespace Azure.Messaging.ServiceBus
         public IList<string> SessionIds { get; } = new List<string>();
 
         /// <summary>
+        /// Gets or sets whether the messages bodies use pooled byte arrays underneath in case of binary data.
+        /// When this option is enabled <see cref="ServiceBusReceivedMessage"/> cannot be safely kept for longer than the
+        /// lifetime of the scope of the <see cref="ServiceBusProcessor.ProcessSessionMessageAsync"/> or
+        /// the <see cref="ServiceBusProcessor.ProcessSessionMessageAsync"/> event handler delegate.
+        /// The default value is false.
+        /// </summary>
+        ///
+        /// <value>true to pool message bodies; otherwise, false.</value>
+        public bool PoolMessageBodies { get; set; }
+
+        /// <summary>
         /// Determines whether the specified <see cref="System.Object" /> is equal to this instance.
         /// </summary>
         ///
@@ -181,6 +192,7 @@ namespace Azure.Messaging.ServiceBus
                 AutoCompleteMessages = AutoCompleteMessages,
                 MaxAutoLockRenewalDuration = MaxAutoLockRenewalDuration,
                 MaxReceiveWaitTime = SessionIdleTimeout,
+                PoolMessageBodies = PoolMessageBodies
             };
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessorOptions.cs
@@ -150,8 +150,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Gets or sets whether the messages bodies use pooled byte arrays underneath in case of binary data.
         /// When this option is enabled <see cref="ServiceBusReceivedMessage"/> cannot be safely kept for longer than the
-        /// lifetime of the scope of the <see cref="ServiceBusProcessor.ProcessSessionMessageAsync"/> or
-        /// the <see cref="ServiceBusProcessor.ProcessSessionMessageAsync"/> event handler delegate.
+        /// lifetime of the scope of the <see cref="ServiceBusProcessor.ProcessSessionMessageAsync"/> event handler delegate.
         /// The default value is false.
         /// </summary>
         ///

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -184,6 +184,7 @@ namespace Azure.Messaging.ServiceBus
                     identifier: Identifier,
                     sessionId: sessionId,
                     isSessionReceiver: IsSessionReceiver,
+                    poolReceivedMessageBodies: options.PoolMessageBodies,
                     cancellationToken: cancellationToken);
                 _scopeFactory = new EntityScopeFactory(EntityPath, FullyQualifiedNamespace);
                 _plugins = plugins;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiverOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiverOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using Azure.Core;
+using Azure.Messaging.ServiceBus.Amqp;
 
 namespace Azure.Messaging.ServiceBus
 {
@@ -46,6 +47,12 @@ namespace Azure.Messaging.ServiceBus
         public SubQueue SubQueue { get; set; } = SubQueue.None;
 
         /// <summary>
+        /// Gets or sets whether the messages bodies use pooled byte arrays underneath in case of binary data. When this option is enabled the receiver needs to
+        /// dispose the received messages by using the <see cref="ServiceBusReceivedMessageExtensions.CreateBodyScope"/> extension.
+        /// </summary>
+        internal bool PoolMessageBodies { get; set; }
+
+        /// <summary>
         /// Determines whether the specified <see cref="System.Object" /> is equal to this instance.
         /// </summary>
         ///
@@ -84,6 +91,7 @@ namespace Azure.Messaging.ServiceBus
                 ReceiveMode = ReceiveMode,
                 PrefetchCount = PrefetchCount,
                 SubQueue = SubQueue,
+                PoolMessageBodies = PoolMessageBodies
             };
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
@@ -52,6 +52,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 sessionId: default,
                 identifier: "someIdentifier",
                 isSessionReceiver: default,
+                poolReceivedMessageBodies: default,
                 cancellationToken: CancellationToken.None),
                 Throws.InstanceOf<ArgumentException>());
         }
@@ -72,6 +73,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 identifier: "someIdentifier",
                 sessionId: default,
                 isSessionReceiver: default,
+                poolReceivedMessageBodies: default,
                 cancellationToken: CancellationToken.None),
             Throws.InstanceOf<ArgumentNullException>());
         }
@@ -92,6 +94,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 identifier: "someIdentifier",
                 sessionId: default,
                 isSessionReceiver: default,
+                poolReceivedMessageBodies: default,
                 cancellationToken: CancellationToken.None),
             Throws.InstanceOf<ArgumentNullException>());
         }
@@ -150,6 +153,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             uint prefetchCount = 0;
             var sessionId = "sessionId";
             bool isSession = true;
+            bool poolReceivedMessageBodies = false;
 
             using var cancellationSource = new CancellationTokenSource();
 
@@ -169,7 +173,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, poolReceivedMessageBodies, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -206,6 +210,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             uint prefetchCount = 0;
             var sessionId = "sessionId";
             bool isSession = true;
+            bool poolReceivedMessageBodies = false;
 
             using var cancellationSource = new CancellationTokenSource();
 
@@ -225,7 +230,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, poolReceivedMessageBodies, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -270,6 +275,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             uint prefetchCount = 0;
             var sessionId = "sessionId";
             bool isSession = true;
+            bool poolReceivedMessageBodies = false;
 
             using var cancellationSource = new CancellationTokenSource();
 
@@ -289,7 +295,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, poolReceivedMessageBodies, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -329,6 +335,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             uint prefetchCount = 0;
             var sessionId = "sessionId";
             bool isSession = true;
+            bool poolReceivedMessageBodies = false;
 
             using var cancellationSource = new CancellationTokenSource();
 
@@ -348,7 +355,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(exception);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, poolReceivedMessageBodies, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -384,6 +391,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             uint prefetchCount = 0;
             var sessionId = "sessionId";
             bool isSession = true;
+            bool poolReceivedMessageBodies = false;
 
             using var cancellationSource = new CancellationTokenSource();
 
@@ -403,7 +411,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(exception);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, poolReceivedMessageBodies, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -439,6 +447,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             uint prefetchCount = 0;
             var sessionId = "sessionId";
             bool isSession = true;
+            bool poolReceivedMessageBodies = false;
 
             using var cancellationSource = new CancellationTokenSource();
 
@@ -458,7 +467,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(exception);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, poolReceivedMessageBodies, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
@@ -485,6 +494,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 Mock.Of<AmqpConnectionScope>(),
                 Mock.Of<ServiceBusRetryPolicy>(),
                 "someIdentifier",
+                default,
                 default,
                 default,
                 default);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -1284,6 +1284,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<bool>(),
+                    It.IsAny<bool>(),
                     CancellationToken.None))
                 .Returns(mockTransportReceiver.Object);
             return mockConnection;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestBase.cs
@@ -105,6 +105,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<bool>(),
+                    It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(mockTransportReceiver.Object);
             return mockConnection.Object;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Primitives/ServiceBusConnectionTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Primitives/ServiceBusConnectionTests.cs
@@ -532,15 +532,17 @@ namespace Azure.Messaging.ServiceBus.Tests
         {
             public bool WasCloseCalled;
 
+            public override TransportReceiver CreateReceiver(string entityPath, ServiceBusRetryPolicy retryPolicy,
+                ServiceBusReceiveMode receiveMode, uint prefetchCount, string identifier, string sessionId, bool isSessionReceiver,
+                bool poolReceivedMessageBodies, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
             public override Task CloseAsync(CancellationToken cancellationToken)
             {
                 WasCloseCalled = true;
                 return Task.CompletedTask;
-            }
-
-            public override TransportReceiver CreateReceiver(string entityPath, ServiceBusRetryPolicy retryPolicy, ServiceBusReceiveMode receiveMode, uint prefetchCount, string identifier, string sessionId, bool isSessionReceiver, CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
             }
 
             public override TransportSender CreateSender(string entityPath, ServiceBusRetryPolicy retryPolicy, string identifier)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -15,11 +15,15 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
     public class ProcessorLiveTests : ServiceBusLiveTestBase
     {
         [Test]
-        [TestCase(1, false)]
-        [TestCase(5, true)]
-        [TestCase(10, false)]
-        [TestCase(20, true)]
-        public async Task ProcessMessages(int numThreads, bool autoComplete)
+        [TestCase(1, false, false)]
+        [TestCase(1, false, true)]
+        [TestCase(5, true, false)]
+        [TestCase(5, true, true)]
+        [TestCase(10, false, false)]
+        [TestCase(10, false, true)]
+        [TestCase(20, true, false)]
+        [TestCase(20, true, true)]
+        public async Task ProcessMessages(int numThreads, bool autoComplete, bool poolMessageBodies)
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(
                 enablePartitioning: false,
@@ -40,6 +44,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 {
                     MaxConcurrentCalls = numThreads,
                     AutoCompleteMessages = autoComplete,
+                    PoolMessageBodies = poolMessageBodies,
                     PrefetchCount = 20
                 };
                 await using var processor = client.CreateProcessor(scope.QueueName, options);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
@@ -136,10 +136,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 PrefetchCount = 5,
                 ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete,
                 MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(60),
-                MaxReceiveWaitTime = TimeSpan.FromSeconds(10)
+                MaxReceiveWaitTime = TimeSpan.FromSeconds(10),
+                PoolMessageBodies = true,
             };
             var processor = client.CreateProcessor("queueName", options);
             Assert.AreEqual(options.AutoCompleteMessages, processor.AutoCompleteMessages);
+            Assert.AreEqual(options.PoolMessageBodies, processor.PoolMessageBodies);
             Assert.AreEqual(options.MaxConcurrentCalls, processor.MaxConcurrentCalls);
             Assert.AreEqual(options.PrefetchCount, processor.PrefetchCount);
             Assert.AreEqual(options.ReceiveMode, processor.ReceiveMode);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -93,11 +93,15 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         }
 
         [Test]
-        [TestCase(1, true)]
-        [TestCase(5, true)]
-        [TestCase(10, false)]
-        [TestCase(20, false)]
-        public async Task ProcessSessionMessage(int numThreads, bool autoComplete)
+        [TestCase(1, true, false)]
+        [TestCase(1, true, true)]
+        [TestCase(5, true, false)]
+        [TestCase(5, true, true)]
+        [TestCase(10, false, false)]
+        [TestCase(10, false, true)]
+        [TestCase(20, false, false)]
+        [TestCase(20, false, true)]
+        public async Task ProcessSessionMessage(int numThreads, bool autoComplete, bool poolMessageBodies)
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(
                 enablePartitioning: false,
@@ -117,7 +121,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var options = new ServiceBusSessionProcessorOptions
                 {
                     MaxConcurrentSessions = numThreads,
-                    AutoCompleteMessages = autoComplete
+                    AutoCompleteMessages = autoComplete,
+                    PoolMessageBodies = poolMessageBodies,
                 };
                 await using var processor = client.CreateSessionProcessor(scope.QueueName, options);
                 int messageCt = 0;


### PR DESCRIPTION
Replaces https://github.com/Azure/azure-sdk-for-net/pull/19885

# Memory Allocations

## Before

Linear growth of allocated memory

### 10k Receives on master 94b6597983a5fd3bf928560967fd5291495d4f7a

![image](https://user-images.githubusercontent.com/174258/114467396-26c48d00-9bea-11eb-9f8d-d79af07cb2be.png)

### 20k Receives on master 94b6597983a5fd3bf928560967fd5291495d4f7a

![image](https://user-images.githubusercontent.com/174258/114467351-17ddda80-9bea-11eb-98af-8b128c52af4e.png)

## After

Stable memory

### 10k Receives

![image](https://user-images.githubusercontent.com/174258/114467473-43f95b80-9bea-11eb-8008-7514118e8ff7.png)

### 20k Receives

![image](https://user-images.githubusercontent.com/174258/114467535-596e8580-9bea-11eb-8611-a83b138b38e2.png)


# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
