### PR TITLE
Fix invalid product slugs in samples

### DIFF
--- a/sdk/communication/Azure.Communication.Identity/samples/README.md
+++ b/sdk/communication/Azure.Communication.Identity/samples/README.md
@@ -4,7 +4,7 @@ languages:
 - csharp
 products:
 - azure
-- azure-communication
+- azure-communication-services
 name: Azure Communication Identity samples for .NET
 description: Samples for the Azure.Communication.Identity client library
 ---

--- a/sdk/communication/Azure.Communication.PhoneNumbers/samples/README.md
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/samples/README.md
@@ -4,7 +4,7 @@ languages:
 - csharp
 products:
 - azure
-- azure-communication
+- azure-communication-services
 name: Azure Communication Phone Number samples for .NET
 description: Samples for the Azure.Communication.PhoneNumbers client library
 ---

--- a/sdk/translation/Azure.AI.Translation.Document/samples/README.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/README.md
@@ -5,7 +5,7 @@ languages:
 products:
 - azure
 - azure-cognitive-services
-- azure-translator-text
+- azure-translator
 name: Azure DocumentTranslation samples for .NET
 description: Samples for the Azure.AI.Translation.Document client library
 ---

--- a/sdk/translation/Azure.AI.Translation.Document/samples/README.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/README.md
@@ -5,7 +5,7 @@ languages:
 products:
 - azure
 - azure-cognitive-services
-- azure-document-translation
+- azure-translator-text
 name: Azure DocumentTranslation samples for .NET
 description: Samples for the Azure.AI.Translation.Document client library
 ---


### PR DESCRIPTION
At this time, there is no slug for Document Translator, so I used azure-translator-text for now.
