### PR TITLE
[Storage] Fix flaky test.

### DIFF
--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
@@ -201,16 +201,15 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             DataLakeServiceClient service = GetServiceClient_SharedKey();
             // Ensure at least one container
-            using (GetNewFileSystem(service: service))
-            {
-                // Act
-                IList<FileSystemItem> fileSystems = await service.GetFileSystemsAsync().ToListAsync();
+            await using DisposingFileSystem test = await GetNewFileSystem(service: service);
 
-                // Assert
-                Assert.IsTrue(fileSystems.Count >= 1);
-                var accountName = new DataLakeUriBuilder(service.Uri).AccountName;
-                TestHelper.AssertCacheableProperty(accountName, () => service.AccountName);
-            }
+            // Act
+            IList<FileSystemItem> fileSystems = await service.GetFileSystemsAsync().ToListAsync();
+
+            // Assert
+            Assert.IsTrue(fileSystems.Count >= 1);
+            var accountName = new DataLakeUriBuilder(service.Uri).AccountName;
+            TestHelper.AssertCacheableProperty(accountName, () => service.AccountName);
         }
 
         [RecordedTest]

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
@@ -201,15 +201,16 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             DataLakeServiceClient service = GetServiceClient_SharedKey();
             // Ensure at least one container
-            await using DisposingFileSystem test = await GetNewFileSystem(service: service);
+            await using (await GetNewFileSystem(service: service))
+            {
+                // Act
+                IList<FileSystemItem> fileSystems = await service.GetFileSystemsAsync().ToListAsync();
 
-            // Act
-            IList<FileSystemItem> fileSystems = await service.GetFileSystemsAsync().ToListAsync();
-
-            // Assert
-            Assert.IsTrue(fileSystems.Count >= 1);
-            var accountName = new DataLakeUriBuilder(service.Uri).AccountName;
-            TestHelper.AssertCacheableProperty(accountName, () => service.AccountName);
+                // Assert
+                Assert.IsTrue(fileSystems.Count >= 1);
+                var accountName = new DataLakeUriBuilder(service.Uri).AccountName;
+                TestHelper.AssertCacheableProperty(accountName, () => service.AccountName);
+            }
         }
 
         [RecordedTest]


### PR DESCRIPTION
Fixes:
```
System.InvalidOperationException : A task may only be disposed if it is in a completion state (RanToCompletion, Faulted or Canceled).


Stack trace
   at System.Threading.Tasks.Task.Dispose(Boolean disposing)
   at System.Threading.Tasks.Task.Dispose()
   at Azure.Storage.Files.DataLake.Tests.ServiceClientTests.GetFileSystemsAsync() in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs:line 213
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
```