### PR TITLE
[Core.Experimental] Add `RequestOptions`

### DIFF
--- a/sdk/core/Azure.Core.Experimental/CHANGELOG.md
+++ b/sdk/core/Azure.Core.Experimental/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.1.0-preview.12 (Unreleased)
 
+### New Features
+- Added `RequestOptions`.
 
 ## 0.1.0-preview.11 (2021-03-22)
 

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -1,3 +1,21 @@
+namespace Azure
+{
+    public partial class RequestOptions
+    {
+        public RequestOptions() { }
+        public RequestOptions(Azure.ResponseStatusOption statusOption) { }
+        public RequestOptions(System.Action<Azure.Core.HttpMessage> perCall) { }
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } set { } }
+        public Azure.Core.Pipeline.HttpPipelinePolicy? PerCallPolicy { get { throw null; } set { } }
+        public Azure.ResponseStatusOption StatusOption { get { throw null; } set { } }
+        public static implicit operator Azure.RequestOptions (Azure.ResponseStatusOption option) { throw null; }
+    }
+    public enum ResponseStatusOption
+    {
+        Default = 0,
+        NoThrow = 1,
+    }
+}
 namespace Azure.Core
 {
     [System.Diagnostics.DebuggerDisplayAttribute("Content: {_body}")]

--- a/sdk/core/Azure.Core.Experimental/src/RequestOptions.cs
+++ b/sdk/core/Azure.Core.Experimental/src/RequestOptions.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure
+{
+    /// <summary>
+    /// Options which can be used to control the behavior of a request sent by a client.
+    /// </summary>
+    public class RequestOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestOptions"/> class.
+        /// </summary>
+        public RequestOptions() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestOptions"/> class using the given <see cref="RequestOptions"/>.
+        /// </summary>
+        /// <param name="statusOption"></param>
+        public RequestOptions(ResponseStatusOption statusOption) => StatusOption = statusOption;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestOptions"/> class.
+        /// </summary>
+        /// <param name="perCall"></param>
+        public RequestOptions(Action<HttpMessage> perCall) => PerCallPolicy = new ActionPolicy(perCall);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestOptions"/> class using the given <see cref="ResponseStatusOption"/>.
+        /// </summary>
+        /// <param name="option"></param>
+        public static implicit operator RequestOptions(ResponseStatusOption option) => new RequestOptions(option);
+
+        /// <summary>
+        /// The token to check for cancellation.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
+
+        /// <summary>
+        /// Controls under what conditions the operation raises an exception if the underlying response indicates a failure.
+        /// </summary>
+        public ResponseStatusOption StatusOption { get; set; } = ResponseStatusOption.Default;
+
+        /// <summary>
+        /// A <see cref="HttpPipelinePolicy"/> to use as part of this operation. This policy will be applied at the start
+        /// of the underlying <see cref="HttpPipeline"/>.
+        /// </summary>
+        public HttpPipelinePolicy? PerCallPolicy { get; set; }
+
+        /// <summary>
+        /// An <see cref="HttpPipelineSynchronousPolicy"/> which invokes an action when a request is being sent.
+        /// </summary>
+        internal class ActionPolicy : HttpPipelineSynchronousPolicy
+        {
+            private Action<HttpMessage> Action { get; }
+
+            public ActionPolicy(Action<HttpMessage> action) => Action = action;
+
+            public override void OnSendingRequest(HttpMessage message) => Action.Invoke(message);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/ResponseStatusOption.cs
+++ b/sdk/core/Azure.Core.Experimental/src/ResponseStatusOption.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure
+{
+    /// <summary>
+    /// ResponseStatusOption controls the behavior of an operation based on the status code of a response.
+    /// </summary>
+    public enum ResponseStatusOption
+    {
+        /// <summary>
+        /// Indicates that an operation should throw an exception when the response indicates a failure.
+        /// </summary>
+        Default = 0,
+        /// <summary>
+        /// Indicates that an operation should not throw an exception when the response indicates a failure.
+        /// </summary>
+        NoThrow = 1,
+    }
+}


### PR DESCRIPTION
For the low level client APIs, we want to have some knobs that help
you control the behavior of the requests. This class holds these
options.
