### PR TITLE
Workaround for issue 20444, ApiVersion not initialized.

### DIFF
--- a/sdk/storagecache/Microsoft.Azure.Management.StorageCache/src/Customizations/StorageCacheManagementClient.cs
+++ b/sdk/storagecache/Microsoft.Azure.Management.StorageCache/src/Customizations/StorageCacheManagementClient.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using System;
+//using Microsoft.Azure.Management.BotService.Customizations;
+//..using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Azure.Management.StorageCache;
+
+namespace Microsoft.Azure.Management.StorageCache
+{
+        using Microsoft.Rest;
+        using Microsoft.Rest.Serialization;
+        using Models;
+        using Newtonsoft.Json;
+        using System.Collections;
+        using System.Collections.Generic;
+        using System.Net;
+        using System.Net.Http;
+
+    /// <summary>
+    /// A Storage Cache provides scalable caching service for NAS clients,
+    /// serving data from either NFSv3 or Blob at-rest storage (referred to as
+    /// "Storage Targets"). These operations allow you to manage Caches.
+    /// </summary>
+    public partial class StorageCacheManagementClient : ServiceClient<StorageCacheManagementClient>, IStorageCacheManagementClient
+    {
+
+        partial void CustomInitialize()
+        {
+            // Override the bot services operations with an augmented bot services operations,
+            // which includes operations required to complete the provisioning of the bot
+            this.ApiVersion = "2021-03-01";
+        }
+    }
+}

--- a/sdk/storagecache/Microsoft.Azure.Management.StorageCache/tests/CustomizationTests.cs
+++ b/sdk/storagecache/Microsoft.Azure.Management.StorageCache/tests/CustomizationTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.Management.StorageCache.Tests
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Management.StorageCache.Models;
+    using Microsoft.Azure.Management.StorageCache.Tests.Fixtures;
+    using Microsoft.Azure.Management.StorageCache.Tests.Utilities;
+    using Microsoft.Azure.Test.HttpRecorder;
+    using Microsoft.Rest;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// Defines the <see cref="CustomizationTests" />.
+    /// </summary>
+    [Collection("StorageCacheCollection")]
+    public class CustomizationTests
+    {
+        /// <summary>
+        /// Defines the testOutputHelper.
+        /// </summary>
+        private readonly ITestOutputHelper testOutputHelper;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomizationTests"/> class.
+        /// </summary>
+        /// <param name="testOutputHelper">The testOutputHelper<see cref="ITestOutputHelper"/>.</param>
+        public CustomizationTests(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+        }
+
+        /// <summary>
+        /// Verify the ApiVersion property of the client is default to the correct version."
+        /// </summary>
+        [Fact]
+        public void TestApiVersion()
+        {
+            RecordedDelegatingHandler recordedDelegatingHandlers = new RecordedDelegatingHandler();
+            ServiceClientCredentials credentials = new TokenCredentials("abc");
+            StorageCacheManagementClient storageCacheManagementClient = new StorageCacheManagementClient(credentials, recordedDelegatingHandlers);
+            Assert.Equal(Constants.DefaultAPIVersion, storageCacheManagementClient.ApiVersion);
+        }
+    }
+}


### PR DESCRIPTION
This is PR to work around issue https://github.com/Azure/azure-sdk-for-net/issues/20444.
The ApiVersion was not initialized in the initialize function in the client class.
This adds a Customization to have CustomInitialize set the default value for the ApiVersion.

A unit test was added to check that the version was set.

@markcowl discussed this issue with me at .net office hours on 4/14/21.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [x] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [x] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
