### PR TITLE
Enable per-operation network timeout override

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/SyncAsyncPolicyTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/SyncAsyncPolicyTestBase.cs
@@ -17,11 +17,16 @@ namespace Azure.Core.TestFramework
         {
         }
 
-        protected async Task<Response> SendRequestAsync(HttpPipeline pipeline, Action<Request> requestAction, bool bufferResponse = true, CancellationToken cancellationToken = default)
+        protected Task<Response> SendRequestAsync(HttpPipeline pipeline, Action<Request> requestAction, bool bufferResponse = true, CancellationToken cancellationToken = default)
+        {
+            return SendRequestAsync(pipeline, message => requestAction(message.Request), bufferResponse, cancellationToken);
+        }
+
+        protected async Task<Response> SendRequestAsync(HttpPipeline pipeline, Action<HttpMessage> messageAction, bool bufferResponse = true, CancellationToken cancellationToken = default)
         {
             HttpMessage message = pipeline.CreateMessage();
             message.BufferResponse = bufferResponse;
-            requestAction(message.Request);
+            messageAction(message);
 
             if (IsAsync)
             {
@@ -35,20 +40,25 @@ namespace Azure.Core.TestFramework
             return message.Response;
         }
 
-        protected async Task<Response> SendRequestAsync(HttpPipelineTransport transport, Action<Request> requestAction, HttpPipelinePolicy policy, ResponseClassifier responseClassifier = null, bool bufferResponse = true, CancellationToken cancellationToken = default)
+        protected async Task<Response> SendRequestAsync(HttpPipelineTransport transport, Action<HttpMessage> messageAction, HttpPipelinePolicy policy, ResponseClassifier responseClassifier = null, bool bufferResponse = true, CancellationToken cancellationToken = default)
         {
             await Task.Yield();
 
             var pipeline = new HttpPipeline(transport, new[] { policy }, responseClassifier);
-            return await SendRequestAsync(pipeline, requestAction, bufferResponse, cancellationToken);
+            return await SendRequestAsync(pipeline, messageAction, bufferResponse, cancellationToken);
+        }
+
+        protected Task<Response> SendRequestAsync(HttpPipelineTransport transport, Action<Request> requestAction, HttpPipelinePolicy policy, ResponseClassifier responseClassifier = null, bool bufferResponse = true, CancellationToken cancellationToken = default)
+        {
+            return SendRequestAsync(transport, message => requestAction(message.Request), policy, responseClassifier, bufferResponse, cancellationToken);
         }
 
         protected async Task<Response> SendGetRequest(HttpPipelineTransport transport, HttpPipelinePolicy policy, ResponseClassifier responseClassifier = null, bool bufferResponse = true, Uri uri = null, CancellationToken cancellationToken = default)
         {
-            return await SendRequestAsync(transport, request =>
+            return await SendRequestAsync(transport, message =>
             {
-                request.Method = RequestMethod.Get;
-                request.Uri.Reset(uri ?? new Uri("http://example.com"));
+                message.Request.Method = RequestMethod.Get;
+                message.Request.Uri.Reset(uri ?? new Uri("http://example.com"));
             }, policy, responseClassifier, bufferResponse, cancellationToken);
         }
     }

--- a/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
@@ -80,7 +80,7 @@ namespace Azure.Core.Tests
                 return mockResponse;
             });
 
-            Task<Response> requestTask = SendRequestAsync(mockTransport, _ => { }, s_enabledPolicy);
+            Task<Response> requestTask = SendGetRequest(mockTransport, s_enabledPolicy);
 
             await requestTask;
 

--- a/sdk/core/Azure.Core/tests/ResponseBodyPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/ResponseBodyPolicyTests.cs
@@ -174,18 +174,16 @@ namespace Azure.Core.Tests
         {
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            MockTransport mockTransport = new MockTransport(r =>
+            MockTransport mockTransport = new MockTransport((_, ct) =>
             {
-                tcs.Task.Wait();
+                tcs.Task.Wait(ct);
                 return null;
             });
 
-            Assert.ThrowsAsync<TaskCanceledException>(async () => await SendRequestAsync(mockTransport, message =>
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await SendRequestAsync(mockTransport, message =>
             {
                 message.SetProperty("NetworkTimeoutOverride", TimeSpan.FromMilliseconds(30));
             }, new ResponseBodyPolicy(TimeSpan.MaxValue), bufferResponse: false));
-
-            tcs.SetCanceled();
         }
 
         [Test]

--- a/sdk/core/Azure.Core/tests/ResponseBodyPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/ResponseBodyPolicyTests.cs
@@ -169,6 +169,45 @@ namespace Azure.Core.Tests
             Assert.That(async () => await getRequestTask, Throws.InstanceOf<OperationCanceledException>());
         }
 
+        [Test]
+        public void CanOverrideDefaultNetworkTimeout()
+        {
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            MockTransport mockTransport = new MockTransport(r =>
+            {
+                tcs.Task.Wait();
+                return null;
+            });
+
+            Assert.ThrowsAsync<TaskCanceledException>(async () => await SendRequestAsync(mockTransport, message =>
+            {
+                message.SetProperty("NetworkTimeoutOverride", TimeSpan.FromMilliseconds(30));
+            }, new ResponseBodyPolicy(TimeSpan.MaxValue), bufferResponse: false));
+
+            tcs.SetCanceled();
+        }
+
+        [Test]
+        public async Task CanOverrideDefaultNetworkTimeout_Stream()
+        {
+            var hangingStream = new HangingReadStream();
+
+            MockResponse mockResponse = new MockResponse(200)
+            {
+                ContentStream = hangingStream
+            };
+
+            MockTransport mockTransport = new MockTransport(mockResponse);
+            Response response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.SetProperty("NetworkTimeoutOverride", TimeSpan.FromMilliseconds(30));
+            }, new ResponseBodyPolicy(TimeSpan.MaxValue), bufferResponse: false);
+
+            Assert.IsInstanceOf<ReadTimeoutStream>(response.ContentStream);
+            Assert.AreEqual(30, hangingStream.ReadTimeout);
+        }
+
         private class SlowReadStream : TestReadStream
         {
             public readonly TaskCompletionSource<object> StartedReader = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
Some services (Monitor Query) don't model long-running operations as LROs instead they require the client to keep the connection open for durations that sometimes can be longer than the default 100sec network timeout we  have. Add support for overriding the network timeout on per-call basis.