### PR TITLE
Add matrix for storage to test all versions in weekly pipeline

### DIFF
--- a/sdk/storage/platform-matrix-all-versions.json
+++ b/sdk/storage/platform-matrix-all-versions.json
@@ -1,0 +1,27 @@
+{
+  "matrix": {
+    "Agent": {
+      "ubuntu-18.04": {
+          "OSVmImage": "MMSUbuntu18.04",
+          "Pool": "azsdk-pool-mms-ubuntu-1804-storage"
+      },
+      "windows-2019": {
+          "OSVmImage": "MMS2019",
+          "Pool": "azsdk-pool-mms-win-2019-storage"
+      }
+    },
+    "TestTargetFramework": [
+        "netcoreapp2.1",
+        "net5.0"
+    ],
+    "AZURE_LIVE_TEST_SERVICE_VERSIONS": [
+        "V2019_02_02",
+        "V2019_07_07",
+        "V2019_12_12",
+        "V2020_02_10",
+        "V2020_04_08",
+        "V2020_06_12",
+        "V2020_08_04"
+    ]
+  }
+}

--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -1,7 +1,7 @@
 trigger: none
 
 extends:
-  template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: storage
     BuildInParallel: true
@@ -11,7 +11,14 @@ extends:
     MatrixReplace:
       # Use dedicated storage pool in canadacentral with higher memory capacity
       - Pool=(.*)-general/$1-storage
+    ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
+      MatrixConfigs:
+        - Name: Storage_all_versions
+          Path: sdk/storage/platform-matrix-all-versions.json
+          Selection: sparse
+          GenerateVMJobs: true
+    ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
+      EnvVars:
+        AZURE_ONLY_TEST_LATEST_SERVICE_VERSION: true
     TestSetupSteps:
     - template: /sdk/storage/tests-install-azurite.yml
-    EnvVars:
-      AZURE_ONLY_TEST_LATEST_SERVICE_VERSION: true


### PR DESCRIPTION
This adds a separate test matrix for our weekly test build for the storage service, which includes coverage of all service versions. We exclude some cases like coverage, projectref, and net461 that are currently covered by the nightly builds, as the main intent of this weekly is to make sure service versions other than latest are tested.