### PR TITLE
[Storage] Don't list all service versions if you don't test them.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/ChangeFeedTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/ChangeFeedTestBase.cs
@@ -13,8 +13,10 @@ using Azure.Storage.Test.Shared;
 namespace Azure.Storage.Blobs.ChangeFeed.Tests
 {
     [ClientTestFixture(
-    BlobClientOptions.ServiceVersion.V2020_06_12,
-    BlobClientOptions.ServiceVersion.V2020_08_04,
+        /* BlobClientOptions.ServiceVersion.V2020_06_12,
+        BlobClientOptions.ServiceVersion.V2020_08_04, */ // https://github.com/Azure/azure-sdk-for-net/issues/20386
+        StorageVersionExtensions.LatestVersion,
+        StorageVersionExtensions.MaxVersion,
     RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
     LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
     public class ChangeFeedTestBase : StorageTestBase

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -19,13 +19,15 @@ using NUnit.Framework;
 namespace Azure.Storage.Test.Shared
 {
     [ClientTestFixture(
-        BlobClientOptions.ServiceVersion.V2019_02_02,
+        /* BlobClientOptions.ServiceVersion.V2019_02_02,
         BlobClientOptions.ServiceVersion.V2019_07_07,
         BlobClientOptions.ServiceVersion.V2019_12_12,
         BlobClientOptions.ServiceVersion.V2020_02_10,
         BlobClientOptions.ServiceVersion.V2020_04_08,
         BlobClientOptions.ServiceVersion.V2020_06_12,
-        BlobClientOptions.ServiceVersion.V2020_08_04,
+        BlobClientOptions.ServiceVersion.V2020_08_04, */ // https://github.com/Azure/azure-sdk-for-net/issues/20386
+        StorageVersionExtensions.LatestVersion,
+        StorageVersionExtensions.MaxVersion,
         RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
         LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
     public abstract class BlobTestBase : StorageTestBase

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -18,13 +18,15 @@ using NUnit.Framework;
 namespace Azure.Storage.Files.DataLake.Tests
 {
     [ClientTestFixture(
-        DataLakeClientOptions.ServiceVersion.V2019_02_02,
+        /* DataLakeClientOptions.ServiceVersion.V2019_02_02,
         DataLakeClientOptions.ServiceVersion.V2019_07_07,
         DataLakeClientOptions.ServiceVersion.V2019_12_12,
         DataLakeClientOptions.ServiceVersion.V2020_02_10,
         DataLakeClientOptions.ServiceVersion.V2020_04_08,
         DataLakeClientOptions.ServiceVersion.V2020_06_12,
-        DataLakeClientOptions.ServiceVersion.V2020_08_04,
+        DataLakeClientOptions.ServiceVersion.V2020_08_04, */ // https://github.com/Azure/azure-sdk-for-net/issues/20386
+        StorageVersionExtensions.LatestVersion,
+        StorageVersionExtensions.MaxVersion,
         RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
         LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
     public abstract class DataLakeTestBase : StorageTestBase

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -16,13 +16,15 @@ using NUnit.Framework;
 namespace Azure.Storage.Files.Shares.Tests
 {
     [ClientTestFixture(
-        ShareClientOptions.ServiceVersion.V2019_02_02,
+        /* ShareClientOptions.ServiceVersion.V2019_02_02,
         ShareClientOptions.ServiceVersion.V2019_07_07,
         ShareClientOptions.ServiceVersion.V2019_12_12,
         ShareClientOptions.ServiceVersion.V2020_02_10,
         ShareClientOptions.ServiceVersion.V2020_04_08,
         ShareClientOptions.ServiceVersion.V2020_06_12,
-        ShareClientOptions.ServiceVersion.V2020_08_04,
+        ShareClientOptions.ServiceVersion.V2020_08_04,*/ // https://github.com/Azure/azure-sdk-for-net/issues/20386
+        StorageVersionExtensions.LatestVersion,
+        StorageVersionExtensions.MaxVersion,
         RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
         LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
     public class FileTestBase : StorageTestBase


### PR DESCRIPTION
This is short-mid term fix to alleviate pain while running storage tests until we find better solution. Contunuation from https://github.com/Azure/azure-sdk-for-net/pull/20357.
We'll be pursuing better solution here https://github.com/Azure/azure-sdk-for-net/issues/20386 .