### PR TITLE
Remove byte array allocations from AmqpReceiver DisposeMessagesAsync

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -74,7 +74,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         private readonly FaultTolerantAmqpObject<ReceivingAmqpLink> _receiveLink;
         private readonly FaultTolerantAmqpObject<RequestResponseAmqpLink> _managementLink;
 
-        private const int SizeOfGuid = 16;
+        private const int SizeOfGuidInBytes = 16;
 
         /// <summary>
         /// Gets the sequence number of the last peeked message.
@@ -448,7 +448,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         {
             ThrowIfSessionLockLost();
 
-            byte[] continuousBufferForLockTokens = ArrayPool<byte>.Shared.Rent(SizeOfGuid*lockTokens.Length);;
+            byte[] continuousBufferForLockTokens = ArrayPool<byte>.Shared.Rent(SizeOfGuidInBytes*lockTokens.Length);;
             List<ArraySegment<byte>> deliveryTags = ConvertLockTokensToDeliveryTags(continuousBufferForLockTokens, lockTokens);
             ReceivingAmqpLink receiveLink = null;
             try
@@ -521,13 +521,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
             for (var i = 0; i < tokens.Length; i++)
             {
                 Guid lockToken = tokens[i];
-                int start = i * SizeOfGuid;
-                if (!MemoryMarshal.TryWrite(buffer.AsSpan(start, SizeOfGuid), ref lockToken))
+                int start = i * SizeOfGuidInBytes;
+                if (!MemoryMarshal.TryWrite(buffer.AsSpan(start, SizeOfGuidInBytes), ref lockToken))
                 {
                     lockToken.ToByteArray().AsSpan().CopyTo(buffer);
                 }
 
-                convertedLockTokens.Add(new ArraySegment<byte>(buffer, start, SizeOfGuid));
+                convertedLockTokens.Add(new ArraySegment<byte>(buffer, start, SizeOfGuidInBytes));
             }
             return convertedLockTokens;
         }


### PR DESCRIPTION
Solves https://github.com/Azure/azure-sdk-for-net/issues/20166 assuming you want to preserve the capability of dispose multiple messages at the same time. The before/after comparison is in the issue including perf comparison about the different approaches considered

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
