### PR TITLE
Lease client updates itself

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
@@ -44,10 +44,15 @@ namespace Azure.Storage.Blobs.Specialized
         /// </summary>
         public Uri Uri => BlobClient?.Uri ?? BlobContainerClient?.Uri;
 
+        private string _leaseId;
         /// <summary>
         /// Gets the Lease ID for this lease.
         /// </summary>
-        public virtual volatile string LeaseId { get; private set; }
+        public virtual string LeaseId
+        {
+            get => Volatile.Read(ref _leaseId);
+            private set => Volatile.Write(ref _leaseId, value);
+        }
 
         /// <summary>
         /// The <see cref="HttpPipeline"/> transport pipeline used to send

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
@@ -299,13 +299,14 @@ namespace Azure.Storage.Blobs.Specialized
                         tagCondition = leaseConditions?.TagConditions;
                     }
 
+                    Response<BlobLease> response;
                     if (BlobClient != null)
                     {
-                        ResponseWithHeaders<BlobAcquireLeaseHeaders> response;
+                        ResponseWithHeaders<BlobAcquireLeaseHeaders> blobClientResponse;
 
                         if (async)
                         {
-                            response = await BlobClient.BlobRestClient.AcquireLeaseAsync(
+                            blobClientResponse = await BlobClient.BlobRestClient.AcquireLeaseAsync(
                                 duration: serviceDuration,
                                 proposedLeaseId: LeaseId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
@@ -318,7 +319,7 @@ namespace Azure.Storage.Blobs.Specialized
                         }
                         else
                         {
-                            response = BlobClient.BlobRestClient.AcquireLease(
+                            blobClientResponse = BlobClient.BlobRestClient.AcquireLease(
                                 duration: serviceDuration,
                                 proposedLeaseId: LeaseId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
@@ -329,9 +330,9 @@ namespace Azure.Storage.Blobs.Specialized
                                 cancellationToken: cancellationToken);
                         }
 
-                        return Response.FromValue(
-                            response.ToBlobLease(),
-                            response.GetRawResponse());
+                        response = Response.FromValue(
+                            blobClientResponse.ToBlobLease(),
+                            blobClientResponse.GetRawResponse());
                     }
                     else
                     {
@@ -342,11 +343,11 @@ namespace Azure.Storage.Blobs.Specialized
                                 nameof(conditions.IfNoneMatch));
                         }
 
-                        ResponseWithHeaders<ContainerAcquireLeaseHeaders> response;
+                        ResponseWithHeaders<ContainerAcquireLeaseHeaders> containerClientResponse;
 
                         if (async)
                         {
-                            response = await BlobContainerClient.ContainerRestClient.AcquireLeaseAsync(
+                            containerClientResponse = await BlobContainerClient.ContainerRestClient.AcquireLeaseAsync(
                                 duration: serviceDuration,
                                 proposedLeaseId: LeaseId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
@@ -356,7 +357,7 @@ namespace Azure.Storage.Blobs.Specialized
                         }
                         else
                         {
-                            response = BlobContainerClient.ContainerRestClient.AcquireLease(
+                            containerClientResponse = BlobContainerClient.ContainerRestClient.AcquireLease(
                                 duration: serviceDuration,
                                 proposedLeaseId: LeaseId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
@@ -364,10 +365,12 @@ namespace Azure.Storage.Blobs.Specialized
                                 cancellationToken: cancellationToken);
                         }
 
-                        return Response.FromValue(
-                            response.ToBlobLease(),
-                            response.GetRawResponse());
+                        response = Response.FromValue(
+                            containerClientResponse.ToBlobLease(),
+                            containerClientResponse.GetRawResponse());
                     }
+                    LeaseId = response.Value.LeaseId;
+                    return response;
                 }
                 catch (Exception ex)
                 {
@@ -518,13 +521,14 @@ namespace Azure.Storage.Blobs.Specialized
                         tagConditions = ((BlobLeaseRequestConditions)conditions).TagConditions;
                     }
 
+                    Response<BlobLease> response;
                     if (BlobClient != null)
                     {
-                        ResponseWithHeaders<BlobRenewLeaseHeaders> response;
+                        ResponseWithHeaders<BlobRenewLeaseHeaders> blobClientResponse;
 
                         if (async)
                         {
-                            response = await BlobClient.BlobRestClient.RenewLeaseAsync(
+                            blobClientResponse = await BlobClient.BlobRestClient.RenewLeaseAsync(
                                 leaseId: LeaseId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
                                 ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
@@ -536,7 +540,7 @@ namespace Azure.Storage.Blobs.Specialized
                         }
                         else
                         {
-                            response = BlobClient.BlobRestClient.RenewLease(
+                            blobClientResponse = BlobClient.BlobRestClient.RenewLease(
                                 leaseId: LeaseId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
                                 ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
@@ -546,9 +550,9 @@ namespace Azure.Storage.Blobs.Specialized
                                 cancellationToken: cancellationToken);
                         }
 
-                        return Response.FromValue(
-                            response.ToBlobLease(),
-                            response.GetRawResponse());
+                        response = Response.FromValue(
+                            blobClientResponse.ToBlobLease(),
+                            blobClientResponse.GetRawResponse());
                     }
                     else
                     {
@@ -559,11 +563,11 @@ namespace Azure.Storage.Blobs.Specialized
                                 nameof(conditions.IfNoneMatch));
                         }
 
-                        ResponseWithHeaders<ContainerRenewLeaseHeaders> response;
+                        ResponseWithHeaders<ContainerRenewLeaseHeaders> containerClientResponse;
 
                         if (async)
                         {
-                            response = await BlobContainerClient.ContainerRestClient.RenewLeaseAsync(
+                            containerClientResponse = await BlobContainerClient.ContainerRestClient.RenewLeaseAsync(
                                 leaseId: LeaseId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
                                 ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
@@ -572,17 +576,20 @@ namespace Azure.Storage.Blobs.Specialized
                         }
                         else
                         {
-                            response = BlobContainerClient.ContainerRestClient.RenewLease(
+                            containerClientResponse = BlobContainerClient.ContainerRestClient.RenewLease(
                                 leaseId: LeaseId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
                                 ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
                                 cancellationToken: cancellationToken);
                         }
 
-                        return Response.FromValue(
-                            response.ToBlobLease(),
-                            response.GetRawResponse());
+                        response = Response.FromValue(
+                            containerClientResponse.ToBlobLease(),
+                            containerClientResponse.GetRawResponse());
                     }
+
+                    LeaseId = response.Value.LeaseId;
+                    return response;
                 }
                 catch (Exception ex)
                 {
@@ -960,13 +967,14 @@ namespace Azure.Storage.Blobs.Specialized
                         tagCondition = ((BlobLeaseRequestConditions)conditions).TagConditions;
                     }
 
+                    Response<BlobLease> response;
                     if (BlobClient != null)
                     {
-                        ResponseWithHeaders<BlobChangeLeaseHeaders> response;
+                        ResponseWithHeaders<BlobChangeLeaseHeaders> blobClientResponse;
 
                         if (async)
                         {
-                            response = await BlobClient.BlobRestClient.ChangeLeaseAsync(
+                            blobClientResponse = await BlobClient.BlobRestClient.ChangeLeaseAsync(
                                 leaseId: LeaseId,
                                 proposedLeaseId: proposedId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
@@ -979,7 +987,7 @@ namespace Azure.Storage.Blobs.Specialized
                         }
                         else
                         {
-                            response = BlobClient.BlobRestClient.ChangeLease(
+                            blobClientResponse = BlobClient.BlobRestClient.ChangeLease(
                                 leaseId: LeaseId,
                                 proposedLeaseId: proposedId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
@@ -990,9 +998,9 @@ namespace Azure.Storage.Blobs.Specialized
                                 cancellationToken: cancellationToken);
                         }
 
-                        return Response.FromValue(
-                            response.ToBlobLease(),
-                            response.GetRawResponse());
+                        response = Response.FromValue(
+                            blobClientResponse.ToBlobLease(),
+                            blobClientResponse.GetRawResponse());
                     }
                     else
                     {
@@ -1003,11 +1011,11 @@ namespace Azure.Storage.Blobs.Specialized
                                 nameof(conditions.IfNoneMatch));
                         }
 
-                        ResponseWithHeaders<ContainerChangeLeaseHeaders> response;
+                        ResponseWithHeaders<ContainerChangeLeaseHeaders> containerClientResponse;
 
                         if (async)
                         {
-                            response = await BlobContainerClient.ContainerRestClient.ChangeLeaseAsync(
+                            containerClientResponse = await BlobContainerClient.ContainerRestClient.ChangeLeaseAsync(
                                 leaseId: LeaseId,
                                 proposedLeaseId: proposedId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
@@ -1017,7 +1025,7 @@ namespace Azure.Storage.Blobs.Specialized
                         }
                         else
                         {
-                            response = BlobContainerClient.ContainerRestClient.ChangeLease(
+                            containerClientResponse = BlobContainerClient.ContainerRestClient.ChangeLease(
                                 leaseId: LeaseId,
                                 proposedLeaseId: proposedId,
                                 ifModifiedSince: conditions?.IfModifiedSince,
@@ -1025,10 +1033,13 @@ namespace Azure.Storage.Blobs.Specialized
                                 cancellationToken: cancellationToken);
                         }
 
-                        return Response.FromValue(
-                            response.ToBlobLease(),
-                            response.GetRawResponse());
+                        response = Response.FromValue(
+                            containerClientResponse.ToBlobLease(),
+                            containerClientResponse.GetRawResponse());
                     }
+
+                    LeaseId = response.Value.LeaseId;
+                    return response;
                 }
                 catch (Exception ex)
                 {

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
@@ -47,7 +47,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// Gets the Lease ID for this lease.
         /// </summary>
-        public virtual string LeaseId { get; private set; }
+        public virtual volatile string LeaseId { get; private set; }
 
         /// <summary>
         /// The <see cref="HttpPipeline"/> transport pipeline used to send

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -4983,12 +4983,14 @@ namespace Azure.Storage.Blobs.Test
 
             var leaseId = Recording.Random.NewGuid().ToString();
             var duration = TimeSpan.FromSeconds(15);
+            var leaseClient = InstrumentClient(blob.GetBlobLeaseClient(leaseId));
 
             // Act
-            Response<BlobLease> response = await InstrumentClient(blob.GetBlobLeaseClient(leaseId)).AcquireAsync(duration);
+            Response<BlobLease> response = await leaseClient.AcquireAsync(duration);
 
             // Assert
             Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
+            Assert.AreEqual(response.Value.LeaseId, leaseClient.LeaseId);
         }
 
         [RecordedTest]
@@ -5148,6 +5150,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Assert
             Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
+            Assert.AreEqual(response.Value.LeaseId, lease.LeaseId);
         }
 
         [RecordedTest]
@@ -5592,6 +5595,8 @@ namespace Azure.Storage.Blobs.Test
 
             // Assert
             Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
+            Assert.AreEqual(newLeaseId, response.Value.LeaseId);
+            Assert.AreEqual(response.Value.LeaseId, lease.LeaseId);
         }
 
         [RecordedTest]

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -2262,12 +2262,14 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             var leaseId = Recording.Random.NewGuid().ToString();
             var duration = TimeSpan.FromSeconds(15);
+            var leaseClient = InstrumentClient(file.GetDataLakeLeaseClient(leaseId));
 
             // Act
-            Response<DataLakeLease> response = await InstrumentClient(file.GetDataLakeLeaseClient(leaseId)).AcquireAsync(duration);
+            Response<DataLakeLease> response = await leaseClient.AcquireAsync(duration);
 
             // Assert
             Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
+            Assert.AreEqual(response.Value.LeaseId, leaseClient.LeaseId);
         }
 
         [RecordedTest]
@@ -2357,6 +2359,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Assert
             Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
+            Assert.AreEqual(response.Value.LeaseId, lease.LeaseId);
         }
 
         [RecordedTest]
@@ -2538,6 +2541,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Assert
             Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
+            Assert.AreEqual(response.Value.LeaseId, lease.LeaseId);
         }
 
         [RecordedTest]


### PR DESCRIPTION
Lease client now retains the latest leaseID response as it's internal
property for the lease ID.

Existing tests updated to assert lease client id matches most recent response.