### PR TITLE
[Storage][Core] Wait for environment to become eventually consistent.

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/LiveTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/LiveTestBase.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading.Tasks;
+using NUnit.Framework;
+
 namespace Azure.Core.TestFramework
 {
     /// <summary>
@@ -16,5 +19,11 @@ namespace Azure.Core.TestFramework
         }
 
         protected TEnvironment TestEnvironment { get; }
+
+        [OneTimeSetUp]
+        public async ValueTask WaitForEnvironment()
+        {
+            await TestEnvironment.WaitForEnvironmentAsync();
+        }
     }
 }

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
@@ -31,7 +31,7 @@ namespace Azure.Core.TestFramework
         [OneTimeSetUp]
         public async Task WaitForEnvironment()
         {
-            await TestEnvironment.WaitForEnvironment();
+            await TestEnvironment.WaitForEnvironmentAsync();
         }
     }
 }

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
@@ -1,12 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
 namespace Azure.Core.TestFramework
 {
 #pragma warning disable SA1649 // File name should match first type name
     public abstract class RecordedTestBase<TEnvironment> : RecordedTestBase where TEnvironment : TestEnvironment, new()
 #pragma warning restore SA1649 // File name should match first type name
     {
+        private static bool IsEnvironmentReady;
+
         protected RecordedTestBase(bool isAsync, RecordedTestMode? mode = null) : base(isAsync, mode)
         {
             TestEnvironment = new TEnvironment();
@@ -23,5 +29,29 @@ namespace Azure.Core.TestFramework
         }
 
         public TEnvironment TestEnvironment { get; }
+
+        [OneTimeSetUp]
+        public async Task WaitForEnvironment()
+        {
+            if (IsEnvironmentReady)
+            {
+                return;
+            }
+
+            int numberOfTries = 60;
+            TimeSpan delay = TimeSpan.FromSeconds(10);
+            for (int i = 0; i < numberOfTries; i++)
+            {
+                var isReady = await TestEnvironment.IsEnvironmentReady();
+                if (isReady)
+                {
+                    IsEnvironmentReady = isReady;
+                    return;
+                }
+                await Task.Delay(delay);
+            }
+
+            throw new InvalidOperationException("The environment has not become ready, check your TestEnvironment.IsEnvironmentReady scenario.");
+        }
     }
 }

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
@@ -11,8 +11,6 @@ namespace Azure.Core.TestFramework
     public abstract class RecordedTestBase<TEnvironment> : RecordedTestBase where TEnvironment : TestEnvironment, new()
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private static bool IsEnvironmentReady;
-
         protected RecordedTestBase(bool isAsync, RecordedTestMode? mode = null) : base(isAsync, mode)
         {
             TestEnvironment = new TEnvironment();
@@ -33,25 +31,7 @@ namespace Azure.Core.TestFramework
         [OneTimeSetUp]
         public async Task WaitForEnvironment()
         {
-            if (IsEnvironmentReady)
-            {
-                return;
-            }
-
-            int numberOfTries = 60;
-            TimeSpan delay = TimeSpan.FromSeconds(10);
-            for (int i = 0; i < numberOfTries; i++)
-            {
-                var isReady = await TestEnvironment.IsEnvironmentReady();
-                if (isReady)
-                {
-                    IsEnvironmentReady = isReady;
-                    return;
-                }
-                await Task.Delay(delay);
-            }
-
-            throw new InvalidOperationException("The environment has not become ready, check your TestEnvironment.IsEnvironmentReady scenario.");
+            await TestEnvironment.WaitForEnvironment();
         }
     }
 }

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
@@ -29,7 +29,7 @@ namespace Azure.Core.TestFramework
         public TEnvironment TestEnvironment { get; }
 
         [OneTimeSetUp]
-        public async Task WaitForEnvironment()
+        public async ValueTask WaitForEnvironment()
         {
             await TestEnvironment.WaitForEnvironmentAsync();
         }

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -188,30 +188,30 @@ namespace Azure.Core.TestFramework
         /// Throw if you want to fail the run fast.
         /// </summary>
         /// <returns>Whether environment is ready to use.</returns>
-        protected virtual Task<bool> IsEnvironmentReady()
+        protected virtual Task<bool> IsEnvironmentReadyAsync()
         {
             return Task.FromResult(true);
         }
 
         /// <summary>
-        /// Waits until environment becomes ready to use. See <see cref="IsEnvironmentReady"/> to define sampling scenario.
+        /// Waits until environment becomes ready to use. See <see cref="IsEnvironmentReadyAsync"/> to define sampling scenario.
         /// </summary>
         /// <returns>A task.</returns>
-        public async Task WaitForEnvironment()
+        public async Task WaitForEnvironmentAsync()
         {
             if (Mode == RecordedTestMode.Live)
             {
-                await s_environmentStateCache.GetOrAdd(GetType(), t => WaitForEnvironmentInternal());
+                await s_environmentStateCache.GetOrAdd(GetType(), t => WaitForEnvironmentInternalAsync());
             }
         }
 
-        private async Task WaitForEnvironmentInternal()
+        private async Task WaitForEnvironmentInternalAsync()
         {
             int numberOfTries = 60;
             TimeSpan delay = TimeSpan.FromSeconds(10);
             for (int i = 0; i < numberOfTries; i++)
             {
-                var isReady = await IsEnvironmentReady();
+                var isReady = await IsEnvironmentReadyAsync();
                 if (isReady)
                 {
                     return;

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -188,16 +188,16 @@ namespace Azure.Core.TestFramework
         /// Throw if you want to fail the run fast.
         /// </summary>
         /// <returns>Whether environment is ready to use.</returns>
-        protected virtual Task<bool> IsEnvironmentReadyAsync()
+        protected virtual ValueTask<bool> IsEnvironmentReadyAsync()
         {
-            return Task.FromResult(true);
+            return new ValueTask<bool>(true);
         }
 
         /// <summary>
         /// Waits until environment becomes ready to use. See <see cref="IsEnvironmentReadyAsync"/> to define sampling scenario.
         /// </summary>
         /// <returns>A task.</returns>
-        public async Task WaitForEnvironmentAsync()
+        public async ValueTask WaitForEnvironmentAsync()
         {
             if (Mode == RecordedTestMode.Live)
             {

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -176,6 +176,21 @@ namespace Azure.Core.TestFramework
         }
 
         /// <summary>
+        /// Returns whether environment is ready to use. Should be overriden to provide service specific sampling scenario.
+        /// The test framework will wait until this returns true before starting tests.
+        /// Use this place to hook up logic that polls if eventual consistency has happened.
+        ///
+        /// Return true if environment is ready to use.
+        /// Return false if environment is not ready to use and framework should wait.
+        /// Throw if you want to fail the run fast.
+        /// </summary>
+        /// <returns>Whether environment is ready to use.</returns>
+        public virtual Task<bool> IsEnvironmentReady()
+        {
+            return Task.FromResult(true);
+        }
+
+        /// <summary>
         /// Returns and records an environment variable value when running live or recorded value during playback.
         /// </summary>
         protected string GetRecordedOptionalVariable(string name)

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -26,7 +26,7 @@ namespace Azure.Core.TestFramework
         [EditorBrowsableAttribute(EditorBrowsableState.Never)]
         public static string RepositoryRoot { get; }
 
-        private static readonly ConcurrentDictionary<Type, Task> EnvironmentStateCache = new ConcurrentDictionary<Type, Task>();
+        private static readonly ConcurrentDictionary<Type, Task> s_environmentStateCache = new ConcurrentDictionary<Type, Task>();
 
         private readonly string _prefix;
 
@@ -201,7 +201,7 @@ namespace Azure.Core.TestFramework
         {
             if (Mode == RecordedTestMode.Live)
             {
-                await EnvironmentStateCache.GetOrAdd(GetType(), t => WaitForEnvironmentInternal());
+                await s_environmentStateCache.GetOrAdd(GetType(), t => WaitForEnvironmentInternal());
             }
         }
 

--- a/sdk/core/Azure.Core/tests/TestEnvironmentTests.cs
+++ b/sdk/core/Azure.Core/tests/TestEnvironmentTests.cs
@@ -298,9 +298,9 @@ namespace Azure.Core.Tests
         {
             public static int InvocationCount { get; private set; }
 
-            protected override Task<bool> IsEnvironmentReadyAsync()
+            protected override ValueTask<bool> IsEnvironmentReadyAsync()
             {
-                return Task.FromResult(InvocationCount++ < 1 ? false : true);
+                return new ValueTask<bool>(InvocationCount++ < 1 ? false : true);
             }
         }
 
@@ -308,9 +308,9 @@ namespace Azure.Core.Tests
         {
             public static int InvocationCount { get; private set; }
 
-            protected override Task<bool> IsEnvironmentReadyAsync()
+            protected override ValueTask<bool> IsEnvironmentReadyAsync()
             {
-                return Task.FromResult(InvocationCount++ < 1 ? false : true);
+                return new ValueTask<bool>(InvocationCount++ < 1 ? false : true);
             }
         }
 
@@ -323,7 +323,7 @@ namespace Azure.Core.Tests
 
             public static int InvocationCount { get; private set; }
 
-            protected override Task<bool> IsEnvironmentReadyAsync()
+            protected override ValueTask<bool> IsEnvironmentReadyAsync()
             {
                 InvocationCount++;
                 throw new InvalidOperationException("kaboom");

--- a/sdk/core/Azure.Core/tests/TestEnvironmentTests.cs
+++ b/sdk/core/Azure.Core/tests/TestEnvironmentTests.cs
@@ -178,7 +178,7 @@ namespace Azure.Core.Tests
 
             try
             {
-                await env.WaitForEnvironment();
+                await env.WaitForEnvironmentAsync();
                 Assert.Fail();
             }
             catch (InvalidOperationException e)
@@ -188,7 +188,7 @@ namespace Azure.Core.Tests
 
             try
             {
-                await env.WaitForEnvironment();
+                await env.WaitForEnvironmentAsync();
                 Assert.Fail();
             }
             catch (InvalidOperationException e)
@@ -298,7 +298,7 @@ namespace Azure.Core.Tests
         {
             public static int InvocationCount { get; private set; }
 
-            protected override Task<bool> IsEnvironmentReady()
+            protected override Task<bool> IsEnvironmentReadyAsync()
             {
                 return Task.FromResult(InvocationCount++ < 1 ? false : true);
             }
@@ -308,7 +308,7 @@ namespace Azure.Core.Tests
         {
             public static int InvocationCount { get; private set; }
 
-            protected override Task<bool> IsEnvironmentReady()
+            protected override Task<bool> IsEnvironmentReadyAsync()
             {
                 return Task.FromResult(InvocationCount++ < 1 ? false : true);
             }
@@ -323,7 +323,7 @@ namespace Azure.Core.Tests
 
             public static int InvocationCount { get; private set; }
 
-            protected override Task<bool> IsEnvironmentReady()
+            protected override Task<bool> IsEnvironmentReadyAsync()
             {
                 InvocationCount++;
                 throw new InvalidOperationException("kaboom");

--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/Azure.Storage.Blobs.Batch.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/Azure.Storage.Blobs.Batch.Tests.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" Link="Shared\Core\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\BlobTestBase.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\BlobTestEnvironment.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)StorageConnectionString.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)SharedAccessSignatureCredentials.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)UriExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/ChangeFeedTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/ChangeFeedTestBase.cs
@@ -19,7 +19,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
         StorageVersionExtensions.MaxVersion,
     RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
     LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
-    public class ChangeFeedTestBase : StorageTestBase
+    public class ChangeFeedTestBase : StorageTestBase<StorageTestEnvironment>
     {
         protected readonly BlobClientOptions.ServiceVersion _serviceVersion;
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -4472,7 +4472,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task SetHttpHeadersAsync()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             await using DisposingContainer test = await GetTestContainerAsync();
             // Arrange
             BlobBaseClient blob = await GetNewBlobClient(test.Container);
@@ -4501,7 +4501,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task SetHttpHeadersAsync_MultipleHeaders()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             await using DisposingContainer test = await GetTestContainerAsync();
             // Arrange
             BlobBaseClient blob = await GetNewBlobClient(test.Container);
@@ -5914,7 +5914,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SetTierAsync_Version()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             await using DisposingContainer test = await GetTestContainerAsync();
             var data = GetRandomBuffer(Constants.KB);
             BlockBlobClient blob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));
@@ -6426,7 +6426,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -6473,7 +6473,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_GetParentBlobContainerClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -6525,7 +6525,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_WithSnapshot_True()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -6550,7 +6550,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_WithSnapshot_False()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Create blob
@@ -6571,7 +6571,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_WithVersion_True()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -6596,7 +6596,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_WithVersion_False()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Create blob
@@ -6634,7 +6634,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.blob.core.windows.net");
@@ -6671,7 +6671,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public void GenerateSas_Builder()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.blob.core.windows.net");
@@ -6718,7 +6718,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateSas_BuilderNullContainerName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string blobName = GetNewBlobName();
             string containerName = GetNewContainerName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.blob.core.windows.net");
@@ -6763,7 +6763,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateSas_BuilderWrongContainerName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string blobName = GetNewBlobName();
             string containerName = GetNewContainerName();
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(new Uri($"https://{constants.Sas.Account}.blob.core.windows.net"))
@@ -6795,7 +6795,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateSas_BuilderNullBlobName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string blobName = GetNewBlobName();
             string containerName = GetNewContainerName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.blob.core.windows.net");
@@ -6843,7 +6843,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateSas_BuilderWrongBlobName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string containerName = GetNewContainerName();
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(new Uri($"https://{constants.Sas.Account}.blob.core.windows.net"))
             {
@@ -6873,7 +6873,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateSas_BuilderNullSnapshot()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string blobName = GetNewBlobName();
             string containerName = GetNewContainerName();
             string snapshot = "2020-07-03T12:45:46.1234567Z";
@@ -6926,7 +6926,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateSas_BuilderWrongSnapshot()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string snapshot = "2020-07-03T12:45:46.1234567Z";
             string differentSnapshot = "2019-07-03T12:45:46.1234567Z";
             string containerName = GetNewContainerName();
@@ -6962,7 +6962,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateSas_BuilderNullVersion()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string blobName = GetNewBlobName();
             string containerName = GetNewContainerName();
             string versionId = "2020-07-03T12:45:46.1234567Z";
@@ -7015,7 +7015,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateSas_BuilderWrongVersion()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string blobVersionId = "2020-07-03T12:45:46.1234567Z";
             string diffBlobVersionId = "2019-07-03T12:45:46.1234567Z";
             string containerName = GetNewContainerName();

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -44,7 +44,7 @@ namespace Azure.Storage.Blobs.Test
         public void ToSasQueryParameters_ContainerTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
             BlobSasBuilder blobSasBuilder = BuildBlobSasBuilder(includeBlob: false, includeSnapshot: false, containerName, blobName, constants);
@@ -72,7 +72,7 @@ namespace Azure.Storage.Blobs.Test
         public void ToSasQueryParameters_ContainerIdentityTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
             BlobSasBuilder blobSasBuilder = BuildBlobSasBuilder(includeBlob: false, includeSnapshot: false, containerName, blobName, constants);
@@ -106,7 +106,7 @@ namespace Azure.Storage.Blobs.Test
         public void ToSasQueryParameters_BlobTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
             BlobSasBuilder blobSasBuilder = BuildBlobSasBuilder(includeBlob: true, includeSnapshot: false, containerName, blobName, constants);
@@ -134,7 +134,7 @@ namespace Azure.Storage.Blobs.Test
         public void ToSasQueryParameters_BlobIdentityTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
             BlobSasBuilder blobSasBuilder = BuildBlobSasBuilder(includeBlob: true, includeSnapshot: false, containerName, blobName, constants);
@@ -168,7 +168,7 @@ namespace Azure.Storage.Blobs.Test
         public void ToSasQueryParameters_SnapshotTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
             BlobSasBuilder blobSasBuilder = BuildBlobSasBuilder(includeBlob: true, includeSnapshot: true, containerName, blobName, constants);
@@ -196,7 +196,7 @@ namespace Azure.Storage.Blobs.Test
         public void ToSasQueryParameters_SnapshotIdentityTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
             BlobSasBuilder blobSasBuilder = BuildBlobSasBuilder(includeBlob: true, includeSnapshot: true, containerName, blobName, constants);
@@ -230,7 +230,7 @@ namespace Azure.Storage.Blobs.Test
         public void ToSasQueryParameters_NullSharedKeyCredentialTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
             BlobSasBuilder blobSasBuilder = BuildBlobSasBuilder(includeBlob: true, includeSnapshot: true, containerName, blobName, constants);
@@ -243,7 +243,7 @@ namespace Azure.Storage.Blobs.Test
         public void ToSasQueryParameters_IdentifierTest()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string containerName = GetNewContainerName();
             string resource = "c";
             BlobSasBuilder sasBuilder = new BlobSasBuilder()

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -13,6 +13,7 @@ using Azure.Core.TestFramework;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using NUnit.Framework;
 
@@ -30,7 +31,7 @@ namespace Azure.Storage.Test.Shared
         StorageVersionExtensions.MaxVersion,
         RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
         LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
-    public abstract class BlobTestBase : StorageTestBase
+    public abstract class BlobTestBase : StorageTestBase<BlobTestEnvironment>
     {
         protected readonly BlobClientOptions.ServiceVersion _serviceVersion;
         public readonly string ReceivedETag = "\"received\"";

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestEnvironment.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestEnvironment.cs
@@ -11,12 +11,12 @@ namespace Azure.Storage.Blobs.Tests
 {
     public class BlobTestEnvironment : StorageTestEnvironment
     {
-        protected override Task<bool> IsEnvironmentReady()
+        protected override Task<bool> IsEnvironmentReadyAsync()
         {
-            return DoesOAuthWork();
+            return DoesOAuthWorkAsync();
         }
 
-        private async Task<bool> DoesOAuthWork()
+        private async Task<bool> DoesOAuthWorkAsync()
         {
             BlobServiceClient blobServiceClient = new BlobServiceClient(new Uri(TestConfigurations.DefaultTargetOAuthTenant.BlobServiceEndpoint), OAuthCredential);
             try

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestEnvironment.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestEnvironment.cs
@@ -11,14 +11,9 @@ namespace Azure.Storage.Blobs.Tests
 {
     public class BlobTestEnvironment : StorageTestEnvironment
     {
-        public override async Task<bool> IsEnvironmentReady()
+        protected override Task<bool> IsEnvironmentReady()
         {
-            if (Mode != RecordedTestMode.Live)
-            {
-                return true;
-            }
-
-            return await DoesOAuthWork();
+            return DoesOAuthWork();
         }
 
         private async Task<bool> DoesOAuthWork()

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestEnvironment.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestEnvironment.cs
@@ -11,18 +11,18 @@ namespace Azure.Storage.Blobs.Tests
 {
     public class BlobTestEnvironment : StorageTestEnvironment
     {
-        public override Task<bool> IsEnvironmentReady()
-        {
-            return DoesOAuthWork();
-        }
-
-        private async Task<bool> DoesOAuthWork()
+        public override async Task<bool> IsEnvironmentReady()
         {
             if (Mode != RecordedTestMode.Live)
             {
                 return true;
             }
 
+            return await DoesOAuthWork();
+        }
+
+        private async Task<bool> DoesOAuthWork()
+        {
             BlobServiceClient blobServiceClient = new BlobServiceClient(new Uri(TestConfigurations.DefaultTargetOAuthTenant.BlobServiceEndpoint), OAuthCredential);
             try
             {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestEnvironment.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestEnvironment.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Azure.Core.TestFramework;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 
@@ -11,9 +10,9 @@ namespace Azure.Storage.Blobs.Tests
 {
     public class BlobTestEnvironment : StorageTestEnvironment
     {
-        protected override Task<bool> IsEnvironmentReadyAsync()
+        protected override async ValueTask<bool> IsEnvironmentReadyAsync()
         {
-            return DoesOAuthWorkAsync();
+            return await DoesOAuthWorkAsync();
         }
 
         private async Task<bool> DoesOAuthWorkAsync()

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestEnvironment.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestEnvironment.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Azure.Storage.Test;
+using Azure.Storage.Test.Shared;
+
+namespace Azure.Storage.Blobs.Tests
+{
+    public class BlobTestEnvironment : StorageTestEnvironment
+    {
+        public override Task<bool> IsEnvironmentReady()
+        {
+            return DoesOAuthWork();
+        }
+
+        private async Task<bool> DoesOAuthWork()
+        {
+            if (Mode != RecordedTestMode.Live)
+            {
+                return true;
+            }
+
+            BlobServiceClient blobServiceClient = new BlobServiceClient(new Uri(TestConfigurations.DefaultTargetOAuthTenant.BlobServiceEndpoint), OAuthCredential);
+            try
+            {
+                await blobServiceClient.GetPropertiesAsync();
+            } catch (RequestFailedException e) when (e.Status == 403 && e.ErrorCode == "AuthorizationPermissionMismatch")
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -1070,7 +1070,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task CommitBlockListAsync_Headers()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             await using DisposingContainer test = await GetTestContainerAsync();
 
             // Arrange
@@ -1856,7 +1856,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task UploadAsync_Headers()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             await using DisposingContainer test = await GetTestContainerAsync();
 
             // Arrange
@@ -2833,7 +2833,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SyncUploadFromUriAsync()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             await using DisposingContainer test = await GetTestContainerAsync();
             BlockBlobClient sourceBlob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));
             BlockBlobClient destBlob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));
@@ -2890,7 +2890,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SyncUploadFromUriAsync_Error()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             await using DisposingContainer test = await GetTestContainerAsync();
             BlockBlobClient sourceBlob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));
             BlockBlobClient destBlob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));
@@ -2906,7 +2906,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SyncUploadFromUriAsync_OverwiteSourceBlobProperties()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             await using DisposingContainer test = await GetTestContainerAsync();
             BlockBlobClient sourceBlob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));
             BlockBlobClient destBlob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -727,7 +727,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_WithClientSideEncryptionOptions_True()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -758,7 +758,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_WithClientSideEncryptionOptions_False()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             var options = new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -2643,7 +2643,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -2705,7 +2705,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_GetBlobClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -2755,7 +2755,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_GetParentServiceClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -2805,7 +2805,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string containerName = GetNewContainerName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.blob.core.windows.net");
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(serviceUri)
@@ -2839,7 +2839,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public void GenerateSas_Builder()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string containerName = GetNewContainerName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.blob.core.windows.net");
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(serviceUri)
@@ -2878,7 +2878,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public void GenerateSas_BuilderNullName()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string containerName = GetNewContainerName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.blob.core.windows.net");
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(serviceUri)
@@ -2918,7 +2918,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateSas_BuilderWrongName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string containerName = GetNewContainerName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.blob.core.windows.net");
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(serviceUri)

--- a/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
@@ -903,7 +903,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -946,7 +946,7 @@ namespace Azure.Storage.Blobs.Test
         public void CanGenerateSas_GetContainerClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -1012,7 +1012,7 @@ namespace Azure.Storage.Blobs.Test
         public void GenerateAccountSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.blob.core.windows.net");
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
@@ -1039,7 +1039,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public void GenerateAccountSas_Builder()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.blob.core.windows.net");
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
@@ -1068,7 +1068,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public void GenerateAccountSas_WrongService_Service()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.blob.core.windows.net");
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);

--- a/sdk/storage/Azure.Storage.Common/tests/CommonTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/CommonTestBase.cs
@@ -19,7 +19,7 @@ namespace Azure.Storage.Test
     BlobClientOptions.ServiceVersion.V2020_08_04,
     RecordingServiceVersion = BlobClientOptions.ServiceVersion.V2020_08_04,
     LiveServiceVersions = new object[] { BlobClientOptions.ServiceVersion.V2020_06_12 })]
-    public abstract class CommonTestBase : StorageTestBase
+    public abstract class CommonTestBase : StorageTestBase<StorageTestEnvironment>
     {
         protected readonly BlobClientOptions.ServiceVersion _serviceVersion;
 

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -20,7 +20,7 @@ using NUnit.Framework;
 
 namespace Azure.Storage.Test.Shared
 {
-    public abstract class StorageTestBase : RecordedTestBase
+    public abstract class StorageTestBase<TEnvironment> : RecordedTestBase<TEnvironment> where TEnvironment : StorageTestEnvironment, new()
     {
         static StorageTestBase()
         {

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestEnvironment.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestEnvironment.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Identity;
+
+namespace Azure.Storage.Test.Shared
+{
+    public class StorageTestEnvironment : TestEnvironment
+    {
+        protected TokenCredential OAuthCredential { get; } = new ClientSecretCredential(
+                    TestConfigurations.DefaultTargetOAuthTenant.ActiveDirectoryTenantId,
+                    TestConfigurations.DefaultTargetOAuthTenant.ActiveDirectoryApplicationId,
+                    TestConfigurations.DefaultTargetOAuthTenant.ActiveDirectoryApplicationSecret,
+                    new TokenCredentialOptions() { AuthorityHost = new Uri(TestConfigurations.DefaultTargetOAuthTenant.ActiveDirectoryAuthEndpoint) });
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestConstants.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestConstants.cs
@@ -31,6 +31,10 @@ namespace Azure.Storage.Test
         public byte[] ContentMD5 { get; private set; }
         public SasConstants Sas { get; private set; }
 
+        private TestConstants()
+        {
+        }
+
         public class SasConstants
         {
             public string KeyObjectId { get; } = "KeyOid";
@@ -59,35 +63,39 @@ namespace Azure.Storage.Test
             public StorageSharedKeyCredential SharedKeyCredential { get; protected internal set; }
         }
 
-        public TestConstants(StorageTestBase test)
+        public static TestConstants Create<TStorageTestEnvironment>(StorageTestBase<TStorageTestEnvironment> test) where TStorageTestEnvironment : StorageTestEnvironment, new()
         {
-            CacheControl = test.GetNewString();
-            ContentDisposition = test.GetNewString();
-            ContentEncoding = test.GetNewString();
-            ContentLanguage = test.GetNewString();
-            ContentType = test.GetNewString();
-            ContentMD5 = MD5.Create().ComputeHash(test.GetRandomBuffer(16));
-
-            Sas = new SasConstants
+            var testConstants = new TestConstants()
             {
-                Version = test.GetNewString(),
-                Account = test.GetNewString(),
-                Identifier = test.GetNewString(),
                 CacheControl = test.GetNewString(),
                 ContentDisposition = test.GetNewString(),
                 ContentEncoding = test.GetNewString(),
                 ContentLanguage = test.GetNewString(),
                 ContentType = test.GetNewString(),
-                AccountKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(test.GetNewString())),
-                StartTime = test.GetUtcNow().AddHours(-1),
-                ExpiryTime = test.GetUtcNow().AddHours(+1),
-                StartAddress = test.GetIPAddress(),
-                EndAddress = test.GetIPAddress(),
-                KeyStart = test.GetUtcNow().AddHours(-1),
-                KeyExpiry = test.GetUtcNow().AddHours(+1)
+                ContentMD5 = MD5.Create().ComputeHash(test.GetRandomBuffer(16)),
+
+                Sas = new SasConstants
+                {
+                    Version = test.GetNewString(),
+                    Account = test.GetNewString(),
+                    Identifier = test.GetNewString(),
+                    CacheControl = test.GetNewString(),
+                    ContentDisposition = test.GetNewString(),
+                    ContentEncoding = test.GetNewString(),
+                    ContentLanguage = test.GetNewString(),
+                    ContentType = test.GetNewString(),
+                    AccountKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(test.GetNewString())),
+                    StartTime = test.GetUtcNow().AddHours(-1),
+                    ExpiryTime = test.GetUtcNow().AddHours(+1),
+                    StartAddress = test.GetIPAddress(),
+                    EndAddress = test.GetIPAddress(),
+                    KeyStart = test.GetUtcNow().AddHours(-1),
+                    KeyExpiry = test.GetUtcNow().AddHours(+1),
+                },
             };
-            Sas.IPRange = new SasIPRange(Sas.StartAddress, Sas.EndAddress);
-            Sas.SharedKeyCredential = new StorageSharedKeyCredential(Sas.Account, Sas.AccountKey);
+            testConstants.Sas.IPRange = new SasIPRange(testConstants.Sas.StartAddress, testConstants.Sas.EndAddress);
+            testConstants.Sas.SharedKeyCredential = new StorageSharedKeyCredential(testConstants.Sas.Account, testConstants.Sas.AccountKey);
+            return testConstants;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -29,7 +29,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         StorageVersionExtensions.MaxVersion,
         RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
         LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
-    public abstract class DataLakeTestBase : StorageTestBase
+    public abstract class DataLakeTestBase : StorageTestBase<StorageTestEnvironment>
     {
         protected readonly DataLakeClientOptions.ServiceVersion _serviceVersion;
         public readonly string ReceivedETag = "\"received\"";

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -3611,7 +3611,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task SetHttpHeadersAsync()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
 
             await using DisposingFileSystem test = await GetNewFileSystem();
             DataLakeDirectoryClient directory = await test.FileSystem.CreateDirectoryAsync(GetNewDirectoryName());
@@ -3640,7 +3640,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task SetHttpHeadersAsync_Error()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
 
             await using DisposingFileSystem test = await GetNewFileSystem();
 
@@ -3664,7 +3664,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task SetHttpHeadersAsync_Conditions()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var garbageLeaseId = GetGarbageLeaseId();
             foreach (AccessConditionParameters parameters in Conditions_Data)
             {
@@ -3700,7 +3700,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task SetHttpHeadersAsync_ConditionsFail()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var garbageLeaseId = GetGarbageLeaseId();
             foreach (AccessConditionParameters parameters in GetConditionsFail_Data(garbageLeaseId))
             {
@@ -4998,7 +4998,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, fileClientOptions options = default)
@@ -5027,7 +5027,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void CanGenerateSas_GetFileClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, fileClientOptions options = default)
@@ -5059,7 +5059,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void CanGenerateSas_GetSubDirectoryClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, fileClientOptions options = default)
@@ -5108,7 +5108,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewDirectoryName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
@@ -5147,7 +5147,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_Builder()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewDirectoryName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
@@ -5192,7 +5192,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_BuilderNullFileSystemName()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewDirectoryName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
@@ -5238,7 +5238,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_BuilderWrongFileSystemName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string directoryName = GetNewDirectoryName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
@@ -5270,7 +5270,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_BuilderNullPath()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewDirectoryName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
@@ -5316,7 +5316,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_BuilderWrongDirectoryName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string directoryName = GetNewDirectoryName();
             string fileSystemName = GetNewFileSystemName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
@@ -5348,7 +5348,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_BuilderIsDirectoryNull()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewDirectoryName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
@@ -5393,7 +5393,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_BuilderIsDirectoryError()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string directoryName = GetNewDirectoryName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -1480,7 +1480,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task SetHttpHeadersAsync()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
 
             await using DisposingFileSystem test = await GetNewFileSystem();
             DataLakeFileClient file = await test.FileSystem.CreateFileAsync(GetNewFileName());
@@ -1509,7 +1509,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task SetHttpHeadersAsync_Error()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
 
             await using DisposingFileSystem test = await GetNewFileSystem();
 
@@ -1533,7 +1533,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task SetHttpHeadersAsync_Conditions()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var garbageLeaseId = GetGarbageLeaseId();
             foreach (AccessConditionParameters parameters in Conditions_Data)
             {
@@ -1569,7 +1569,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task SetHttpHeadersAsync_ConditionsFail()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var garbageLeaseId = GetGarbageLeaseId();
             foreach (AccessConditionParameters parameters in GetConditionsFail_Data(garbageLeaseId))
             {
@@ -4860,7 +4860,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Act - DataLakeFileClient(Uri blobContainerUri, fileClientOptions options = default)
@@ -4906,7 +4906,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewFileName();
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
@@ -4943,7 +4943,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_Builder()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewFileName();
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
@@ -4986,7 +4986,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_BuilderNullFileSystemName()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewFileName();
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
@@ -5030,7 +5030,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_BuilderWrongFileSystemName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewFileName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
@@ -5061,7 +5061,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_BuilderNullFileName()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewFileName();
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
@@ -5105,7 +5105,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_BuilderWrongFileName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewFileName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
@@ -5136,7 +5136,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_BuilderIsDirectoryError()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string fileName = GetNewFileName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
@@ -2343,7 +2343,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -2375,7 +2375,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void CanGenerateSas_GetFileClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -2410,7 +2410,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void CanGenerateSas_GetDirectoryClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -2462,7 +2462,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             DataLakeFileSystemSasPermissions permissions = DataLakeFileSystemSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
@@ -2497,7 +2497,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_Builder()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             DataLakeFileSystemSasPermissions permissions = DataLakeFileSystemSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
@@ -2538,7 +2538,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_BuilderNullName()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             DataLakeFileSystemSasPermissions permissions = DataLakeFileSystemSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
@@ -2580,7 +2580,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_BuilderWrongName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
 
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/PathClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/PathClientTests.cs
@@ -165,7 +165,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -214,7 +214,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewFileName();
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
@@ -244,7 +244,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_Builder()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             string fileSystemName = GetNewFileSystemName();
             string path = GetNewFileName();
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
@@ -282,7 +282,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_BuilderWrongFileSystemName()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("http://127.0.0.1/");
             UriBuilder blobUriBuilder = new UriBuilder(blobEndpoint);
             string path = GetNewFileName();
@@ -317,7 +317,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_BuilderWrongPath()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("http://127.0.0.1/");
             UriBuilder blobUriBuilder = new UriBuilder(blobEndpoint);
             string fileSystemName = GetNewFileSystemName();
@@ -351,7 +351,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateSas_BuilderIsDirectoryError()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("http://127.0.0.1/");
             UriBuilder blobUriBuilder = new UriBuilder(blobEndpoint);
             string fileSystemName = GetNewFileSystemName();

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
@@ -781,7 +781,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var uriEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (uriEndpoint, blobSecondaryEndpoint));
@@ -812,7 +812,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void CanGenerateSas_GetFileSystemClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var uriEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (uriEndpoint, blobSecondaryEndpoint));
@@ -863,7 +863,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("http://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("http://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -894,7 +894,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void GenerateAccountSas_Builder()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
@@ -927,7 +927,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public void GenerateAccountSas_WrongService_Service()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -1155,7 +1155,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -1194,7 +1194,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void CanGenerateSas_GetFileClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -1237,7 +1237,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void CanGenerateSas_GetSubdirectoryClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -1297,7 +1297,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             ShareFileSasPermissions permissions = ShareFileSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
 
@@ -1336,7 +1336,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateSas_Builder()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             ShareFileSasPermissions permissions = ShareFileSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
 
@@ -1382,7 +1382,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateSas_BuilderNullShareName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             ShareFileSasPermissions permissions = ShareFileSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
 
@@ -1428,7 +1428,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateSas_BuilderWrongShareName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string shareName = GetNewShareName();
             string directoryName = GetNewDirectoryName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.file.core.windows.net");
@@ -1458,7 +1458,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateSas_builderNullDirectoryName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             ShareFileSasPermissions permissions = ShareFileSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
 
@@ -1504,7 +1504,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateSas_BuilderWrongDirectoryName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string shareName = GetNewShareName();
             string directoryName = GetNewDirectoryName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.file.core.windows.net");

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -340,7 +340,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateAsync_Headers()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
 
             await using DisposingDirectory test = await GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
@@ -910,7 +910,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetHttpHeadersAsync()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
 
             await using DisposingFile test = await GetTestFileAsync();
             ShareFileClient file = test.File;
@@ -943,7 +943,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task SetHttpHeadersAsync_Lease()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
 
             await using DisposingFile test = await GetTestFileAsync();
             ShareFileClient file = test.File;
@@ -970,7 +970,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task SetHttpHeadersAsync_InvalidLease()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
 
             await using DisposingFile test = await GetTestFileAsync();
             ShareFileClient file = test.File;
@@ -1045,7 +1045,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetPropertiesAsync_FilePermissionTooLong()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
 
             await using DisposingDirectory test = await GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
@@ -1089,7 +1089,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetPropertiesAsync_Error()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             await using DisposingDirectory test = await GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
@@ -4015,7 +4015,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -4071,7 +4071,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             ShareFileSasPermissions permissions = ShareFileSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             string shareName = GetNewShareName();
@@ -4108,7 +4108,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public void GenerateSas_Builder()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             ShareFileSasPermissions permissions = ShareFileSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
 
@@ -4153,7 +4153,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public void GenerateSas_BuilderNullShareName()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             ShareFileSasPermissions permissions = ShareFileSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
 
@@ -4199,7 +4199,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateSas_BuilderWrongShareName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string shareName = GetNewShareName();
             string fileName = GetNewFileName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.file.core.windows.net");
@@ -4228,7 +4228,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public void GenerateSas_BuilderNullFileName()
         {
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             ShareFileSasPermissions permissions = ShareFileSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
 
@@ -4274,7 +4274,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateSas_BuilderWrongFileName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string shareName = GetNewShareName();
             string fileName = GetNewFileName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.file.core.windows.net");

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
@@ -24,7 +24,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void FileSasBuilder_ToSasQueryParameters_FilePathTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var shareName = GetNewShareName();
             var filePath = GetNewDirectoryName();
             ShareSasBuilder fileSasBuilder = BuildFileSasBuilder(includeVersion: true, includeFilePath: true, constants, shareName, filePath);
@@ -52,7 +52,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void FileSasBuilder_ToSasQueryParameters_NoVersionTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var shareName = GetNewShareName();
             var filePath = GetNewDirectoryName();
             ShareSasBuilder fileSasBuilder = BuildFileSasBuilder(includeVersion: false, includeFilePath: false, constants, shareName, filePath);
@@ -80,7 +80,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void FileSasBuilder_NullSharedKeyCredentialTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var shareName = GetNewShareName();
             var filePath = GetNewDirectoryName();
             ShareSasBuilder fileSasBuilder = BuildFileSasBuilder(includeVersion: true, includeFilePath: true, constants, shareName, filePath);
@@ -93,7 +93,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void FileSasBuilder_IdentifierTest()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string shareName = GetNewShareName();
             string resource = "s";
             ShareSasBuilder sasBuilder = new ShareSasBuilder

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -27,7 +27,7 @@ namespace Azure.Storage.Files.Shares.Tests
         StorageVersionExtensions.MaxVersion,
         RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
         LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
-    public class FileTestBase : StorageTestBase
+    public class FileTestBase : StorageTestBase<StorageTestEnvironment>
     {
         protected readonly ShareClientOptions.ServiceVersion _serviceVersion;
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -435,7 +435,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -470,7 +470,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void CanGenerateSas_GetShareClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -526,7 +526,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateAccountSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.file.core.windows.net");
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
@@ -555,7 +555,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public void GenerateAccountSas_Builder()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.file.core.windows.net");
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
@@ -584,7 +584,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public void GenerateAccountSas_WrongService_Service()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.file.core.windows.net");
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -2056,7 +2056,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -2093,7 +2093,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void CanGenerateSas_GetRootDirectoryClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -2134,7 +2134,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void CanGenerateSas_GetDirectoryClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -2175,7 +2175,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void CanGenerateSas_WithSnapshot_False()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var shareEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Create blob
@@ -2196,7 +2196,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void CanGenerateSas_WithSnapshot_True()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -2237,7 +2237,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string shareName = GetNewShareName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.file.core.windows.net");
             ShareUriBuilder shareUriBuilder = new ShareUriBuilder(serviceUri)
@@ -2271,7 +2271,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public void GenerateSas_Builder()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string shareName = GetNewShareName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.file.core.windows.net");
             ShareUriBuilder shareUriBuilder = new ShareUriBuilder(serviceUri)
@@ -2310,7 +2310,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public void GenerateSas_BuilderNullName()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string shareName = GetNewShareName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.file.core.windows.net");
             ShareUriBuilder shareUriBuilder = new ShareUriBuilder(serviceUri)
@@ -2350,7 +2350,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void GenerateSas_BuilderWrongName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             string shareName = GetNewShareName();
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.file.core.windows.net");
             ShareUriBuilder shareUriBuilder = new ShareUriBuilder(serviceUri)

--- a/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
@@ -738,7 +738,7 @@ namespace Azure.Storage.Queues.Test
         public void CanGenerateSas_WithClientSideEncryptionOptions_True()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -768,7 +768,7 @@ namespace Azure.Storage.Queues.Test
         public void CanGenerateSas_WithClientSideEncryptionOptions_False()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             var options = new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
@@ -1594,7 +1594,7 @@ namespace Azure.Storage.Queues.Test
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, queueStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -1648,7 +1648,7 @@ namespace Azure.Storage.Queues.Test
         public void GenerateSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.queue.core.windows.net");
             string queueName = GetNewQueueName();
             QueueUriBuilder queueUriBuilder = new QueueUriBuilder(serviceUri)
@@ -1684,7 +1684,7 @@ namespace Azure.Storage.Queues.Test
         public void GenerateSas_Builder()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.queue.core.windows.net");
             string queueName = GetNewQueueName();
             QueueUriBuilder queueUriBuilder = new QueueUriBuilder(serviceUri)
@@ -1724,7 +1724,7 @@ namespace Azure.Storage.Queues.Test
         public void GenerateSas_BuilderNullName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.queue.core.windows.net");
             string queueName = GetNewQueueName();
             QueueUriBuilder queueUriBuilder = new QueueUriBuilder(serviceUri)
@@ -1764,7 +1764,7 @@ namespace Azure.Storage.Queues.Test
         public void GenerateSas_BuilderWrongName()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.queue.core.windows.net");
             string queueName = GetNewQueueName();
             QueueUriBuilder queueUriBuilder = new QueueUriBuilder(serviceUri)

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Storage.Queues.Test
         public void QueueSasBuilder_ToSasQueryParameters_VersionTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var queueName = GetNewQueueName();
             QueueSasBuilder queueSasBuilder = BuildQueueSasBuilder(constants, queueName, includeVersion: true);
             var signature = BuildSignature(constants, queueName, includeVersion: true);
@@ -51,7 +51,7 @@ namespace Azure.Storage.Queues.Test
         public void QueueSasBuilder_ToSasQueryParameters_NoVersionTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var queueName = GetNewQueueName();
             QueueSasBuilder queueSasBuilder = BuildQueueSasBuilder(constants, queueName, includeVersion: false);
             var signature = BuildSignature(constants, queueName, includeVersion: false);
@@ -77,7 +77,7 @@ namespace Azure.Storage.Queues.Test
         public void QueueSasBuilder_NullSharedKeyCredentialTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var queueName = GetNewQueueName();
             QueueSasBuilder queueSasBuilder = BuildQueueSasBuilder(constants, queueName, includeVersion: true);
 
@@ -89,7 +89,7 @@ namespace Azure.Storage.Queues.Test
         public void ToSasQueryParameters_IdentifierTest()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var queueName = GetNewQueueName();
 
             QueueSasBuilder sasBuilder = new QueueSasBuilder

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
@@ -15,7 +15,7 @@ using Azure.Storage.Test.Shared;
 
 namespace Azure.Storage.Queues.Tests
 {
-    public class QueueTestBase : StorageTestBase
+    public class QueueTestBase : StorageTestBase<StorageTestEnvironment>
     {
         public string GetNewQueueName() => $"test-queue-{Recording.Random.NewGuid()}";
         public string GetNewMessageId() => $"test-message-{Recording.Random.NewGuid()}";

--- a/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
@@ -365,7 +365,7 @@ namespace Azure.Storage.Queues.Test
         public void CanGenerateSas_ClientConstructors()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, queueStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -400,7 +400,7 @@ namespace Azure.Storage.Queues.Test
         public void CanGenerateSas_GetQueueClient()
         {
             // Arrange
-            var constants = new TestConstants(this);
+            var constants = TestConstants.Create(this);
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
             var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, queueStorageUri: (blobEndpoint, blobSecondaryEndpoint));
@@ -456,7 +456,7 @@ namespace Azure.Storage.Queues.Test
         public void GenerateAccountSas_RequiredParameters()
         {
             // Arrange
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.queue.core.windows.net");
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
@@ -485,7 +485,7 @@ namespace Azure.Storage.Queues.Test
         [RecordedTest]
         public void GenerateAccountSas_Builder()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.queue.core.windows.net");
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
@@ -515,7 +515,7 @@ namespace Azure.Storage.Queues.Test
         [RecordedTest]
         public void GenerateAccountSas_WrongService_Service()
         {
-            TestConstants constants = new TestConstants(this);
+            TestConstants constants = TestConstants.Create(this);
             Uri serviceUri = new Uri($"https://{constants.Sas.Account}.queue.core.windows.net");
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);


### PR DESCRIPTION
This is another attempt to solve https://github.com/Azure/azure-sdk-for-net/issues/17384 and https://github.com/Azure/azure-sdk-tools/issues/1567 .

Based on discussion in https://github.com/Azure/azure-sdk-for-net/pull/20559 .

The idea is that:
- `TestEnvironment` exposes a overridable method that represents service provided sampling scenario
- `RecordedTestBase<TEnvironment>` shall keep executing the sampling scenario until it signals it's ready (or fail fast if the error is severe)
- Service will implement sampling scenario to call some API that fail if environment hasn't reach usable state

Out of scope:
- Moving configuration from `StorageTestBase` to `StorageTestEnvironment`. However some work towards it is accomplished here.
- The retry strategy and it's configuration in `RecordedTestBase<TEnvironment>` is simplified now. I think we should make it fancy when there's a need.
- I'll cover other storage services in separate PR. Here just blobs as PoC.