### PR TITLE
[Event Hubs Client] Connection Close Test Fix

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -507,7 +507,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ReceiveAsyncValidatesConnectionClosed()
+        public void ReceiveAsyncValidatesConnectionClosed()
         {
             var endpoint = new Uri("amqps://not.real.com");
             var eventHub = "eventHubName";
@@ -519,10 +519,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
             var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
-            scope.Dispose();
-
             var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, null, null, null, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
-            await consumer.CloseAsync(CancellationToken.None);
+
+            scope.Dispose();
 
             Assert.That(async () => await consumer.ReceiveAsync(100, null, CancellationToken.None),
                 Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -1075,7 +1075,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task SendEnumerableEnsuresConnectionNotClosed()
+        public void SendEnumerableEnsuresConnectionNotClosed()
         {
             var endpoint = new Uri("amqps://not.real.com");
             var eventHub = "eventHubName";
@@ -1085,10 +1085,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
             var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
-            scope.Dispose();
-
             var producer = new AmqpProducer(eventHub, partition, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
-            await producer.CloseAsync(CancellationToken.None);
+
+            scope.Dispose();
 
             Assert.That(async () => await producer.SendAsync(Enumerable.Empty<EventData>(), new SendEventOptions(), CancellationToken.None),
                 Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
@@ -1418,7 +1417,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task SendBatchConnectionEnsuresNotClosed()
+        public void SendBatchEnsuresConnectionNotClosed()
         {
             var endpoint = new Uri("amqps://not.real.com");
             var eventHub = "eventHubName";
@@ -1428,10 +1427,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
             var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
-            scope.Dispose();
-
             var producer = new AmqpProducer(eventHub, partition, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
-            await producer.CloseAsync(CancellationToken.None);
+
+            scope.Dispose();
 
             Assert.That(async () => await producer.SendAsync(EventHubsModelFactory.EventDataBatch(2048, new List<EventData>()), CancellationToken.None),
                 Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));


### PR DESCRIPTION
# Summary

The focus of these changes is to fix an error in the unit tests to validate transport producer and consumer operations validate the connection.  This change ensures that the transport clients are left open and valid while only the connection has been closed. 

# Last Upstream Rebase

Monday, April 19, 9am (EDT)

# References and Related

- [[Event Hubs Client] Detect Closed Shared Connection #20469](https://github.com/Azure/azure-sdk-for-net/pull/20469)