### PR TITLE
[Event Hubs] Track Two Performance Test Cleanup

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf.sln
@@ -3,7 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31005.135
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.EventHubs.Perf", "Azure.Messaging.EventHubs.Perf.csproj", "{91411BDA-79AE-45EA-AE76-A630680CE72F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs.Perf", "Azure.Messaging.EventHubs.Perf.csproj", "{91411BDA-79AE-45EA-AE76-A630680CE72F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{76EAF780-5E6E-408F-AF80-94E5E9A1D7A5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs", "..\src\Azure.Messaging.EventHubs.csproj", "{0ACC7C01-8FB1-441A-85E3-41C1C9078043}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,9 +19,16 @@ Global
 		{91411BDA-79AE-45EA-AE76-A630680CE72F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{91411BDA-79AE-45EA-AE76-A630680CE72F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{91411BDA-79AE-45EA-AE76-A630680CE72F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0ACC7C01-8FB1-441A-85E3-41C1C9078043}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0ACC7C01-8FB1-441A-85E3-41C1C9078043}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0ACC7C01-8FB1-441A-85E3-41C1C9078043}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0ACC7C01-8FB1-441A-85E3-41C1C9078043}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0ACC7C01-8FB1-441A-85E3-41C1C9078043} = {76EAF780-5E6E-408F-AF80-94E5E9A1D7A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0EF42B14-3D19-4BE9-AE4E-B23186F2E985}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/BatchPublishPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/BatchPublishPerfTest.cs
@@ -24,10 +24,10 @@ namespace Azure.Messaging.EventHubs.Perf
         /// <summary>The producer instance for publishing events; shared across all concurrent instances of the scenario.</summary>
         private static EventHubProducerClient s_producer;
 
-        /// <summary>The body to use when creating events.</summary>
+        /// <summary>The body to use when creating events; shared across all concurrent instances of the scenario.</summary>
         private static ReadOnlyMemory<byte> s_eventBody;
 
-        /// <summary>The set of options to use when creating batches.</summary>
+        /// <summary>The set of options to use when creating batches; shared across all concurrent instances of the scenario.</summary>
         private static CreateBatchOptions s_batchOptions;
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventHubsPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventHubsPerfTest.cs
@@ -9,7 +9,7 @@ using Azure.Test.Perf;
 namespace Azure.Messaging.EventHubs.Perf
 {
     /// <summary>
-    ///   A base class for Event Hubs performance test scenarios, facilitating.
+    ///   A base class for Event Hubs performance test scenarios.
     /// </summary>
     ///
     /// <seealso cref="Azure.Test.Perf.PerfTest{SizeCountOptions}" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventPublishPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventPublishPerfTest.cs
@@ -25,10 +25,10 @@ namespace Azure.Messaging.EventHubs.Perf
         /// <summary>The producer instance for publishing events; shared across all concurrent instances of the scenario.</summary>
         private static EventHubProducerClient s_producer;
 
-        /// <summary>The body to use when creating events.</summary>
+        /// <summary>The body to use when creating events; shared across all concurrent instances of the scenario.</summary>
         private static ReadOnlyMemory<byte> s_eventBody;
 
-        /// <summary>The set of options to use when publishing events.</summary>
+        /// <summary>The set of options to use when publishing events; shared across all concurrent instances of the scenario.</summary>
         private static SendEventOptions s_sendOptions;
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/ReadPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/ReadPerfTest.cs
@@ -13,8 +13,8 @@ using Azure.Test.Perf;
 namespace Azure.Messaging.EventHubs.Perf
 {
     /// <summary>
-    ///   The performance test scenario focused on publishing sets of events
-    ///   without a batch.
+    ///   The performance test scenario focused on reading events from an
+    ///   Event Hub partition.
     /// </summary>
     ///
     /// <seealso cref="EventHubsPerfTest" />
@@ -28,13 +28,15 @@ namespace Azure.Messaging.EventHubs.Perf
         protected static EventHubScope Scope { get; private set; }
 
         /// <summary>
-        ///   The set of consumer groups available for readers to reserve an instance of.
+        ///   The set of consumer groups available for readers to reserve an instance of; shared across
+        ///   all concurrent instances of the scenario.
         /// </summary>
         ///
         protected static ConcurrentQueue<string> ConsumerGroups { get; private set;}
 
         /// <summary>
-        ///   The identifier of the Event Hub partition from which events should be read.
+        ///   The identifier of the Event Hub partition from which events should be read; shared across
+        ///   all concurrent instances of the scenario.
         /// </summary>
         ///
         protected static string PartitionId { get; private set; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Program.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Program.cs
@@ -27,9 +27,8 @@ finally
         }
         catch
         {
-            // This should not be considered a critical failure that results in a test run failure.  Due
-            // to ARM being temperamental, some management operations may be rejected.  Throwing here
-            // does not help to ensure resource cleanup.
+            // This should not be considered a critical failure.  Due to ARM being temperamental, some
+            // management operations may be rejected.  Throwing here does not help to ensure resource cleanup.
             //
             // Assume the standard orphan resource cleanup is being run and will take responsibility
             // for cleaning up any orphans.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/PublishBatchesToPartition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/PublishBatchesToPartition.cs
@@ -9,7 +9,8 @@ using Azure.Test.Perf;
 namespace Azure.Messaging.EventHubs.Perf.Scenarios
 {
     /// <summary>
-    ///   The performance test scenario focused on publishing a set of events.
+    ///   The performance test scenario focused on publishing a set of events to
+    ///   an Event Hub partition.
     /// </summary>
     ///
     /// <seealso cref="BatchPublishPerfTest" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/PublishEventsToPartition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/PublishEventsToPartition.cs
@@ -10,7 +10,7 @@ namespace Azure.Messaging.EventHubs.Perf.Scenarios
 {
     /// <summary>
     ///   The performance test scenario focused on publishing events
-    ///   to an Event Hubs partition.
+    ///   to an Event Hub partition.
     /// </summary>
     ///
     /// <seealso cref="EventPublishPerfTest" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithConsumer.cs
@@ -11,8 +11,8 @@ using Azure.Test.Perf;
 namespace Azure.Messaging.EventHubs.Perf.Scenarios
 {
     /// <summary>
-    ///   The performance test scenario focused on publishing events
-    ///   to an Event Hubs partition.
+    ///   The performance test scenario focused on reading events from an
+    ///   Event Hub partition using the <see cref="EventHubConsumerClient" />.
     /// </summary>
     ///
     /// <seealso cref="ReadPerfTest" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithReceiver.cs
@@ -12,8 +12,8 @@ using Azure.Test.Perf;
 namespace Azure.Messaging.EventHubs.Perf.Scenarios
 {
     /// <summary>
-    ///   The performance test scenario focused on publishing events
-    ///   to an Event Hubs partition.
+    ///   The performance test scenario focused on reading events from an
+    ///   Event Hub partition using the <see cref="PartitionReceiver" />.
     /// </summary>
     ///
     /// <seealso cref="ReadPerfTest" />


### PR DESCRIPTION
# Summary

The focus of the changes is to perform some small refactorings to cleanup the performance tests.

# Last Upstream Rebase

Tuesday, April 13, 5:30pm (EDT)