### PR TITLE
Update identity to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialLiveTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -35,7 +36,7 @@ namespace Azure.Identity.Tests
 
             var credential = InstrumentClient(new ClientCertificateCredential(tenantId, clientId, certPath, options));
 
-            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(AzureAuthorityHosts.AzurePublicCloud) });
+            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(new Uri(TestEnvironment.AuthorityHostUrl)) });
 
             // ensure we can initially acquire a  token
             AccessToken token = await credential.GetTokenAsync(tokenRequestContext);
@@ -70,7 +71,7 @@ namespace Azure.Identity.Tests
 
             var credential = InstrumentClient(new ClientCertificateCredential(tenantId, clientId, cert, options));
 
-            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(AzureAuthorityHosts.AzurePublicCloud) });
+            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(new Uri(TestEnvironment.AuthorityHostUrl)) });
 
             // ensure we can initially acquire a  token
             AccessToken token = await credential.GetTokenAsync(tokenRequestContext);
@@ -105,7 +106,7 @@ namespace Azure.Identity.Tests
 
             var credential = InstrumentClient(new ClientCertificateCredential(tenantId, clientId, certPath, options));
 
-            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(AzureAuthorityHosts.AzurePublicCloud) });
+            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(new Uri(TestEnvironment.AuthorityHostUrl)) });
 
             // ensure we can initially acquire a  token
             AccessToken token = await credential.GetTokenAsync(tokenRequestContext);
@@ -124,7 +125,7 @@ namespace Azure.Identity.Tests
 
             var credential = InstrumentClient(new ClientCertificateCredential(tenantId, clientId, new X509Certificate2(certPath), options));
 
-            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(AzureAuthorityHosts.AzurePublicCloud) });
+            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(new Uri(TestEnvironment.AuthorityHostUrl)) });
 
             // ensure the incorrect client claim is rejected, handled and wrapped in AuthenticationFailedException
             Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(tokenRequestContext));

--- a/sdk/identity/Azure.Identity/tests/ClientSecretCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientSecretCredentialLiveTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Identity.Tests
 
             var credential = InstrumentClient(new ClientSecretCredential(tenantId, clientId, secret, options));
 
-            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(AzureAuthorityHosts.AzurePublicCloud) });
+            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(new Uri(TestEnvironment.AuthorityHostUrl)) });
 
             // ensure we can initially acquire a  token
             AccessToken token = await credential.GetTokenAsync(tokenRequestContext);
@@ -70,7 +70,7 @@ namespace Azure.Identity.Tests
 
             var credential = InstrumentClient(new ClientSecretCredential(tenantId, clientId, secret, options));
 
-            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(AzureAuthorityHosts.AzurePublicCloud) });
+            var tokenRequestContext = new TokenRequestContext(new[] { AzureAuthorityHosts.GetDefaultScope(new Uri(TestEnvironment.AuthorityHostUrl)) });
 
             // ensure we can initially acquire a  token
             Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(tokenRequestContext));

--- a/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
+++ b/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
@@ -146,13 +146,15 @@ namespace Azure.Identity.Tests
             var clientId = "aebc6443-996d-45c2-90f0-388ff96faa56";
             var username = testEnvironment.Username;
             var password = testEnvironment.Password;
+            var authorityUri = new Uri(new Uri(testEnvironment.AuthorityHostUrl), testEnvironment.TestTenantId).ToString();
 
             var client = PublicClientApplicationBuilder.Create(clientId)
+                .WithAuthority(authorityUri)
                 .WithTenantId(testEnvironment.TestTenantId)
                 .Build();
 
             var retriever = new RefreshTokenRetriever(client.UserTokenCache);
-            await client.AcquireTokenByUsernamePassword(new[] {".default"}, username, password.ToSecureString()).ExecuteAsync();
+            await client.AcquireTokenByUsernamePassword(new[] { ".default" }, username, password.ToSecureString()).ExecuteAsync();
 
             StaticCachesUtilities.ClearStaticMetadataProviderCache();
             StaticCachesUtilities.ClearAuthorityEndpointResolutionManagerCache();

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
@@ -45,7 +45,7 @@ namespace Azure.Identity.Tests
 
             using (ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure.Identity")))
             {
-                token = await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None);
+                token = await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None);
                 scopes = diagnosticListener.Scopes;
             }
 
@@ -66,6 +66,7 @@ namespace Azure.Identity.Tests
                 ExcludeEnvironmentCredential = true,
                 ExcludeInteractiveBrowserCredential = true,
                 ExcludeSharedTokenCacheCredential = true,
+                ExcludeManagedIdentityCredential = true,
                 VisualStudioCodeTenantId = TestEnvironment.TestTenantId
             });
 
@@ -82,7 +83,7 @@ namespace Azure.Identity.Tests
             using (await CredentialTestHelpers.CreateRefreshTokenFixtureAsync(TestEnvironment, Mode, ExpectedServiceName, cloudName))
             using (ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure.Identity")))
             {
-                token = await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None);
+                token = await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None);
                 scopes = diagnosticListener.Scopes;
             }
 
@@ -102,6 +103,7 @@ namespace Azure.Identity.Tests
                 ExcludeEnvironmentCredential = true,
                 ExcludeInteractiveBrowserCredential = true,
                 ExcludeSharedTokenCacheCredential = true,
+                ExcludeManagedIdentityCredential = true,
                 VisualStudioCodeTenantId = TestEnvironment.TestTenantId
             });
 
@@ -117,7 +119,7 @@ namespace Azure.Identity.Tests
             {
                 for (int i = 0; i < 10; i++)
                 {
-                    tasks.Add(Task.Run(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None)));
+                    tasks.Add(Task.Run(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None)));
                 }
 
                 await Task.WhenAll(tasks);
@@ -153,7 +155,7 @@ namespace Azure.Identity.Tests
 
             using (ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure.Identity")))
             {
-                token = await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None);
+                token = await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None);
                 scopes = diagnosticListener.Scopes;
             }
 
@@ -187,7 +189,7 @@ namespace Azure.Identity.Tests
             var tasks = new List<Task<AccessToken>>();
             for (int i = 0; i < 10; i++)
             {
-                tasks.Add(Task.Run(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None)));
+                tasks.Add(Task.Run(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None)));
             }
 
             await Task.WhenAll(tasks);
@@ -218,7 +220,7 @@ namespace Azure.Identity.Tests
 
             using (ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure.Identity")))
             {
-                Assert.CatchAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None));
+                Assert.CatchAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None));
                 scopes = diagnosticListener.Scopes;
             }
 
@@ -275,7 +277,7 @@ namespace Azure.Identity.Tests
 
             using (ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure.Identity")))
             {
-                Assert.CatchAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None));
+                Assert.CatchAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None));
                 scopes = diagnosticListener.Scopes;
             }
 

--- a/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
@@ -176,6 +176,7 @@ namespace Azure.Identity.Tests
         [Test]
         public void AuthenticateWithDeviceCodeCallbackThrowsAsync()
         {
+            IdentityTestEnvironment testEnvironment = new IdentityTestEnvironment();
             var expectedCode = Guid.NewGuid().ToString();
 
             var expectedToken = Guid.NewGuid().ToString();
@@ -188,7 +189,7 @@ namespace Azure.Identity.Tests
 
             var cred = InstrumentClient(new DeviceCodeCredential(ThrowingDeviceCodeCallback, ClientId, options: options));
 
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await cred.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" }), cancelSource.Token));
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await cred.GetTokenAsync(new TokenRequestContext(new string[] { testEnvironment.KeyvaultScope }), cancelSource.Token));
 
             Assert.IsInstanceOf(typeof(MockException), ex.InnerException);
         }
@@ -196,6 +197,7 @@ namespace Azure.Identity.Tests
         [Test]
         public void DisableAutomaticAuthenticationException()
         {
+            IdentityTestEnvironment testEnvironment = new IdentityTestEnvironment();
             var expectedCode = Guid.NewGuid().ToString();
 
             var cred = InstrumentClient(new DeviceCodeCredential(new DeviceCodeCredentialOptions { DisableAutomaticAuthentication = true, DeviceCodeCallback = (code, cancelToken) => VerifyDeviceCode(code, expectedCode) }));
@@ -209,14 +211,15 @@ namespace Azure.Identity.Tests
 
         private MockResponse ProcessMockRequest(MockRequest mockRequest, string code, string token)
         {
+            IdentityTestEnvironment testEnvironment = new IdentityTestEnvironment();
             string requestUrl = mockRequest.Uri.ToUri().AbsoluteUri;
 
-            if (requestUrl.StartsWith("https://login.microsoftonline.com/common/discovery/instance"))
+            if (requestUrl.StartsWith(new Uri(new Uri(testEnvironment.AuthorityHostUrl), "common/discovery/instance").ToString()))
             {
                 return DiscoveryInstanceResponse;
             }
 
-            if (requestUrl.StartsWith("https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration"))
+            if (requestUrl.StartsWith(new Uri(new Uri(testEnvironment.AuthorityHostUrl), "organizations/v2.0/.well-known/openid-configuration").ToString()))
             {
                 return OpenIdConfigurationResponse;
             }

--- a/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
+++ b/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
@@ -31,7 +31,7 @@ namespace Azure.Identity.Tests
 
         public string TestPassword => GetOptionalVariable("AZURE_IDENTITY_TEST_PASSWORD") ?? "SANITIZED";
         public string TestTenantId => GetRecordedOptionalVariable("TENANT_ID") ?? GetRecordedVariable("AZURE_IDENTITY_TEST_TENANTID");
-
+        public string KeyvaultScope => GetRecordedOptionalVariable("AZURE_KEYVAULT_SCOPE") ?? TestEnvVar.KeyVaultDefaultScope;
         public string ServicePrincipalClientId => GetRecordedVariable("IDENTITY_SP_CLIENT_ID");
         public string ServicePrincipalTenantId => GetRecordedVariable("IDENTITY_SP_TENANT_ID");
         public string ServicePrincipalClientSecret => GetOptionalVariable("IDENTITY_SP_CLIENT_SECRET") ?? "SANITIZED";

--- a/sdk/identity/Azure.Identity/tests/TestEnvVar.cs
+++ b/sdk/identity/Azure.Identity/tests/TestEnvVar.cs
@@ -9,6 +9,7 @@ namespace Azure.Identity.Tests
 {
     internal class TestEnvVar : IDisposable
     {
+        public const string KeyVaultDefaultScope = "https://vault.azure.net/.default";
         private static SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
         private readonly Dictionary<string, string> _originalValues = new Dictionary<string, string>()
         {

--- a/sdk/identity/Azure.Identity/tests/UsernamePasswordCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/UsernamePasswordCredentialLiveTests.cs
@@ -72,7 +72,7 @@ namespace Azure.Identity.Tests
 
             var cred = InstrumentClient(new UsernamePasswordCredential(username, password, tenantId, ClientId, options));
 
-            AccessToken token = await cred.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" }));
+            AccessToken token = await cred.GetTokenAsync(new TokenRequestContext(new string[] { TestEnvironment.KeyvaultScope }));
 
             Assert.IsNotNull(token.Token);
         }
@@ -107,7 +107,7 @@ namespace Azure.Identity.Tests
 
             var cred = InstrumentClient(new UsernamePasswordCredential(username, password, tenantId, ClientId, options));
 
-            AuthenticationRecord record = await cred.AuthenticateAsync(new TokenRequestContext(new[] { "https://vault.azure.net/.default" }));
+            AuthenticationRecord record = await cred.AuthenticateAsync(new TokenRequestContext(new[] { TestEnvironment.KeyvaultScope }));
 
             Assert.IsNotNull(record);
 

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialLiveTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Identity.Tests
 
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystem, default));
-            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None);
+            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] { TestEnvironment.KeyvaultScope}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
         }
 
@@ -43,7 +43,7 @@ namespace Azure.Identity.Tests
 
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
-            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None);
+            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] { TestEnvironment.KeyvaultScope}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
         }
 
@@ -56,7 +56,7 @@ namespace Azure.Identity.Tests
 
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
-            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None);
+            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
         }
 
@@ -70,7 +70,7 @@ namespace Azure.Identity.Tests
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
 
-            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None);
+            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
         }
 
@@ -86,7 +86,7 @@ namespace Azure.Identity.Tests
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = Guid.NewGuid().ToString() });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, default));
 
-            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None);
+            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
         }
 
@@ -100,7 +100,7 @@ namespace Azure.Identity.Tests
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystem, default));
 
-            Assert.CatchAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None));
+            Assert.CatchAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None));
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace Azure.Identity.Tests
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystem, vscAdapter));
 
-            Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None));
+            Assert.CatchAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None));
         }
 
         [Test]
@@ -126,7 +126,7 @@ namespace Azure.Identity.Tests
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
 
-            Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None));
+            Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None));
         }
 
         [Test]
@@ -139,7 +139,7 @@ namespace Azure.Identity.Tests
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
 
-            Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None));
+            Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { TestEnvironment.KeyvaultScope }), CancellationToken.None));
         }
     }
 }

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -17,6 +17,7 @@ extends:
         Selection: sparse
         GenerateContainerJobs: true
     ServiceDirectory: identity
+    SupportedClouds: 'Public,UsGov,China,Canary'
     PreSteps:
       - pwsh: Install-Module -Name Az -Scope CurrentUser -AllowClobber -Force -Verbose
         displayName: Install Azure PowerShell module


### PR DESCRIPTION
These changes contain fixes for the identity to be able to run live tests against AzureUsGovernment and AzureChina clouds. The sovereign cloud live tests will be green with the changes.