### PR TITLE
[Service Bus Client] Detect Closed Shared Connection

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusAdministrationClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ServiceBusAdministrationClient.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -37,6 +37,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <summary>The URI scheme to apply when using web sockets for service communication.</summary>
         private const string WebSocketsUriScheme = "wss";
 
+        /// <summary>Indicates whether or not this instance has been disposed.</summary>
+        private volatile bool _disposed;
+
         /// <summary>
         ///   The version of AMQP to use within the scope.
         /// </summary>
@@ -83,7 +86,12 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// </summary>
         ///
         /// <value><c>true</c> if disposed; otherwise, <c>false</c>.</value>
-        public override bool IsDisposed { get; protected set; }
+        ///
+        public override bool IsDisposed
+        {
+            get => _disposed;
+            protected set => _disposed = value;
+        }
 
         /// <summary>
         ///   The cancellation token to use with operations initiated by the scope.
@@ -254,6 +262,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             ServiceBusEventSource.Log.CreateManagementLinkStart(identifier);
             try
             {
+                Argument.AssertNotDisposed(_disposed, nameof(AmqpConnectionScope));
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                 var stopWatch = ValueStopwatch.StartNew();
@@ -303,6 +312,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             bool isSessionReceiver,
             CancellationToken cancellationToken)
         {
+            Argument.AssertNotDisposed(_disposed, nameof(AmqpConnectionScope));
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             var stopWatch = ValueStopwatch.StartNew();
@@ -347,6 +357,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
+            Argument.AssertNotDisposed(_disposed, nameof(AmqpConnectionScope));
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             var stopWatch = ValueStopwatch.StartNew();
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -190,6 +190,8 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         internal const int RequestAuthorizationCompleteEvent = 106;
         internal const int RequestAuthorizationExceptionEvent = 107;
 
+        internal const int ProcessorClientClosedExceptionEvent = 108;
+
         #endregion
         // add new event numbers here incrementing from previous
 
@@ -775,6 +777,15 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             if (IsEnabled())
             {
                 WriteEvent(ProcessorMessageHandlerExceptionEvent, identifier, sequenceNumber, exception);
+            }
+        }
+
+        [Event(ProcessorClientClosedExceptionEvent, Level = EventLevel.Error, Message = "{0}: The Service Bus client associated with the processor was closed by the host application.  The processor cannot continue and is shutting down.")]
+        public void ProcessorClientClosedException(string identifier)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ProcessorClientClosedExceptionEvent, identifier);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -77,7 +77,7 @@ namespace Azure.Messaging.ServiceBus
             try
             {
                 // loop within the context of this thread
-                while (!cancellationToken.IsCancellationRequested)
+                while (!cancellationToken.IsCancellationRequested && !Processor.Connection.IsClosed)
                 {
                     errorSource = ServiceBusErrorSource.Receive;
                     ServiceBusReceivedMessage message = await Receiver.ReceiveMessageAsync(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -434,7 +434,7 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Invokes the process message event handler after a message has been received.
-        /// This method can be overriden to raise an event manually for testing purposes.
+        /// This method can be overridden to raise an event manually for testing purposes.
         /// </summary>
         /// <param name="args">The event args containing information related to the message.</param>
         protected internal virtual async Task OnProcessMessageAsync(ProcessMessageEventArgs args)
@@ -443,8 +443,8 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
-        /// Invokes the error event handler when an error has occured during processing.
-        /// This method can be overriden to raise an event manually for testing purposes.
+        /// Invokes the error event handler when an error has occurred during processing.
+        /// This method can be overridden to raise an event manually for testing purposes.
         /// </summary>
         /// <param name="args">The event args containing information related to the error.</param>
         protected internal async virtual Task OnProcessErrorAsync(ProcessErrorEventArgs args)
@@ -486,6 +486,7 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusProcessor));
+            Connection.ThrowIfClosed();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             bool releaseGuard = false;
             try
@@ -672,7 +673,7 @@ namespace Azure.Messaging.ServiceBus
             List<Task> tasks = new List<Task>(_maxConcurrentCalls + _receiverManagers.Count);
             try
             {
-                while (!cancellationToken.IsCancellationRequested)
+                while (!cancellationToken.IsCancellationRequested && !Connection.IsClosed)
                 {
                     foreach (ReceiverManager receiverManager in _receiverManagers)
                     {
@@ -691,6 +692,42 @@ namespace Azure.Messaging.ServiceBus
                     {
                         tasks.RemoveAll(t => t.IsCompleted);
                     }
+                }
+
+                // If the main loop is aborting due to the connection being canceled, then
+                // force the processor to stop.
+                if (!cancellationToken.IsCancellationRequested && Connection.IsClosed)
+                {
+                    Logger.ProcessorClientClosedException(Identifier);
+
+                    // Because this is a highly unusual situation
+                    // and goes against the goal of resiliency for the processor, surface
+                    // a fatal exception with an explicit message detailing that processing
+                    // will be stopped.
+                    try
+                    {
+                        await OnProcessErrorAsync(
+                            new ProcessErrorEventArgs(
+                                new ObjectDisposedException(nameof(ServiceBusConnection), Resources.DisposedConnectionMessageProcessorMustStop),
+                                ServiceBusErrorSource.Receive,
+                                FullyQualifiedNamespace,
+                                EntityPath,
+                                cancellationToken))
+                        .ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Don't bubble up exceptions raised from customer exception handler.
+                        Logger.ProcessorErrorHandlerThrewException(ex.ToString());
+                    }
+
+                    // This call will deadlock if awaited, as StopProcessingAsync awaits
+                    // completion of this task.  The processor is already known to be in a bad
+                    // state and exceptions in StopProcessingAsync are likely and will be logged
+                    // in that call.  There is little value in surfacing those expected exceptions
+                    // to the customer error handler as well; allow StopProcessingAsync to run
+                    // in a fire-and-forget manner.
+                    _ = StopProcessingAsync();
                 }
             }
             finally

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -252,6 +252,8 @@ namespace Azure.Messaging.ServiceBus
         {
             Argument.AssertAtLeast(maxMessages, 1, nameof(maxMessages));
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            _connection.ThrowIfClosed();
+
             if (maxWaitTime.HasValue)
             {
                 Argument.AssertPositive(maxWaitTime.Value, nameof(maxWaitTime));
@@ -438,8 +440,9 @@ namespace Azure.Messaging.ServiceBus
             int maxMessages,
             CancellationToken cancellationToken)
         {
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
             Argument.AssertAtLeast(maxMessages, 1, nameof(maxMessages));
+            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            _connection.ThrowIfClosed();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             Logger.PeekMessageStart(Identifier, sequenceNumber, maxMessages);
@@ -527,6 +530,7 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            _connection.ThrowIfClosed();
             ThrowIfNotPeekLockMode();
             ThrowIfLockTokenIsEmpty(lockToken);
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
@@ -614,6 +618,7 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            _connection.ThrowIfClosed();
             ThrowIfNotPeekLockMode();
             ThrowIfLockTokenIsEmpty(lockToken);
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
@@ -798,6 +803,7 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            _connection.ThrowIfClosed();
             ThrowIfNotPeekLockMode();
             ThrowIfLockTokenIsEmpty(lockToken);
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
@@ -891,6 +897,7 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            _connection.ThrowIfClosed();
             ThrowIfNotPeekLockMode();
             ThrowIfLockTokenIsEmpty(lockToken);
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
@@ -978,8 +985,9 @@ namespace Azure.Messaging.ServiceBus
             IEnumerable<long> sequenceNumbers,
             CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
             Argument.AssertNotNull(sequenceNumbers, nameof(sequenceNumbers));
+            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            _connection.ThrowIfClosed();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             // the sequence numbers MUST be in array form for them to be encoded correctly
@@ -1067,6 +1075,7 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            _connection.ThrowIfClosed();
             ThrowIfNotPeekLockMode();
             ThrowIfSessionReceiver();
             ThrowIfLockTokenIsEmpty(lockToken);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -21,6 +21,13 @@ namespace Azure.Messaging.ServiceBus
     public class ServiceBusSessionReceiver : ServiceBusReceiver
     {
         /// <summary>
+        /// The active connection to the Azure Service Bus service, enabling client communications for metadata
+        /// about the associated Service Bus entity and access to transport-aware receivers.
+        /// </summary>
+        ///
+        private readonly ServiceBusConnection _connection;
+
+        /// <summary>
         /// The Session Id associated with the receiver.
         /// </summary>
         public virtual string SessionId => InnerReceiver.SessionId;
@@ -89,6 +96,7 @@ namespace Azure.Messaging.ServiceBus
             string sessionId = default) :
             base(connection, entityPath, true, plugins, options?.ToReceiverOptions(), sessionId, cancellationToken)
         {
+            _connection = connection;
         }
 
         /// <summary>
@@ -111,6 +119,7 @@ namespace Azure.Messaging.ServiceBus
         public virtual async Task<BinaryData> GetSessionStateAsync(CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSessionReceiver));
+            _connection.ThrowIfClosed();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.GetSessionStateStart(Identifier, SessionId);
             using DiagnosticScope scope = ScopeFactory.CreateScope(
@@ -154,6 +163,7 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSessionReceiver));
+            _connection.ThrowIfClosed();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.SetSessionStateStart(Identifier, SessionId);
             using DiagnosticScope scope = ScopeFactory.CreateScope(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
@@ -212,6 +212,15 @@ namespace Azure.Messaging.ServiceBus {
                 return ResourceManager.GetString("DefaultServerBusyException", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to he message processor is unable to continue and will stop processing; the host application has closed the connection to the Service Bus service..
+        /// </summary>
+        internal static string DisposedConnectionMessageProcessorMustStop {
+            get {
+                return ResourceManager.GetString("DisposedConnectionMessageProcessorMustStop", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to The minimum back off period &apos;{0}&apos; cannot exceed the maximum back off period of &apos;{1}&apos;..

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
@@ -309,4 +309,7 @@
   <data name="InvalidAmqpMessageValueBody" xml:space="preserve">
     <value>{0} is not a supported value body type.</value>
   </data>
+  <data name="DisposedConnectionMessageProcessorMustStop" xml:space="preserve">
+    <value>The message processor is unable to continue and will stop processing; the host application has closed the connection to the Service Bus service.</value>
+  </data>
 </root>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -189,6 +188,8 @@ namespace Azure.Messaging.ServiceBus
         {
             Argument.AssertNotNull(messages, nameof(messages));
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSender));
+            _connection.ThrowIfClosed();
+
             IReadOnlyList<ServiceBusMessage> messageList = messages switch
             {
                 IReadOnlyList<ServiceBusMessage> alreadyList => alreadyList,
@@ -299,6 +300,8 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSender));
+            _connection.ThrowIfClosed();
+
             options = options?.Clone() ?? new CreateMessageBatchOptions();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.CreateMessageBatchStart(Identifier);
@@ -334,6 +337,8 @@ namespace Azure.Messaging.ServiceBus
         {
             Argument.AssertNotNull(messageBatch, nameof(messageBatch));
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSender));
+            _connection.ThrowIfClosed();
+
             if (messageBatch.Count == 0)
             {
                 return;
@@ -419,6 +424,7 @@ namespace Azure.Messaging.ServiceBus
         {
             Argument.AssertNotNull(messages, nameof(messages));
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSender));
+            _connection.ThrowIfClosed();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             IReadOnlyList<ServiceBusMessage> messageList = messages switch
@@ -486,8 +492,9 @@ namespace Azure.Messaging.ServiceBus
             IEnumerable<long> sequenceNumbers,
             CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSender));
             Argument.AssertNotNull(sequenceNumbers, nameof(sequenceNumbers));
+            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSender));
+            _connection.ThrowIfClosed();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             // the sequence numbers MUST be in array form for them to be encoded correctly

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -42,6 +43,31 @@ namespace Azure.Messaging.ServiceBus.Tests
                 {
                     RetryOptions = retryOptions
                 });
+        }
+
+        protected static async Task SendMessagesAsync(
+            ServiceBusClient client,
+            string entityPath,
+            int numberOfMessages)
+        {
+            await using var sender = client.CreateSender(entityPath);
+
+            var batch = default(ServiceBusMessageBatch);
+
+            while (numberOfMessages > 0)
+            {
+                batch ??= await sender.CreateMessageBatchAsync();
+
+                while ((numberOfMessages > 0) && (batch.TryAddMessage(new ServiceBusMessage(Guid.NewGuid().ToString()))))
+                {
+                    --numberOfMessages;
+                }
+
+                await sender.SendMessagesAsync(batch);
+
+                batch.Dispose();
+                batch = default;
+            }
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core.Pipeline;
 using Azure.Messaging.ServiceBus.Tests.Infrastructure;
 using NUnit.Framework;
 
@@ -666,6 +666,112 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 else
                 {
                     Assert.IsNull(msg);
+                }
+            }
+        }
+
+        [Test]
+        [TestCase(1)]
+        [TestCase(3)]
+        [TestCase(5)]
+        [TestCase(10)]
+        public async Task ProcessorStopsWhenClientIsClosed(int maxConcurrent)
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var messageCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var errorCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                // Create the client and seed the queue with some messages to process.
+
+                await using var client = CreateClient(60);
+                await SendMessagesAsync(client, scope.QueueName, 100);
+
+                // Create the processor and define the message handlers.
+
+                await using var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
+                {
+                    MaxConcurrentCalls = maxConcurrent,
+                    AutoCompleteMessages = true,
+                    PrefetchCount = 20
+                });
+
+                Task processMessageAsync(ProcessMessageEventArgs args)
+                {
+                    // If any message is dispatched for processing, then the
+                    // processor is actively reading from the Service Bus
+                    // service and should react to the client being closed.
+
+                    messageCompletionSource.TrySetResult(true);
+                    return Task.CompletedTask;
+                }
+
+                Task processErrorAsync(ProcessErrorEventArgs args)
+                {
+                    // If the client is closed, an exception should be thrown
+                    // for the disposed connection.  This is the condition that
+                    // should set the completion source.
+
+                    if ((args.Exception is ObjectDisposedException ex)
+                        && ex.ObjectName == nameof(ServiceBusConnection)
+                        && ex.Message.StartsWith(Resources.DisposedConnectionMessageProcessorMustStop))
+                    {
+                        errorCompletionSource.TrySetResult(true);
+                    }
+
+                    return Task.CompletedTask;
+                }
+
+                try
+                {
+                    processor.ProcessMessageAsync += processMessageAsync;
+                    processor.ProcessErrorAsync += processErrorAsync;
+
+                    // Set a cancellation source to use as a safety timer to prevent a
+                    // potential test hang; this should not trigger if things are
+                    // working correctly.
+
+                    using var cancellationSource = new CancellationTokenSource();
+                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(10));
+
+                    // Start processing and wait for a message.
+
+                    await processor.StartProcessingAsync(cancellationSource.Token);
+                    await messageCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+
+                    // Now that it's been confirmed that the processor is interacting with the
+                    // Service Bus service close the client.
+
+                    await client.DisposeAsync();
+                    await errorCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+
+                    // The processor surfaced the expected exception.  Verify that it has stopped
+                    // processing and cancellation wasn't triggered.  This is a non-deterministic
+                    // operation, so allow for a few attempts.
+
+                    var attemptsRemaining = 5;
+
+                    while ((attemptsRemaining > 0) && (processor.IsProcessing))
+                    {
+                        --attemptsRemaining;
+                        await Task.Delay(500, cancellationSource.Token);
+                    }
+
+                    Assert.IsFalse(processor.IsProcessing, "The processor should have stopped when the client was closed.");
+                }
+                catch (OperationCanceledException)
+                {
+                    Assert.Fail("The cancellation token should not have been triggered.");
+                }
+                finally
+                {
+                    if (processor.IsProcessing)
+                    {
+                        await processor.StopProcessingAsync();
+                    }
+
+                    processor.ProcessMessageAsync -= processMessageAsync;
+                    processor.ProcessErrorAsync -= processErrorAsync;
                 }
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void CannotAddNullHandler()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedConnection(),
+                GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusPlugin[] { },
                 new ServiceBusSessionProcessorOptions());
@@ -33,7 +33,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void MustSetMessageHandler()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedConnection(),
+                GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusPlugin[] { },
                 new ServiceBusSessionProcessorOptions());
@@ -45,7 +45,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void MustSetErrorHandler()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedConnection(),
+                GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusPlugin[] { },
                 new ServiceBusSessionProcessorOptions());
@@ -59,7 +59,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void CannotAddTwoHandlersToTheSameEvent()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedConnection(),
+                GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusPlugin[] { },
                 new ServiceBusSessionProcessorOptions());
@@ -79,7 +79,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void CannotRemoveHandlerThatHasNotBeenAdded()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedConnection(),
+                GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusPlugin[] { },
                 new ServiceBusSessionProcessorOptions());
@@ -108,7 +108,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void CanRemoveHandlerThatHasBeenAdded()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedConnection(),
+                GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusPlugin[] { },
                 new ServiceBusSessionProcessorOptions());

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         }
 
         [Test]
-        public async Task PeekUsingConnectionStringWithSisgnature()
+        public async Task PeekUsingConnectionStringWithSas()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
@@ -921,6 +921,420 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     async () => await receiver.RenewMessageLockAsync(peekedMessage),
                     Throws.InstanceOf<InvalidOperationException>());
             }
+        }
+
+        [Test]
+        public async Task ReceiveMessageReactsToClosingTheClient()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var messageCount = 5;
+
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+
+                // Send a batch of messages.
+
+                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                await sender.SendMessagesAsync(batch);
+
+                // Receive the first message.
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                var firstMessage = await receiver.ReceiveMessageAsync();
+
+                Assert.IsNotNull(firstMessage, "The first message should have been received.");
+
+                // Close the client and attempt to receive another message.
+
+                await client.DisposeAsync();
+
+                Assert.That(async () => await receiver.ReceiveMessageAsync(),
+                    Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+            }
+        }
+
+        [Test]
+        public async Task ReceiveMessagesReactsToClosingTheClient()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var messageCount = 10;
+                var halfMessageCount = (messageCount / 2);
+
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+
+                // Send a batch of messages.
+
+                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                await sender.SendMessagesAsync(batch);
+
+                // Receive the first batch message.
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                var firstReceivedBatch = await ReceiveMessagesAsync(halfMessageCount, receiver);
+
+                Assert.IsNotNull(firstReceivedBatch, "The first batch of messages should have been received.");
+                Assert.AreEqual(halfMessageCount, firstReceivedBatch.Count, "The first batch of messages should have the correct count.");
+
+                // Close the client and attempt to receive another message batch.
+
+                await client.DisposeAsync();
+
+                Assert.That(async () => await receiver.ReceiveMessagesAsync(halfMessageCount),
+                    Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+            }
+        }
+
+        [Test]
+        public async Task ReceiveDeferredMessageReactsToClosingTheClient()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var messageCount = 5;
+
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+
+                // Send a batch of messages.
+
+                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                await sender.SendMessagesAsync(batch);
+
+                // Receive the first message.
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                var firstMessage = await receiver.ReceiveMessageAsync();
+
+                Assert.IsNotNull(firstMessage, "The first message should have been received.");
+
+                // Capture the sequence number and defer the message.
+
+                var sequenceNumber = firstMessage.SequenceNumber;
+                await receiver.DeferMessageAsync(firstMessage);
+
+                // Receive the deferred message, and defer it again.
+
+                var deferredMessage = await receiver.ReceiveDeferredMessageAsync(sequenceNumber);
+                Assert.IsNotNull(deferredMessage, "The deferred message should have been received.");
+
+                await receiver.DeferMessageAsync(deferredMessage);
+
+                // Close the client and attempt to receive another message.
+
+                await client.DisposeAsync();
+
+                Assert.That(async () => await receiver.ReceiveDeferredMessageAsync(sequenceNumber),
+                    Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+            }
+        }
+
+        [Test]
+        public async Task ReceiveDeferredMessagesReactsToClosingTheClient()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var messageCount = 10;
+                var halfMessageCount = (messageCount / 2);
+
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+
+                // Send a batch of messages.
+
+                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                await sender.SendMessagesAsync(batch);
+
+                // Receive the first batch message.
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                var firstReceivedBatch = await ReceiveMessagesAsync(halfMessageCount, receiver);
+
+                Assert.IsNotNull(firstReceivedBatch, "The first batch of messages should have been received.");
+                Assert.AreEqual(halfMessageCount, firstReceivedBatch.Count, "The first batch of messages should have the correct count.");
+
+                // Capture the sequence numbers and defer the messages.
+
+                var sequenceNumbers = new List<long>(halfMessageCount);
+                var deferTasks = new List<Task>(halfMessageCount);
+
+                foreach (var message in firstReceivedBatch)
+                {
+                    sequenceNumbers.Add(message.SequenceNumber);
+                    deferTasks.Add(receiver.DeferMessageAsync(message));
+                }
+
+                await Task.WhenAll(deferTasks);
+                deferTasks.Clear();
+
+                // Receive the deferred messages and defer them again.
+
+                var deferredMessages = await receiver.ReceiveDeferredMessagesAsync(sequenceNumbers);
+
+                Assert.IsNotNull(deferredMessages, "The batch of deferred messages should have been received.");
+                Assert.AreEqual(halfMessageCount, deferredMessages.Count, "The batch of deferred messages should have the correct count.");
+
+                foreach (var message in deferredMessages)
+                {
+                    deferTasks.Add(receiver.DeferMessageAsync(message));
+                }
+
+                await Task.WhenAll(deferTasks);
+
+                // Close the client and attempt to receive another message batch.
+
+                await client.DisposeAsync();
+
+                Assert.That(async () => await receiver.ReceiveDeferredMessagesAsync(sequenceNumbers),
+                    Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+            }
+        }
+
+        [Test]
+        public async Task PeekMessageReactsToClosingTheClient()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var messageCount = 5;
+
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+
+                // Send a batch of messages.
+
+                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                await sender.SendMessagesAsync(batch);
+
+                // Peek the first message.
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                var firstMessage = await receiver.PeekMessageAsync();
+
+                Assert.IsNotNull(firstMessage, "The first message should have been received.");
+
+                // Close the client and attempt to peek another message.
+
+                await client.DisposeAsync();
+
+                Assert.That(async () => await receiver.PeekMessageAsync(),
+                    Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+            }
+        }
+
+        [Test]
+        public async Task PeekMessagesReactsToClosingTheClient()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var messageCount = 10;
+                var halfMessgageCount = (messageCount / 2);
+
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+
+                // Send a batch of messages.
+
+                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                await sender.SendMessagesAsync(batch);
+
+                // Peek the first batch message.
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                var firstReceivedBatch = await PeekMessagesAsync(halfMessgageCount, receiver);
+
+                Assert.IsNotNull(firstReceivedBatch, "The first batch of messages should have been received.");
+
+                // Close the client and attempt to peek another message batch.
+
+                await client.DisposeAsync();
+
+                Assert.That(async () => await receiver.PeekMessagesAsync(halfMessgageCount),
+                    Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+            }
+        }
+
+        [Test]
+        public async Task CompleteMessageReactsToClosingTheClient()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var sendCount = 5;
+                var receiveCount = 2;
+
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+
+                // Send a batch of messages.
+
+                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
+                await sender.SendMessagesAsync(batch);
+
+                // Receive the messages.
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                var receivedMessages = await ReceiveMessagesAsync(receiveCount, receiver);
+
+                Assert.AreEqual(receiveCount, receivedMessages.Count, "An incorrect number of messages were received.");
+
+                // Settle the first message.
+
+                await receiver.CompleteMessageAsync(receivedMessages[0]);
+
+                // Close the client and attempt to settle another message.
+
+                await client.DisposeAsync();
+
+                Assert.That(async () => await receiver.CompleteMessageAsync(receivedMessages[1]),
+                    Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+            }
+        }
+
+        [Test]
+        public async Task AbandonMessageReactsToClosingTheClient()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var sendCount = 5;
+                var receiveCount = 2;
+
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+
+                // Send a batch of messages.
+
+                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
+                await sender.SendMessagesAsync(batch);
+
+                // Receive the messages.
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                var receivedMessages = await ReceiveMessagesAsync(receiveCount, receiver);
+
+                Assert.AreEqual(receiveCount, receivedMessages.Count, "An incorrect number of messages were received.");
+
+                // Settle the first message.
+
+                await receiver.AbandonMessageAsync(receivedMessages[0]);
+
+                // Close the client and attempt to settle another message.
+
+                await client.DisposeAsync();
+
+                Assert.That(async () => await receiver.AbandonMessageAsync(receivedMessages[1]),
+                    Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+            }
+        }
+
+        [Test]
+        public async Task DeadLetterMessageReactsToClosingTheClient()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var sendCount = 5;
+                var receiveCount = 2;
+
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+
+                // Send a batch of messages.
+
+                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
+                await sender.SendMessagesAsync(batch);
+
+                // Receive the messages.
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                var receivedMessages = await ReceiveMessagesAsync(receiveCount, receiver);
+
+                Assert.AreEqual(receiveCount, receivedMessages.Count, "An incorrect number of messages were received.");
+
+                // Settle the first message.
+
+                await receiver.DeadLetterMessageAsync(receivedMessages[0]);
+
+                // Close the client and attempt to settle another message.
+
+                await client.DisposeAsync();
+
+                Assert.That(async () => await receiver.DeadLetterMessageAsync(receivedMessages[1]),
+                    Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+            }
+        }
+
+        [Test]
+        public async Task DeferMessageReactsToClosingTheClient()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var sendCount = 5;
+                var receiveCount = 2;
+
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+
+                // Send a batch of messages.
+
+                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
+                await sender.SendMessagesAsync(batch);
+
+                // Receive the messages.
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                var receivedMessages = await ReceiveMessagesAsync(receiveCount, receiver);
+
+                Assert.AreEqual(receiveCount, receivedMessages.Count, "An incorrect number of messages were received.");
+
+                // Settle the first message.
+
+                await receiver.DeferMessageAsync(receivedMessages[0]);
+
+                // Close the client and attempt to settle another message.
+
+                await client.DisposeAsync();
+
+                Assert.That(async () => await receiver.DeferMessageAsync(receivedMessages[1]),
+                    Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+            }
+        }
+
+        private static async Task<List<ServiceBusReceivedMessage>> ReceiveMessagesAsync(
+            int messageCount,
+            ServiceBusReceiver receiver,
+            TimeSpan? maxWaitTime = default,
+            CancellationToken cancellationToken = default)
+        {
+            var receivedMessages = new List<ServiceBusReceivedMessage>(messageCount);
+
+            while (messageCount > 0)
+            {
+                foreach (var message in (await receiver.ReceiveMessagesAsync(messageCount, maxWaitTime, cancellationToken)))
+                {
+                    receivedMessages.Add(message);
+                    --messageCount;
+                }
+            }
+
+            return receivedMessages;
+        }
+
+        private static async Task<List<ServiceBusReceivedMessage>> PeekMessagesAsync(
+            int messageCount,
+            ServiceBusReceiver receiver,
+            CancellationToken cancellationToken = default)
+        {
+            var receivedMessages = new List<ServiceBusReceivedMessage>(messageCount);
+
+            while (messageCount > 0)
+            {
+                foreach (var message in (await receiver.PeekMessagesAsync(messageCount, cancellationToken: cancellationToken)))
+                {
+                    receivedMessages.Add(message);
+                    --messageCount;
+                }
+            }
+
+            return receivedMessages;
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Text;
+using System.Threading.Tasks;
+using Azure.Core;
 using Moq;
 using NUnit.Framework;
 
@@ -114,6 +116,127 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             Assert.That(
                 async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(-1)),
                 Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public async Task ReceiveMessageValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.ReceiveMessageAsync(),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task ReceiveMessagesValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.ReceiveMessagesAsync().GetAsyncEnumerator().MoveNextAsync(),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task PeekMessageValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.PeekMessageAsync(),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task PeekMessagesValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.PeekMessagesAsync(10),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task CompleteMessageValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.CompleteMessageAsync(new ServiceBusReceivedMessage()),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task AbandonMessageValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.AbandonMessageAsync(new ServiceBusReceivedMessage()),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task DeadLetterMessageValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.DeadLetterMessageAsync(new ServiceBusReceivedMessage()),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task DeferValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.DeferMessageAsync(new ServiceBusReceivedMessage()),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task ReceiveDeferredMessageValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.ReceiveDeferredMessageAsync(12345),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task ReceiveDeferredMessagesValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.ReceiveDeferredMessagesAsync(new[] { 12345L, 678910L }),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task RenewMessageLockValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.RenewMessageLockAsync(new ServiceBusReceivedMessage()),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverTests.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
 using Azure.Messaging.ServiceBus.Plugins;
 using Moq;
 using NUnit.Framework;
@@ -16,7 +18,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         public void SessionReceiverCannotPerformMessageLock()
         {
             var receiver = new ServiceBusSessionReceiver(
-                GetMockedConnection(),
+                GetMockedReceiverConnection(),
                 "fakeQueue",
                 options: new ServiceBusSessionReceiverOptions(),
                 plugins: new ServiceBusPlugin[] { },
@@ -25,6 +27,28 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             Assert.That(async () => await receiver.RenewMessageLockAsync(
                 new ServiceBusReceivedMessage()),
                 Throws.InstanceOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public async Task GetSessionStateAsyncValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = new ServiceBusSessionReceiver(client.Connection, "fake", default, default, CancellationToken.None);
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.GetSessionStateAsync(),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task SetSessionStateAsyncValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = new ServiceBusSessionReceiver(client.Connection, "fake", default, default, CancellationToken.None);
+
+            await client.DisposeAsync();
+            Assert.That(async () => await receiver.SetSessionStateAsync(new BinaryData("new!")),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -7,10 +7,13 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.ServiceBus.Authorization;
 using Azure.Messaging.ServiceBus.Core;
 using Azure.Messaging.ServiceBus.Diagnostics;
 using Azure.Messaging.ServiceBus.Plugins;
 using Moq;
+using Moq.Protected;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Sender
@@ -40,20 +43,22 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         [Test]
         public async Task SendEmptyListShouldNotThrow()
         {
-            var mock = new Mock<ServiceBusSender>()
+            var mock = new Mock<ServiceBusSender>("fake", new ServiceBusSenderOptions(), CreateMockConnection().Object, null)
             {
                 CallBase = true
             };
+
             await mock.Object.SendMessagesAsync(new List<ServiceBusMessage>());
         }
 
         [Test]
         public async Task SendSingleDelegatesToSendList()
         {
-            var mock = new Mock<ServiceBusSender>()
+           var mock = new Mock<ServiceBusSender>("fake", new ServiceBusSenderOptions(), CreateMockConnection().Object, null)
             {
                 CallBase = true
             };
+
             mock
                .Setup(m => m.SendMessagesAsync(
                    It.Is<IEnumerable<ServiceBusMessage>>(value => value.Count() == 1),
@@ -97,7 +102,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         [Test]
         public async Task ScheduleEmptyListShouldNotThrow()
         {
-            var mock = new Mock<ServiceBusSender>()
+            var mock = new Mock<ServiceBusSender>("fake", new ServiceBusSenderOptions(), CreateMockConnection().Object, null)
             {
                 CallBase = true
             };
@@ -129,15 +134,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
             var queueName = Encoding.Default.GetString(GetRandomBuffer(12));
             var client = new ServiceBusClient(connString);
-            var sender = client.CreateSender(queueName,
-                null);
+
+            Assert.That(() => client.CreateSender(queueName, null), Throws.Nothing);
         }
 
-        /// <summary>
-        ///   Verifies functionality of the <see cref="ServiceBusSender.SendMessagesAsync"/>
-        ///   method.
-        /// </summary>
-        ///
         [Test]
         public async Task SendBatchManagesLockingTheBatch()
         {
@@ -149,18 +149,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             var mockScope = new EntityScopeFactory("mock", "mock");
             var batch = new ServiceBusMessageBatch(mockTransportBatch.Object, mockScope);
             var mockTransportSender = new Mock<TransportSender>();
-            var mockConnection = new Mock<ServiceBusConnection>();
-
-            mockConnection
-                .Setup(connection => connection.RetryOptions)
-                .Returns(new ServiceBusRetryOptions());
+            var mockConnection = CreateMockConnection();
 
             mockConnection
                 .Setup(connection => connection.CreateTransportSender(It.IsAny<string>(), It.IsAny<ServiceBusRetryPolicy>(), It.IsAny<string>()))
                 .Returns(mockTransportSender.Object);
-
-            mockConnection
-                .Setup(connection => connection.ThrowIfClosed());
 
             mockTransportBatch
                 .Setup(transport => transport.TryAddMessage(It.IsAny<ServiceBusMessage>()))
@@ -187,6 +180,85 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             Assert.That(batch.TryAddMessage(new ServiceBusMessage(Array.Empty<byte>())), Is.True, "The batch should not be locked after sending.");
 
             cancellationSource.Cancel();
+        }
+
+        [Test]
+        public async Task CreateMessageBatchAsyncValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var sender = client.CreateSender("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await sender.CreateMessageBatchAsync(),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task SendMessageAsyncValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var sender = client.CreateSender("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await sender.SendMessageAsync(new ServiceBusMessage("test")),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task SendMessagesAsyncValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var sender = client.CreateSender("fake");
+
+            using var batch = ServiceBusModelFactory.ServiceBusMessageBatch(4096, new List<ServiceBusMessage> { new ServiceBusMessage("test") });
+
+            await client.DisposeAsync();
+            Assert.That(async () => await sender.SendMessagesAsync(batch),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task ScheduleMessageAsyncValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var sender = client.CreateSender("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await sender.ScheduleMessageAsync(new ServiceBusMessage("test"), new DateTimeOffset(2015, 10, 27, 12, 0, 0, TimeSpan.Zero)),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task ScheduleMessagesAsyncValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var sender = client.CreateSender("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await sender.ScheduleMessagesAsync(new[] { new ServiceBusMessage("one"), new ServiceBusMessage("two") }, new DateTimeOffset(2015, 10, 27, 12, 0, 0, TimeSpan.Zero)),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task CancelScheduledMessageAsyncValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var sender = client.CreateSender("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await sender.CancelScheduledMessageAsync(12345),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
+        }
+
+        [Test]
+        public async Task CancelScheduledMessagesAsyncValidatesClientIsNotDisposed()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var sender = client.CreateSender("fake");
+
+            await client.DisposeAsync();
+            Assert.That(async () => await sender.CancelScheduledMessagesAsync(new[] { 12345L, 678910L }),
+                Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
         }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to guard against a shared connection being closed when the `ServiceBusClient` that spawned a sender/receiver/processor is.  Previously, the sender and receiver did not validate the connection status and would trigger exception behavior in the AMQP library, where the type of exception could vary depending on the library's internal state. This scenario will now trigger a consistent `ObjectDisposedException` with an error message stating that the connection was closed.

The processor would trigger the AMQP exception and fail to recognize it as fatal; signaling the customer error handler and continuing to retry forever, though it cannot recover.  The exception surfaced did not provide customers enough context to differentiate between the fatal scenario and one that was recoverable.  The processor will now detect the connection being closed and interpret that  as fatal, signaling the customer exception handler with an `ObjectDisposedException` with explicit message indicating an unrecoverable scenario and will then stop processing.

# Last Upstream Rebase

Wednesday, April 21, 2:30pm (EDT)

# References and Related

- [Service Bus: System.ObjectDisposedException when opening a receiver link (#19731)](https://github.com/Azure/azure-sdk-for-net/issues/19731)
- [[Event Hubs Client] Detect Closed Shared Connection (#20469)](https://github.com/Azure/azure-sdk-for-net/pull/20469)
