### PR TITLE
Split nuget caches

### DIFF
--- a/eng/pipelines/templates/jobs/ci.mgmt.yml
+++ b/eng/pipelines/templates/jobs/ci.mgmt.yml
@@ -61,6 +61,8 @@ jobs:
           AgentImage: $(OSVmImage)
       - script: "echo $(system.pullrequest.pullrequestnumber), http://github.com/$(build.repository.id), http://github.com/$(build.repository.ID)"
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
+        parameters:
+          NuGetCacheKey: Test
       - script: "dotnet msbuild mgmt.proj /v:n /t:RunTests /p:Scope=${{parameters.Scope}} /p:ForPublishing=$(ShouldPublish) /clp:ShowtimeStamp $(RPScopeArgs)"
         displayName: "Build & Run Tests"
       - task: PublishTestResults@2

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -47,6 +47,8 @@ jobs:
         - ${{ each pair in step }}:
             ${{ pair.key }}: ${{ pair.value }}
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
+        parameters:
+          NuGetCacheKey: Test
       - script: >-
           dotnet test eng/service.proj --filter "(TestCategory!=Manually) & (TestCategory!=Live)" --framework $(TestTargetFramework)
           --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -1,6 +1,9 @@
 # All required SDKs/runtimes are available on DevOps agents
 #steps: []
 # Installation steps need to be uncommented when switching to a newer SDK that's not available on DevOps agents
+parameters:
+  NuGetCacheKey: 'Build' # ArtifactName (aka "packages")
+
 steps:
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK'
@@ -15,8 +18,9 @@ steps:
       version: "2.1.x"
   - task: Cache@2
     inputs:
-      key: 'nuget | "$(Agent.OS)" | $(Build.SourcesDirectory)/eng/Packages.Data.props'
+      key: 'nuget | "$(Agent.OS)" | $(Build.SourcesDirectory)/eng/Packages.Data.props | ${{parameters.NuGetCacheKey}}'
       restoreKeys: |
+        nuget | "$(Agent.OS)" | $(Build.SourcesDirectory)/eng/Packages.Data.props
         nuget | "$(Agent.OS)"
       path: $(NUGET_PACKAGES)
     displayName: Cache NuGet packages

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -2,7 +2,7 @@
 #steps: []
 # Installation steps need to be uncommented when switching to a newer SDK that's not available on DevOps agents
 parameters:
-  NuGetCacheKey: 'Build' # ArtifactName (aka "packages")
+  NuGetCacheKey: 'Build'
 
 steps:
   - task: UseDotNet@2


### PR DESCRIPTION
Build step finishes faster and has much smaller nuget restore folder so test runs get that cache instead of the full one they produce.