### PR TITLE
[Event Hubs] Track One Performance Tests

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithConsumer.cs
@@ -43,7 +43,7 @@ namespace Azure.Messaging.EventHubs.Perf.Scenarios
         ///
         public async override Task SetupAsync()
         {
-            await base.SetupAsync();
+            await base.SetupAsync().ConfigureAwait(false);
 
             // Attempt to take a consumer group from the available set; to ensure that the
             // test scenario can support the requested level of parallelism without violating
@@ -83,7 +83,7 @@ namespace Azure.Messaging.EventHubs.Perf.Scenarios
         {
             await _readEnumerator.DisposeAsync();
             await _consumer.CloseAsync().ConfigureAwait(false);
-            await base.CleanupAsync();
+            await base.CleanupAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithReceiver.cs
@@ -41,7 +41,7 @@ namespace Azure.Messaging.EventHubs.Perf.Scenarios
         ///
         public async override Task SetupAsync()
         {
-            await base.SetupAsync();
+            await base.SetupAsync().ConfigureAwait(false);
 
             // Attempt to take a consumer group from the available set; to ensure that the
             // test scenario can support the requested level of parallelism without violating
@@ -74,7 +74,7 @@ namespace Azure.Messaging.EventHubs.Perf.Scenarios
         public async override Task CleanupAsync()
         {
             await _receiver.CloseAsync().ConfigureAwait(false);
-            await base.CleanupAsync();
+            await base.CleanupAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Infrastructure/EventGenerator.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Infrastructure/EventGenerator.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Microsoft.Azure.EventHubs.Perf
+{
+    /// <summary>
+    ///   Provides operations related to generating instances of <see cref="EventData" />
+    ///   and <see cref="EventDataBatch" /> for use in testing scenarios.
+    /// </summary>
+    ///
+    public static class EventGenerator
+    {
+        /// <summary>The seed to use for initializing random number generated for a given thread-specific instance.</summary>
+        private static int s_randomSeed = Environment.TickCount;
+
+        /// <summary>The name of the custom event property which holds a test-specific artificial event identifier.</summary>
+        public static readonly string IdPropertyName = $"{ nameof(EventGenerator) }::Identifier";
+
+        /// <summary>The random number generator to use for a specific thread.</summary>
+        private static readonly ThreadLocal<Random> RandomNumberGenerator = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref s_randomSeed)), false);
+
+        /// <summary>
+        ///   Creates a buffer of read-only memory with random values to serve
+        ///   as the body of an event.
+        /// </summary>
+        ///
+        /// <param name="bodySizeBytes">The size of the body, in bytes.</param>
+        ///
+        /// <returns>A memory buffer of the requested size range containing randomized data.</returns>
+        ///
+        public static byte[] CreateRandomBody(long bodySizeBytes)
+        {
+            var buffer = new byte[bodySizeBytes];
+            RandomNumberGenerator.Value.NextBytes(buffer);
+
+            return buffer;
+        }
+
+        /// <summary>
+        ///   Creates a set of events with random data and random body size.
+        /// </summary>
+        ///
+        /// <param name="numberOfEvents">The number of events to create.</param>
+        ///
+        /// <returns>The requested set of events.</returns>
+        ///
+        public static IEnumerable<EventData> CreateEvents(int numberOfEvents)
+        {
+            const int minimumBodySize = 15;
+            const int maximumBodySize = 83886;
+
+            for (var index = 0; index < numberOfEvents; ++index)
+            {
+                var buffer = new byte[RandomNumberGenerator.Value.Next(minimumBodySize, maximumBodySize)];
+                RandomNumberGenerator.Value.NextBytes(buffer);
+
+                yield return CreateEventFromBody(buffer);
+            }
+        }
+
+        /// <summary>
+        ///   Creates a set of events with random data and a small body size.
+        /// </summary>
+        ///
+        /// <param name="numberOfEvents">The number of events to create.</param>
+        ///
+        /// <returns>The requested set of events.</returns>
+        ///
+        public static IEnumerable<EventData> CreateSmallEvents(int numberOfEvents)
+        {
+            const int minimumBodySize = 5;
+            const int maximumBodySize = 25;
+
+            for (var index = 0; index < numberOfEvents; ++index)
+            {
+                var buffer = new byte[RandomNumberGenerator.Value.Next(minimumBodySize, maximumBodySize)];
+                RandomNumberGenerator.Value.NextBytes(buffer);
+
+                yield return CreateEventFromBody(buffer);
+            }
+        }
+
+        /// <summary>
+        ///   Creates and configures an <see cref="EventData" /> instance using the
+        ///   provided <paramref name="eventBody" /> as the embedded data.
+        /// </summary>
+        ///
+        /// <param name="eventBody">The set of bytes to use as the data body of the event.</param>
+        ///
+        /// <returns>The event that was created.</returns>
+        ///
+        public static EventData CreateEventFromBody(byte[] eventBody)
+        {
+            var currentEvent = new EventData(eventBody);
+            currentEvent.Properties.Add(IdPropertyName, Guid.NewGuid().ToString());
+
+            return currentEvent;
+        }
+
+        /// <summary>
+        ///   Creates and configures an <see cref="EventData" /> instance using the
+        ///   provided <paramref name="eventBody" /> as the embedded data.
+        /// </summary>
+        ///
+        /// <param name="numberOfEvents">The number of events to create.</param>
+        /// <param name="eventBody">The set of bytes to use as the data body of the event.</param>
+        ///
+        /// <returns>The requested set of events.</returns>
+        ///
+        public static IEnumerable<EventData> CreateEventsFromBody(int numberOfEvents,
+                                                                  byte[] eventBody)
+        {
+            for (var index = 0; index < numberOfEvents; ++index)
+            {
+                yield return CreateEventFromBody(eventBody);
+            }
+        }
+
+        /// <summary>
+        ///   Builds a set of batches from the provided events.
+        /// </summary>
+        ///
+        /// <param name="events">The events to group into batches.</param>
+        /// <param name="client">The client to use for creating batches.</param>
+        /// <param name="batchEvents">A dictionary to which the events included in the batches should be tracked.</param>
+        /// <param name="batchOptions">The set of options to apply when creating batches.</param>
+        ///
+        /// <returns>The set of batches needed to contain the entire set of <paramref name="events"/>.</returns>
+        ///
+        /// <remarks>
+        ///   Callers are assumed to be responsible for taking ownership of the lifespan of the returned batches, including
+        ///   their disposal.
+        ///
+        ///   This method is intended for use within the test suite only; it is not hardened for general purpose use.
+        /// </remarks>
+        ///
+        public static IEnumerable<EventDataBatch> BuildBatchesAsync(IEnumerable<EventData> events,
+                                                                    EventHubClient client,
+                                                                    BatchOptions batchOptions = default)
+        {
+            EventData eventData;
+
+            var queuedEvents = new Queue<EventData>(events);
+            var batches = new List<EventDataBatch>();
+            var currentBatch = default(EventDataBatch);
+
+            while (queuedEvents.Count > 0)
+            {
+                currentBatch ??= client.CreateBatch(batchOptions);
+                eventData = queuedEvents.Peek();
+
+                if (!currentBatch.TryAdd(eventData))
+                {
+                    if (currentBatch.Count == 0)
+                    {
+                        throw new InvalidOperationException("There was an event too large to fit into a batch.");
+                    }
+
+                    batches.Add(currentBatch);
+                    currentBatch = default;
+                }
+                else
+                {
+                    queuedEvents.Dequeue();
+                }
+            }
+
+            if ((currentBatch != default) && (currentBatch.Count > 0))
+            {
+                batches.Add(currentBatch);
+            }
+
+            return batches;
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Infrastructure/EventHubsPerfTest.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Infrastructure/EventHubsPerfTest.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using Azure.Test.Perf;
+
+namespace Microsoft.Azure.EventHubs.Perf
+{
+    /// <summary>
+    ///   A base class for Event Hubs performance test scenarios, facilitating.
+    /// </summary>
+    ///
+    /// <seealso cref="Azure.Test.Perf.PerfTest{SizeCountOptions}" />
+    ///
+    public abstract class EventHubsPerfTest : PerfTest<SizeCountOptions>
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsPerfTest"/> class.
+        /// </summary>
+        ///
+        /// /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        protected EventHubsPerfTest(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Executes the performance test scenario synchronously.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The token used to signal when cancellation is requested.</param>
+        ///
+        public override void Run(CancellationToken cancellationToken) => throw new InvalidOperationException("Only asynchronous execution is supported.");
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Microsoft.Azure.EventHubs.Perf.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Microsoft.Azure.EventHubs.Perf.csproj
@@ -1,0 +1,31 @@
+﻿
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>1.0.0</Version>
+    <OutputType>Exe</OutputType>
+    <LangVersion>latest</LangVersion>
+    <IsTestSupportProject>true</IsTestSupportProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
+    <PackageReference Include="Microsoft.Azure.Management.Storage" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" />
+    <PackageReference Include="Polly" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\Microsoft.Azure.EventHubs.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj" />
+  </ItemGroup>
+
+  <!-- Import Event Hubs shared source -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)..\tests\Infrastructure\TestUtility.cs" LinkBase="SharedSource" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\tests\Infrastructure\EventHubScope.cs" LinkBase="SharedSource" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\tests\Infrastructure\TestConstants.cs" LinkBase="SharedSource" />
+  </ItemGroup>
+</Project>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Microsoft.Azure.EventHubs.Perf.sln
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Microsoft.Azure.EventHubs.Perf.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.EventHubs.Perf", "Microsoft.Azure.EventHubs.Perf.csproj", "{91411BDA-79AE-45EA-AE76-A630680CE72F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{91411BDA-79AE-45EA-AE76-A630680CE72F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91411BDA-79AE-45EA-AE76-A630680CE72F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91411BDA-79AE-45EA-AE76-A630680CE72F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91411BDA-79AE-45EA-AE76-A630680CE72F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0EF42B14-3D19-4BE9-AE4E-B23186F2E985}
+	EndGlobalSection
+EndGlobal

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Program.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Program.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using Microsoft.Azure.EventHubs.Tests;
+using Azure.Test.Perf;
+
+try
+{
+    // Ensure that there is an active Event Hubs namespace that can be used across all
+    // scenarios.  Requesting the connection string will trigger creation of an ephemeral
+    // namespace if an existing one wasn't explicitly provided.
+
+    _ = TestUtility.EventHubsConnectionString;
+
+    // Allow the framework to execute the test scenarios.
+
+    await PerfProgram.Main(Assembly.GetEntryAssembly(), args);
+}
+finally
+{
+    if (TestUtility.ShouldRemoveNamespaceAfterTestRunCompletion)
+    {
+        try
+        {
+            await EventHubScope.DeleteNamespaceAsync(TestUtility.EventHubsNamespace).ConfigureAwait(false);
+        }
+        catch
+        {
+            // This should not be considered a critical failure that results in a run failure.  Due
+            // to ARM being temperamental, some management operations may be rejected.  Throwing here
+            // does not help to ensure resource cleanup.
+            //
+            // Assume the standard orphan resource cleanup is being run and will take responsibility
+            // for cleaning up any orphans.
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Scenarios/PublishBatchesToGateway.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Scenarios/PublishBatchesToGateway.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Test.Perf;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Perf;
+using Microsoft.Azure.EventHubs.Tests;
+
+namespace Azure.Messaging.EventHubs.Perf.Scenarios
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing batches of events
+    ///   to the Event Hubs gateway endpoint.
+    /// </summary>
+    ///
+    /// <seealso cref="EventHubsPerfTest" />
+    ///
+    public sealed class PublishBatchesToGateway : EventHubsPerfTest
+    {
+        /// <summary>The Event Hub to publish events to; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubScope s_scope;
+
+        /// <summary>The client instance for publishing events; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubClient s_client;
+
+        /// <summary>The body to use when creating events; shared across all concurrent instances of the scenario.</summary>
+        private static byte[] s_eventBody;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PublishBatchesToGateway"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public PublishBatchesToGateway(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the setup will take place once, prior to the
+        ///   execution of the first test instance.
+        /// </summary>
+        ///
+        public async override Task GlobalSetupAsync()
+        {
+            await base.GlobalSetupAsync().ConfigureAwait(false);
+
+            s_scope = await EventHubScope.CreateAsync(4).ConfigureAwait(false);
+            s_client = EventHubClient.CreateFromConnectionString(TestUtility.BuildEventHubsConnectionString(s_scope.EventHubName));
+            s_eventBody = EventGenerator.CreateRandomBody(Options.Size);
+
+            // Publish an empty event to force the connection and link to be established.
+
+            using var batch = s_client.CreateBatch();
+
+            if (!batch.TryAdd(new EventData(Array.Empty<byte>())))
+            {
+                throw new InvalidOperationException("The empty event could not be added to the batch during global setup.");
+            }
+
+            await s_client.SendAsync(batch).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the cleanup will take place once,
+        ///   after the execution of all test instances.
+        /// </summary>
+        ///
+        public async override Task GlobalCleanupAsync()
+        {
+            await s_client.CloseAsync().ConfigureAwait(false);
+            await s_scope.DisposeAsync().ConfigureAwait(false);
+            await base.GlobalCleanupAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Executes the performance test scenario asynchronously.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The token used to signal when cancellation is requested.</param>
+        ///
+        public async override Task RunAsync(CancellationToken cancellationToken)
+        {
+            using var batch = s_client.CreateBatch();
+
+            // Fill the batch with events using the same body.  This will result in a batch of events of equal size.
+            // The events will only differ by the id property that is assigned to them.
+
+            foreach (var eventData in EventGenerator.CreateEventsFromBody(Options.Count, s_eventBody))
+            {
+                if (!batch.TryAdd(eventData))
+                {
+                    throw new InvalidOperationException("It was not possible to fit the requested number of events in a single batch.");
+                }
+            }
+
+            await s_client.SendAsync(batch).ConfigureAwait(false);
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Scenarios/PublishBatchesToPartition.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Scenarios/PublishBatchesToPartition.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Test.Perf;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Perf;
+using Microsoft.Azure.EventHubs.Tests;
+
+namespace Azure.Messaging.EventHubs.Perf.Scenarios
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing batches of events
+    ///   to an Event Hubs partition.
+    /// </summary>
+    ///
+    /// <seealso cref="EventHubsPerfTest" />
+    ///
+    public sealed class PublishBatchesToPartition : EventHubsPerfTest
+    {
+        /// <summary>The Event Hub to publish events to; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubScope s_scope;
+
+        /// <summary>The client instance that owns the connection to the Event Hubs namespace; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubClient s_client;
+
+        /// <summary>The sender instance for publishing events; shared across all concurrent instances of the scenario.</summary>
+        private static PartitionSender s_sender;
+
+        /// <summary>The body to use when creating events; shared across all concurrent instances of the scenario.</summary>
+        private static byte[] s_eventBody;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PublishBatchesToPartition"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public PublishBatchesToPartition(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the setup will take place once, prior to the
+        ///   execution of the first test instance.
+        /// </summary>
+        ///
+        public async override Task GlobalSetupAsync()
+        {
+            await base.GlobalSetupAsync().ConfigureAwait(false);
+
+            s_scope = await EventHubScope.CreateAsync(4).ConfigureAwait(false);
+            s_client = EventHubClient.CreateFromConnectionString(TestUtility.BuildEventHubsConnectionString(s_scope.EventHubName));
+            s_eventBody = EventGenerator.CreateRandomBody(Options.Size);
+
+            var partition = (await s_client.GetRuntimeInformationAsync().ConfigureAwait(false)).PartitionIds[0];
+            s_sender = s_client.CreatePartitionSender(partition);
+
+            // Publish an empty event to force the connection and link to be established.
+
+            using var batch = s_sender.CreateBatch();
+
+            if (!batch.TryAdd(new EventData(Array.Empty<byte>())))
+            {
+                throw new InvalidOperationException("The empty event could not be added to the batch during global setup.");
+            }
+
+            await s_sender.SendAsync(batch).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the cleanup will take place once,
+        ///   after the execution of all test instances.
+        /// </summary>
+        ///
+        public async override Task GlobalCleanupAsync()
+        {
+            await s_sender.CloseAsync().ConfigureAwait(false);
+            await s_client.CloseAsync().ConfigureAwait(false);
+            await s_scope.DisposeAsync().ConfigureAwait(false);
+            await base.GlobalCleanupAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Executes the performance test scenario asynchronously.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The token used to signal when cancellation is requested.</param>
+        ///
+        public async override Task RunAsync(CancellationToken cancellationToken)
+        {
+            using var batch = s_sender.CreateBatch();
+
+            // Fill the batch with events using the same body.  This will result in a batch of events of equal size.
+            // The events will only differ by the id property that is assigned to them.
+
+            foreach (var eventData in EventGenerator.CreateEventsFromBody(Options.Count, s_eventBody))
+            {
+                if (!batch.TryAdd(eventData))
+                {
+                    throw new InvalidOperationException("It was not possible to fit the requested number of events in a single batch.");
+                }
+            }
+
+            await s_sender.SendAsync(batch).ConfigureAwait(false);
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Scenarios/PublishEventsToGateway.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Scenarios/PublishEventsToGateway.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Test.Perf;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Perf;
+using Microsoft.Azure.EventHubs.Tests;
+
+namespace Azure.Messaging.EventHubs.Perf.Scenarios
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing events
+    ///   to the Event Hubs gateway endpoint.
+    /// </summary>
+    ///
+    /// <seealso cref="EventHubsPerfTest" />
+    ///
+    public sealed class PublishEventsToGateway : EventHubsPerfTest
+    {
+        /// <summary>The Event Hub to publish events to; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubScope s_scope;
+
+        /// <summary>The client instance for publishing events; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubClient s_client;
+
+        /// <summary>The body to use when creating events; shared across all concurrent instances of the scenario.</summary>
+        private static byte[] s_eventBody;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PublishEventsToGateway"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public PublishEventsToGateway(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the setup will take place once, prior to the
+        ///   execution of the first test instance.
+        /// </summary>
+        ///
+        public async override Task GlobalSetupAsync()
+        {
+            await base.GlobalSetupAsync().ConfigureAwait(false);
+
+            s_scope = await EventHubScope.CreateAsync(4).ConfigureAwait(false);
+            s_client = EventHubClient.CreateFromConnectionString(TestUtility.BuildEventHubsConnectionString(s_scope.EventHubName));
+            s_eventBody = EventGenerator.CreateRandomBody(Options.Size);
+
+            // Publish an empty event to force the connection and link to be established.
+
+            await s_client.SendAsync(new[] { new EventData(Array.Empty<byte>()) }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the cleanup will take place once,
+        ///   after the execution of all test instances.
+        /// </summary>
+        ///
+        public async override Task GlobalCleanupAsync()
+        {
+            await s_client.CloseAsync().ConfigureAwait(false);
+            await s_scope.DisposeAsync().ConfigureAwait(false);
+            await base.GlobalCleanupAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Executes the performance test scenario asynchronously.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The token used to signal when cancellation is requested.</param>
+        ///
+        public async override Task RunAsync(CancellationToken cancellationToken)
+        {
+            // Generate a set of events using the same body.  This will result in publishing a set of events
+            // of equal size. The events will only differ by the id property that is assigned to them.
+
+            var events = EventGenerator.CreateEventsFromBody(Options.Count, s_eventBody);
+
+            try
+            {
+                await s_client.SendAsync(events).ConfigureAwait(false);
+            }
+            finally
+            {
+                foreach (var eventData in events)
+                {
+                    eventData.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Scenarios/PublishEventsToPartition.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Scenarios/PublishEventsToPartition.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Test.Perf;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Perf;
+using Microsoft.Azure.EventHubs.Tests;
+
+namespace Azure.Messaging.EventHubs.Perf.Scenarios
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing events
+    ///   to an Event Hubs partition.
+    /// </summary>
+    ///
+    /// <seealso cref="EventHubsPerfTest" />
+    ///
+    public sealed class  PublishEventsToPartition : EventHubsPerfTest
+    {
+        /// <summary>The Event Hub to publish events to; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubScope s_scope;
+
+        /// <summary>The client instance that owns the connection to the Event Hubs namespace; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubClient s_client;
+
+        /// <summary>The sender instance for publishing events; shared across all concurrent instances of the scenario.</summary>
+        private static PartitionSender s_sender;
+
+        /// <summary>The body to use when creating events; shared across all concurrent instances of the scenario.</summary>
+        private static byte[] s_eventBody;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PublishEventsToPartition"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public PublishEventsToPartition(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the setup will take place once, prior to the
+        ///   execution of the first test instance.
+        /// </summary>
+        ///
+        public async override Task GlobalSetupAsync()
+        {
+            await base.GlobalSetupAsync().ConfigureAwait(false);
+
+            s_scope = await EventHubScope.CreateAsync(4).ConfigureAwait(false);
+            s_client = EventHubClient.CreateFromConnectionString(TestUtility.BuildEventHubsConnectionString(s_scope.EventHubName));
+            s_eventBody = EventGenerator.CreateRandomBody(Options.Size);
+
+            var partition = (await s_client.GetRuntimeInformationAsync().ConfigureAwait(false)).PartitionIds[0];
+            s_sender = s_client.CreatePartitionSender(partition);
+
+            // Publish an empty event to force the connection and link to be established.
+
+            await s_sender.SendAsync(new[] { new EventData(Array.Empty<byte>()) }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the cleanup will take place once,
+        ///   after the execution of all test instances.
+        /// </summary>
+        ///
+        public async override Task GlobalCleanupAsync()
+        {
+            await s_sender.CloseAsync().ConfigureAwait(false);
+            await s_client.CloseAsync().ConfigureAwait(false);
+            await s_scope.DisposeAsync().ConfigureAwait(false);
+            await base.GlobalCleanupAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Executes the performance test scenario asynchronously.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The token used to signal when cancellation is requested.</param>
+        ///
+        public async override Task RunAsync(CancellationToken cancellationToken)
+        {
+            // Generate a set of events using the same body.  This will result in publishing a set of events
+            // of equal size. The events will only differ by the id property that is assigned to them.
+
+            var events = EventGenerator.CreateEventsFromBody(Options.Count, s_eventBody);
+
+            try
+            {
+                await s_sender.SendAsync(events).ConfigureAwait(false);
+            }
+            finally
+            {
+                foreach (var eventData in events)
+                {
+                    eventData.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Scenarios/ReadFromPartitionWithReceiver.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Scenarios/ReadFromPartitionWithReceiver.cs
@@ -1,0 +1,234 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Test.Perf;
+using Microsoft.Azure.EventHubs.Tests;
+
+namespace Microsoft.Azure.EventHubs.Perf.Scenarios
+{
+    /// <summary>
+    ///   The performance test scenario focused on reading events
+    ///   with the <see cref="PartitionReceiver" />.
+    /// </summary>
+    ///
+    /// <seealso cref="EventHubsPerfTest" />
+    ///
+    public sealed class ReadFromPartitionWithReceiver : EventHubsPerfTest
+    {
+        /// <summary>The Event Hub to publish events to; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubScope s_scope ;
+
+        /// <summary>The set of consumer groups available for readers to reserve an instance of; shared across all concurrent instances of the scenario.</summary>
+        private static ConcurrentQueue<string> s_consumerGroups;
+
+        /// <summary>The client instance that owns the connection to the Event Hubs namespace; each concurrent instance of the scenario will use an independent connection.</summary>
+        private EventHubClient _client;
+
+        /// <summary>The receiver instance for reading events.</summary>
+        private PartitionReceiver _receiver;
+
+        /// <summary>The identifier of the Event Hub partition from which events should be read.</summary>
+        private string _partitionId;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ReadFromPartitionWithReceiver"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public ReadFromPartitionWithReceiver(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the setup will take place once, prior to the
+        ///   execution of the first test instance.
+        /// </summary>
+        ///
+        public async override Task GlobalSetupAsync()
+        {
+            await base.GlobalCleanupAsync().ConfigureAwait(false);
+
+            // The limit for concurrent readers in a consumer group is 5; create
+            // enough consumer groups to support the requested parallelism.
+
+            var consumerGroups = Enumerable
+                .Range(0, (int)Math.Ceiling(Options.Parallel / 5.0d))
+                .Select(index => $"group{ index }");
+
+            // Create the Event Hub scope using the computed consumer groups; queue the
+            // groups with 5 instances each, so that readers can reserve one without
+            // exceeding the concurrent reader limit.
+
+            s_scope = await EventHubScope.CreateAsync(4, consumerGroups).ConfigureAwait(false);
+            s_consumerGroups = new ConcurrentQueue<string>(consumerGroups.SelectMany(group => Repeat(group, 5)));
+
+            // Seed the necessary number of events to the selected partition.  Note that this
+            // method makes heavy use of class state such as the TestUtility, Options, and
+            // PartitionId.
+
+            await SeedEventsToBeReadAsync(_client, _partitionId).ConfigureAwait(false);
+
+            // Force a pause to give the events time to be committed in the Event Hubs
+            // service and made available to read.
+
+            await Task.Delay(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the cleanup will take place once,
+        ///   after the execution of all test instances.
+        /// </summary>
+        ///
+        public async override Task GlobalCleanupAsync()
+        {
+            await s_scope.DisposeAsync().ConfigureAwait(false);
+            await base.GlobalCleanupAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for an instance
+        ///   of the test scenario.  When multiple instances are run in parallel, setup will be
+        ///   run once for each prior to its execution.
+        /// </summary>
+        ///
+        public async override Task SetupAsync()
+        {
+            await base.SetupAsync().ConfigureAwait(false);
+
+            // Attempt to take a consumer group from the available set; to ensure that the
+            // test scenario can support the requested level of parallelism without violating
+            // the concurrent reader limits of a consumer group, the default consumer group
+            // should not be used.
+
+            if (!s_consumerGroups.TryDequeue(out var consumerGroup))
+            {
+                throw new InvalidOperationException("Unable to reserve a consumer group to read from.");
+            }
+
+            _client = EventHubClient.CreateFromConnectionString(TestUtility.BuildEventHubsConnectionString(s_scope.EventHubName));
+            _partitionId = (await _client.GetRuntimeInformationAsync().ConfigureAwait(false)).PartitionIds[0];
+
+            _receiver = _client.CreateReceiver(
+                consumerGroup,
+                _partitionId,
+                EventPosition.FromStart());
+
+            // Force the connection and link creation by reading a single event.
+
+            await _receiver.ReceiveAsync(1).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the environment for an instance
+        ///   of the test scenario.  When multiple instances are run in parallel, cleanup
+        ///   will be run once for each after execution has completed.
+        /// </summary>
+        ///
+        public async override Task CleanupAsync()
+        {
+            await _client.CloseAsync().ConfigureAwait(false);
+            await _receiver.CloseAsync().ConfigureAwait(false);
+            await base.CleanupAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Executes the performance test scenario asynchronously.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The token used to signal when cancellation is requested.</param>
+        ///
+        public async override Task RunAsync(CancellationToken cancellationToken)
+        {
+            // Read the requested number of events.
+
+            var remainingEvents = Options.Count;
+
+            while ((!cancellationToken.IsCancellationRequested) && (remainingEvents > 0))
+            {
+                remainingEvents -= (await _receiver.ReceiveAsync(remainingEvents).ConfigureAwait(false)).Count();
+            }
+
+            // If iteration stopped due to cancellation, ensure that the expected exception is thrown.
+
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        /// <summary>
+        ///   Seeds the Event Hub partition with enough events to satisfy the read operations the test scenario
+        ///   is expected to perform.
+        /// </summary>
+        ///
+        /// <param name="client">The client to use for publishing events; ownership is assumed to be retained by the caller.</param>
+        /// <param name="partitionId">The identifier of the partition to which events should be published.</param>
+        ///
+        /// <remarks>
+        ///   This method makes heavy use of class state, including the
+        ///   test environment and command line options.
+        /// </remarks>
+        ///
+        private async Task SeedEventsToBeReadAsync(EventHubClient client,
+                                                   string partitionId)
+        {
+            // Calculate the number of events needed to satisfy the number of events per iteration
+            // and then buffer it to allow for the warm-up.
+
+            var eventCount = Options.Count * Options.Iterations * 3;
+            var eventBody = EventGenerator.CreateRandomBody(Options.Size);
+            var sender = client.CreatePartitionSender(partitionId);
+
+            try
+            {
+                foreach (var eventData in EventGenerator.CreateEventsFromBody(eventCount, eventBody))
+                {
+                    using var batch = sender.CreateBatch();
+
+                    // Fill the batch with as many events that will fit.
+
+                    while (batch.TryAdd(EventGenerator.CreateEventFromBody(eventBody)))
+                    {
+                    }
+
+                    // If there were no events in the batch, then a single event was generated that is too large to
+                    // ever send.  In this context, it will be detected on the first TryAdd call, since events are
+                    // sharing a common body.
+
+                    if (batch.Count == 0)
+                    {
+                        throw new InvalidOperationException("There was an event too large to fit into a batch.");
+                    }
+
+                    await sender.SendAsync(batch).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                await sender.CloseAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        ///   Repeats the specified string the requested number of times, capturing the instances
+        ///   into a set.
+        /// </summary>
+        ///
+        /// <param name="item">The item to duplicate.</param>
+        /// <param name="count">The number of duplicate items that the resulting set should contain.</param>
+        ///
+        /// <returns>A set of <paramref name="item" /> duplicated <paramref name="count" /> times.</returns>
+        ///
+        private IEnumerable<string> Repeat(string item,
+                                           int count) =>
+            Enumerable
+                .Range(1, count)
+                .Select(index => item);
+    }
+}


### PR DESCRIPTION
# Summary

The focus of these changes is to introduce a set of performance tests for `Microsoft.Azure.EventHubs` that parallels the equivalent scenarios in the suite for `Azure.Messaging.EventHubs`.

# Last Upstream Rebase

Tuesday, April 13, 5pm (EST)

# References and Related

- [Event Hubs: Performance Tests for Microsoft.Azure.EventHubs (#20099)](https://github.com/Azure/azure-sdk-for-net/issues/20099)