### PR TITLE
Update eventhub to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/eventhub/tests.data.yml
+++ b/sdk/eventhub/tests.data.yml
@@ -7,4 +7,4 @@ extends:
     ServiceDirectory: eventhub
     SDKType: data
     TimeoutInMinutes: 240
-    Clouds: 'Public,UsGov,China,Canary'
+    Clouds: 'Public,UsGov,China,Canary' 

--- a/sdk/eventhub/tests.data.yml
+++ b/sdk/eventhub/tests.data.yml
@@ -6,5 +6,5 @@ extends:
     MaxParallel: 6
     ServiceDirectory: eventhub
     SDKType: data
-    TimeoutInMinutes: 190
-    Clouds: 'Public,Canary'
+    TimeoutInMinutes: 240
+    Clouds: 'Public,Preview,UsGov,China,Canary'

--- a/sdk/eventhub/tests.data.yml
+++ b/sdk/eventhub/tests.data.yml
@@ -7,4 +7,4 @@ extends:
     ServiceDirectory: eventhub
     SDKType: data
     TimeoutInMinutes: 240
-    Clouds: 'Public,UsGov,China,Canary' 
+    Clouds: 'Public,UsGov,China,Canary'

--- a/sdk/eventhub/tests.data.yml
+++ b/sdk/eventhub/tests.data.yml
@@ -7,4 +7,4 @@ extends:
     ServiceDirectory: eventhub
     SDKType: data
     TimeoutInMinutes: 240
-    Clouds: 'Public,Preview,UsGov,China,Canary'
+    Clouds: 'Public,UsGov,China,Canary'

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -7,4 +7,4 @@ extends:
     ServiceDirectory: eventhub
     SDKType: client
     TimeoutInMinutes: 240
-     Clouds: 'Public,Preview,UsGov,China,Canary'
+    Clouds: 'Public,Preview,UsGov,China,Canary'

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -7,4 +7,4 @@ extends:
     ServiceDirectory: eventhub
     SDKType: client
     TimeoutInMinutes: 240
-     Clouds: 'Public,Preview,UsGov,China,Canary'
+    Clouds: 'Public,UsGov,China,Canary'

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -8,4 +8,3 @@ extends:
     SDKType: client
     TimeoutInMinutes: 240
     Clouds: 'Public,UsGov,China,Canary'
-

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -6,5 +6,5 @@ extends:
     MaxParallel: 6
     ServiceDirectory: eventhub
     SDKType: client
-    TimeoutInMinutes: 190
-    Clouds: 'Public,Canary'
+    TimeoutInMinutes: 240
+     Clouds: 'Public,Preview,UsGov,China,Canary'


### PR DESCRIPTION
These changes enable eventhub to run live tests against AzureUsGovernment and AzureChina clouds. The sovereign cloud live tests will be green with the changes.
@benbp @danieljurek @jongio 