### PR TITLE
[MetricsAdvisor] Randomly generating resource names in samples

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
@@ -201,7 +201,7 @@ string sqlServerQuery = "<query>";
 
 var dataFeed = new DataFeed();
 
-dataFeed.Name = "Sample data feed";
+dataFeed.Name = "<dataFeedName>";
 dataFeed.DataSource = new SqlServerDataFeedSource(sqlServerConnectionString, sqlServerQuery);
 dataFeed.Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
 
@@ -283,7 +283,7 @@ Create an [`AnomalyDetectionConfiguration`](#data-point-anomaly) to tell the ser
 
 ```C# Snippet:CreateDetectionConfigurationAsync
 string metricId = "<metricId>";
-string configurationName = "Sample anomaly detection configuration";
+string configurationName = "<configurationName>";
 
 var detectionConfiguration = new AnomalyDetectionConfiguration()
 {
@@ -317,7 +317,7 @@ Console.WriteLine($"Anomaly detection configuration ID: {createdDetectionConfigu
 Metrics Advisor supports the [`EmailNotificationHook`](#notification-hook) and the [`WebNotificationHook`](#notification-hook) classes as means of subscribing to [alerts](#anomaly-alert) notifications. In this example we'll illustrate how to create an `EmailNotificationHook`. Note that you need to pass the hook to an anomaly alert configuration to start getting notifications. See the sample [Create an anomaly alert configuration](#create-an-anomaly-alert-configuration) below for more information.
 
 ```C# Snippet:CreateHookAsync
-string hookName = "Sample hook";
+string hookName = "<hookName>";
 
 var emailHook = new EmailNotificationHook()
 {
@@ -341,8 +341,7 @@ Create an [`AnomalyAlertConfiguration`](#anomaly-alert) to tell the service whic
 ```C# Snippet:CreateAlertConfigurationAsync
 string hookId = "<hookId>";
 string anomalyDetectionConfigurationId = "<anomalyDetectionConfigurationId>";
-
-string configurationName = "Sample anomaly alert configuration";
+string configurationName = "<configurationName>";
 
 AnomalyAlertConfiguration alertConfiguration = new AnomalyAlertConfiguration()
 {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorTestEnvironment.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorTestEnvironment.cs
@@ -28,5 +28,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public string AlertId => Environment.GetEnvironmentVariable("METRICSADVISOR_ALERT_ID");
         public string IncidentId => Environment.GetEnvironmentVariable("METRICSADVISOR_INCIDENT_ID");
         public string FeedbackId => Environment.GetEnvironmentVariable("METRICSADVISOR_FEEDBACK_ID");
+
+        protected string GetUniqueName() => $"net-sample-{Guid.NewGuid().ToString("N")}";
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
@@ -35,7 +35,11 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             var dataFeed = new DataFeed();
 
-            dataFeed.Name = "Sample data feed";
+#if SNIPPET
+            dataFeed.Name = "<dataFeedName>";
+#else
+            dataFeed.Name = GetUniqueName();
+#endif
             dataFeed.DataSource = new SqlServerDataFeedSource(sqlServerConnectionString, sqlServerQuery);
             dataFeed.Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample03_DetectionConfigurationCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample03_DetectionConfigurationCrudOperations.cs
@@ -25,10 +25,11 @@ namespace Azure.AI.MetricsAdvisor.Samples
             #region Snippet:CreateDetectionConfigurationAsync
 #if SNIPPET
             string metricId = "<metricId>";
+            string configurationName = "<configurationName>";
 #else
             string metricId = MetricId;
+            string configurationName = GetUniqueName();
 #endif
-            string configurationName = "Sample anomaly detection configuration";
 
             var detectionConfiguration = new AnomalyDetectionConfiguration()
             {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample04_HookCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample04_HookCrudOperations.cs
@@ -24,7 +24,11 @@ namespace Azure.AI.MetricsAdvisor.Samples
             var adminClient = new MetricsAdvisorAdministrationClient(new Uri(endpoint), credential);
 
             #region Snippet:CreateHookAsync
-            string hookName = "Sample hook";
+#if SNIPPET
+            string hookName = "<hookName>";
+#else
+            string hookName = GetUniqueName();
+#endif
 
             var emailHook = new EmailNotificationHook()
             {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample05_AlertConfigurationCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample05_AlertConfigurationCrudOperations.cs
@@ -27,12 +27,12 @@ namespace Azure.AI.MetricsAdvisor.Samples
 #if SNIPPET
             string hookId = "<hookId>";
             string anomalyDetectionConfigurationId = "<anomalyDetectionConfigurationId>";
+            string configurationName = "<configurationName>";
 #else
             string hookId = HookId;
             string anomalyDetectionConfigurationId = DetectionConfigurationId;
+            string configurationName = GetUniqueName();
 #endif
-
-            string configurationName = "Sample anomaly alert configuration";
 
             AnomalyAlertConfiguration alertConfiguration = new AnomalyAlertConfiguration()
             {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/20659.

We were not generating names in our samples randomly, so we often got name conflicts because of tests running in parallel. Example in the issue linked above.