### PR TITLE
[Storage][Webjobs] Improve queues options.

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueProcessorOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueProcessorOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
             Queue = queue ?? throw new ArgumentNullException(nameof(queue));
             PoisonQueue = poisonQueue;
             Logger = loggerFactory?.CreateLogger(LogCategories.CreateTriggerCategory("Queue"));
-            Options = options;
+            Options = options.Clone();
         }
 
         /// <summary>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Host
         /// Both the <see cref="NewBatchThreshold"/> and <see cref="BatchSize"/> settings control how many messages are being processed in parallel.
         /// The job keeps requesting messages in batches of <see cref="BatchSize"/> size until number of messages currently being processed
         /// is above <see cref="NewBatchThreshold"/>. Then the job requests new batch of messages only if number of currently processed messages
-        /// drops below <see cref="NewBatchThreshold"/>.
+        /// drops at or below <see cref="NewBatchThreshold"/>.
         ///
         /// The maximum number of messages processed in parallel by the job is <see cref="NewBatchThreshold"/> plus <see cref="BatchSize"/>.
         /// </remarks>
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Host
         /// Both the <see cref="NewBatchThreshold"/> and <see cref="BatchSize"/> settings control how many messages are being processed in parallel.
         /// The job keeps requesting messages in batches of <see cref="BatchSize"/> size until number of messages currently being processed
         /// is above <see cref="NewBatchThreshold"/>. Then the job requests new batch of messages only if number of currently processed messages
-        /// drops below <see cref="NewBatchThreshold"/>.
+        /// drops at or below <see cref="NewBatchThreshold"/>.
         ///
         /// The maximum number of messages processed in parallel by the job is <see cref="NewBatchThreshold"/> plus <see cref="BatchSize"/>.
         /// </remarks>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
@@ -47,7 +47,17 @@ namespace Microsoft.Azure.WebJobs.Host
         }
 
         /// <summary>
-        /// Gets or sets the number of queue messages to retrieve and process in parallel (per job method).
+        /// Gets or sets the number of queue messages to retrieve from queue (per job method).
+        /// Must be in range within 1 and 32. The default is 16.
+        ///
+        /// <remarks>
+        /// Both the <see cref="NewBatchThreshold"/> and <see cref="BatchSize"/> settings control how many messages are being processed in parallel.
+        /// The job keeps requesting messages in batches of <see cref="BatchSize"/> size until number of messages currently being processed
+        /// is above <see cref="NewBatchThreshold"/>. Then the job requests new batch of messages only if number of currently processed messages
+        /// drops below <see cref="NewBatchThreshold"/>.
+        ///
+        /// The maximum number of messages processed in parallel by the job is <see cref="NewBatchThreshold"/> plus <see cref="BatchSize"/>.
+        /// </remarks>
         /// </summary>
         public int BatchSize
         {
@@ -70,7 +80,17 @@ namespace Microsoft.Azure.WebJobs.Host
         }
 
         /// <summary>
-        /// Gets or sets the threshold at which a new batch of messages will be fetched.
+        /// Gets or sets the threshold at which a new batch of messages will be fetched (per job method).
+        /// Must be zero or positive integer. If not set then it defaults to <code>BatchSize/2*processorCount</code>.
+        ///
+        /// <remarks>
+        /// Both the <see cref="NewBatchThreshold"/> and <see cref="BatchSize"/> settings control how many messages are being processed in parallel.
+        /// The job keeps requesting messages in batches of <see cref="BatchSize"/> size until number of messages currently being processed
+        /// is above <see cref="NewBatchThreshold"/>. Then the job requests new batch of messages only if number of currently processed messages
+        /// drops below <see cref="NewBatchThreshold"/>.
+        ///
+        /// The maximum number of messages processed in parallel by the job is <see cref="NewBatchThreshold"/> plus <see cref="BatchSize"/>.
+        /// </remarks>
         /// </summary>
         public int NewBatchThreshold
         {
@@ -197,15 +217,15 @@ namespace Microsoft.Azure.WebJobs.Host
 
         internal QueuesOptions Clone()
         {
-            return new QueuesOptions()
-            {
-                BatchSize = BatchSize,
-                MaxDequeueCount = MaxDequeueCount,
-                MaxPollingInterval = MaxPollingInterval,
-                MessageEncoding = MessageEncoding,
-                NewBatchThreshold = NewBatchThreshold,
-                VisibilityTimeout = VisibilityTimeout,
-            };
+            QueuesOptions copy = new QueuesOptions();
+            // making copy of private members, i.e. the _newBatchThreshold can be "unset" - copying that via properties would always set it.
+            copy._batchSize = _batchSize;
+            copy._maxDequeueCount = _maxDequeueCount;
+            copy._maxPollingInterval = _maxPollingInterval;
+            copy._messageEncoding = _messageEncoding;
+            copy._newBatchThreshold = _newBatchThreshold;
+            copy._visibilityTimeout = _visibilityTimeout;
+            return copy;
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
@@ -194,5 +194,18 @@ namespace Microsoft.Azure.WebJobs.Host
 
             return options.ToString(Formatting.Indented);
         }
+
+        internal QueuesOptions Clone()
+        {
+            return new QueuesOptions()
+            {
+                BatchSize = BatchSize,
+                MaxDequeueCount = MaxDequeueCount,
+                MaxPollingInterval = MaxPollingInterval,
+                MessageEncoding = MessageEncoding,
+                NewBatchThreshold = NewBatchThreshold,
+                VisibilityTimeout = VisibilityTimeout,
+            };
+        }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0-beta.4 (Unreleased)
 
+- Fixed bug where custom implementations of `IQueueProcessorFactory` could overwrite each other settings.
 
 ## 5.0.0-beta.3 (2021-03-09)
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/CustomQueueProcessorTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/CustomQueueProcessorTests.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Queues;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
+{
+    public class CustomQueueProcessorTests
+    {
+        private const string QueueName1 = "input1-customprocessortests";
+        private const string QueueName2 = "input2-customprocessortests";
+        private const string QueueName3 = "input3-customprocessortests";
+        private const string TestQueueMessage = "ignore";
+        private QueueServiceClient queueServiceClient;
+
+        private static QueuesOptions ExpectedQueuesOptions1 = new QueuesOptions(); // defaults
+        private static QueuesOptions ExpectedQueuesOptions2 = new QueuesOptions()
+        {
+            BatchSize = 1,
+            MaxDequeueCount = 1,
+            MaxPollingInterval = TimeSpan.FromSeconds(1),
+            MessageEncoding = QueueMessageEncoding.None,
+            NewBatchThreshold = 1,
+            VisibilityTimeout = TimeSpan.FromSeconds(1),
+        };
+        private static QueuesOptions ExpectedQueuesOptions3 = new QueuesOptions()
+        {
+            BatchSize = 2,
+            MaxDequeueCount = 2,
+            MaxPollingInterval = TimeSpan.FromSeconds(2),
+            MessageEncoding = QueueMessageEncoding.Base64,
+            NewBatchThreshold = 2,
+            VisibilityTimeout = TimeSpan.FromSeconds(2),
+        };
+
+        private static QueuesOptions ActualQueuesOptions1;
+        private static QueuesOptions ActualQueuesOptions2;
+        private static QueuesOptions ActualQueuesOptions3;
+
+        [SetUp]
+        public async Task SetUp()
+        {
+            queueServiceClient = AzuriteNUnitFixture.Instance.GetQueueServiceClient();
+            await queueServiceClient.GetQueueClient(QueueName1).DeleteIfExistsAsync();
+            await queueServiceClient.GetQueueClient(QueueName1).CreateIfNotExistsAsync();
+            await queueServiceClient.GetQueueClient(QueueName2).DeleteIfExistsAsync();
+            await queueServiceClient.GetQueueClient(QueueName2).CreateIfNotExistsAsync();
+            await queueServiceClient.GetQueueClient(QueueName3).DeleteIfExistsAsync();
+            await queueServiceClient.GetQueueClient(QueueName3).CreateIfNotExistsAsync();
+        }
+
+        [Test]
+        public async Task FactoriesShouldNotOverwriteSettings()
+        {
+            // make sure inputs are correct
+            Assert.IsFalse(AreOptionsEqual(ExpectedQueuesOptions1, ExpectedQueuesOptions2));
+            Assert.IsFalse(AreOptionsEqual(ExpectedQueuesOptions1, ExpectedQueuesOptions3));
+            Assert.IsFalse(AreOptionsEqual(ExpectedQueuesOptions2, ExpectedQueuesOptions3));
+
+            // run triggers
+            await queueServiceClient.GetQueueClient(QueueName1).SendMessageAsync(TestQueueMessage);
+            await queueServiceClient.GetQueueClient(QueueName2).SendMessageAsync(TestQueueMessage);
+            await queueServiceClient.GetQueueClient(QueueName3).SendMessageAsync(TestQueueMessage);
+
+            await FunctionalTest.RunTriggerAsync<bool>(
+                b => ConfigureStorage(b), typeof(SampleProgram), s => SampleProgram.TaskSource = s);
+
+            // assert options were not overwritten
+            Assert.IsTrue(AreOptionsEqual(ExpectedQueuesOptions1, ActualQueuesOptions1));
+            Assert.IsTrue(AreOptionsEqual(ExpectedQueuesOptions2, ActualQueuesOptions2));
+            Assert.IsTrue(AreOptionsEqual(ExpectedQueuesOptions3, ActualQueuesOptions3));
+        }
+
+        private bool AreOptionsEqual(QueuesOptions queuesOptions1, QueuesOptions queuesOptions2)
+        {
+            return queuesOptions1.BatchSize == queuesOptions2.BatchSize
+                && queuesOptions1.MaxDequeueCount == queuesOptions2.MaxDequeueCount
+                 && queuesOptions1.MaxPollingInterval == queuesOptions2.MaxPollingInterval
+                  && queuesOptions1.MessageEncoding == queuesOptions2.MessageEncoding
+                   && queuesOptions1.NewBatchThreshold == queuesOptions2.NewBatchThreshold
+                    && queuesOptions1.VisibilityTimeout == queuesOptions2.VisibilityTimeout;
+        }
+
+        private class CustomQueueProcessorFactory : IQueueProcessorFactory
+        {
+            public QueueProcessor Create(QueueProcessorOptions queueProcessorOptions)
+            {
+                QueuesOptions overrideOptions = null;
+                switch (queueProcessorOptions.Queue.Name)
+                {
+                    case QueueName1:
+                        ActualQueuesOptions1 = queueProcessorOptions.Options;
+                        // defaults
+                        break;
+                    case QueueName2:
+                        ActualQueuesOptions2 = queueProcessorOptions.Options;
+                        overrideOptions = ExpectedQueuesOptions2;
+                        break;
+                    case QueueName3:
+                        ActualQueuesOptions3 = queueProcessorOptions.Options;
+                        overrideOptions = ExpectedQueuesOptions3;
+                        break;
+                }
+
+                if (overrideOptions != null)
+                {
+                    queueProcessorOptions.Options.BatchSize = overrideOptions.BatchSize;
+                    queueProcessorOptions.Options.MaxDequeueCount = overrideOptions.MaxDequeueCount;
+                    queueProcessorOptions.Options.MaxPollingInterval = overrideOptions.MaxPollingInterval;
+                    queueProcessorOptions.Options.MessageEncoding = overrideOptions.MessageEncoding;
+                    queueProcessorOptions.Options.NewBatchThreshold = overrideOptions.NewBatchThreshold;
+                    queueProcessorOptions.Options.VisibilityTimeout = overrideOptions.VisibilityTimeout;
+                }
+
+                return new QueueProcessor(queueProcessorOptions);
+            }
+        }
+
+        private class SampleProgram
+        {
+            public static TaskCompletionSource<bool> TaskSource { get; set; }
+            private static int counter = 0;
+
+            public static void ProcessMessage1([QueueTrigger(QueueName1)] string message)
+            {
+                SetResult();
+            }
+
+            public static void ProcessMessage2([QueueTrigger(QueueName2)] string message)
+            {
+                SetResult();
+            }
+
+            public static void ProcessMessage3([QueueTrigger(QueueName3)] string message)
+            {
+                SetResult();
+            }
+
+            private static void SetResult()
+            {
+                int incremented = Interlocked.Increment(ref counter);
+                if (incremented == 3)
+                {
+                    TaskSource.SetResult(true);
+                }
+            }
+        }
+
+        private void ConfigureStorage(IWebJobsBuilder builder)
+        {
+            builder.AddAzureStorageQueues();
+            builder.UseQueueService(queueServiceClient);
+            builder.Services.AddSingleton<IQueueProcessorFactory, CustomQueueProcessorFactory>();
+        }
+    }
+}


### PR DESCRIPTION
This is to address https://github.com/Azure/azure-sdk-for-net/issues/20455 .

In this PR:
- Clarify how `BatchSize` and `NewBatchThreshold` work.
- Fixed bug where many `IQueueProcessorFactory` instances could overwrite each other settings.