### PR TITLE
Alternative: Remove byte array allocations from AmqpReceiver DisposeMessagesAsync

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -411,7 +411,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 cancellationToken).ConfigureAwait(false);
 
         /// <summary>
-        /// Completes a series of <see cref="ServiceBusMessage"/> using a list of lock tokens. This will delete the message from the service.
+        /// Completes a <see cref="ServiceBusReceivedMessage"/> using a lock token. This will delete the message from the service.
         /// </summary>
         ///
         /// <param name="lockToken">The lockToken of the <see cref="ServiceBusReceivedMessage"/> to complete.</param>
@@ -434,10 +434,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
         }
 
         /// <summary>
-        /// Completes a series of <see cref="ServiceBusMessage"/> using a list of lock tokens. This will delete the message from the service.
+        /// Settles a <see cref="ServiceBusReceivedMessage"/> using a lock token.
         /// </summary>
         ///
-        /// <param name="lockToken">The lock token of the corresponding message to complete.</param>
+        /// <param name="lockToken">The lockToken of the <see cref="ServiceBusReceivedMessage"/> to complete.</param>
         /// <param name="outcome"></param>
         /// <param name="timeout"></param>
         private async Task DisposeMessageAsync(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -430,7 +430,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     SessionId).ConfigureAwait(false);
                 return;
             }
-            await DisposeMessagesAsync(lockTokenGuid, AmqpConstants.AcceptedOutcome, timeout).ConfigureAwait(false);
+            await DisposeMessageAsync(lockTokenGuid, AmqpConstants.AcceptedOutcome, timeout).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -440,7 +440,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="lockToken">The lock token of the corresponding message to complete.</param>
         /// <param name="outcome"></param>
         /// <param name="timeout"></param>
-        private async Task DisposeMessagesAsync(
+        private async Task DisposeMessageAsync(
             Guid lockToken,
             Outcome outcome,
             TimeSpan timeout)
@@ -580,7 +580,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     SessionId,
                     propertiesToModify);
             }
-            return DisposeMessagesAsync(lockTokenGuid, GetDeferOutcome(propertiesToModify), timeout);
+            return DisposeMessageAsync(lockTokenGuid, GetDeferOutcome(propertiesToModify), timeout);
         }
 
         /// <summary>
@@ -637,7 +637,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     SessionId,
                     propertiesToModify);
             }
-            return DisposeMessagesAsync(lockTokenGuid, GetAbandonOutcome(propertiesToModify), timeout);
+            return DisposeMessageAsync(lockTokenGuid, GetAbandonOutcome(propertiesToModify), timeout);
         }
 
         /// <summary>
@@ -712,7 +712,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     deadLetterErrorDescription);
             }
 
-            return DisposeMessagesAsync(
+            return DisposeMessageAsync(
                 lockTokenGuid,
                 GetRejectedOutcome(propertiesToModify, deadLetterReason, deadLetterErrorDescription),
                 timeout);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -71,6 +73,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
         private readonly string _identifier;
         private readonly FaultTolerantAmqpObject<ReceivingAmqpLink> _receiveLink;
         private readonly FaultTolerantAmqpObject<RequestResponseAmqpLink> _managementLink;
+
+        private const int SizeOfGuidInBytes = 16;
 
         /// <summary>
         /// Gets the sequence number of the last peeked message.
@@ -417,34 +421,39 @@ namespace Azure.Messaging.ServiceBus.Amqp
             TimeSpan timeout)
         {
             Guid lockTokenGuid = new Guid(lockToken);
-            var lockTokenGuids = new[] { lockTokenGuid };
             if (_requestResponseLockedMessages.Contains(lockTokenGuid))
             {
                 await DisposeMessageRequestResponseAsync(
-                    lockTokenGuids,
+                    lockTokenGuid,
                     timeout,
                     DispositionStatus.Completed,
                     SessionId).ConfigureAwait(false);
                 return;
             }
-            await DisposeMessagesAsync(lockTokenGuids, AmqpConstants.AcceptedOutcome, timeout).ConfigureAwait(false);
+            await DisposeMessagesAsync(lockTokenGuid, AmqpConstants.AcceptedOutcome, timeout).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Completes a series of <see cref="ServiceBusMessage"/> using a list of lock tokens. This will delete the message from the service.
         /// </summary>
         ///
-        /// <param name="lockTokens">An <see cref="IEnumerable{T}"/> containing the lock tokens of the corresponding messages to complete.</param>
+        /// <param name="lockToken">The lock token of the corresponding message to complete.</param>
         /// <param name="outcome"></param>
         /// <param name="timeout"></param>
         private async Task DisposeMessagesAsync(
-            IEnumerable<Guid> lockTokens,
+            Guid lockToken,
             Outcome outcome,
             TimeSpan timeout)
         {
             ThrowIfSessionLockLost();
-            List<ArraySegment<byte>> deliveryTags = ConvertLockTokensToDeliveryTags(lockTokens);
 
+            byte[] bufferForLockToken = ArrayPool<byte>.Shared.Rent(SizeOfGuidInBytes);
+            if (!MemoryMarshal.TryWrite(bufferForLockToken, ref lockToken))
+            {
+                lockToken.ToByteArray().AsSpan().CopyTo(bufferForLockToken);
+            }
+
+            ArraySegment<byte> deliveryTag = new ArraySegment<byte>(bufferForLockToken, 0, SizeOfGuidInBytes);
             ReceivingAmqpLink receiveLink = null;
             try
             {
@@ -463,27 +472,21 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     receiveLink = await _receiveLink.GetOrCreateAsync(timeout).ConfigureAwait(false);
                 }
 
-                var disposeMessageTasks = new Task<Outcome>[deliveryTags.Count];
-                var i = 0;
-                foreach (ArraySegment<byte> deliveryTag in deliveryTags)
-                {
-                    disposeMessageTasks[i++] = receiveLink.DisposeMessageAsync(deliveryTag, transactionId, outcome, true, timeout);
-                }
-
-                Outcome[] outcomes = await Task.WhenAll(disposeMessageTasks).ConfigureAwait(false);
+                Outcome outcomeResult = await receiveLink
+                    .DisposeMessageAsync(deliveryTag, transactionId, outcome, true, timeout).ConfigureAwait(false);
                 Error error = null;
-                foreach (Outcome item in outcomes)
+                Outcome disposedOutcome =
+                    outcomeResult.DescriptorCode == Rejected.Code && ((error = ((Rejected)outcomeResult).Error) != null)
+                        ? outcomeResult
+                        : null;
+                if (disposedOutcome != null)
                 {
-                    Outcome disposedOutcome = item.DescriptorCode == Rejected.Code && ((error = ((Rejected)item).Error) != null) ? item : null;
-                    if (disposedOutcome != null)
+                    if (error.Condition.Equals(AmqpErrorCode.NotFound))
                     {
-                        if (error.Condition.Equals(AmqpErrorCode.NotFound))
-                        {
-                            ThrowLockLostException();
-                        }
-
-                        throw error.ToMessagingContractException();
+                        ThrowLockLostException();
                     }
+
+                    throw error.ToMessagingContractException();
                 }
             }
             catch (Exception exception)
@@ -502,6 +505,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 }
 
                 throw;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(bufferForLockToken);
             }
         }
 
@@ -564,17 +571,16 @@ namespace Azure.Messaging.ServiceBus.Amqp
             IDictionary<string, object> propertiesToModify = null)
         {
             Guid lockTokenGuid = new Guid(lockToken);
-            var lockTokenGuids = new[] { lockTokenGuid };
             if (_requestResponseLockedMessages.Contains(lockTokenGuid))
             {
                 return DisposeMessageRequestResponseAsync(
-                    lockTokenGuids,
+                    lockTokenGuid,
                     timeout,
                     DispositionStatus.Defered,
                     SessionId,
                     propertiesToModify);
             }
-            return DisposeMessagesAsync(lockTokenGuids, GetDeferOutcome(propertiesToModify), timeout);
+            return DisposeMessagesAsync(lockTokenGuid, GetDeferOutcome(propertiesToModify), timeout);
         }
 
         /// <summary>
@@ -622,17 +628,16 @@ namespace Azure.Messaging.ServiceBus.Amqp
             IDictionary<string, object> propertiesToModify = null)
         {
             Guid lockTokenGuid = new Guid(lockToken);
-            var lockTokenGuids = new[] { lockTokenGuid };
             if (_requestResponseLockedMessages.Contains(lockTokenGuid))
             {
                 return DisposeMessageRequestResponseAsync(
-                    lockTokenGuids,
+                    lockTokenGuid,
                     timeout,
                     DispositionStatus.Abandoned,
                     SessionId,
                     propertiesToModify);
             }
-            return DisposeMessagesAsync(lockTokenGuids, GetAbandonOutcome(propertiesToModify), timeout);
+            return DisposeMessagesAsync(lockTokenGuid, GetAbandonOutcome(propertiesToModify), timeout);
         }
 
         /// <summary>
@@ -695,11 +700,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
             Argument.AssertNotTooLong(deadLetterErrorDescription, Constants.MaxDeadLetterReasonLength, nameof(deadLetterErrorDescription));
 
             Guid lockTokenGuid = new Guid(lockToken);
-            var lockTokenGuids = new[] { lockTokenGuid };
             if (_requestResponseLockedMessages.Contains(lockTokenGuid))
             {
                 return DisposeMessageRequestResponseAsync(
-                    lockTokenGuids,
+                    lockTokenGuid,
                     timeout,
                     DispositionStatus.Suspended,
                     SessionId,
@@ -709,7 +713,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
 
             return DisposeMessagesAsync(
-                lockTokenGuids,
+                lockTokenGuid,
                 GetRejectedOutcome(propertiesToModify, deadLetterReason, deadLetterErrorDescription),
                 timeout);
         }
@@ -756,7 +760,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// Updates the disposition status of deferred messages.
         /// </summary>
         ///
-        /// <param name="lockTokens">Message lock tokens to update disposition status.</param>
+        /// <param name="lockToken">Message lock token to update disposition status.</param>
         /// <param name="timeout"></param>
         /// <param name="dispositionStatus"></param>
         /// <param name="sessionId"></param>
@@ -764,7 +768,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="deadLetterReason"></param>
         /// <param name="deadLetterDescription"></param>
         private async Task DisposeMessageRequestResponseAsync(
-            Guid[] lockTokens,
+            Guid lockToken,
             TimeSpan timeout,
             DispositionStatus dispositionStatus,
             string sessionId = null,
@@ -780,7 +784,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 amqpRequestMessage.AmqpMessage.ApplicationProperties.Map[ManagementConstants.Request.AssociatedLinkName] = receiveLink.Name;
             }
 
-            amqpRequestMessage.Map[ManagementConstants.Properties.LockTokens] = lockTokens;
+            amqpRequestMessage.Map[ManagementConstants.Properties.LockTokens] = new Guid[]{ lockToken };
             amqpRequestMessage.Map[ManagementConstants.Properties.DispositionStatus] = dispositionStatus.ToString().ToLowerInvariant();
 
             if (deadLetterReason != null)
@@ -835,11 +839,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
         private static Outcome GetDeferOutcome(IDictionary<string, object> propertiesToModify) =>
             GetModifiedOutcome(propertiesToModify, true);
-
-        private static List<ArraySegment<byte>> ConvertLockTokensToDeliveryTags(IEnumerable<Guid> lockTokens)
-        {
-            return lockTokens.Select(lockToken => new ArraySegment<byte>(lockToken.ToByteArray())).ToList();
-        }
 
         private static Outcome GetModifiedOutcome(
             IDictionary<string, object> propertiesToModify,


### PR DESCRIPTION
Alternative to https://github.com/Azure/azure-sdk-for-net/pull/20425

Would also close https://github.com/Azure/azure-sdk-for-net/issues/20166

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
