### PR TITLE
[Messaging] AMQP Exception Special Case Handling

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Net;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Messaging.ServiceBus.Amqp;
@@ -11,6 +12,7 @@ using Azure.Messaging.ServiceBus.Authorization;
 using Microsoft.Azure.Amqp;
 using Microsoft.Azure.Amqp.Transport;
 using Moq;
+using Moq.Protected;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests
@@ -32,7 +34,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         public void CalculateLinkAuthorizationRefreshIntervalRespectsTheRefreshBuffer()
         {
             var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
-            var mockScope = new MockConnectionMockScope(new Uri("sb://mine.hubs.com"), credential.Object, ServiceBusTransportType.AmqpTcp, null);
+            var mockScope = new MockConnectionScope(new Uri("sb://mine.hubs.com"), credential.Object, ServiceBusTransportType.AmqpTcp, null);
             var currentTime = new DateTime(2015, 10, 27, 00, 00, 00);
             var expireTime = currentTime.AddHours(1);
             var buffer = GetAuthorizationRefreshBuffer();
@@ -52,7 +54,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         public void CalculateLinkAuthorizationRefreshIntervalRespectsTheMinimumDuration()
         {
             var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
-            var mockScope = new MockConnectionMockScope(new Uri("sb://mine.hubs.com"), credential.Object, ServiceBusTransportType.AmqpTcp, null);
+            var mockScope = new MockConnectionScope(new Uri("sb://mine.hubs.com"), credential.Object, ServiceBusTransportType.AmqpTcp, null);
             var currentTime = new DateTime(2015, 10, 27, 00, 00, 00);
             var minimumRefresh = GetMinimumAuthorizationRefresh();
             var expireTime = currentTime.Add(minimumRefresh.Subtract(TimeSpan.FromMilliseconds(500)));
@@ -70,7 +72,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         public void CalculateLinkAuthorizationRefreshIntervalRespectsTheMaximumDuration()
         {
             var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
-            var mockScope = new MockConnectionMockScope(new Uri("sb://mine.hubs.com"), credential.Object, ServiceBusTransportType.AmqpTcp, null);
+            var mockScope = new MockConnectionScope(new Uri("sb://mine.hubs.com"), credential.Object, ServiceBusTransportType.AmqpTcp, null);
             var currentTime = new DateTime(2015, 10, 27, 00, 00, 00);
             var refreshBuffer = GetAuthorizationRefreshBuffer();
             var maximumRefresh = GetMaximumAuthorizationRefresh();
@@ -78,6 +80,46 @@ namespace Azure.Messaging.ServiceBus.Tests
             var calculatedRefresh = mockScope.InvokeCalculateLinkAuthorizationRefreshInterval(expireTime, currentTime);
 
             Assert.That(calculatedRefresh, Is.EqualTo(maximumRefresh), "The maximum refresh duration should have been used.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenAmqpObjectAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(typeof(InvalidOperationException))]
+        [TestCase(typeof(ObjectDisposedException))]
+        public async Task OpenAmqpObjectAsyncTranslatesInvalidStateExceptions(Type exceptionType)
+        {
+            var observedException = default(Exception);
+            var openException = (Exception)Activator.CreateInstance(exceptionType, "stringArg");
+            var endpoint = new Uri("amqp://test.service.gov");
+            var transport = ServiceBusTransportType.AmqpTcp;
+            var mockCredential = new Mock<TokenCredential>();
+            var mockServiceBusCredential = new Mock<ServiceBusTokenCredential>(mockCredential.Object);
+            var mockScope = new MockConnectionScope(endpoint, mockServiceBusCredential.Object, transport, null);
+
+            mockScope.MockConnection
+                .Protected()
+                .Setup("OpenInternal")
+                .Throws(openException)
+                .Verifiable();
+
+            try
+            {
+                await mockScope.InvokeOpenAmqpObjectAsync(mockScope.MockConnection.Object, TimeSpan.FromMinutes(5), CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                observedException = ex;
+            }
+
+            Assert.That(observedException, Is.Not.Null, "An exception should have been observed.");
+            Assert.That(observedException, Is.TypeOf<ServiceBusException>(), "The exception should have been translated.");
+            Assert.That(((ServiceBusException)observedException).IsTransient, Is.True, "The exception should be transient.");
+
+            mockScope.MockConnection.VerifyAll();
         }
 
         /// <summary>
@@ -148,11 +190,11 @@ namespace Azure.Messaging.ServiceBus.Tests
         ///   Provides a mock to use with a mocked connection.
         /// </summary>
         ///
-        private class MockConnectionMockScope : AmqpConnectionScope
+        private class MockConnectionScope : AmqpConnectionScope
         {
             public readonly Mock<AmqpConnection> MockConnection;
 
-            public MockConnectionMockScope(
+            public MockConnectionScope(
                 Uri serviceEndpoint,
                 ServiceBusTokenCredential credential,
                 ServiceBusTransportType transport,
@@ -160,6 +202,11 @@ namespace Azure.Messaging.ServiceBus.Tests
             {
                 MockConnection = new Mock<AmqpConnection>(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
             }
+
+            public Task InvokeOpenAmqpObjectAsync(
+                AmqpObject target,
+                TimeSpan timeout,
+                CancellationToken cancellationToken) => base.OpenAmqpObjectAsync(target, timeout, cancellationToken);
 
             public TimeSpan InvokeCalculateLinkAuthorizationRefreshInterval(
                 DateTime expirationTimeUtc,


### PR DESCRIPTION
# Summary

The focus of these changes is to follow advice offered by the maintainers of the `Microsoft.Azure.Amqp` library to consider any `InvalidOperationException`
or derrivitive that occurs when opening an AMQP connection, link, or session to be transient and allow retries.

This is needed because the AMQP library state becomes invalidated when certain network conditions occur, such as the TCP socket being reset.  This results in the AMQP library throwing when a connection or link is requested. Rather than surfacing exceptions for the caller's context, an `InvalidOperationException`
or `ObjectDisposedException` is thrown to represent the internal state.

# Last Upstream Rebase

Thursday, April 15, 3:30pm (EDT)

# References and Related

- [Occasional eventhub sending message error (#20255)](https://github.com/Azure/azure-sdk-for-net/issues/20255)