### PR TITLE
Test framework - run environment probe only in CI.

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -199,7 +199,7 @@ namespace Azure.Core.TestFramework
         /// <returns>A task.</returns>
         public async ValueTask WaitForEnvironmentAsync()
         {
-            if (Mode == RecordedTestMode.Live)
+            if (GlobalIsRunningInCI && Mode == RecordedTestMode.Live)
             {
                 await s_environmentStateCache.GetOrAdd(GetType(), t => WaitForEnvironmentInternalAsync());
             }

--- a/sdk/core/Azure.Core/tests/TestEnvironmentTests.cs
+++ b/sdk/core/Azure.Core/tests/TestEnvironmentTests.cs
@@ -174,29 +174,32 @@ namespace Azure.Core.Tests
         [Test]
         public async Task ShouldCacheExceptionIfWaitingForEnvironmentFailed()
         {
-            var env = new WaitForEnvironmentTestEnvironmentFailureMode();
+            if (TestEnvironment.GlobalIsRunningInCI)
+            {
+                var env = new WaitForEnvironmentTestEnvironmentFailureMode();
 
-            try
-            {
-                await env.WaitForEnvironmentAsync();
-                Assert.Fail();
-            }
-            catch (InvalidOperationException e)
-            {
-                StringAssert.Contains("kaboom", e.Message);
-            }
+                try
+                {
+                    await env.WaitForEnvironmentAsync();
+                    Assert.Fail();
+                }
+                catch (InvalidOperationException e)
+                {
+                    StringAssert.Contains("kaboom", e.Message);
+                }
 
-            try
-            {
-                await env.WaitForEnvironmentAsync();
-                Assert.Fail();
-            }
-            catch (InvalidOperationException e)
-            {
-                StringAssert.Contains("kaboom", e.Message);
-            }
+                try
+                {
+                    await env.WaitForEnvironmentAsync();
+                    Assert.Fail();
+                }
+                catch (InvalidOperationException e)
+                {
+                    StringAssert.Contains("kaboom", e.Message);
+                }
 
-            Assert.AreEqual(1, WaitForEnvironmentTestEnvironmentFailureMode.InvocationCount);
+                Assert.AreEqual(1, WaitForEnvironmentTestEnvironmentFailureMode.InvocationCount);
+            }
         }
 
         private class RecordedVariableMisuse : RecordedTestBase<MockTestEnvironment>
@@ -263,7 +266,10 @@ namespace Azure.Core.Tests
             [Test]
             public void ShouldCacheStateCorrectly()
             {
-                Assert.AreEqual(2, WaitForEnvironmentTestEnvironmentOne.InvocationCount);
+                if (Core.TestFramework.TestEnvironment.GlobalIsRunningInCI)
+                {
+                    Assert.AreEqual(2, WaitForEnvironmentTestEnvironmentOne.InvocationCount);
+                }
             }
         }
 
@@ -276,7 +282,10 @@ namespace Azure.Core.Tests
             [Test]
             public void ShouldCacheStateCorrectly()
             {
-                Assert.AreEqual(2, WaitForEnvironmentTestEnvironmentTwo.InvocationCount);
+                if (Core.TestFramework.TestEnvironment.GlobalIsRunningInCI)
+                {
+                    Assert.AreEqual(2, WaitForEnvironmentTestEnvironmentTwo.InvocationCount);
+                }
             }
         }
 
@@ -290,7 +299,10 @@ namespace Azure.Core.Tests
             [Test]
             public void ShouldCacheStateCorrectly()
             {
-                Assert.AreEqual(2, WaitForEnvironmentTestEnvironmentTwo.InvocationCount);
+                if (Core.TestFramework.TestEnvironment.GlobalIsRunningInCI)
+                {
+                    Assert.AreEqual(2, WaitForEnvironmentTestEnvironmentTwo.InvocationCount);
+                }
             }
         }
 


### PR DESCRIPTION
The probe doesn't matter much in local dev as there's plenty of time to reach stable state.
Also we don't want dev see extra requests in local env - these might be confusing if tools like fiddler are used.