### PR TITLE
adt(doc): specify code snippet language

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/CHANGELOG.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.3.0-beta.1 (Unreleased)
+
+
 ## 1.2.2 (2021-04-12)
 
 ### Fixes and improvements

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -53,7 +53,7 @@ namespace Azure.DigitalTwins.Core
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/digitaltwins/Azure.DigitalTwins.Core/samples">our repo samples</see>.
         /// </remarks>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleCreateServiceClientWithClientSecret">
+        /// <code snippet="Snippet:DigitalTwinsSampleCreateServiceClientWithClientSecret" language="csharp">
         /// // DefaultAzureCredential supports different authentication mechanisms and determines the appropriate credential type based of the environment it is executing in.
         /// // It attempts to use multiple credential types in an order until it finds a working credential.
         /// TokenCredential tokenCredential = new DefaultAzureCredential();
@@ -138,7 +138,7 @@ namespace Azure.DigitalTwins.Core
         /// <example>
         /// This sample demonstrates getting and deserializing a digital twin into a custom data type.
         ///
-        /// <code snippet="Snippet:DigitalTwinsSampleGetCustomDigitalTwin">
+        /// <code snippet="Snippet:DigitalTwinsSampleGetCustomDigitalTwin" language="csharp">
         /// Response&lt;CustomDigitalTwin&gt; getCustomDtResponse = await client.GetDigitalTwinAsync&lt;CustomDigitalTwin&gt;(customDtId);
         /// CustomDigitalTwin customDt = getCustomDtResponse.Value;
         /// Console.WriteLine($&quot;Retrieved and deserialized digital twin {customDt.Id}:\n\t&quot; +
@@ -255,7 +255,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="digitalTwinId"/> or <paramref name="digitalTwin"/> is <c>null</c>.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleCreateCustomTwin">
+        /// <code snippet="Snippet:DigitalTwinsSampleCreateCustomTwin" language="csharp">
         /// var customTwin = new CustomDigitalTwin
         /// {
         ///     Id = customDtId,
@@ -393,7 +393,7 @@ namespace Azure.DigitalTwins.Core
         /// To delete a digital twin, any relationships referencing it must be deleted first.
         /// </remarks>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleDeleteTwin">
+        /// <code snippet="Snippet:DigitalTwinsSampleDeleteTwin" language="csharp">
         /// await client.DeleteDigitalTwinAsync(digitalTwinId);
         /// Console.WriteLine($&quot;Deleted digital twin &apos;{digitalTwinId}&apos;.&quot;);
         /// </code>
@@ -558,7 +558,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="digitalTwinId"/> or <paramref name="componentName"/> is <c>null</c>.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleGetComponent">
+        /// <code snippet="Snippet:DigitalTwinsSampleGetComponent" language="csharp">
         /// await client.GetComponentAsync&lt;MyCustomComponent&gt;(basicDtId, SamplesConstants.ComponentName);
         /// Console.WriteLine($&quot;Retrieved component for digital twin &apos;{basicDtId}&apos;.&quot;);
         /// </code>
@@ -653,7 +653,7 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="digitalTwinId"/> or <paramref name="componentName"/> is <c>null</c>.
         /// </exception>
-        /// <code snippet="Snippet:DigitalTwinsSampleUpdateComponent">
+        /// <code snippet="Snippet:DigitalTwinsSampleUpdateComponent" language="csharp">
         /// // Update Component1 by replacing the property ComponentProp1 value,
         /// // using an optional utility to build the payload.
         /// var componentJsonPatchDocument = new JsonPatchDocument();
@@ -770,7 +770,7 @@ namespace Azure.DigitalTwins.Core
         /// </exception>
         /// <example>
         /// This sample demonstrates iterating over outgoing relationships and deserializing relationship strings into BasicRelationship objects.
-        /// <code snippet="Snippet:DigitalTwinsSampleGetAllRelationships">
+        /// <code snippet="Snippet:DigitalTwinsSampleGetAllRelationships" language="csharp">
         /// AsyncPageable&lt;BasicRelationship&gt; relationships = client.GetRelationshipsAsync&lt;BasicRelationship&gt;(&quot;buildingTwinId&quot;);
         /// await foreach (BasicRelationship relationship in relationships)
         /// {
@@ -936,7 +936,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="digitalTwinId"/> is <c>null</c>.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleGetIncomingRelationships">
+        /// <code snippet="Snippet:DigitalTwinsSampleGetIncomingRelationships" language="csharp">
         /// AsyncPageable&lt;IncomingRelationship&gt; incomingRelationships = client.GetIncomingRelationshipsAsync(&quot;buildingTwinId&quot;);
         ///
         /// await foreach (IncomingRelationship incomingRelationship in incomingRelationships)
@@ -1086,7 +1086,7 @@ namespace Azure.DigitalTwins.Core
         /// </exception>
         /// <example>
         /// This sample demonstrates getting and deserializing a digital twin relationship into a custom data type.
-        /// <code snippet="Snippet:DigitalTwinsSampleGetCustomRelationship">
+        /// <code snippet="Snippet:DigitalTwinsSampleGetCustomRelationship" language="csharp">
         /// Response&lt;CustomRelationship&gt; getCustomRelationshipResponse = await client.GetRelationshipAsync&lt;CustomRelationship&gt;(
         ///     &quot;floorTwinId&quot;,
         ///     &quot;floorBuildingRelationshipId&quot;);
@@ -1285,7 +1285,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="digitalTwinId"/> or <paramref name="relationshipId"/> is <c>null</c>.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleCreateCustomRelationship">
+        /// <code snippet="Snippet:DigitalTwinsSampleCreateCustomRelationship" language="csharp">
         /// var floorBuildingRelationshipPayload = new CustomRelationship
         /// {
         ///     Id = &quot;floorBuildingRelationshipId&quot;,
@@ -1529,7 +1529,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception that captures the errors from the service. Check the <see cref="RequestFailedException.ErrorCode"/> and <see cref="RequestFailedException.Status"/> properties for more details.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleGetModels">
+        /// <code snippet="Snippet:DigitalTwinsSampleGetModels" language="csharp">
         /// AsyncPageable&lt;DigitalTwinsModelData&gt; allModels = client.GetModelsAsync();
         /// await foreach (DigitalTwinsModelData model in allModels)
         /// {
@@ -1689,7 +1689,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="modelId"/> is <c>null</c>.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleGetModel">
+        /// <code snippet="Snippet:DigitalTwinsSampleGetModel" language="csharp">
         /// Response&lt;DigitalTwinsModelData&gt; sampleModelResponse = await client.GetModelAsync(sampleModelId);
         /// Console.WriteLine($&quot;Retrieved model &apos;{sampleModelResponse.Value.Id}&apos;.&quot;);
         /// </code>
@@ -1771,7 +1771,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="modelId"/> is <c>null</c>.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleDecommisionModel">
+        /// <code snippet="Snippet:DigitalTwinsSampleDecommisionModel" language="csharp">
         /// try
         /// {
         ///     await client.DecommissionModelAsync(sampleModelId);
@@ -1866,7 +1866,7 @@ namespace Azure.DigitalTwins.Core
         /// </remarks>
         /// <seealso href="https://docs.microsoft.com/en-us/azure/digital-twins/concepts-models" />
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleCreateModels">
+        /// <code snippet="Snippet:DigitalTwinsSampleCreateModels" language="csharp">
         /// await client.CreateModelsAsync(new[] { newComponentModelPayload, newModelPayload });
         /// Console.WriteLine($&quot;Created models &apos;{componentModelId}&apos; and &apos;{sampleModelId}&apos;.&quot;);
         /// </code>
@@ -1967,7 +1967,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="modelId"/> is <c>null</c>.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleDeleteModel">
+        /// <code snippet="Snippet:DigitalTwinsSampleDeleteModel" language="csharp">
         /// try
         /// {
         ///     await client.DeleteModelAsync(sampleModelId);
@@ -2058,7 +2058,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception that captures the errors from the service. Check the <see cref="RequestFailedException.ErrorCode"/> and <see cref="RequestFailedException.Status"/> properties for more details.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleQueryTwins">
+        /// <code snippet="Snippet:DigitalTwinsSampleQueryTwins" language="csharp">
         /// // This code snippet demonstrates the simplest way to iterate over the digital twin results, where paging
         /// // happens under the covers.
         /// AsyncPageable&lt;BasicDigitalTwin&gt; asyncPageableResponse = client.QueryAsync&lt;BasicDigitalTwin&gt;(&quot;SELECT * FROM digitaltwins&quot;);
@@ -2277,7 +2277,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception that captures the errors from the service. Check the <see cref="RequestFailedException.ErrorCode"/> and <see cref="RequestFailedException.Status"/> properties for more details.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleGetEventRoutes">
+        /// <code snippet="Snippet:DigitalTwinsSampleGetEventRoutes" language="csharp">
         /// AsyncPageable&lt;DigitalTwinsEventRoute&gt; response = client.GetEventRoutesAsync();
         /// await foreach (DigitalTwinsEventRoute er in response)
         /// {
@@ -2509,7 +2509,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="eventRouteId"/> is <c>null</c>.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleCreateEventRoute">
+        /// <code snippet="Snippet:DigitalTwinsSampleCreateEventRoute" language="csharp">
         /// string eventFilter = &quot;$eventType = &apos;DigitalTwinTelemetryMessages&apos; or $eventType = &apos;DigitalTwinLifecycleNotification&apos;&quot;;
         /// var eventRoute = new DigitalTwinsEventRoute(eventhubEndpointName, eventFilter);
         ///
@@ -2587,7 +2587,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="eventRouteId"/> is <c>null</c>.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleDeleteEventRoute">
+        /// <code snippet="Snippet:DigitalTwinsSampleDeleteEventRoute" language="csharp">
         /// await client.DeleteEventRouteAsync(_eventRouteId);
         /// Console.WriteLine($&quot;Deleted event route &apos;{_eventRouteId}&apos;.&quot;);
         /// </code>
@@ -2665,7 +2665,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="digitalTwinId"/> or <paramref name="payload"/> is <c>null</c>.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSamplePublishTelemetry">
+        /// <code snippet="Snippet:DigitalTwinsSamplePublishTelemetry" language="csharp">
         /// // construct your json telemetry payload by hand.
         /// await client.PublishTelemetryAsync(twinId, Guid.NewGuid().ToString(), &quot;{\&quot;Telemetry1\&quot;: 5}&quot;);
         /// Console.WriteLine($&quot;Published telemetry message to twin &apos;{twinId}&apos;.&quot;);
@@ -2788,7 +2788,7 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="digitalTwinId"/> or <paramref name="componentName"/> or <paramref name="payload"/> is <c>null</c>.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSamplePublishComponentTelemetry">
+        /// <code snippet="Snippet:DigitalTwinsSamplePublishComponentTelemetry" language="csharp">
         /// // construct your json telemetry payload by serializing a dictionary.
         /// var telemetryPayload = new Dictionary&lt;string, int&gt;
         /// {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwin.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwin.cs
@@ -20,7 +20,7 @@ namespace Azure.DigitalTwins.Core
     /// <example>
     /// Here's an example of  how to use the BasicDigitalTwin helper class to serialize and create a digital twin.
     ///
-    /// <code snippet="Snippet:DigitalTwinsSampleCreateBasicTwin">
+    /// <code snippet="Snippet:DigitalTwinsSampleCreateBasicTwin" language="csharp">
     /// // Create digital twin with component payload using the BasicDigitalTwin serialization helper
     ///
     /// var basicTwin = new BasicDigitalTwin
@@ -55,7 +55,7 @@ namespace Azure.DigitalTwins.Core
     ///
     /// Here's an example of  how to use the BasicDigitalTwin helper class to get and deserialize a digital twin.
     ///
-    /// <code snippet="Snippet:DigitalTwinsSampleGetBasicDigitalTwin">
+    /// <code snippet="Snippet:DigitalTwinsSampleGetBasicDigitalTwin" language="csharp">
     /// Response&lt;BasicDigitalTwin&gt; getBasicDtResponse = await client.GetDigitalTwinAsync&lt;BasicDigitalTwin&gt;(basicDtId);
     /// BasicDigitalTwin basicDt = getBasicDtResponse.Value;
     ///
@@ -101,7 +101,7 @@ namespace Azure.DigitalTwins.Core
         /// If the property is a component, use the <see cref="BasicDigitalTwinComponent"/> class to deserialize the payload.
         /// </remarks>
         /// <example>
-        /// <code snippet="Snippet:DigitalTwinsSampleGetBasicDigitalTwin">
+        /// <code snippet="Snippet:DigitalTwinsSampleGetBasicDigitalTwin" language="csharp">
         /// Response&lt;BasicDigitalTwin&gt; getBasicDtResponse = await client.GetDigitalTwinAsync&lt;BasicDigitalTwin&gt;(basicDtId);
         /// BasicDigitalTwin basicDt = getBasicDtResponse.Value;
         ///

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicRelationship.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicRelationship.cs
@@ -23,7 +23,7 @@ namespace Azure.DigitalTwins.Core
     /// <example>
     /// Here's an example of how to use the BasicRelationship helper class to serialize and create a relationship from a building digital twin to a floor digital twin.
     ///
-    /// <code snippet="Snippet:DigitalTwinsSampleCreateBasicRelationship">
+    /// <code snippet="Snippet:DigitalTwinsSampleCreateBasicRelationship" language="csharp">
     /// var buildingFloorRelationshipPayload = new BasicRelationship
     /// {
     ///     Id = &quot;buildingFloorRelationshipId&quot;,
@@ -45,7 +45,7 @@ namespace Azure.DigitalTwins.Core
     ///
     /// Here's an example of how to use the BasicRelationship helper class to get and deserialize a relationship.
     ///
-    /// <code snippet="Snippet:DigitalTwinsSampleGetBasicRelationship">
+    /// <code snippet="Snippet:DigitalTwinsSampleGetBasicRelationship" language="csharp">
     /// Response&lt;BasicRelationship&gt; getBasicRelationshipResponse = await client.GetRelationshipAsync&lt;BasicRelationship&gt;(
     ///     &quot;buildingTwinId&quot;,
     ///     &quot;buildingFloorRelationshipId&quot;);
@@ -98,6 +98,7 @@ namespace Azure.DigitalTwins.Core
         [JsonExtensionData]
 #pragma warning disable CA2227 // Collection properties should be readonly
         public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+
 #pragma warning restore CA2227 // Collection properties should be readonly
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Queries/QueryChargeHelper.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Queries/QueryChargeHelper.cs
@@ -24,7 +24,7 @@ namespace Azure.DigitalTwins.Core
         /// <remarks>
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/digitaltwins/Azure.DigitalTwins.Core/samples">our repo samples</see>.
         /// </remarks>
-        /// <code snippet="Snippet:DigitalTwinsSampleQueryTwinsWithQueryCharge">
+        /// <code snippet="Snippet:DigitalTwinsSampleQueryTwinsWithQueryCharge" language="csharp">
         /// // This code snippet demonstrates how you could extract the query charges incurred when calling
         /// // the query API. It iterates over the response pages first to access to the query-charge header,
         /// // and then the digital twin results within each page.


### PR DESCRIPTION
The [bug](https://ceapex.visualstudio.com/Engineering/_workitems/edit/227459/?triage=true) that caused code snippets in doc comments to not show up with code coloring for the type of language has been fixed.

This updates our doc comment code tags to specify the language as csharp.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
