### PR TITLE
Enable xunit assembly parallelization

### DIFF
--- a/eng/xunit.runner.json
+++ b/eng/xunit.runner.json
@@ -1,3 +1,4 @@
 {
-  "shadowCopy": false
+  "shadowCopy": false,
+  "parallelizeAssembly": true
 }


### PR DESCRIPTION
Otherwise the entire testing gets blocked on waiting for xunit assemblies.