### PR TITLE
[Event Hubs Client] Detect Closed Shared Connection

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -237,6 +237,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         public virtual async Task<RequestResponseAmqpLink> OpenManagementLinkAsync(TimeSpan timeout,
                                                                                    CancellationToken cancellationToken)
         {
+            Argument.AssertNotDisposed(_disposed, nameof(AmqpConnectionScope));
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             var stopWatch = ValueStopwatch.StartNew();
@@ -278,6 +279,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                                                                            bool trackLastEnqueuedEventProperties,
                                                                            CancellationToken cancellationToken)
         {
+            Argument.AssertNotDisposed(_disposed, nameof(AmqpConnectionScope));
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
 
@@ -327,6 +329,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                                                                          TimeSpan timeout,
                                                                          CancellationToken cancellationToken)
         {
+            Argument.AssertNotDisposed(_disposed, nameof(AmqpConnectionScope));
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             var stopWatch = ValueStopwatch.StartNew();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -206,6 +206,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                                                                           CancellationToken cancellationToken)
         {
             Argument.AssertNotClosed(_closed, nameof(AmqpConsumer));
+            Argument.AssertNotClosed(ConnectionScope.IsDisposed, nameof(EventHubConnection));
             Argument.AssertAtLeast(maximumEventCount, 1, nameof(maximumEventCount));
 
             var receivedEventCount = 0;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -186,6 +186,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         {
             Argument.AssertNotNull(events, nameof(events));
             Argument.AssertNotClosed(_closed, nameof(AmqpProducer));
+            Argument.AssertNotClosed(ConnectionScope.IsDisposed, nameof(EventHubConnection));
 
             AmqpMessage messageFactory() => MessageConverter.CreateBatchFromEvents(events, sendOptions?.PartitionKey);
             await SendAsync(messageFactory, sendOptions?.PartitionKey, cancellationToken).ConfigureAwait(false);
@@ -210,6 +211,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         {
             Argument.AssertNotNull(eventBatch, nameof(eventBatch));
             Argument.AssertNotClosed(_closed, nameof(AmqpProducer));
+            Argument.AssertNotClosed(ConnectionScope.IsDisposed, nameof(EventHubConnection));
 
             // Make a defensive copy of the messages in the batch.
 
@@ -236,6 +238,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         {
             Argument.AssertNotNull(options, nameof(options));
             Argument.AssertNotClosed(_closed, nameof(AmqpProducer));
+            Argument.AssertNotClosed(ConnectionScope.IsDisposed, nameof(EventHubConnection));
 
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
@@ -308,6 +311,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         public override async ValueTask<PartitionPublishingProperties> ReadInitializationPublishingPropertiesAsync(CancellationToken cancellationToken)
         {
             Argument.AssertNotClosed(_closed, nameof(AmqpProducer));
+            Argument.AssertNotClosed(ConnectionScope.IsDisposed, nameof(EventHubConnection));
 
             // If the properties were already initialized, use them.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Messaging.EventHubs.Amqp;
+using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Core;
 using Microsoft.Azure.Amqp;
@@ -498,6 +499,33 @@ namespace Azure.Messaging.EventHubs.Tests
             await consumer.CloseAsync(cancellationSource.Token);
 
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.ReceiveAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiveAsyncValidatesConnectionClosed()
+        {
+            var endpoint = new Uri("amqps://not.real.com");
+            var eventHub = "eventHubName";
+            var consumerGroup = "$DEFAULT";
+            var partition = "3";
+            var eventPosition = EventPosition.FromOffset(123);
+            var options = new EventHubConsumerClientOptions();
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
+            var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
+
+            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
+            scope.Dispose();
+
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, null, null, null, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            await consumer.CloseAsync(CancellationToken.None);
+
+            Assert.That(async () => await consumer.ReceiveAsync(100, null, CancellationToken.None),
+                Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -7,7 +7,9 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
 using Azure.Messaging.EventHubs.Amqp;
+using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Producer;
 using Microsoft.Azure.Amqp;
@@ -222,6 +224,31 @@ namespace Azure.Messaging.EventHubs.Tests
             await producer.Object.CloseAsync(CancellationToken.None);
 
             Assert.That(async () => await producer.Object.CreateBatchAsync(new CreateBatchOptions(), CancellationToken.None), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpProducer.CreateBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateBatchAsyncEnsuresConnectionNotClosed()
+        {
+            var endpoint = new Uri("amqps://not.real.com");
+            var eventHub = "eventHubName";
+            var partition = "3";
+            var options = new EventHubProducerClientOptions();
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
+            var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
+
+            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
+            scope.Dispose();
+
+            var producer = new AmqpProducer(eventHub, partition, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            await producer.CloseAsync(CancellationToken.None);
+
+            Assert.That(async () => await producer.CreateBatchAsync(new CreateBatchOptions(), CancellationToken.None),
+                Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
         }
 
         /// <summary>
@@ -660,6 +687,31 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public async Task ReadInitializationPublishingPropertiesAsyncEnsuresConnectionNotClosed()
+        {
+            var endpoint = new Uri("amqps://not.real.com");
+            var eventHub = "eventHubName";
+            var partition = "3";
+            var options = new EventHubProducerClientOptions();
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
+            var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
+
+            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
+            scope.Dispose();
+
+            var producer = new AmqpProducer(eventHub, partition, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            await producer.CloseAsync(CancellationToken.None);
+
+            Assert.That(async () => await producer.ReadInitializationPublishingPropertiesAsync(CancellationToken.None),
+                Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpProducer.ReadInitializationPublishingPropertiesAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
         public async Task ReadInitializationPublishingPropertiesAsyncEnsuresPropertiesArePopulated()
         {
             var expectedProperties = new PartitionPublishingProperties(false, null, null, null);
@@ -1023,6 +1075,31 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public async Task SendEnumerableEnsuresConnectionNotClosed()
+        {
+            var endpoint = new Uri("amqps://not.real.com");
+            var eventHub = "eventHubName";
+            var partition = "3";
+            var options = new EventHubProducerClientOptions();
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
+            var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
+
+            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
+            scope.Dispose();
+
+            var producer = new AmqpProducer(eventHub, partition, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            await producer.CloseAsync(CancellationToken.None);
+
+            Assert.That(async () => await producer.SendAsync(Enumerable.Empty<EventData>(), new SendEventOptions(), CancellationToken.None),
+                Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
         public async Task SendEnumerableUsesThePartitionKey()
         {
             var expectedPartitionKey = "some key";
@@ -1333,6 +1410,31 @@ namespace Azure.Messaging.EventHubs.Tests
 
             await producer.Object.CloseAsync(CancellationToken.None);
             Assert.That(async () => await producer.Object.SendAsync(new EventDataBatch(batch, "ns", "eh", new SendEventOptions()), CancellationToken.None), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendBatchConnectionEnsuresNotClosed()
+        {
+            var endpoint = new Uri("amqps://not.real.com");
+            var eventHub = "eventHubName";
+            var partition = "3";
+            var options = new EventHubProducerClientOptions();
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
+            var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
+
+            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
+            scope.Dispose();
+
+            var producer = new AmqpProducer(eventHub, partition, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            await producer.CloseAsync(CancellationToken.None);
+
+            Assert.That(async () => await producer.SendAsync(EventHubsModelFactory.EventDataBatch(2048, new List<EventData>()), CancellationToken.None),
+                Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to guard against a shared connection being closed when performing service operations.  Previously, the consumer and producer clients were not aware and would trigger exception behavior in the AMQP library, the type of which could vary depending on its internal state.  This scenario will now trigger a consistent `EventHubsException` that is not retriable and offers an error message stating that the connection was closed.

# Last Upstream Rebase

Friday, April 16, 3:15pm (EDT)