### PR TITLE
Include string as list of allowed types in exception message.

### DIFF
--- a/sdk/core/Azure.Core/src/Messaging/CloudEventExtensionAttributes.cs
+++ b/sdk/core/Azure.Core/src/Messaging/CloudEventExtensionAttributes.cs
@@ -125,7 +125,7 @@ namespace Azure.Messaging
                     return;
                 default:
                     throw new ArgumentException($"Values of type {value.GetType()} are not supported. " +
-                        "Attribute values must be of type bool, byte, int, Uri, DateTime, or DateTimeOffset.");
+                        "Attribute values must be of type string, bool, byte, int, Uri, DateTime, or DateTimeOffset.");
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/20332