### PR TITLE
[System.Memory.Data] Add Empty to BinaryData

### DIFF
--- a/sdk/core/System.Memory.Data/CHANGELOG.md
+++ b/sdk/core/System.Memory.Data/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 1.1.0-beta.1 (Unreleased)
-
+- Add `BinaryData.Empty`
 
 ## 1.0.2 (2021-04-07)
 - Add System.Text.Encodings.Web dependency

--- a/sdk/core/System.Memory.Data/api/System.Memory.Data.net461.cs
+++ b/sdk/core/System.Memory.Data/api/System.Memory.Data.net461.cs
@@ -6,6 +6,7 @@ namespace System
         public BinaryData(object? jsonSerializable, System.Text.Json.JsonSerializerOptions? options = null, System.Type? type = null) { }
         public BinaryData(System.ReadOnlyMemory<byte> data) { }
         public BinaryData(string data) { }
+        public static System.BinaryData Empty { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         public static System.BinaryData FromBytes(byte[] data) { throw null; }

--- a/sdk/core/System.Memory.Data/api/System.Memory.Data.netstandard2.0.cs
+++ b/sdk/core/System.Memory.Data/api/System.Memory.Data.netstandard2.0.cs
@@ -6,6 +6,7 @@ namespace System
         public BinaryData(object? jsonSerializable, System.Text.Json.JsonSerializerOptions? options = null, System.Type? type = null) { }
         public BinaryData(System.ReadOnlyMemory<byte> data) { }
         public BinaryData(string data) { }
+        public static System.BinaryData Empty { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         public static System.BinaryData FromBytes(byte[] data) { throw null; }

--- a/sdk/core/System.Memory.Data/src/BinaryData.cs
+++ b/sdk/core/System.Memory.Data/src/BinaryData.cs
@@ -24,6 +24,11 @@ namespace System
         private readonly ReadOnlyMemory<byte> _bytes;
 
         /// <summary>
+        /// Returns an empty BinaryData.
+        /// </summary>
+        public static BinaryData Empty { get; } = new BinaryData(ReadOnlyMemory<byte>.Empty);
+
+        /// <summary>
         /// Creates a <see cref="BinaryData"/> instance by wrapping the
         /// provided byte array.
         /// </summary>

--- a/sdk/core/System.Memory.Data/tests/BinaryDataTests.cs
+++ b/sdk/core/System.Memory.Data/tests/BinaryDataTests.cs
@@ -565,6 +565,18 @@ namespace System.Tests
             Assert.False(stream.CanSeek);
         }
 
+        [Fact]
+        public void EmptyIsEmpty()
+        {
+            Assert.Equal(Array.Empty<byte>(), BinaryData.Empty.ToArray());
+        }
+
+        [Fact]
+        public void EmptyIsSingleton()
+        {
+            Assert.Same(BinaryData.Empty, BinaryData.Empty);
+        }
+
         private class DerivedModel : TestModel
         {
             public string E { get; set; }


### PR DESCRIPTION
Updating our copy based on the additions we did in the BCL Version
(see: https://github.com/dotnet/runtime/pull/49777).

This will allow us to take a dependency on this sooner than GA of .NET
6 if we would like to.