### PR TITLE
TestFramework, env proble, use double-check-lock instead of GetOrAdd which isn't atomic.

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -12,7 +12,6 @@ using Azure.Identity;
 using System.ComponentModel;
 using System.Linq;
 using NUnit.Framework;
-using System.Collections.Concurrent;
 
 namespace Azure.Core.TestFramework
 {
@@ -25,7 +24,7 @@ namespace Azure.Core.TestFramework
         [EditorBrowsableAttribute(EditorBrowsableState.Never)]
         public static string RepositoryRoot { get; }
 
-        private static readonly ConcurrentDictionary<Type, Task> s_environmentStateCache = new ConcurrentDictionary<Type, Task>();
+        private static readonly Dictionary<Type, Task> s_environmentStateCache = new Dictionary<Type, Task>();
 
         private readonly string _prefix;
 

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -199,16 +199,13 @@ namespace Azure.Core.TestFramework
         {
             if (GlobalIsRunningInCI && Mode == RecordedTestMode.Live)
             {
-                // GetOrAdd from ConcurrentDictionary isn't atomic, hence double-checked-lock.
-                if (!s_environmentStateCache.TryGetValue(GetType(), out Task task))
+                Task task;
+                lock (s_environmentStateCache)
                 {
-                    lock (s_environmentStateCache)
+                    if (!s_environmentStateCache.TryGetValue(GetType(), out task))
                     {
-                        if (!s_environmentStateCache.TryGetValue(GetType(), out task))
-                        {
-                            task = WaitForEnvironmentInternalAsync();
-                            s_environmentStateCache[GetType()] = task;
-                        }
+                        task = WaitForEnvironmentInternalAsync();
+                        s_environmentStateCache[GetType()] = task;
                     }
                 }
                 await task;


### PR DESCRIPTION
[GetOrAdd](https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd?view=net-5.0#System_Collections_Concurrent_ConcurrentDictionary_2_GetOrAdd__0_System_Func__0__1__) isn't atomic.
Use double check lock instead to prevent multiple probes.