### PR TITLE
Support #if SNIPPET in snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,12 +197,12 @@ When run, the code regions in the format below (where `<snippetName>` is the nam
 //some sample code
 string snippet = "some snippet code";
 
-// Lines prefixed with the below comment format will be ignored by the snippet updater.
-/*@@*/ string ignored = "this code will not appear in the snippet markdown";
-
-// Lines prefixed with the below comment format will appear in the snippet markdown, but will remain comments in the C#` code.
-// Note: these comments should only be used for non-critical code as it will not be compiled or refactored as the code changes.
-//@@ snippet = "value that would never pass a test but looks good in a sample!";
+// The snippet updater defines the SNIPPET directive while parsing. You can use #if SNIPPET to filter lines in or out of the snippet.
+#if SNIPPET
+snippet = "value that would never pass a test but looks good in a sample!";
+#else
+string ignored = "this code will not appear in the snippet markdown";
+#endif
 
 #endregion
 ```

--- a/eng/SnippetGenerator/DirectoryProcessor.cs
+++ b/eng/SnippetGenerator/DirectoryProcessor.cs
@@ -232,7 +232,6 @@ namespace SnippetGenerator
             var directiveWalker = new DirectiveWalker();
             directiveWalker.Visit(syntaxTree.GetRoot());
 
-
             foreach (var region in directiveWalker.Regions)
             {
                 var leadingTrivia = region.Item1.EndOfDirectiveToken.LeadingTrivia;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample02_EventProcessorConfigurationLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample02_EventProcessorConfigurationLiveTests.cs
@@ -445,7 +445,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
             Assert.That(options, Is.Not.Null);
         }
 
-#if NETCOREAPP3_1 || NET5
+#if NETCOREAPP3_1 || NET5 || SNIPPET
         /// <summary>
         ///   Performs basic smoke test validation of the contained snippet.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample02_EventHubsClientsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample02_EventHubsClientsLiveTests.cs
@@ -299,7 +299,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
             Assert.That(options, Is.Not.Null);
         }
 
-#if NETCOREAPP3_1 || NET5
+#if NETCOREAPP3_1 || NET5 || SNIPPET
         /// <summary>
         ///   Performs basic smoke test validation of the contained snippet.
         /// </summary>

--- a/sdk/monitor/Azure.Monitory.Query/tests/LogsClientSamples.cs
+++ b/sdk/monitor/Azure.Monitory.Query/tests/LogsClientSamples.cs
@@ -41,8 +41,11 @@ namespace Azure.Template.Tests
             #region Snippet:QueryLogsPrintTable
 
             LogsClient client = new LogsClient(new DefaultAzureCredential());
-            /*@@*/string workspaceId = TestEnvironment.WorkspaceId;
-            //@@string workspaceId = "<workspace_id>";
+#if SNIPPET
+            string workspaceId = "<workspace_id>";
+#else
+            string workspaceId = TestEnvironment.WorkspaceId;
+#endif
             Response<LogsQueryResult> response = await client.QueryAsync(workspaceId, "AzureActivity | top 10 by TimeGenerated");
 
             LogsQueryResultTable table = response.Value.PrimaryTable;
@@ -74,8 +77,11 @@ namespace Azure.Template.Tests
             #region Snippet:QueryLogsAsPrimitive
 
             LogsClient client = new LogsClient(new DefaultAzureCredential());
-            /*@@*/string workspaceId = TestEnvironment.WorkspaceId;
-            //@@string workspaceId = "<workspace_id>";
+#if SNIPPET
+            string workspaceId = "<workspace_id>";
+#else
+            string workspaceId = TestEnvironment.WorkspaceId;
+#endif
 
             // Query TOP 10 resource groups by event count
             Response<IReadOnlyList<string>> response = await client.QueryAsync<string>(workspaceId,
@@ -95,8 +101,11 @@ namespace Azure.Template.Tests
             #region Snippet:QueryLogsAsModels
 
             LogsClient client = new LogsClient(new DefaultAzureCredential());
-            /*@@*/string workspaceId = TestEnvironment.WorkspaceId;
-            //@@string workspaceId = "<workspace_id>";
+#if SNIPPET
+            string workspaceId = "<workspace_id>";
+#else
+            string workspaceId = TestEnvironment.WorkspaceId;
+#endif
 
             // Query TOP 10 resource groups by event count
             Response<IReadOnlyList<MyLogEntryModel>> response = await client.QueryAsync<MyLogEntryModel>(workspaceId,
@@ -116,8 +125,11 @@ namespace Azure.Template.Tests
             #region Snippet:BatchQuery
 
             LogsClient client = new LogsClient(new DefaultAzureCredential());
-            /*@@*/string workspaceId = TestEnvironment.WorkspaceId;
-            //@@string workspaceId = "<workspace_id>";
+#if SNIPPET
+            string workspaceId = "<workspace_id>";
+#else
+            string workspaceId = TestEnvironment.WorkspaceId;
+#endif
 
             // Query TOP 10 resource groups by event count
             // And total event count


### PR DESCRIPTION
It's closer to C# syntax, can be used to verify that snippets still build after replacement and I can type it without having to consult the doc.