### PR TITLE
Add a common definition for sub-resource

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceContainerBase.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceContainerBase.cs
@@ -14,9 +14,9 @@ namespace Azure.ResourceManager.Core
     /// <typeparam name="TOperations"> The type of the class containing operations for the underlying resource. </typeparam>
     /// <typeparam name="TResource"> The type of the class containing properties for the underlying resource. </typeparam>
     public abstract class ResourceContainerBase<TIdentifier, TOperations, TResource> : ContainerBase<TIdentifier, TOperations>
-        where TOperations : ResourceOperationsBase<TIdentifier, TOperations>
-        where TResource : Resource<TIdentifier>
         where TIdentifier : TenantResourceIdentifier
+        where TOperations : ResourceOperationsBase<TIdentifier, TOperations>
+        where TResource : class
     {
         private static readonly object _parentLock = new object();
         private object _parentResource;

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResource.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResource.Serialization.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json;
+using Azure.Core;
+
+namespace Azure.ResourceManager.Core
+{
+    /// <summary>
+    /// A class representing a sub-resource that contains only the ID.
+    /// </summary>
+    public partial class SubResource : IUtf8JsonSerializable
+    {
+        /// <summary>
+        /// Serialize the input SubResource object.
+        /// </summary>
+        /// <param name="writer"> Input Json writer. </param>
+        void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
+        {
+            if (writer is null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            writer.WriteStartObject();
+            if (Optional.IsDefined(Id))
+            {
+                writer.WritePropertyName("id");
+                writer.WriteStringValue(Id);
+            }
+            writer.WriteEndObject();
+        }
+
+        /// <summary>
+        /// Deserialize the input JSON element to a SubResource object.
+        /// </summary>
+        /// <param name="element">The JSON element to be deserialized.</param>
+        /// <returns>Deserialized SubResource object.</returns>
+        internal static SubResource DeserializeSubResource(JsonElement element)
+        {
+            Optional<string> id = default;
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("id"))
+                {
+                    id = property.Value.GetString();
+                    continue;
+                }
+            }
+            return new SubResource(id.Value);
+        }
+    }
+}

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResource.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResource.cs
@@ -7,8 +7,15 @@ namespace Azure.ResourceManager.Core
     /// A class representing a sub-resource that contains only the ID.
     /// </summary>
     [ReferenceType]
-    public abstract class SubResource
+    public partial class SubResource
     {
+        /// <summary> Initializes a new instance of SubResource. </summary>
+        /// <param name="id"> ARM resource Id. </param>
+        internal SubResource(string id)
+        {
+            Id = id;
+        }
+
         /// <summary>
         /// ARM resource identifier.
         /// </summary>
@@ -16,3 +23,6 @@ namespace Azure.ResourceManager.Core
         public virtual ResourceIdentifier Id { get; set; }
     }
 }
+
+// Todo: we want to make the default one (SubResource) to represent read-only data,
+// that is the pattern we used in Resource and TrackedResource

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResource.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResource.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.ResourceManager.Core
+{
+    /// <summary>
+    /// A class representing a sub-resource that contains only the ID.
+    /// </summary>
+    [ReferenceType]
+    public abstract class SubResource
+    {
+        /// <summary>
+        /// ARM resource identifier.
+        /// </summary>
+        /// <value></value>
+        public virtual ResourceIdentifier Id { get; set; }
+    }
+}

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResource.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResource.cs
@@ -11,7 +11,7 @@ namespace Azure.ResourceManager.Core
     {
         /// <summary> Initializes a new instance of SubResource. </summary>
         /// <param name="id"> ARM resource Id. </param>
-        internal SubResource(string id)
+        protected internal SubResource(string id)
         {
             Id = id;
         }

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResourceReadOnly.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResourceReadOnly.Serialization.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json;
+using Azure.Core;
+
+namespace Azure.ResourceManager.Core
+{
+    /// <summary>
+    /// A class representing a sub-resource that contains only the ID.
+    /// </summary>
+    public partial class SubResourceReadOnly : IUtf8JsonSerializable
+    {
+        /// <summary>
+        /// Serialize the input SubResourceReadOnly object.
+        /// </summary>
+        /// <param name="writer"> Input Json writer. </param>
+        void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
+        {
+            if (writer is null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            writer.WriteStartObject();
+            writer.WriteEndObject();
+        }
+
+        /// <summary>
+        /// Deserialize the input JSON element to a SubResourceReadOnly object.
+        /// </summary>
+        /// <param name="element">The JSON element to be deserialized.</param>
+        /// <returns>Deserialized SubResourceReadOnly object.</returns>
+        internal static SubResourceReadOnly DeserializeSubResourceReadOnly(JsonElement element)
+        {
+            Optional<string> id = default;
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("id"))
+                {
+                    id = property.Value.GetString();
+                    continue;
+                }
+            }
+            return new SubResourceReadOnly(id.Value);
+        }
+    }
+}

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResourceReadOnly.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResourceReadOnly.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.ResourceManager.Core
+{
+    /// <summary>
+    /// A class representing a sub-resource that contains only the read-only ID.
+    /// </summary>
+    [ReferenceType]
+    public abstract class SubResourceReadOnly
+    {
+        /// <summary>
+        /// ARM resource identifier (read-only).
+        /// </summary>
+        /// <value></value>
+        public virtual ResourceIdentifier Id { get; }
+    }
+}

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResourceReadOnly.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResourceReadOnly.cs
@@ -7,12 +7,19 @@ namespace Azure.ResourceManager.Core
     /// A class representing a sub-resource that contains only the read-only ID.
     /// </summary>
     [ReferenceType]
-    public abstract class SubResourceReadOnly
+    public partial class SubResourceReadOnly
     {
+        /// <summary> Initializes a new instance of SubResourceReadOnly. </summary>
+        /// <param name="id"> ARM resource Id. </param>
+        internal SubResourceReadOnly(string id)
+        {
+            Id = id;
+        }
+
         /// <summary>
         /// ARM resource identifier (read-only).
         /// </summary>
         /// <value></value>
-        public virtual ResourceIdentifier Id { get; }
+        public virtual ResourceIdentifier Id { get; protected set; }
     }
 }

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResourceReadOnly.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubResourceReadOnly.cs
@@ -11,7 +11,7 @@ namespace Azure.ResourceManager.Core
     {
         /// <summary> Initializes a new instance of SubResourceReadOnly. </summary>
         /// <param name="id"> ARM resource Id. </param>
-        internal SubResourceReadOnly(string id)
+        protected internal SubResourceReadOnly(string id)
         {
             Id = id;
         }

--- a/sdk/resourcemanager/Proto.Client/compute/Placeholder/AvailabilitySetData.cs
+++ b/sdk/resourcemanager/Proto.Client/compute/Placeholder/AvailabilitySetData.cs
@@ -52,13 +52,13 @@ namespace Proto.Compute
         }
 
         /// <summary> A list of references to all virtual machines in the availability set. </summary>
-        public IList<SubResource> VirtualMachines
+        public IList<Azure.ResourceManager.Compute.Models.SubResource> VirtualMachines
         {
             get => Model.VirtualMachines;
         }
 
         /// <summary> Specifies information about the proximity placement group that the availability set should be assigned to. &lt;br&gt;&lt;br&gt;Minimum api-version: 2018-04-01. </summary>
-        public SubResource ProximityPlacementGroup
+        public Azure.ResourceManager.Compute.Models.SubResource ProximityPlacementGroup
         {
             get => Model.ProximityPlacementGroup;
             set => Model.ProximityPlacementGroup = value;

--- a/sdk/resourcemanager/Proto.Client/compute/Placeholder/VirtualMachineData.cs
+++ b/sdk/resourcemanager/Proto.Client/compute/Placeholder/VirtualMachineData.cs
@@ -31,7 +31,7 @@ namespace Proto.Compute
         public string ProvisioningState => Model.ProvisioningState;
 
         /// <summary> Specifies information about the dedicated host that the virtual machine resides in. &lt;br&gt;&lt;br&gt;Minimum api-version: 2018-10-01. </summary>
-        public SubResource Host
+        public Azure.ResourceManager.Compute.Models.SubResource Host
         {
             get => Model.Host;
             set => Model.Host = value;
@@ -59,21 +59,21 @@ namespace Proto.Compute
         }
 
         /// <summary> Specifies information about the proximity placement group that the virtual machine should be assigned to. &lt;br&gt;&lt;br&gt;Minimum api-version: 2018-04-01. </summary>
-        public SubResource ProximityPlacementGroup
+        public Azure.ResourceManager.Compute.Models.SubResource ProximityPlacementGroup
         {
             get => Model.ProximityPlacementGroup;
             set => Model.ProximityPlacementGroup = value;
         }
 
         /// <summary> Specifies information about the virtual machine scale set that the virtual machine should be assigned to. Virtual machines specified in the same virtual machine scale set are allocated to different nodes to maximize availability. Currently, a VM can only be added to virtual machine scale set at creation time. An existing VM cannot be added to a virtual machine scale set. &lt;br&gt;&lt;br&gt;This property cannot exist along with a non-null properties.availabilitySet reference. &lt;br&gt;&lt;br&gt;Minimum api‐version: 2019‐03‐01. </summary>
-        public SubResource VirtualMachineScaleSet
+        public Azure.ResourceManager.Compute.Models.SubResource VirtualMachineScaleSet
         {
             get => Model.VirtualMachineScaleSet;
             set => Model.VirtualMachineScaleSet = value;
         }
 
         /// <summary> Specifies information about the availability set that the virtual machine should be assigned to. Virtual machines specified in the same availability set are allocated to different nodes to maximize availability. For more information about availability sets, see [Manage the availability of virtual machines](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-manage-availability?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json). &lt;br&gt;&lt;br&gt; For more information on Azure planned maintenance, see [Planned maintenance for virtual machines in Azure](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-planned-maintenance?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json) &lt;br&gt;&lt;br&gt; Currently, a VM can only be added to availability set at creation time. The availability set to which the VM is being added should be under the same resource group as the availability set resource. An existing VM cannot be added to an availability set. &lt;br&gt;&lt;br&gt;This property cannot exist along with a non-null properties.virtualMachineScaleSet reference. </summary>
-        public SubResource AvailabilitySet
+        public Azure.ResourceManager.Compute.Models.SubResource AvailabilitySet
         {
             get => Model.AvailabilitySet;
             set => Model.AvailabilitySet = value;

--- a/sdk/resourcemanager/Proto.Client/compute/VirtualMachineContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/compute/VirtualMachineContainer.cs
@@ -116,7 +116,7 @@ namespace Proto.Compute
         /// <returns> Object used to create a <see cref="VirtualMachine"/>. </returns>
         public VirtualMachineModelBuilder Construct(string hostName, string adminUser, string adminPassword, ResourceIdentifier networkInterfaceId, ResourceIdentifier availabilitySetId, LocationData location = null)
         {
-            var parent = GetParentResource<ResourceGroup, ResourceGroupResourceIdentifier,ResourceGroupOperations>();
+            var parent = GetParentResource<ResourceGroup, ResourceGroupResourceIdentifier, ResourceGroupOperations>();
             var vm = new Azure.ResourceManager.Compute.Models.VirtualMachine(location ?? parent.Data.Location)
             {
                 NetworkProfile = new NetworkProfile(),
@@ -138,7 +138,7 @@ namespace Proto.Compute
                     },
                 },
                 HardwareProfile = new HardwareProfile() { VmSize = VirtualMachineSizeTypes.StandardB1Ms },
-                AvailabilitySet = new SubResource() { Id = availabilitySetId }
+                AvailabilitySet = new Azure.ResourceManager.Compute.Models.SubResource() { Id = availabilitySetId }
             };
             vm.NetworkProfile.NetworkInterfaces.Add(new NetworkInterfaceReference() { Id = networkInterfaceId });
 
@@ -230,7 +230,7 @@ namespace Proto.Compute
         /// <inheritdoc />
         public override ArmResponse<VirtualMachine> Get(string virtualMachineName, CancellationToken cancellationToken = default)
         {
-            return new PhArmResponse<VirtualMachine, Azure.ResourceManager.Compute.Models.VirtualMachine>(Operations.Get(Id.ResourceGroupName, virtualMachineName, cancellationToken), 
+            return new PhArmResponse<VirtualMachine, Azure.ResourceManager.Compute.Models.VirtualMachine>(Operations.Get(Id.ResourceGroupName, virtualMachineName, cancellationToken),
                 v => new VirtualMachine(Parent, new VirtualMachineData(v)));
         }
 

--- a/sdk/resourcemanager/Proto.Client/network/Placeholder/NetworkInterfaceData.cs
+++ b/sdk/resourcemanager/Proto.Client/network/Placeholder/NetworkInterfaceData.cs
@@ -41,7 +41,7 @@ namespace Proto.Network
         /// <summary>
         /// Gets the reference to a linked virtual machine.
         /// </summary>
-        public SubResource VirtualMachine => Model.VirtualMachine;
+        public Azure.ResourceManager.Network.Models.SubResource VirtualMachine => Model.VirtualMachine;
 
         /// <summary>
         ///  Gets the reference to the linked NetworkSecurityGroup resource.
@@ -68,7 +68,7 @@ namespace Proto.Network
         /// <summary>
         /// Gets a list of TapConfigurations of the newtork interface.
         /// </summary>
-        public IReadOnlyList<NetworkInterfaceTapConfiguration> TapConfigurations=> Model.TapConfigurations;
+        public IReadOnlyList<NetworkInterfaceTapConfiguration> TapConfigurations => Model.TapConfigurations;
 
         /// <summary>
         /// Gets or sets the DNS settings in network interface.

--- a/sdk/resourcemanager/Proto.Client/network/Placeholder/PublicIPAddressData.cs
+++ b/sdk/resourcemanager/Proto.Client/network/Placeholder/PublicIPAddressData.cs
@@ -93,7 +93,7 @@ namespace Proto.Network
         }
 
         /// <summary> The Public IP Prefix this Public IP Address should be allocated from. </summary>
-        public SubResource PublicIPPrefix
+        public Azure.ResourceManager.Network.Models.SubResource PublicIPPrefix
         {
             get => Model.PublicIPPrefix;
             set => Model.PublicIPPrefix = value;

--- a/sdk/resourcemanager/Proto.Client/network/Placeholder/SubnetData.cs
+++ b/sdk/resourcemanager/Proto.Client/network/Placeholder/SubnetData.cs
@@ -4,29 +4,29 @@ using System.Collections.Generic;
 
 namespace Proto.Network
 {
-    /// <summary> 
+    /// <summary>
     /// A class representing the subnet data model.
     /// </summary>
     public class SubnetData : ProxyResource<ResourceGroupResourceIdentifier, Azure.ResourceManager.Network.Models.Subnet>
     {
-        /// <summary> 
-        /// Initializes a new instance of the <see cref="SubnetData"/> class. 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubnetData"/> class.
         /// </summary>
         public SubnetData(Azure.ResourceManager.Network.Models.Subnet sub) : base(sub.Id, sub)
         {
         }
 
         /// <summary>
-        /// Gets the subnet id. 
+        /// Gets the subnet id.
         ///</summary>
         public override string Name => Model.Name;
 
-        /// <summary> 
-        /// The provisioning state of the subnet resource. 
+        /// <summary>
+        /// The provisioning state of the subnet resource.
         /// </summary>
         public ProvisioningState? ProvisioningState => Model.ProvisioningState;
 
-        /// <summary> 
+        /// <summary>
         /// A read-only string identifying the intention use for this subnet based on delegations and other user-defined properties.
         /// </summary>
         public string Purpose => Model.Purpose;
@@ -44,7 +44,7 @@ namespace Proto.Network
         public IReadOnlyList<ResourceNavigationLink> ResourceNavigationLinks => Model.ResourceNavigationLinks;
 
         /// <summary> Array of IpAllocation which reference this subnet. </summary>
-        public IList<SubResource> IpAllocations
+        public IList<Azure.ResourceManager.Network.Models.SubResource> IpAllocations
         {
             get => Model.IpAllocations;
         }
@@ -70,9 +70,9 @@ namespace Proto.Network
         {
             get => Model.ServiceEndpoints;
         }
-        
+
         /// <summary> Nat gateway associated with this subnet. </summary>
-        public SubResource NatGateway
+        public Azure.ResourceManager.Network.Models.SubResource NatGateway
         {
             get => Model.NatGateway;
             set => Model.NatGateway = value;

--- a/sdk/resourcemanager/Proto.Client/network/Placeholder/VirtualNetworkData.cs
+++ b/sdk/resourcemanager/Proto.Client/network/Placeholder/VirtualNetworkData.cs
@@ -79,7 +79,7 @@ namespace Proto.Network
         }
 
         /// <summary> The DDoS protection plan associated with the virtual network. </summary>
-        public SubResource DdosProtectionPlan
+        public Azure.ResourceManager.Network.Models.SubResource DdosProtectionPlan
 
         {
             get => Model.DdosProtectionPlan;
@@ -94,7 +94,7 @@ namespace Proto.Network
         }
 
         /// <summary> Array of IpAllocation which reference this VNET. </summary>
-        public IList<SubResource> IpAllocations
+        public IList<Azure.ResourceManager.Network.Models.SubResource> IpAllocations
         {
             get => Model.IpAllocations;
         }


### PR DESCRIPTION
## What I did

- Added common definitions for sub-resource and its read-only version.
- Modified `ResourceContainerBase` so it does not require the type argument `TResource` to inherit `Resource<T>`
  - As we disscussed, for now it is unnecessary to be that strict
