### PR TITLE
Format snippets for examples

### DIFF
--- a/eng/SnippetGenerator/CSharpProcessor.cs
+++ b/eng/SnippetGenerator/CSharpProcessor.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Linq;
 using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -12,7 +11,9 @@ namespace SnippetGenerator
     public class CSharpProcessor
     {
         private static readonly string _snippetFormat = "{3} <code snippet=\"{0}\">{1}{2} </code>";
-        private static readonly Regex _snippetRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<code snippet=\\\"(?<name>[\\w:]+)\\\">.*?\\/{3}\\s*<\\/code>",
+        private static readonly string _snippetExampleFormat = "{3} <example>{1}{3} <code snippet=\"{0}\">{1}{2} </code>{1}{3} </example>";
+
+        private static readonly Regex _snippetRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<code snippet=\"(?<name>[\\w:]+)\"(?<example> example=\"true\")?>.*?\\s*<\\/code>",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.IgnoreCase);
 
         public static string Process(string markdown, Func<string, string> snippetProvider)
@@ -21,6 +22,7 @@ namespace SnippetGenerator
             {
                 var name = match.Groups["name"].Value;
                 var prefix = match.Groups["indent"].Value + "///";
+                var isExample = match.Groups["example"].Success;
 
                 var snippetText = snippetProvider(name);
 
@@ -41,9 +43,10 @@ namespace SnippetGenerator
                     builder.Length -= Environment.NewLine.Length;
                 }
 
-                return string.Format(_snippetFormat, name, Environment.NewLine, builder, prefix);
+                return isExample ?
+                    string.Format(_snippetExampleFormat, name, Environment.NewLine, builder, prefix) :
+                    string.Format(_snippetFormat, name, Environment.NewLine, builder, prefix);
             });
         }
-
     }
 }

--- a/eng/SnippetGenerator/CSharpProcessor.cs
+++ b/eng/SnippetGenerator/CSharpProcessor.cs
@@ -11,7 +11,7 @@ namespace SnippetGenerator
     public class CSharpProcessor
     {
         private static readonly string _snippetFormat = "{3} <code snippet=\"{0}\">{1}{2} </code>";
-        private static readonly string _snippetExampleFormat = "{3} <example>{1}{3} <code snippet=\"{0}\" example=\"true\">{1}{2} </code>{1}{3} </example>";
+        private static readonly string _snippetExampleFormat = "{3} <example>{1}{3} <code snippet=\"{0}\">{1}{2} </code>{1}{3} </example>";
 
         private static readonly Regex _snippetRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<code snippet=\"(?<name>[\\w:]+)\">.*?\\s*<\\/code>",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.IgnoreCase);

--- a/eng/SnippetGenerator/CSharpProcessor.cs
+++ b/eng/SnippetGenerator/CSharpProcessor.cs
@@ -11,7 +11,7 @@ namespace SnippetGenerator
     public class CSharpProcessor
     {
         private static readonly string _snippetFormat = "{3} <code snippet=\"{0}\">{1}{2} </code>";
-        private static readonly string _snippetExampleFormat = "{3} <example>{1}{3} <code snippet=\"{0}\">{1}{2} </code>{1}{3} </example>";
+        private static readonly string _snippetExampleFormat = "{3} <example>{1}{3} <code snippet=\"{0}\" example=\"true\">{1}{2} </code>{1}{3} </example>";
 
         private static readonly Regex _snippetRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<code snippet=\"(?<name>[\\w:]+)\"(?<example> example=\"true\")?>.*?\\s*<\\/code>",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.IgnoreCase);

--- a/eng/SnippetGenerator/CSharpProcessor.cs
+++ b/eng/SnippetGenerator/CSharpProcessor.cs
@@ -11,7 +11,7 @@ namespace SnippetGenerator
     public class CSharpProcessor
     {
         private static readonly string _snippetFormat = "{3} <code snippet=\"{0}\">{1}{2} </code>";
-        private static readonly string _snippetExampleFormat = "{3} <example>{1}{3} <code snippet=\"{0}\">{1}{2} </code>{1}{3} </example>";
+        private static readonly string _snippetExampleFormat = "{3} <example snippet=\"{0}\">{1}{3} <code>{1}{2} </code>{1}{3} </example>";
 
         private static readonly Regex _snippetRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<code snippet=\"(?<name>[\\w:]+)\">.*?\\s*<\\/code>",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.IgnoreCase);

--- a/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
+++ b/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using SnippetGenerator;
+
+namespace SnippetGenerator.Tests
+{
+    public class Tests
+    {
+        private const string Processed = "processed";
+
+        [Test]
+        [TestCaseSource(nameof(CodeInputs))]
+        public void CSharpProcsesorFindsCodeXMLDocs(string code, string expected)
+        {
+            var actual = CSharpProcessor.Process(code, SnippetProvider);
+            Assert.AreEqual(expected, actual);
+        }
+
+        private string SnippetProvider(string s) => Processed;
+
+        public static IEnumerable<object[]> CodeInputs()
+        {
+            yield return new[]
+            {
+                @"    /// </remarks>" + Environment.NewLine +
+                @"    /// <code snippet=""Snippet:A""></code>" + Environment.NewLine +
+                "    foo" + Environment.NewLine +
+                "        {",
+                @"    /// </remarks>" + Environment.NewLine +
+                @"    /// <code snippet=""Snippet:A"">" + Environment.NewLine +
+                $"    /// {Processed} </code>" + Environment.NewLine +
+                "    foo" + Environment.NewLine +
+                "        {"
+            };
+
+            yield return new[]
+            {
+                @"/// <code snippet=""Snippet:B""></code>",
+                @"/// <code snippet=""Snippet:B"">" + Environment.NewLine +
+                $"/// {Processed} </code>"
+            };
+
+            yield return new[]
+            {
+                @"    /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:" + Environment.NewLine +
+                @"    /// <code snippet=""Snippet:C""></code>" + Environment.NewLine +
+                "     foo",
+                @"    /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:" + Environment.NewLine +
+                @"    /// <code snippet=""Snippet:C"">" + Environment.NewLine +
+                $"    /// {Processed} </code>" + Environment.NewLine +
+                "     foo"
+            };
+
+            yield return new[]
+            {
+                @"    /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:" + Environment.NewLine +
+                @"    /// <code snippet=""Snippet:Example"" example=""true""></code>" + Environment.NewLine +
+                "     foo",
+                @"    /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:" + Environment.NewLine +
+                @"    /// <example>" + Environment.NewLine +
+                @"    /// <code snippet=""Snippet:Example"">" + Environment.NewLine +
+                $"    /// {Processed} </code>" + Environment.NewLine +
+                @"    /// </example>" + Environment.NewLine +
+                "     foo"
+            };
+        }
+    }
+}

--- a/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
+++ b/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
@@ -61,8 +61,8 @@ namespace SnippetGenerator.Tests
                 @"    /// <example snippet=""Snippet:Example""></example>" + Environment.NewLine +
                 "     foo",
                 @"    /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:" + Environment.NewLine +
-                @"    /// <example>" + Environment.NewLine +
-                @"    /// <code snippet=""Snippet:Example"">" + Environment.NewLine +
+                @"    /// <example snippet=""Snippet:Example"">" + Environment.NewLine +
+                @"    /// <code>" + Environment.NewLine +
                 $"    /// {Processed} </code>" + Environment.NewLine +
                 @"    /// </example>" + Environment.NewLine +
                 "     foo"

--- a/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
+++ b/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
@@ -15,6 +15,9 @@ namespace SnippetGenerator.Tests
         {
             var actual = CSharpProcessor.Process(code, SnippetProvider);
             Assert.AreEqual(expected, actual);
+
+            var reProcessed = CSharpProcessor.Process(actual, SnippetProvider);
+            Assert.AreEqual(expected, reProcessed);
         }
 
         private string SnippetProvider(string s) => Processed;
@@ -55,7 +58,7 @@ namespace SnippetGenerator.Tests
             yield return new[]
             {
                 @"    /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:" + Environment.NewLine +
-                @"    /// <code snippet=""Snippet:Example"" example=""true""></code>" + Environment.NewLine +
+                @"    /// <example snippet=""Snippet:Example""></example>" + Environment.NewLine +
                 "     foo",
                 @"    /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:" + Environment.NewLine +
                 @"    /// <example>" + Environment.NewLine +

--- a/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
+++ b/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
@@ -62,7 +62,7 @@ namespace SnippetGenerator.Tests
                 "     foo",
                 @"    /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:" + Environment.NewLine +
                 @"    /// <example>" + Environment.NewLine +
-                @"    /// <code snippet=""Snippet:Example"" example=""true"">" + Environment.NewLine +
+                @"    /// <code snippet=""Snippet:Example"">" + Environment.NewLine +
                 $"    /// {Processed} </code>" + Environment.NewLine +
                 @"    /// </example>" + Environment.NewLine +
                 "     foo"

--- a/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
+++ b/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
@@ -59,7 +59,7 @@ namespace SnippetGenerator.Tests
                 "     foo",
                 @"    /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:" + Environment.NewLine +
                 @"    /// <example>" + Environment.NewLine +
-                @"    /// <code snippet=""Snippet:Example"">" + Environment.NewLine +
+                @"    /// <code snippet=""Snippet:Example"" example=""true"">" + Environment.NewLine +
                 $"    /// {Processed} </code>" + Environment.NewLine +
                 @"    /// </example>" + Environment.NewLine +
                 "     foo"

--- a/eng/SnippetGenerator/SnippetGenerator.Tests/SnippetGenerator.Tests.csproj
+++ b/eng/SnippetGenerator/SnippetGenerator.Tests/SnippetGenerator.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+      <PackageReference Include="NUnit" Version="3.13.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\SnippetGenerator.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/eng/SnippetGenerator/SnippetGenerator.csproj
+++ b/eng/SnippetGenerator/SnippetGenerator.csproj
@@ -6,6 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="SnippetGenerator.Tests\**" />
+    <EmbeddedResource Remove="SnippetGenerator.Tests\**" />
+    <None Remove="SnippetGenerator.Tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.2.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.2.1" />

--- a/eng/SnippetGenerator/SnippetGenerator.sln
+++ b/eng/SnippetGenerator/SnippetGenerator.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.29315.20
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SnippetGenerator", "SnippetGenerator.csproj", "{DC46BB54-17A2-471C-A21A-D7F329505955}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SnippetGenerator.Tests", "SnippetGenerator.Tests\SnippetGenerator.Tests.csproj", "{49A0F579-8121-472C-A2A7-B812FEC8CA18}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,9 @@ Global
 		{DC46BB54-17A2-471C-A21A-D7F329505955}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DC46BB54-17A2-471C-A21A-D7F329505955}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DC46BB54-17A2-471C-A21A-D7F329505955}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49A0F579-8121-472C-A2A7-B812FEC8CA18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49A0F579-8121-472C-A2A7-B812FEC8CA18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49A0F579-8121-472C-A2A7-B812FEC8CA18}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds a formatting option for `<code>` snippets to be wrapped with an <example> tag.
