### PR TITLE
Don't hardcode runsettings if built from VS

### DIFF
--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -180,7 +180,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzSdkTestLibKey.snk</AssemblyOriginatorKeyFile>
     <!-- Disable doc comments for test projects -->
     <DocumentationFile></DocumentationFile>
-    <RunSettingsFilePath Condition="'$(BuildingInsideVisualStudio)' != 'true'">$(RepoEngPath)\nunit.runsettings</RunSettingsFilePath>
+    <RunSettingsFilePath Condition="'$(AZURE_SKIP_DEFAULT_RUN_SETTINGS)' != 'true'">$(RepoEngPath)\nunit.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsPerfProject)' == 'true' or '$(IsStressProject)' == 'true'">

--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -180,7 +180,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzSdkTestLibKey.snk</AssemblyOriginatorKeyFile>
     <!-- Disable doc comments for test projects -->
     <DocumentationFile></DocumentationFile>
-    <RunSettingsFilePath>$(RepoEngPath)\nunit.runsettings</RunSettingsFilePath>
+    <RunSettingsFilePath Condition="'$(BuildingInsideVisualStudio)' != 'true'">$(RepoEngPath)\nunit.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsPerfProject)' == 'true' or '$(IsStressProject)' == 'true'">

--- a/sdk/core/Azure.Core.TestFramework/README.md
+++ b/sdk/core/Azure.Core.TestFramework/README.md
@@ -156,7 +156,7 @@ Test settings can be configured via `.runsettings` files. See [nunit.runsettings
 There are two ways to work with `.runsettings`. Both are picked up by Visual Studio without restart.
 - You can edit [nunit.runsettings](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/nunit.runsettings) locally to achieve desired configuration.
 - You can prepare few copies of `.runsettings` by cloning [nunit.runsettings](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/nunit.runsettings).
-Load them in Visual Studio (`Test>Configure Run Settings` menu) and switch between them. This option requires setting an environment varialbe `AZURE_SKIP_DEFAULT_RUN_SETTINGS=true`.
+Load them in Visual Studio (`Test>Configure Run Settings` menu) and switch between them. This option requires setting an environment variable `AZURE_SKIP_DEFAULT_RUN_SETTINGS=true`.
 
 ## TokenCredential
 

--- a/sdk/core/Azure.Core.TestFramework/README.md
+++ b/sdk/core/Azure.Core.TestFramework/README.md
@@ -149,6 +149,15 @@ public class AppConfigurationTestEnvironment : TestEnvironment
 }
 ```
 
+## Test settings
+
+Test settings can be configured via `.runsettings` files. See [nunit.runsettings](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/nunit.runsettings) for available knobs.
+
+There are two ways to work with `.runsettings`. Both are picked up by Visual Studio without restart.
+- You can edit [nunit.runsettings](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/nunit.runsettings) locally to achieve desired configuration.
+- You can prepare few copies of `.runsettings` by cloning [nunit.runsettings](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/nunit.runsettings).
+Load them in Visual Studio (`Test>Configure Run Settings` menu) and switch between them. This option requires setting an environment varialbe `AZURE_SKIP_DEFAULT_RUN_SETTINGS=true`.
+
 ## TokenCredential
 
 If a test or sample uses `TokenCredential` to construct the client use `TestEnvironment.Credential` to retrieve it.


### PR DESCRIPTION
Attempt to fix https://github.com/Azure/azure-sdk-for-net/issues/20674 .

The `<RunSettingsFilePath Condition="'$(RunSettingsFilePath)' == ''">$(RepoEngPath)\nunit.runsettings</RunSettingsFilePath>` didn't work :-(

https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2015/msbuild/visual-studio-integration-msbuild?view=vs-2015&redirectedfrom=MSDN#building-solutions