### PR TITLE
Switch APIs to use the lock token guid to avoid converting from and to string

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -81,7 +81,7 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         public abstract Task CompleteAsync(
-            string lockToken,
+            Guid lockToken,
             CancellationToken cancellationToken);
 
         /// <summary> Indicates that the receiver wants to defer the processing for the message.</summary>
@@ -91,7 +91,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <remarks>
-        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockToken"/>,
+        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockTokenGuid"/>,
         /// only when <see cref="ServiceBusReceiveMode"/> is set to <see cref="ServiceBusReceiveMode.PeekLock"/>.
         /// In order to receive this message again in the future, you will need to save the <see cref="ServiceBusReceivedMessage.SequenceNumber"/>
         /// and receive it using ReceiveDeferredMessageBatchAsync(IEnumerable, CancellationToken).
@@ -101,7 +101,7 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         public abstract Task DeferAsync(
-            string lockToken,
+            Guid lockToken,
             IDictionary<string, object> propertiesToModify = null,
             CancellationToken cancellationToken = default);
 
@@ -141,7 +141,7 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         public abstract Task AbandonAsync(
-            string lockToken,
+            Guid lockToken,
             IDictionary<string, object> propertiesToModify = null,
             CancellationToken cancellationToken = default);
 
@@ -165,7 +165,7 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         public abstract Task DeadLetterAsync(
-            string lockToken,
+            Guid lockToken,
             string deadLetterReason = default,
             string deadLetterErrorDescription = default,
             IDictionary<string, object> propertiesToModify = default,
@@ -191,7 +191,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <param name="lockToken">Lock token associated with the message.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         public abstract Task<DateTimeOffset> RenewMessageLockAsync(
-            string lockToken,
+            Guid lockToken,
             CancellationToken cancellationToken);
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -413,8 +413,18 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         #endregion
 
         #region Settlement
+
+        [NonEvent]
+        public virtual void CompleteMessageStart(string identifier, int messageCount, Guid lockToken)
+        {
+            if (IsEnabled())
+            {
+                CompleteMessageStartCore(identifier, messageCount, lockToken.ToString());
+            }
+        }
+
         [Event(CompleteMessageStartEvent, Level = EventLevel.Informational, Message = "{0}: CompleteAsync start. MessageCount = {1}, LockTokens = {2}")]
-        public virtual void CompleteMessageStart(string identifier, int messageCount, string lockTokens)
+        public virtual void CompleteMessageStartCore(string identifier, int messageCount, string lockTokens)
         {
             if (IsEnabled())
             {
@@ -440,8 +450,17 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
+        [NonEvent]
+        public virtual void DeferMessageStart(string identifier, int messageCount, Guid lockToken)
+        {
+            if (IsEnabled())
+            {
+                DeferMessageStartCore(identifier, messageCount, lockToken.ToString());
+            }
+        }
+
         [Event(DeferMessageStartEvent, Level = EventLevel.Informational, Message = "{0}: DeferAsync start. MessageCount = {1}, LockToken = {2}")]
-        public virtual void DeferMessageStart(string identifier, int messageCount, string lockToken)
+        public virtual void DeferMessageStartCore(string identifier, int messageCount, string lockToken)
         {
             if (IsEnabled())
             {
@@ -464,8 +483,17 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             WriteEvent(DeferMessageExceptionEvent, identifier, exception);
         }
 
+        [NonEvent]
+        public virtual void AbandonMessageStart(string identifier, int messageCount, Guid lockToken)
+        {
+            if (IsEnabled())
+            {
+                AbandonMessageStartCore(identifier, messageCount, lockToken.ToString());
+            }
+        }
+
         [Event(AbandonMessageStartEvent, Level = EventLevel.Informational, Message = "{0}: AbandonAsync start. MessageCount = {1}, LockToken = {2}")]
-        public virtual void AbandonMessageStart(string identifier, int messageCount, string lockToken)
+        public virtual void AbandonMessageStartCore(string identifier, int messageCount, string lockToken)
         {
             if (IsEnabled())
             {
@@ -491,8 +519,17 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
+        [NonEvent]
+        public virtual void DeadLetterMessageStart(string identifier, int messageCount, Guid lockToken)
+        {
+            if (IsEnabled())
+            {
+                DeadLetterMessageStartCore(identifier, messageCount, lockToken.ToString());
+            }
+        }
+
         [Event(DeadLetterMessageStartEvent, Level = EventLevel.Informational, Message = "{0}: DeadLetterAsync start. MessageCount = {1}, LockToken = {2}")]
-        public virtual void DeadLetterMessageStart(string identifier, int messageCount, string lockToken)
+        public virtual void DeadLetterMessageStartCore(string identifier, int messageCount, string lockToken)
         {
             if (IsEnabled())
             {
@@ -520,8 +557,18 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         #endregion
 
         #region Lock renewal
+
+        [NonEvent]
+        public virtual void RenewMessageLockStart(string identifier, int messageCount, Guid lockToken)
+        {
+            if (IsEnabled())
+            {
+                RenewMessageLockStartCore(identifier, messageCount, lockToken.ToString());
+            }
+        }
+
         [Event(RenewMessageLockStartEvent, Level = EventLevel.Informational, Message = "{0}: RenewLockAsync start. MessageCount = {1}, LockToken = {2}")]
-        public virtual void RenewMessageLockStart(string identifier, int messageCount, string lockToken)
+        public virtual void RenewMessageLockStartCore(string identifier, int messageCount, string lockToken)
         {
             if (IsEnabled())
             {
@@ -688,8 +735,17 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
+        [NonEvent]
+        public virtual void ProcessorRenewMessageLockStart(string identifier, int messageCount, Guid lockToken)
+        {
+            if (IsEnabled())
+            {
+                ProcessorRenewMessageLockStartCore(identifier, messageCount, lockToken.ToString());
+            }
+        }
+
         [Event(ProcessorRenewMessageLockStartEvent, Level = EventLevel.Informational, Message = "{0}: Processor RenewMessageLock start. MessageCount = {1}, LockToken = {2}")]
-        public virtual void ProcessorRenewMessageLockStart(string identifier, int messageCount, string lockToken)
+        public virtual void ProcessorRenewMessageLockStartCore(string identifier, int messageCount, string lockToken)
         {
             if (IsEnabled())
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -175,7 +175,7 @@ namespace Azure.Messaging.ServiceBus
                     // as we want in flight auto-completion to be able
                     // to finish
                     await Receiver.CompleteMessageAsync(
-                        message.LockToken,
+                        message.LockTokenGuid,
                         CancellationToken.None)
                         .ConfigureAwait(false);
                 }
@@ -212,7 +212,7 @@ namespace Azure.Messaging.ServiceBus
                         // as we want in flight abandon to be able
                         // to finish even if user stopped processing
                         await Receiver.AbandonMessageAsync(
-                            message.LockToken,
+                            message.LockTokenGuid,
                             cancellationToken: CancellationToken.None)
                             .ConfigureAwait(false);
                     }
@@ -256,7 +256,7 @@ namespace Azure.Messaging.ServiceBus
             {
                 try
                 {
-                    ServiceBusEventSource.Log.ProcessorRenewMessageLockStart(Processor.Identifier, 1, message.LockToken);
+                    ServiceBusEventSource.Log.ProcessorRenewMessageLockStart(Processor.Identifier, 1, message.LockTokenGuid);
                     TimeSpan delay = CalculateRenewDelay(message.LockedUntil);
 
                     // We're awaiting the task created by 'ContinueWith' to avoid awaiting the Delay task which may be canceled

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -506,7 +506,7 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(message, nameof(message));
-            await CompleteMessageAsync(message.LockToken, cancellationToken).ConfigureAwait(false);
+            await CompleteMessageAsync(message.LockTokenGuid, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -523,7 +523,7 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         internal virtual async Task CompleteMessageAsync(
-            string lockToken,
+            Guid lockToken,
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
@@ -588,7 +588,7 @@ namespace Azure.Messaging.ServiceBus
         {
             Argument.AssertNotNull(message, nameof(message));
             await AbandonMessageAsync(
-                message.LockToken,
+                message.LockTokenGuid,
                 propertiesToModify,
                 cancellationToken).ConfigureAwait(false);
         }
@@ -609,7 +609,7 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         internal virtual async Task AbandonMessageAsync(
-            string lockToken,
+            Guid lockToken,
             IDictionary<string, object> propertiesToModify = null,
             CancellationToken cancellationToken = default)
         {
@@ -676,7 +676,7 @@ namespace Azure.Messaging.ServiceBus
         {
             Argument.AssertNotNull(message, nameof(message));
             await DeadLetterMessageAsync(
-                lockToken: message.LockToken,
+                lockToken: message.LockTokenGuid,
                 propertiesToModify: propertiesToModify,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -698,7 +698,7 @@ namespace Azure.Messaging.ServiceBus
         /// This operation can only be performed when <see cref="ReceiveMode"/> is set to <see cref="ServiceBusReceiveMode.PeekLock"/>.
         /// </remarks>
         internal virtual async Task DeadLetterMessageAsync(
-            string lockToken,
+            Guid lockToken,
             IDictionary<string, object> propertiesToModify = null,
             CancellationToken cancellationToken = default) =>
             await DeadLetterInternalAsync(
@@ -716,7 +716,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <remarks>
-        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockToken"/>,
+        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockTokenGuid"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBusReceiveMode.PeekLock"/>.
         /// In order to receive a message from the dead-letter queue, you will need a new <see cref="ServiceBusReceiver"/>, with the corresponding path.
         /// You can use EntityNameHelper.FormatDeadLetterPath(string) to help with this.
@@ -740,7 +740,7 @@ namespace Azure.Messaging.ServiceBus
         {
             Argument.AssertNotNull(message, nameof(message));
             await DeadLetterMessageAsync(
-                lockToken: message.LockToken,
+                lockToken: message.LockTokenGuid,
                 deadLetterReason: deadLetterReason,
                 deadLetterErrorDescription: deadLetterErrorDescription,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -756,14 +756,14 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <remarks>
-        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockToken"/>,
+        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockTokenGuid"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBusReceiveMode.PeekLock"/>.
         /// In order to receive a message from the dead-letter queue, you will need a new <see cref="ServiceBusReceiver"/>, with the corresponding path.
         /// You can use EntityNameHelper.FormatDeadLetterPath(string) to help with this.
         /// This operation can only be performed on messages that were received by this receiver.
         /// </remarks>
         internal virtual async Task DeadLetterMessageAsync(
-            string lockToken,
+            Guid lockToken,
             string deadLetterReason,
             string deadLetterErrorDescription = null,
             CancellationToken cancellationToken = default) =>
@@ -784,14 +784,14 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="cancellationToken"></param>
         ///
         /// <remarks>
-        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockToken"/>,
+        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockTokenGuid"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBusReceiveMode.PeekLock"/>.
         /// In order to receive a message from the dead-letter queue, you will need a new <see cref="ServiceBusReceiver"/>, with the corresponding path.
         /// You can use EntityNameHelper.FormatDeadLetterPath(string) to help with this.
         /// This operation can only be performed on messages that were received by this receiver.
         /// </remarks>
         private async Task DeadLetterInternalAsync(
-            string lockToken,
+            Guid lockToken,
             string deadLetterReason = default,
             string deadLetterErrorDescription = default,
             IDictionary<string, object> propertiesToModify = default,
@@ -836,7 +836,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <remarks>
-        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockToken"/>,
+        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockTokenGuid"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBusReceiveMode.PeekLock"/>.
         /// In order to receive this message again in the future, you will need to save the
         /// <see cref="ServiceBusReceivedMessage.SequenceNumber"/>
@@ -863,7 +863,7 @@ namespace Azure.Messaging.ServiceBus
         {
             Argument.AssertNotNull(message, nameof(message));
             await DeferMessageAsync(
-                message.LockToken,
+                message.LockTokenGuid,
                 propertiesToModify,
                 cancellationToken).ConfigureAwait(false);
         }
@@ -875,7 +875,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <remarks>
-        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockToken"/>,
+        /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockTokenGuid"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBusReceiveMode.PeekLock"/>.
         /// In order to receive this message again in the future, you will need to save the
         /// <see cref="ServiceBusReceivedMessage.SequenceNumber"/>
@@ -886,7 +886,7 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         internal virtual async Task DeferMessageAsync(
-            string lockToken,
+            Guid lockToken,
             IDictionary<string, object> propertiesToModify = null,
             CancellationToken cancellationToken = default)
         {
@@ -934,9 +934,9 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Throws an InvalidOperationException when the lock token is empty.
         /// </summary>
-        private static void ThrowIfLockTokenIsEmpty(string lockToken)
+        private static void ThrowIfLockTokenIsEmpty(Guid lockToken)
         {
-            if (Guid.Parse(lockToken) == Guid.Empty)
+            if (lockToken == Guid.Empty)
             {
                 throw new InvalidOperationException(Resources.PeekLockModeRequired);
             }
@@ -953,7 +953,7 @@ namespace Azure.Messaging.ServiceBus
         /// <returns>The deferred message identified by the specified sequence number. Returns null if no message is found.
         /// Throws if the message has not been deferred.</returns>
         /// <seealso cref="DeferMessageAsync(ServiceBusReceivedMessage, IDictionary{string, object}, CancellationToken)"/>
-        /// <seealso cref="DeferMessageAsync(string, IDictionary{string, object}, CancellationToken)"/>
+        /// <seealso cref="DeferMessageAsync(Guid, IDictionary{string, object}, CancellationToken)"/>
         public virtual async Task<ServiceBusReceivedMessage> ReceiveDeferredMessageAsync(
             long sequenceNumber,
             CancellationToken cancellationToken = default) =>
@@ -969,7 +969,7 @@ namespace Azure.Messaging.ServiceBus
         /// <returns>Messages identified by sequence number are returned. Returns null if no messages are found.
         /// Throws if the messages have not been deferred.</returns>
         /// <seealso cref="DeferMessageAsync(ServiceBusReceivedMessage, IDictionary{string, object}, CancellationToken)"/>
-        /// <seealso cref="DeferMessageAsync(string, IDictionary{string, object}, CancellationToken)"/>
+        /// <seealso cref="DeferMessageAsync(Guid, IDictionary{string, object}, CancellationToken)"/>
         /// <exception cref="ServiceBusException">
         ///   The specified sequence number does not correspond to a message that has been deferred.
         ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageNotFound"/> in this case.
@@ -1044,7 +1044,7 @@ namespace Azure.Messaging.ServiceBus
         {
             Argument.AssertNotNull(message, nameof(message));
             DateTimeOffset lockedUntil = await RenewMessageLockAsync(
-                message.LockToken,
+                message.LockTokenGuid,
                 cancellationToken).ConfigureAwait(false);
             message.LockedUntil = lockedUntil;
         }
@@ -1063,7 +1063,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="lockToken">The lockToken of the <see cref="ServiceBusReceivedMessage"/> to renew the lock for.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         internal virtual async Task<DateTimeOffset> RenewMessageLockAsync(
-            string lockToken,
+            Guid lockToken,
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusManagementClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusManagementClientLiveTests.cs
@@ -460,7 +460,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Management
 
             ServiceBusReceiver receiver = sbClient.CreateReceiver(queueName);
             ServiceBusReceivedMessage msg = await receiver.ReceiveMessageAsync();
-            await receiver.DeadLetterMessageAsync(msg.LockToken);
+            await receiver.DeadLetterMessageAsync(msg);
 
             List<QueueRuntimeProperties> runtimeInfoList = new List<QueueRuntimeProperties>();
             await foreach (QueueRuntimeProperties queueRuntimeInfo in mgmtClient.GetQueuesRuntimePropertiesAsync())
@@ -528,7 +528,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Management
 
             ServiceBusReceiver receiver = sbClient.CreateReceiver(topicName, subscriptionName);
             ServiceBusReceivedMessage msg = await receiver.ReceiveMessageAsync();
-            await receiver.DeadLetterMessageAsync(msg.LockToken);
+            await receiver.DeadLetterMessageAsync(msg);
 
             List<SubscriptionRuntimeProperties> runtimeInfoList = new List<SubscriptionRuntimeProperties>();
             await foreach (SubscriptionRuntimeProperties subscriptionRuntimeInfo in client.GetSubscriptionsRuntimePropertiesAsync(topicName))
@@ -775,13 +775,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Management
             ServiceBusReceivedMessage msg = await receiver.ReceiveMessageAsync();
             Assert.NotNull(msg);
             Assert.AreEqual("mid", msg.MessageId);
-            await receiver.DeadLetterMessageAsync(msg.LockToken);
+            await receiver.DeadLetterMessageAsync(msg);
 
             receiver = sbClient.CreateReceiver(dlqDestinationName);
             msg = await receiver.ReceiveMessageAsync();
             Assert.NotNull(msg);
             Assert.AreEqual("mid", msg.MessageId);
-            await receiver.CompleteMessageAsync(msg.LockToken);
+            await receiver.CompleteMessageAsync(msg);
 
             await mgmtClient.DeleteQueueAsync(queueName);
             await mgmtClient.DeleteQueueAsync(destinationName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -624,7 +624,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     log => log.CompleteMessageStart(
                         receiver.Identifier,
                         1,
-                        msg.LockToken),
+                        msg.LockTokenGuid),
                 Times.Once);
             mockLogger
                 .Verify(
@@ -642,7 +642,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
             mockTransportReceiver.Setup(
                 transportReceiver => transportReceiver.CompleteAsync(
-                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
             var receiver = new ServiceBusReceiver(
@@ -665,7 +665,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     log => log.CompleteMessageStart(
                         receiver.Identifier,
                         1,
-                        msg.LockToken),
+                        msg.LockTokenGuid),
                 Times.Once);
             mockLogger
                 .Verify(
@@ -699,7 +699,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     log => log.DeferMessageStart(
                         receiver.Identifier,
                         1,
-                        msg.LockToken),
+                        msg.LockTokenGuid),
                 Times.Once);
             mockLogger
                 .Verify(
@@ -716,7 +716,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockConnection = GetMockConnection(mockTransportReceiver);
             mockTransportReceiver.Setup(
                 transportReceiver => transportReceiver.DeferAsync(
-                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
                     It.IsAny<IDictionary<string, object>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
@@ -740,7 +740,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     log => log.DeferMessageStart(
                         receiver.Identifier,
                         1,
-                        msg.LockToken),
+                        msg.LockTokenGuid),
                 Times.Once);
             mockLogger
                 .Verify(
@@ -774,7 +774,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     log => log.DeadLetterMessageStart(
                         receiver.Identifier,
                         1,
-                        msg.LockToken),
+                        msg.LockTokenGuid),
                 Times.Once);
             mockLogger
                 .Verify(
@@ -791,7 +791,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockConnection = GetMockConnection(mockTransportReceiver);
             mockTransportReceiver.Setup(
                 transportReceiver => transportReceiver.DeadLetterAsync(
-                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<IDictionary<string, object>>(),
@@ -817,7 +817,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     log => log.DeadLetterMessageStart(
                         receiver.Identifier,
                         1,
-                        msg.LockToken),
+                        msg.LockTokenGuid),
                 Times.Once);
             mockLogger
                 .Verify(
@@ -851,7 +851,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     log => log.AbandonMessageStart(
                         receiver.Identifier,
                         1,
-                        msg.LockToken),
+                        msg.LockTokenGuid),
                 Times.Once);
             mockLogger
                 .Verify(
@@ -868,7 +868,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockConnection = GetMockConnection(mockTransportReceiver);
             mockTransportReceiver.Setup(
                 transportReceiver => transportReceiver.AbandonAsync(
-                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
                     It.IsAny<IDictionary<string, object>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
@@ -892,7 +892,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     log => log.AbandonMessageStart(
                         receiver.Identifier,
                         1,
-                        msg.LockToken),
+                        msg.LockTokenGuid),
                 Times.Once);
             mockLogger
                 .Verify(
@@ -926,7 +926,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     log => log.RenewMessageLockStart(
                         receiver.Identifier,
                         1,
-                        msg.LockToken),
+                        msg.LockTokenGuid),
                 Times.Once);
             mockLogger
                 .Verify(
@@ -943,7 +943,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockConnection = GetMockConnection(mockTransportReceiver);
             mockTransportReceiver.Setup(
                 transportReceiver => transportReceiver.RenewMessageLockAsync(
-                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
             var receiver = new ServiceBusReceiver(
@@ -966,7 +966,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     log => log.RenewMessageLockStart(
                         receiver.Identifier,
                         1,
-                        msg.LockToken),
+                        msg.LockTokenGuid),
                 Times.Once);
             mockLogger
                 .Verify(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -88,7 +88,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                 await client.CreateSender(scope.QueueName).SendMessageAsync(maxSizeMessage);
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var receivedMaxSizeMessage = await receiver.ReceiveMessageAsync();
-                await receiver.CompleteMessageAsync(receivedMaxSizeMessage.LockToken);
+                await receiver.CompleteMessageAsync(receivedMaxSizeMessage);
                 Assert.AreEqual(maxPayload, receivedMaxSizeMessage.Body.ToArray());
             }
         }
@@ -106,7 +106,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var receivedMessage = await receiver.ReceiveMessageAsync();
                 Assert.IsNotNull(receivedMessage);
-                await receiver.CompleteMessageAsync(receivedMessage.LockToken);
+                await receiver.CompleteMessageAsync(receivedMessage);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -272,7 +272,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         remainingMessages--;
                         messageEnum.MoveNext();
                         Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                        await receiver.CompleteMessageAsync(item.LockToken);
+                        await receiver.CompleteMessageAsync(item);
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -308,7 +308,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     await foreach (var msg in receiver.ReceiveMessagesAsync(cts.Token))
                     {
                         Assert.AreEqual(messages[ct].MessageId, msg.MessageId);
-                        await receiver.CompleteMessageAsync(msg.LockToken);
+                        await receiver.CompleteMessageAsync(msg, CancellationToken.None);
                         ct++;
                     }
                 }
@@ -396,7 +396,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         messageEnum.MoveNext();
                         Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                         Assert.AreEqual(messageEnum.Current.Body.ToArray(), item.Body.ToArray());
-                        await receiver.DeadLetterMessageAsync(item.LockToken);
+                        await receiver.DeadLetterMessageAsync(item);
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -416,7 +416,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         remainingMessages--;
                         messageEnum.MoveNext();
                         Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                        await deadLetterReceiver.CompleteMessageAsync(item.LockToken);
+                        await deadLetterReceiver.CompleteMessageAsync(item);
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -453,7 +453,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         messageEnum.MoveNext();
                         Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                         sequenceNumbers.Add(item.SequenceNumber);
-                        await receiver.DeferMessageAsync(item.LockToken);
+                        await receiver.DeferMessageAsync(item);
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -507,7 +507,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         messageEnum.MoveNext();
                         Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                         sequenceNumbers[idx++] = item.SequenceNumber;
-                        await receiver.DeferMessageAsync(item.LockToken);
+                        await receiver.DeferMessageAsync(item);
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -555,7 +555,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         messageEnum.MoveNext();
                         Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                         sequenceNumbers[idx++] = item.SequenceNumber;
-                        await receiver.DeferMessageAsync(item.LockToken);
+                        await receiver.DeferMessageAsync(item);
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -711,7 +711,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 Assert.Greater(receivedMessage.LockedUntil, firstLockedUntilUtcTime);
 
                 // Complete Messages
-                await receiver.CompleteMessageAsync(receivedMessage.LockToken);
+                await receiver.CompleteMessageAsync(receivedMessage);
 
                 Assert.AreEqual(messageCount, receivedMessages.Length);
                 Assert.AreEqual(message.MessageId, receivedMessage.MessageId);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -366,7 +366,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         messageEnum.MoveNext();
                         Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                         Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
-                        await receiver.CompleteMessageAsync(item.LockToken);
+                        await receiver.CompleteMessageAsync(item);
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -464,7 +464,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         messageEnum.MoveNext();
                         Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                         Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
-                        await receiver.DeadLetterMessageAsync(item.LockToken, "testReason", "testDescription");
+                        await receiver.DeadLetterMessageAsync(item, "testReason", "testDescription");
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -489,7 +489,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         Assert.AreEqual(messageEnum.Current.SessionId, msg.SessionId);
                         Assert.AreEqual("testReason", msg.DeadLetterReason);
                         Assert.AreEqual("testDescription", msg.DeadLetterErrorDescription);
-                        await deadLetterReceiver.CompleteMessageAsync(msg.LockToken);
+                        await deadLetterReceiver.CompleteMessageAsync(msg);
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -537,7 +537,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         props[AmqpMessageConstants.DeadLetterReasonHeader] = DateTime.UtcNow;
                         props[AmqpMessageConstants.DeadLetterErrorDescriptionHeader] = DateTime.UtcNow;
 
-                        await receiver.DeadLetterMessageAsync(item.LockToken, props);
+                        await receiver.DeadLetterMessageAsync(item, props);
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -564,7 +564,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         Assert.IsNull(msg.DeadLetterReason);
                         Assert.IsNotNull(msg.ApplicationProperties[AmqpMessageConstants.DeadLetterReasonHeader]);
                         Assert.IsNotNull(msg.ApplicationProperties[AmqpMessageConstants.DeadLetterErrorDescriptionHeader]);
-                        await deadLetterReceiver.CompleteMessageAsync(msg.LockToken);
+                        await deadLetterReceiver.CompleteMessageAsync(msg);
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -606,7 +606,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                         Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
                         sequenceNumbers.Add(item.SequenceNumber);
-                        await receiver.DeferMessageAsync(item.LockToken);
+                        await receiver.DeferMessageAsync(item);
                     }
                 }
                 Assert.AreEqual(0, remainingMessages);
@@ -658,7 +658,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 Assert.Greater(receiver.SessionLockedUntil, firstLockedUntilUtcTime);
 
                 // Complete Messages
-                await receiver.CompleteMessageAsync(receivedMessage.LockToken);
+                await receiver.CompleteMessageAsync(receivedMessage);
 
                 Assert.AreEqual(messageCount, receivedMessages.Length);
                 if (isSessionSpecified)
@@ -864,7 +864,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     await foreach (var msg in receiver.ReceiveMessagesAsync(cts.Token))
                     {
                         Assert.AreEqual(messages[ct].MessageId, msg.MessageId);
-                        await receiver.CompleteMessageAsync(msg.LockToken);
+                        await receiver.CompleteMessageAsync(msg);
                         ct++;
                         if (ct == messageCount)
                         {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
@@ -401,7 +401,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
 
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    await receiver.CompleteMessageAsync(receivedMessage.LockToken);
+                    await receiver.CompleteMessageAsync(receivedMessage);
                     await sender.SendMessageAsync(message2);
                 }
 
@@ -410,7 +410,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 await Task.Delay(TimeSpan.FromSeconds(2));
 
                 // Following should succeed without exceptions
-                await receiver.CompleteMessageAsync(receivedMessage.LockToken);
+                await receiver.CompleteMessageAsync(receivedMessage);
 
                 // Assert that send failed
                 receivedMessage = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));


### PR DESCRIPTION
Related to #20483 

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
