### PR TITLE
Remove create from container base; remove ArmBuilder abstract class

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceContainerBase.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceContainerBase.cs
@@ -49,68 +49,6 @@ namespace Azure.ResourceManager.Core
         }
 
         /// <summary>
-        /// The operation to create or update a resource. Please note some properties can be set only during creation.
-        /// </summary>
-        /// <param name="name"> The name of the resource. </param>
-        /// <param name="resourceDetails"> The desired resource configuration. </param>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A response with the <see cref="ArmResponse{TOperations}"/> operation for this resource. </returns>
-        /// <exception cref="ArgumentException"> Name of the resource cannot be null or a whitespace. </exception>
-        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
-        public abstract ArmResponse<TOperations> CreateOrUpdate(
-            string name,
-            TResource resourceDetails,
-            CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// The operation to create or update a resource. Please note some properties can be set only during creation.
-        /// </summary>
-        /// <param name="name"> The name of the resource. </param>
-        /// <param name="resourceDetails"> The desired resource configuration. </param>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{TOperations}"/> operation for this resource. </returns>
-        /// <exception cref="ArgumentException"> Name of the resource cannot be null or a whitespace. </exception>
-        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
-        public abstract Task<ArmResponse<TOperations>> CreateOrUpdateAsync(
-            string name,
-            TResource resourceDetails,
-            CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// The operation to create or update a resource. Please note some properties can be set only during creation.
-        /// </summary>
-        /// <param name="name"> The name of the resource. </param>
-        /// <param name="resourceDetails"> The desired resource configuration. </param>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> An <see cref="ArmOperation{TOperations}"/> that allows polling for completion of the operation. </returns>
-        /// <remarks>
-        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
-        /// </remarks>
-        /// <exception cref="ArgumentException"> Name of the resource cannot be null or a whitespace. </exception>
-        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
-        public abstract ArmOperation<TOperations> StartCreateOrUpdate(
-            string name,
-            TResource resourceDetails,
-            CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// The operation to create or update a resource. Please note some properties can be set only during creation.
-        /// </summary>
-        /// <param name="name"> The name of the resource. </param>
-        /// <param name="resourceDetails"> The desired resource configuration. </param>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{TOperations}"/> that allows polling for completion of the operation. </returns>
-        /// <remarks>
-        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
-        /// </remarks>
-        /// <exception cref="ArgumentException"> Name of the resource cannot be null or a whitespace. </exception>
-        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
-        public abstract Task<ArmOperation<TOperations>> StartCreateOrUpdateAsync(
-            string name,
-            TResource resourceDetails,
-            CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Gets the location of the parent object.
         /// </summary>
         /// <typeparam name="TParent"> The type of the parents full resource object. </typeparam>

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceGroupContainer.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceGroupContainer.cs
@@ -111,7 +111,7 @@ namespace Azure.ResourceManager.Core
         /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{ResourceGroup}"/> operation for this resource group. </returns>
         /// <exception cref="ArgumentException"> Name of the resource group cannot be null or a whitespace. </exception>
         /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
-        public async Task<ArmResponse<ResourceGroup>> CreateOrUpdateAsync(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
+        public virtual async Task<ArmResponse<ResourceGroup>> CreateOrUpdateAsync(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("name cannot be null or a whitespace.", nameof(name));
@@ -182,7 +182,7 @@ namespace Azure.ResourceManager.Core
         /// </remarks>
         /// <exception cref="ArgumentException"> Name of the resource group cannot be null or a whitespace. </exception>
         /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
-        public async Task<ArmOperation<ResourceGroup>> StartCreateOrUpdateAsync(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
+        public virtual async Task<ArmOperation<ResourceGroup>> StartCreateOrUpdateAsync(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("name cannot be null or a whitespace.", nameof(name));

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceGroupContainer.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceGroupContainer.cs
@@ -57,7 +57,7 @@ namespace Azure.ResourceManager.Core
         /// <param name="managedBy"> Who the resource group is managed by. </param>
         /// <returns> A builder with <see cref="ResourceGroup"/> and <see cref="ResourceGroupData"/>. </returns>
         /// <exception cref="ArgumentNullException"> Location cannot be null. </exception>
-        public ArmBuilder<ResourceGroupResourceIdentifier, ResourceGroup, ResourceGroupData> Construct(LocationData location, IDictionary<string, string> tags = default, string managedBy = default)
+        public ResourceGroupBuilder Construct(LocationData location, IDictionary<string, string> tags = default, string managedBy = default)
         {
             if (location is null)
                 throw new ArgumentNullException(nameof(location));
@@ -66,11 +66,19 @@ namespace Azure.ResourceManager.Core
             if (!(tags is null))
                 model.Tags.ReplaceWith(tags);
             model.ManagedBy = managedBy;
-            return new ArmBuilder<ResourceGroupResourceIdentifier, ResourceGroup, ResourceGroupData>(this, new ResourceGroupData(model));
+            return new ResourceGroupBuilder(this, new ResourceGroupData(model));
         }
 
-        /// <inheritdoc/>
-        public override ArmResponse<ResourceGroup> CreateOrUpdate(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a resource group. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the resource group. </param>
+        /// <param name="resourceDetails"> The desired resource group configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A response with the <see cref="ArmResponse{ResourceGroup}"/> operation for this resource. </returns>
+        /// <exception cref="ArgumentException"> Name of the resource group cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmResponse<ResourceGroup> CreateOrUpdate(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("name cannot be null or a whitespace.", nameof(name));
@@ -94,8 +102,16 @@ namespace Azure.ResourceManager.Core
             }
         }
 
-        /// <inheritdoc/>
-        public override async Task<ArmResponse<ResourceGroup>> CreateOrUpdateAsync(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a resource group. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the resource group. </param>
+        /// <param name="resourceDetails"> The desired resource group configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{ResourceGroup}"/> operation for this resource group. </returns>
+        /// <exception cref="ArgumentException"> Name of the resource group cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmResponse<ResourceGroup>> CreateOrUpdateAsync(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("name cannot be null or a whitespace.", nameof(name));
@@ -119,8 +135,19 @@ namespace Azure.ResourceManager.Core
             }
         }
 
-        /// <inheritdoc/>
-        public override ArmOperation<ResourceGroup> StartCreateOrUpdate(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a resource group. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the resource group. </param>
+        /// <param name="resourceDetails"> The desired resource group configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> An <see cref="ArmOperation{ResourceGroup}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the resource group cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmOperation<ResourceGroup> StartCreateOrUpdate(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("name cannot be null or a whitespace.", nameof(name));
@@ -143,8 +170,19 @@ namespace Azure.ResourceManager.Core
             }
         }
 
-        /// <inheritdoc/>
-        public override async Task<ArmOperation<ResourceGroup>> StartCreateOrUpdateAsync(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a resource group. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the resource group. </param>
+        /// <param name="resourceDetails"> The desired resource group configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{ResourceGroup}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the resource group cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmOperation<ResourceGroup>> StartCreateOrUpdateAsync(string name, ResourceGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("name cannot be null or a whitespace.", nameof(name));

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceGroupOperations.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceGroupOperations.cs
@@ -19,6 +19,16 @@ namespace Azure.ResourceManager.Core
         ITaggableResource<ResourceGroupResourceIdentifier, ResourceGroup>, IDeletableResource
     {
         /// <summary>
+        /// Name of the CreateOrUpdate() method in [Resource]Container classes.
+        /// </summary>
+        private const string CreateOrUpdateMethodName = "CreateOrUpdate";
+
+        /// <summary>
+        /// Name of the CreateOrUpdateAsync() method in [Resource]Container classes.
+        /// </summary>
+        private const string CreateOrUpdateAsyncMethodName = "CreateOrUpdateAsync";
+
+        /// <summary>
         /// Gets the resource type definition for a ResourceType.
         /// </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Resources/subscriptions/resourceGroups";
@@ -334,8 +344,8 @@ namespace Azure.ResourceManager.Core
 
             var myResource = model as TrackedResource<TIdentifier>;
             TContainer container = Activator.CreateInstance(typeof(TContainer), ClientOptions, myResource) as TContainer;
-
-            return container.CreateOrUpdate(name, model);
+            var createOrUpdateMethod = typeof(TContainer).GetMethod(CreateOrUpdateMethodName);
+            return createOrUpdateMethod.Invoke(container, new object[] { name, model }) as ArmResponse<TOperations>;
         }
 
         /// <summary>
@@ -365,8 +375,8 @@ namespace Azure.ResourceManager.Core
             var myResource = model as TrackedResource<TIdentifier>;
 
             TContainer container = Activator.CreateInstance(typeof(TContainer), ClientOptions, myResource) as TContainer;
-
-            return container.CreateOrUpdateAsync(name, model, cancellationToken);
+            var createOrUpdateAsyncMethod = typeof(TContainer).GetMethod(CreateOrUpdateAsyncMethodName);
+            return createOrUpdateAsyncMethod.Invoke(container, new object[] { name, model, cancellationToken }) as Task<ArmResponse<TOperations>>;
         }
 
         /// <inheritdoc/>

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceGroupBuilder.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceGroupBuilder.cs
@@ -1,24 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.ResourceManager.Core;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Proto.Network
+namespace Azure.ResourceManager.Core
 {
     /// <summary>
     /// A class representing a builder object used to create Azure resources.
     /// </summary>
-    public class SubnetBuilder
+    public class ResourceGroupBuilder
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SubnetBuilder"/> class.
+        /// Initializes a new instance of the <see cref="ResourceGroupBuilder"/> class.
         /// </summary>
         /// <param name="container"> The container object to create the resource in. </param>
         /// <param name="resource"> The resource to create. </param>
-        public SubnetBuilder(SubnetContainer container, SubnetData resource)
+        public ResourceGroupBuilder(ResourceGroupContainer container, ResourceGroupData resource)
         {
             Resource = resource;
             UnTypedContainer = container;
@@ -27,7 +26,7 @@ namespace Proto.Network
         /// <summary>
         /// Gets the resource object to create.
         /// </summary>
-        protected SubnetData Resource { get; private set; }
+        protected ResourceGroupData Resource { get; private set; }
 
         /// <summary>
         /// Gets the resource name.
@@ -37,13 +36,13 @@ namespace Proto.Network
         /// <summary>
         /// Gets the container object to create the resource in.
         /// </summary>
-        protected SubnetContainer UnTypedContainer { get; private set; }
+        protected ResourceGroupContainer UnTypedContainer { get; private set; }
 
         /// <summary>
         /// Creates the resource object to send to the Azure API.
         /// </summary>
         /// <returns> The resource to create. </returns>
-        public SubnetData Build()
+        public ResourceGroupData Build()
         {
             ThrowIfNotValid();
             OnBeforeBuild();
@@ -58,9 +57,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A response with the <see cref="ArmResponse{ResourceGroup}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmResponse<Subnet> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmResponse<ResourceGroup> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -76,9 +75,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{ResourceGroup}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmResponse<Subnet>> CreateOrUpdateAsync(
+        public async Task<ArmResponse<ResourceGroup>> CreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -96,12 +95,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> An <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> An <see cref="ArmOperation{ResourceGroup}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmOperation<Subnet> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmOperation<ResourceGroup> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -117,12 +116,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{ResourceGroup}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmOperation<Subnet>> StartCreateOrUpdateAsync(
+        public async Task<ArmOperation<ResourceGroup>> StartCreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -159,7 +158,6 @@ namespace Proto.Network
         /// </summary>
         protected virtual void OnBeforeBuild()
         {
-            Resource.Model.Name = ResourceName;
         }
 
         private static void InternalBuild()

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceGroupBuilder.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceGroupBuilder.cs
@@ -20,7 +20,7 @@ namespace Azure.ResourceManager.Core
         public ResourceGroupBuilder(ResourceGroupContainer container, ResourceGroupData resource)
         {
             Resource = resource;
-            UnTypedContainer = container;
+            Container = container;
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Gets the container object to create the resource in.
         /// </summary>
-        protected ResourceGroupContainer UnTypedContainer { get; private set; }
+        protected ResourceGroupContainer Container { get; private set; }
 
         /// <summary>
         /// Creates the resource object to send to the Azure API.
@@ -67,7 +67,7 @@ namespace Azure.ResourceManager.Core
             ResourceName = name;
             Resource = Build();
 
-            return UnTypedContainer.CreateOrUpdate(name, Resource, cancellationToken);
+            return Container.CreateOrUpdate(name, Resource, cancellationToken);
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace Azure.ResourceManager.Core
             ResourceName = name;
             Resource = Build();
 
-            return await UnTypedContainer.CreateOrUpdateAsync(name, Resource, cancellationToken).ConfigureAwait(false);
+            return await Container.CreateOrUpdateAsync(name, Resource, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Azure.ResourceManager.Core
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
         /// <returns> An <see cref="ArmOperation{ResourceGroup}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
-        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// See <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning" /> for details on long running operation object.
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
         public ArmOperation<ResourceGroup> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
@@ -108,7 +108,7 @@ namespace Azure.ResourceManager.Core
             ResourceName = name;
             Resource = Build();
 
-            return UnTypedContainer.StartCreateOrUpdate(name, Resource, cancellationToken);
+            return Container.StartCreateOrUpdate(name, Resource, cancellationToken);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Azure.ResourceManager.Core
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
         /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{ResourceGroup}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
-        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// See <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning" /> for details on long running operation object.
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
         public async Task<ArmOperation<ResourceGroup>> StartCreateOrUpdateAsync(
@@ -131,7 +131,7 @@ namespace Azure.ResourceManager.Core
             ResourceName = name;
             Resource = Build();
 
-            return await UnTypedContainer.StartCreateOrUpdateAsync(name, Resource, cancellationToken).ConfigureAwait(false);
+            return await Container.StartCreateOrUpdateAsync(name, Resource, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -147,14 +147,14 @@ namespace Azure.ResourceManager.Core
         }
 
         /// <summary>
-        /// Perform any tasks necessary after the resource is built
+        /// Perform any tasks necessary after the resource is built.
         /// </summary>
         protected virtual void OnAfterBuild()
         {
         }
 
         /// <summary>
-        /// Perform any tasks necessary before the resource is built
+        /// Perform any tasks necessary before the resource is built.
         /// </summary>
         protected virtual void OnBeforeBuild()
         {

--- a/sdk/resourcemanager/Proto.Client/compute/AvailabilitySetBuilder.cs
+++ b/sdk/resourcemanager/Proto.Client/compute/AvailabilitySetBuilder.cs
@@ -6,19 +6,19 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Proto.Network
+namespace Proto.Compute
 {
     /// <summary>
-    /// A class representing a builder object used to create Azure resources.
+    /// A class representing a builder object used to create availability sets.
     /// </summary>
-    public class SubnetBuilder
+    public class AvailabilitySetBuilder
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SubnetBuilder"/> class.
+        /// Initializes a new instance of the <see cref="AvailabilitySetBuilder"/> class.
         /// </summary>
         /// <param name="container"> The container object to create the resource in. </param>
-        /// <param name="resource"> The resource to create. </param>
-        public SubnetBuilder(SubnetContainer container, SubnetData resource)
+        /// <param name="resource"> The data required to create the resource. </param>
+        public AvailabilitySetBuilder(AvailabilitySetContainer container, AvailabilitySetData resource)
         {
             Resource = resource;
             UnTypedContainer = container;
@@ -27,7 +27,7 @@ namespace Proto.Network
         /// <summary>
         /// Gets the resource object to create.
         /// </summary>
-        protected SubnetData Resource { get; private set; }
+        protected AvailabilitySetData Resource { get; private set; }
 
         /// <summary>
         /// Gets the resource name.
@@ -37,13 +37,13 @@ namespace Proto.Network
         /// <summary>
         /// Gets the container object to create the resource in.
         /// </summary>
-        protected SubnetContainer UnTypedContainer { get; private set; }
+        protected AvailabilitySetContainer UnTypedContainer { get; private set; }
 
         /// <summary>
         /// Creates the resource object to send to the Azure API.
         /// </summary>
         /// <returns> The resource to create. </returns>
-        public SubnetData Build()
+        public AvailabilitySetData Build()
         {
             ThrowIfNotValid();
             OnBeforeBuild();
@@ -58,9 +58,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A response with the <see cref="ArmResponse{AvailabilitySet}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmResponse<Subnet> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmResponse<AvailabilitySet> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -76,9 +76,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{AvailabilitySet}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmResponse<Subnet>> CreateOrUpdateAsync(
+        public async Task<ArmResponse<AvailabilitySet>> CreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -96,12 +96,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> An <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> An <see cref="ArmOperation{AvailabilitySet}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmOperation<Subnet> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmOperation<AvailabilitySet> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -117,12 +117,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{AvailabilitySet}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmOperation<Subnet>> StartCreateOrUpdateAsync(
+        public async Task<ArmOperation<AvailabilitySet>> StartCreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -159,7 +159,6 @@ namespace Proto.Network
         /// </summary>
         protected virtual void OnBeforeBuild()
         {
-            Resource.Model.Name = ResourceName;
         }
 
         private static void InternalBuild()

--- a/sdk/resourcemanager/Proto.Client/compute/AvailabilitySetContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/compute/AvailabilitySetContainer.cs
@@ -29,8 +29,16 @@ namespace Proto.Compute
         /// </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;
 
-        /// <inheritdoc/>
-        public override ArmResponse<AvailabilitySet> CreateOrUpdate(string name, AvailabilitySetData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update an availability set. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name">The name of the availability set.</param>
+        /// <param name="resourceDetails">The desired availability set configuration.</param>
+        /// <param name="cancellationToken">A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />.</param>
+        /// <returns>A response with the <see cref="ArmResponse{AvailabilitySet}"/> operation for this resource.</returns>
+        /// <exception cref="ArgumentException"> Name of the availability set cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmResponse<AvailabilitySet> CreateOrUpdate(string name, AvailabilitySetData resourceDetails, CancellationToken cancellationToken = default)
         {
             var response = Operations.CreateOrUpdate(Id.ResourceGroupName, name, resourceDetails.Model);
             return new PhArmResponse<AvailabilitySet, Azure.ResourceManager.Compute.Models.AvailabilitySet>(
@@ -38,8 +46,16 @@ namespace Proto.Compute
                 a => new AvailabilitySet(Parent, new AvailabilitySetData(a)));
         }
 
-        /// <inheritdoc/>
-        public async override Task<ArmResponse<AvailabilitySet>> CreateOrUpdateAsync(string name, AvailabilitySetData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update an availability set. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the availability set. </param>
+        /// <param name="resourceDetails"> The desired availability set configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{AvailabilitySet}"/> operation for this resource group. </returns>
+        /// <exception cref="ArgumentException"> Name of the availability set cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmResponse<AvailabilitySet>> CreateOrUpdateAsync(string name, AvailabilitySetData resourceDetails, CancellationToken cancellationToken = default)
         {
             var containerId = Id as ResourceGroupResourceIdentifier;
             var response = await Operations.CreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken).ConfigureAwait(false);
@@ -48,16 +64,38 @@ namespace Proto.Compute
                 a => new AvailabilitySet(Parent, new AvailabilitySetData(a)));
         }
 
-        /// <inheritdoc/>
-        public override ArmOperation<AvailabilitySet> StartCreateOrUpdate(string name, AvailabilitySetData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update an availability set. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the availability set. </param>
+        /// <param name="resourceDetails"> The desired availability set configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> An <see cref="ArmOperation{AvailabilitySet}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the availability set cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmOperation<AvailabilitySet> StartCreateOrUpdate(string name, AvailabilitySetData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<AvailabilitySet, Azure.ResourceManager.Compute.Models.AvailabilitySet>(
                 Operations.CreateOrUpdate(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken),
                 a => new AvailabilitySet(Parent, new AvailabilitySetData(a)));
         }
 
-        /// <inheritdoc/>
-        public async override Task<ArmOperation<AvailabilitySet>> StartCreateOrUpdateAsync(string name, AvailabilitySetData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update an availability set. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the availability set. </param>
+        /// <param name="resourceDetails"> The desired availability set configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{AvailabilitySet}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the availability set cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmOperation<AvailabilitySet>> StartCreateOrUpdateAsync(string name, AvailabilitySetData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<AvailabilitySet, Azure.ResourceManager.Compute.Models.AvailabilitySet>(
                 await Operations.CreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken).ConfigureAwait(false),
@@ -70,7 +108,7 @@ namespace Proto.Compute
         /// <param name="skuName"> The sku name of the resource. </param>
         /// <param name="location"> The location of the resource. </param>
         /// <returns> A builder with <see cref="AvailabilitySet"/> and <see cref="AvailabilitySetData"/>. </returns>
-        public ArmBuilder<ResourceGroupResourceIdentifier, AvailabilitySet, AvailabilitySetData> Construct(string skuName, LocationData location = null)
+        public AvailabilitySetBuilder Construct(string skuName, LocationData location = null)
         {
             var parent = GetParentResource<ResourceGroup, ResourceGroupResourceIdentifier, ResourceGroupOperations>();
             var availabilitySet = new Azure.ResourceManager.Compute.Models.AvailabilitySet(location ?? parent.Data.Location)
@@ -80,7 +118,7 @@ namespace Proto.Compute
                 Sku = new Azure.ResourceManager.Compute.Models.Sku() { Name = skuName }
             };
 
-            return new ArmBuilder<ResourceGroupResourceIdentifier, AvailabilitySet, AvailabilitySetData>(this, new AvailabilitySetData(availabilitySet));
+            return new AvailabilitySetBuilder(this, new AvailabilitySetData(availabilitySet));
         }
 
         /// <summary>

--- a/sdk/resourcemanager/Proto.Client/compute/Convenience/VirtualMachineModelBuilderBase.cs
+++ b/sdk/resourcemanager/Proto.Client/compute/Convenience/VirtualMachineModelBuilderBase.cs
@@ -5,7 +5,7 @@ namespace Proto.Compute.Convenience
     /// <summary>
     /// A class representing the base for a builder object to help create a virtual machine.
     /// </summary>
-    public abstract class VirtualMachineModelBuilderBase : ArmBuilder<ResourceGroupResourceIdentifier, VirtualMachine, VirtualMachineData>
+    public abstract class VirtualMachineModelBuilderBase : VirtualMachineBuilder
     {
         /// <summary>
         /// Initializes a new instance of <see cref="VirtualMachineModelBuilderBase"/>.

--- a/sdk/resourcemanager/Proto.Client/compute/VirtualMachineBuilder.cs
+++ b/sdk/resourcemanager/Proto.Client/compute/VirtualMachineBuilder.cs
@@ -1,29 +1,24 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.ResourceManager.Core;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Azure.ResourceManager.Core
+namespace Proto.Compute
 {
     /// <summary>
     /// A class representing a builder object used to create Azure resources.
     /// </summary>
-    /// <typeparam name="TIdentifier"> The type of the Identifier class for a specific resource. </typeparam>
-    /// <typeparam name="TOperations"> The type of the operations class for a specific resource. </typeparam>
-    /// <typeparam name="TResource"> The type of the class containing properties for the underlying resource. </typeparam>
-    public class ArmBuilder<TIdentifier, TOperations, TResource>
-        where TIdentifier: TenantResourceIdentifier
-        where TResource : Resource<TIdentifier>
-        where TOperations : ResourceOperationsBase<TIdentifier, TOperations>
+    public class VirtualMachineBuilder
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ArmBuilder{TIdentifier, TOperations, TResource}"/> class.
+        /// Initializes a new instance of the <see cref="VirtualMachineBuilder"/> class.
         /// </summary>
         /// <param name="container"> The container object to create the resource in. </param>
         /// <param name="resource"> The resource to create. </param>
-        public ArmBuilder(ResourceContainerBase<TIdentifier, TOperations, TResource> container, TResource resource)
+        public VirtualMachineBuilder(VirtualMachineContainer container, VirtualMachineData resource)
         {
             Resource = resource;
             UnTypedContainer = container;
@@ -32,7 +27,7 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Gets the resource object to create.
         /// </summary>
-        protected TResource Resource { get; private set; }
+        protected VirtualMachineData Resource { get; private set; }
 
         /// <summary>
         /// Gets the resource name.
@@ -42,13 +37,13 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Gets the container object to create the resource in.
         /// </summary>
-        protected ResourceContainerBase<TIdentifier, TOperations, TResource> UnTypedContainer { get; private set; }
+        protected VirtualMachineContainer UnTypedContainer { get; private set; }
 
         /// <summary>
         /// Creates the resource object to send to the Azure API.
         /// </summary>
         /// <returns> The resource to create. </returns>
-        public TResource Build()
+        public VirtualMachineData Build()
         {
             ThrowIfNotValid();
             OnBeforeBuild();
@@ -63,9 +58,9 @@ namespace Azure.ResourceManager.Core
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A response with the <see cref="ArmResponse{TOperations}"/> operation for this resource. </returns>
+        /// <returns> A response with the <see cref="ArmResponse{VirtualMachine}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmResponse<TOperations> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmResponse<VirtualMachine> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -81,9 +76,9 @@ namespace Azure.ResourceManager.Core
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{TOperations}"/> operation for this resource. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{VirtualMachine}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmResponse<TOperations>> CreateOrUpdateAsync(
+        public async Task<ArmResponse<VirtualMachine>> CreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -101,12 +96,12 @@ namespace Azure.ResourceManager.Core
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> An <see cref="ArmOperation{TOperations}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> An <see cref="ArmOperation{VirtualMachine}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmOperation<TOperations> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmOperation<VirtualMachine> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -122,12 +117,12 @@ namespace Azure.ResourceManager.Core
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{TOperations}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{VirtualMachine}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmOperation<TOperations>> StartCreateOrUpdateAsync(
+        public async Task<ArmOperation<VirtualMachine>> StartCreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {

--- a/sdk/resourcemanager/Proto.Client/compute/VirtualMachineContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/compute/VirtualMachineContainer.cs
@@ -47,7 +47,7 @@ namespace Proto.Compute
         /// <param name="resourceDetails"> Parameters supplied to the Create Virtual Machine operation. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="P:System.Threading.CancellationToken.None" />. </param>
         /// <returns> A response with the <see cref="ArmResponse{VirtualMachine}"/> operation for this resource. </returns>
-        public override ArmResponse<VirtualMachine> CreateOrUpdate(string name, VirtualMachineData resourceDetails, CancellationToken cancellationToken = default)
+        public ArmResponse<VirtualMachine> CreateOrUpdate(string name, VirtualMachineData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = Operations.StartCreateOrUpdate(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken);
             return new PhArmResponse<VirtualMachine, Azure.ResourceManager.Compute.Models.VirtualMachine>(
@@ -62,7 +62,7 @@ namespace Proto.Compute
         /// <param name="resourceDetails"> Parameters supplied to the Create Virtual Machine operation. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="P:System.Threading.CancellationToken.None" />. </param>
         /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{VirtualMachine}"/> operation for this resource. </returns>
-        public async override Task<ArmResponse<VirtualMachine>> CreateOrUpdateAsync(string name, VirtualMachineData resourceDetails, CancellationToken cancellationToken = default)
+        public async Task<ArmResponse<VirtualMachine>> CreateOrUpdateAsync(string name, VirtualMachineData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken).ConfigureAwait(false);
             return new PhArmResponse<VirtualMachine, Azure.ResourceManager.Compute.Models.VirtualMachine>(
@@ -80,7 +80,7 @@ namespace Proto.Compute
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <returns> An <see cref="ArmOperation{VirtualMachine}"/> that allows polling for completion of the operation. </returns>
-        public override ArmOperation<VirtualMachine> StartCreateOrUpdate(string name, VirtualMachineData resourceDetails, CancellationToken cancellationToken = default)
+        public ArmOperation<VirtualMachine> StartCreateOrUpdate(string name, VirtualMachineData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<VirtualMachine, Azure.ResourceManager.Compute.Models.VirtualMachine>(
                 Operations.StartCreateOrUpdate(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken),
@@ -97,7 +97,7 @@ namespace Proto.Compute
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{VirtualMachine}"/> that allows polling for completion of the operation. </returns>
-        public async override Task<ArmOperation<VirtualMachine>> StartCreateOrUpdateAsync(string name, VirtualMachineData resourceDetails, CancellationToken cancellationToken = default)
+        public async Task<ArmOperation<VirtualMachine>> StartCreateOrUpdateAsync(string name, VirtualMachineData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<VirtualMachine, Azure.ResourceManager.Compute.Models.VirtualMachine>(
                 await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken).ConfigureAwait(false),

--- a/sdk/resourcemanager/Proto.Client/network/NetworkInterfaceBuilder.cs
+++ b/sdk/resourcemanager/Proto.Client/network/NetworkInterfaceBuilder.cs
@@ -11,14 +11,14 @@ namespace Proto.Network
     /// <summary>
     /// A class representing a builder object used to create Azure resources.
     /// </summary>
-    public class SubnetBuilder
+    public class NetworkInterfaceBuilder
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SubnetBuilder"/> class.
+        /// Initializes a new instance of the <see cref="NetworkInterfaceBuilder"/> class.
         /// </summary>
         /// <param name="container"> The container object to create the resource in. </param>
         /// <param name="resource"> The resource to create. </param>
-        public SubnetBuilder(SubnetContainer container, SubnetData resource)
+        public NetworkInterfaceBuilder(NetworkInterfaceContainer container, NetworkInterfaceData resource)
         {
             Resource = resource;
             UnTypedContainer = container;
@@ -27,7 +27,7 @@ namespace Proto.Network
         /// <summary>
         /// Gets the resource object to create.
         /// </summary>
-        protected SubnetData Resource { get; private set; }
+        protected NetworkInterfaceData Resource { get; private set; }
 
         /// <summary>
         /// Gets the resource name.
@@ -37,13 +37,13 @@ namespace Proto.Network
         /// <summary>
         /// Gets the container object to create the resource in.
         /// </summary>
-        protected SubnetContainer UnTypedContainer { get; private set; }
+        protected NetworkInterfaceContainer UnTypedContainer { get; private set; }
 
         /// <summary>
         /// Creates the resource object to send to the Azure API.
         /// </summary>
         /// <returns> The resource to create. </returns>
-        public SubnetData Build()
+        public NetworkInterfaceData Build()
         {
             ThrowIfNotValid();
             OnBeforeBuild();
@@ -58,9 +58,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A response with the <see cref="ArmResponse{NetworkInterface}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmResponse<Subnet> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmResponse<NetworkInterface> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -76,9 +76,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{NetworkInterface}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmResponse<Subnet>> CreateOrUpdateAsync(
+        public async Task<ArmResponse<NetworkInterface>> CreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -96,12 +96,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> An <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> An <see cref="ArmOperation{NetworkInterface}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmOperation<Subnet> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmOperation<NetworkInterface> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -117,12 +117,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{NetworkInterface}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmOperation<Subnet>> StartCreateOrUpdateAsync(
+        public async Task<ArmOperation<NetworkInterface>> StartCreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -159,7 +159,6 @@ namespace Proto.Network
         /// </summary>
         protected virtual void OnBeforeBuild()
         {
-            Resource.Model.Name = ResourceName;
         }
 
         private static void InternalBuild()

--- a/sdk/resourcemanager/Proto.Client/network/NetworkInterfaceContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/NetworkInterfaceContainer.cs
@@ -40,8 +40,16 @@ namespace Proto.Network
         /// </summary>
         protected override ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
 
-        /// <inheritdoc/>
-        public override ArmResponse<NetworkInterface> CreateOrUpdate(string name, NetworkInterfaceData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a network interface. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the network interface. </param>
+        /// <param name="resourceDetails"> The desired network interface configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A response with the <see cref="ArmResponse{NetworkInterface}"/> operation for this resource. </returns>
+        /// <exception cref="ArgumentException"> Name of the network interface cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmResponse<NetworkInterface> CreateOrUpdate(string name, NetworkInterfaceData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = Operations.StartCreateOrUpdate(Id.ResourceGroupName, name, resourceDetails, cancellationToken);
             return new PhArmResponse<NetworkInterface, Azure.ResourceManager.Network.Models.NetworkInterface>(
@@ -49,8 +57,16 @@ namespace Proto.Network
                 n => new NetworkInterface(Parent, new NetworkInterfaceData(n)));
         }
 
-        /// <inheritdoc/>
-        public async override Task<ArmResponse<NetworkInterface>> CreateOrUpdateAsync(string name, NetworkInterfaceData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a network interface. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the network interface. </param>
+        /// <param name="resourceDetails"> The desired network interface configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{NetworkInterface}"/> operation for this network interface. </returns>
+        /// <exception cref="ArgumentException"> Name of the network interface cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmResponse<NetworkInterface>> CreateOrUpdateAsync(string name, NetworkInterfaceData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails, cancellationToken).ConfigureAwait(false);
             return new PhArmResponse<NetworkInterface, Azure.ResourceManager.Network.Models.NetworkInterface>(
@@ -58,16 +74,38 @@ namespace Proto.Network
                 n => new NetworkInterface(Parent, new NetworkInterfaceData(n)));
         }
 
-        /// <inheritdoc/>
-        public override ArmOperation<NetworkInterface> StartCreateOrUpdate(string name, NetworkInterfaceData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a network interface. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the network interface. </param>
+        /// <param name="resourceDetails"> The desired network interface configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> An <see cref="ArmOperation{NetworkInterface}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the network interface cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmOperation<NetworkInterface> StartCreateOrUpdate(string name, NetworkInterfaceData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<NetworkInterface, Azure.ResourceManager.Network.Models.NetworkInterface>(
                 Operations.StartCreateOrUpdate(Id.ResourceGroupName, name, resourceDetails, cancellationToken),
                 n => new NetworkInterface(Parent, new NetworkInterfaceData(n)));
         }
 
-        /// <inheritdoc/>
-        public async override Task<ArmOperation<NetworkInterface>> StartCreateOrUpdateAsync(string name, NetworkInterfaceData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a network interface. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the network interface. </param>
+        /// <param name="resourceDetails"> The desired network interface configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{NetworkInterface}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the network interface cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmOperation<NetworkInterface>> StartCreateOrUpdateAsync(string name, NetworkInterfaceData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<NetworkInterface, Azure.ResourceManager.Network.Models.NetworkInterface>(
                 await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails, cancellationToken).ConfigureAwait(false),
@@ -81,7 +119,7 @@ namespace Proto.Network
         /// <param name="subnetId"> The resource identifier of the subnet attached to this <see cref="NetworkInterface"/>. </param>
         /// <param name="location"> The <see cref="LocationData"/> that will contain the <see cref="NetworkInterface"/>. </param>
         /// <returns>An object used to create a <see cref="NetworkInterface"/>. </returns>
-        public ArmBuilder<ResourceGroupResourceIdentifier, NetworkInterface, NetworkInterfaceData> Construct(string subnetId, PublicIPAddressData ip = default, LocationData location = null)
+        public NetworkInterfaceBuilder Construct(string subnetId, PublicIPAddressData ip = default, LocationData location = null)
         {
             var parent = GetParentResource<ResourceGroup, ResourceGroupResourceIdentifier, ResourceGroupOperations>();
             var nic = new Azure.ResourceManager.Network.Models.NetworkInterface()
@@ -100,13 +138,13 @@ namespace Proto.Network
             if (ip != null)
                 nic.IpConfigurations[0].PublicIPAddress = new PublicIPAddress() { Id = ip.Id };
 
-            return new ArmBuilder<ResourceGroupResourceIdentifier, NetworkInterface, NetworkInterfaceData>(this, new NetworkInterfaceData(nic));
+            return new NetworkInterfaceBuilder(this, new NetworkInterfaceData(nic));
         }
 
         /// <summary>
         /// Lists the <see cref="NetworkInterface"/> for this <see cref="ResourceGroup"/>.
         /// </summary>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. 
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service.
         /// The default value is <see cref="System.Threading.CancellationToken.None"/>. </param>
         /// <returns> A collection of <see cref="NetworkInterface"/> that may take multiple service requests to iterate over. </returns>
         public Pageable<NetworkInterfaceOperations> List(CancellationToken cancellationToken = default)
@@ -119,7 +157,7 @@ namespace Proto.Network
         /// <summary>
         /// Lists the <see cref="NetworkInterface"/> for this <see cref="ResourceGroup"/>.
         /// </summary>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. 
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service.
         /// The default value is <see cref="System.Threading.CancellationToken.None" />. </param>
         /// <returns> An async collection of <see cref="NetworkInterface"/> that may take multiple service requests to iterate over. </returns>
         public AsyncPageable<NetworkInterfaceOperations> ListAsync(CancellationToken cancellationToken = default)
@@ -135,7 +173,7 @@ namespace Proto.Network
         /// </summary>
         /// <param name="nameFilter"> A string to filter the <see cref="NetworkInterface"/> resources by name. </param>
         /// <param name="top"> The number of results to return per page of data. </param>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. 
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service.
         /// The default value is <see cref="System.Threading.CancellationToken.None" />. </param>
         /// <returns> A collection of resource operations that may take multiple service requests to iterate over. </returns>
         public Pageable<GenericResource> ListAsGenericResource(string nameFilter, int? top = null, CancellationToken cancellationToken = default)
@@ -150,7 +188,7 @@ namespace Proto.Network
         /// </summary>
         /// <param name="nameFilter"> A string to filter the <see cref="NetworkInterface"/> resources by name. </param>
         /// <param name="top"> The number of results to return per page of data. </param>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. 
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service.
         /// The default value is <see cref="System.Threading.CancellationToken.None" />. </param>
         /// <returns> An async collection of resource operations that may take multiple service requests to iterate over. </returns>
         public AsyncPageable<GenericResource> ListAsGenericResourceAsync(string nameFilter, int? top = null, CancellationToken cancellationToken = default)
@@ -161,12 +199,12 @@ namespace Proto.Network
         }
 
         /// <summary>
-        /// Filters the list of <see cref="NetworkInterface"/> resources for this <see cref="ResourceGroup"/>. 
+        /// Filters the list of <see cref="NetworkInterface"/> resources for this <see cref="ResourceGroup"/>.
         /// Makes an additional network call to retrieve the full data model for each <see cref="NetworkInterface"/>.
         /// </summary>
         /// <param name="nameFilter"> A string to filter the <see cref="NetworkInterface"/> resources by name. </param>
         /// <param name="top"> The number of results to return per page of data. </param>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. 
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service.
         /// The default value is <see cref="System.Threading.CancellationToken.None" />. </param>
         /// <returns> A collection of resource operations that may take multiple service requests to iterate over. </returns>
         public Pageable<NetworkInterface> List(string nameFilter, int? top = null, CancellationToken cancellationToken = default)
@@ -176,12 +214,12 @@ namespace Proto.Network
         }
 
         /// <summary>
-        /// Filters the list of <see cref="NetworkInterface"/> resources for this <see cref="ResourceGroup"/>. 
+        /// Filters the list of <see cref="NetworkInterface"/> resources for this <see cref="ResourceGroup"/>.
         /// Makes an additional network call to retrieve the full data model for each <see cref="NetworkInterface"/>.
         /// </summary>
         /// <param name="nameFilter"> A string to filter the <see cref="NetworkInterface"/> resources by name. </param>
         /// <param name="top"> The number of results to return per page of data. </param>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. 
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service.
         /// The default value is <see cref="System.Threading.CancellationToken.None" />. </param>
         /// <returns> An async collection of resource operations that may take multiple service requests to iterate over. </returns>
         public AsyncPageable<NetworkInterface> ListAsync(string nameFilter, int? top = null, CancellationToken cancellationToken = default)

--- a/sdk/resourcemanager/Proto.Client/network/NetworkSecurityGroupBuilder.cs
+++ b/sdk/resourcemanager/Proto.Client/network/NetworkSecurityGroupBuilder.cs
@@ -11,14 +11,14 @@ namespace Proto.Network
     /// <summary>
     /// A class representing a builder object used to create Azure resources.
     /// </summary>
-    public class SubnetBuilder
+    public class NetworkSecurityGroupBuilder
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SubnetBuilder"/> class.
+        /// Initializes a new instance of the <see cref="NetworkSecurityGroupBuilder"/> class.
         /// </summary>
         /// <param name="container"> The container object to create the resource in. </param>
         /// <param name="resource"> The resource to create. </param>
-        public SubnetBuilder(SubnetContainer container, SubnetData resource)
+        public NetworkSecurityGroupBuilder(NetworkSecurityGroupContainer container, NetworkSecurityGroupData resource)
         {
             Resource = resource;
             UnTypedContainer = container;
@@ -27,7 +27,7 @@ namespace Proto.Network
         /// <summary>
         /// Gets the resource object to create.
         /// </summary>
-        protected SubnetData Resource { get; private set; }
+        protected NetworkSecurityGroupData Resource { get; private set; }
 
         /// <summary>
         /// Gets the resource name.
@@ -37,13 +37,13 @@ namespace Proto.Network
         /// <summary>
         /// Gets the container object to create the resource in.
         /// </summary>
-        protected SubnetContainer UnTypedContainer { get; private set; }
+        protected NetworkSecurityGroupContainer UnTypedContainer { get; private set; }
 
         /// <summary>
         /// Creates the resource object to send to the Azure API.
         /// </summary>
         /// <returns> The resource to create. </returns>
-        public SubnetData Build()
+        public NetworkSecurityGroupData Build()
         {
             ThrowIfNotValid();
             OnBeforeBuild();
@@ -58,9 +58,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A response with the <see cref="ArmResponse{NetworkSecurityGroup}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmResponse<Subnet> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmResponse<NetworkSecurityGroup> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -76,9 +76,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{NetworkSecurityGroup}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmResponse<Subnet>> CreateOrUpdateAsync(
+        public async Task<ArmResponse<NetworkSecurityGroup>> CreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -96,12 +96,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> An <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> An <see cref="ArmOperation{NetworkSecurityGroup}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmOperation<Subnet> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmOperation<NetworkSecurityGroup> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -117,12 +117,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{NetworkSecurityGroup}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmOperation<Subnet>> StartCreateOrUpdateAsync(
+        public async Task<ArmOperation<NetworkSecurityGroup>> StartCreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -159,7 +159,6 @@ namespace Proto.Network
         /// </summary>
         protected virtual void OnBeforeBuild()
         {
-            Resource.Model.Name = ResourceName;
         }
 
         private static void InternalBuild()

--- a/sdk/resourcemanager/Proto.Client/network/NetworkSecurityGroupContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/NetworkSecurityGroupContainer.cs
@@ -54,8 +54,16 @@ namespace Proto.Network
             Credential,
             ClientOptions.Convert<NetworkManagementClientOptions>()).NetworkSecurityGroups;
 
-        /// <inheritdoc />
-        public override ArmResponse<NetworkSecurityGroup> CreateOrUpdate(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a network security group. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the network security group. </param>
+        /// <param name="resourceDetails"> The desired network security group configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A response with the <see cref="ArmResponse{NetworkSecurityGroup}"/> operation for this resource. </returns>
+        /// <exception cref="ArgumentException"> Name of the network security group cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmResponse<NetworkSecurityGroup> CreateOrUpdate(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = Operations.StartCreateOrUpdate(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken);
             return new PhArmResponse<NetworkSecurityGroup, Azure.ResourceManager.Network.Models.NetworkSecurityGroup>(
@@ -63,8 +71,16 @@ namespace Proto.Network
                 n => new NetworkSecurityGroup(Parent, new NetworkSecurityGroupData(n)));
         }
 
-        /// <inheritdoc />
-        public override async Task<ArmResponse<NetworkSecurityGroup>> CreateOrUpdateAsync(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a network security group. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the network security group. </param>
+        /// <param name="resourceDetails"> The desired network security group configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{NetworkSecurityGroup}"/> operation for this network security group. </returns>
+        /// <exception cref="ArgumentException"> Name of the network security group cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmResponse<NetworkSecurityGroup>> CreateOrUpdateAsync(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken).ConfigureAwait(false);
             return new PhArmResponse<NetworkSecurityGroup, Azure.ResourceManager.Network.Models.NetworkSecurityGroup>(
@@ -72,16 +88,38 @@ namespace Proto.Network
                 n => new NetworkSecurityGroup(Parent, new NetworkSecurityGroupData(n)));
         }
 
-        /// <inheritdoc />
-        public override ArmOperation<NetworkSecurityGroup> StartCreateOrUpdate(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a network security group. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the network security group. </param>
+        /// <param name="resourceDetails"> The desired network security group configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> An <see cref="ArmOperation{NetworkSecurityGroup}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the network security group cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmOperation<NetworkSecurityGroup> StartCreateOrUpdate(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<NetworkSecurityGroup, Azure.ResourceManager.Network.Models.NetworkSecurityGroup>(
                 Operations.StartCreateOrUpdate(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken),
                 n => new NetworkSecurityGroup(Parent, new NetworkSecurityGroupData(n)));
         }
 
-        /// <inheritdoc />
-        public override async Task<ArmOperation<NetworkSecurityGroup>> StartCreateOrUpdateAsync(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a network security group. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the network security group. </param>
+        /// <param name="resourceDetails"> The desired network security group configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{NetworkSecurityGroup}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the network security group cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmOperation<NetworkSecurityGroup>> StartCreateOrUpdateAsync(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<NetworkSecurityGroup, Azure.ResourceManager.Network.Models.NetworkSecurityGroup>(
                 await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken).ConfigureAwait(false),
@@ -94,7 +132,7 @@ namespace Proto.Network
         /// <param name="locationData"> The location to create the network security group. </param>
         /// <param name="openPorts"> The location to create the network security group. </param>
         /// <returns> Object used to create a <see cref="NetworkSecurityGroup"/>. </returns>
-        public ArmBuilder<ResourceGroupResourceIdentifier, NetworkSecurityGroup, NetworkSecurityGroupData> Construct(LocationData locationData = null, params int[] openPorts)
+        public NetworkSecurityGroupBuilder Construct(LocationData locationData = null, params int[] openPorts)
         {
             var parent = GetParentResource<ResourceGroup, ResourceGroupResourceIdentifier, ResourceGroupOperations>();
             var nsg = new Azure.ResourceManager.Network.Models.NetworkSecurityGroup
@@ -120,7 +158,7 @@ namespace Proto.Network
                 nsg.SecurityRules.Add(securityRule);
             }
 
-            return new ArmBuilder<ResourceGroupResourceIdentifier, NetworkSecurityGroup, NetworkSecurityGroupData>(this, new NetworkSecurityGroupData(nsg));
+            return new NetworkSecurityGroupBuilder(this, new NetworkSecurityGroupData(nsg));
         }
 
         /// <summary>
@@ -128,7 +166,7 @@ namespace Proto.Network
         /// </summary>
         /// <param name="openPorts"> The location to create the network security group. </param>
         /// <returns> Object used to create a <see cref="NetworkSecurityGroup"/>. </returns>
-        public ArmBuilder<ResourceGroupResourceIdentifier, NetworkSecurityGroup, NetworkSecurityGroupData> Construct(params int[] openPorts)
+        public NetworkSecurityGroupBuilder Construct(params int[] openPorts)
         {
             var parent = GetParentResource<ResourceGroup, ResourceGroupResourceIdentifier, ResourceGroupOperations>();
             var nsg = new Azure.ResourceManager.Network.Models.NetworkSecurityGroup
@@ -154,11 +192,11 @@ namespace Proto.Network
                 nsg.SecurityRules.Add(securityRule);
             }
 
-            return new ArmBuilder<ResourceGroupResourceIdentifier, NetworkSecurityGroup, NetworkSecurityGroupData>(this, new NetworkSecurityGroupData(nsg));
+            return new NetworkSecurityGroupBuilder(this, new NetworkSecurityGroupData(nsg));
         }
 
         /// <summary>
-        /// List the network security groups for this resource group.
+        /// List the network security groups for this network security group.
         /// </summary>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="P:System.Threading.CancellationToken.None" />. </param>
         /// <returns> A collection of <see cref="NetworkSecurityGroup"/> that may take multiple service requests to iterate over. </returns>
@@ -170,7 +208,7 @@ namespace Proto.Network
         }
 
         /// <summary>
-        /// List the network security groups for this resource group.
+        /// List the network security groups for this network security group.
         /// </summary>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="P:System.Threading.CancellationToken.None" />. </param>
         /// <returns> An async collection of <see cref="NetworkSecurityGroup"/> that may take multiple service requests to iterate over. </returns>
@@ -251,6 +289,6 @@ namespace Proto.Network
             return new PhArmResponse<NetworkSecurityGroup, Azure.ResourceManager.Network.Models.NetworkSecurityGroup>(
                 await Operations.GetAsync(Id.ResourceGroupName, networkSecurityGroup, null, cancellationToken),
                     g => new NetworkSecurityGroup(Parent, new NetworkSecurityGroupData(g)));
-        }     
+        }
     }
 }

--- a/sdk/resourcemanager/Proto.Client/network/NetworkSecurityGroupContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/NetworkSecurityGroupContainer.cs
@@ -61,8 +61,6 @@ namespace Proto.Network
         /// <param name="resourceDetails"> The desired network security group configuration. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
         /// <returns> A response with the <see cref="ArmResponse{NetworkSecurityGroup}"/> operation for this resource. </returns>
-        /// <exception cref="ArgumentException"> Name of the network security group cannot be null or a whitespace. </exception>
-        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
         public ArmResponse<NetworkSecurityGroup> CreateOrUpdate(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = Operations.StartCreateOrUpdate(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken);
@@ -78,8 +76,6 @@ namespace Proto.Network
         /// <param name="resourceDetails"> The desired network security group configuration. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
         /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{NetworkSecurityGroup}"/> operation for this network security group. </returns>
-        /// <exception cref="ArgumentException"> Name of the network security group cannot be null or a whitespace. </exception>
-        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
         public async Task<ArmResponse<NetworkSecurityGroup>> CreateOrUpdateAsync(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails.Model, cancellationToken).ConfigureAwait(false);
@@ -98,8 +94,6 @@ namespace Proto.Network
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
-        /// <exception cref="ArgumentException"> Name of the network security group cannot be null or a whitespace. </exception>
-        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
         public ArmOperation<NetworkSecurityGroup> StartCreateOrUpdate(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<NetworkSecurityGroup, Azure.ResourceManager.Network.Models.NetworkSecurityGroup>(
@@ -117,8 +111,6 @@ namespace Proto.Network
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
-        /// <exception cref="ArgumentException"> Name of the network security group cannot be null or a whitespace. </exception>
-        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
         public async Task<ArmOperation<NetworkSecurityGroup>> StartCreateOrUpdateAsync(string name, NetworkSecurityGroupData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<NetworkSecurityGroup, Azure.ResourceManager.Network.Models.NetworkSecurityGroup>(

--- a/sdk/resourcemanager/Proto.Client/network/PublicIpAddressBuilder.cs
+++ b/sdk/resourcemanager/Proto.Client/network/PublicIpAddressBuilder.cs
@@ -11,14 +11,14 @@ namespace Proto.Network
     /// <summary>
     /// A class representing a builder object used to create Azure resources.
     /// </summary>
-    public class SubnetBuilder
+    public class PublicIpAddressBuilder
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SubnetBuilder"/> class.
+        /// Initializes a new instance of the <see cref="PublicIpAddressBuilder"/> class.
         /// </summary>
         /// <param name="container"> The container object to create the resource in. </param>
         /// <param name="resource"> The resource to create. </param>
-        public SubnetBuilder(SubnetContainer container, SubnetData resource)
+        public PublicIpAddressBuilder(PublicIpAddressContainer container, PublicIPAddressData resource)
         {
             Resource = resource;
             UnTypedContainer = container;
@@ -27,7 +27,7 @@ namespace Proto.Network
         /// <summary>
         /// Gets the resource object to create.
         /// </summary>
-        protected SubnetData Resource { get; private set; }
+        protected PublicIPAddressData Resource { get; private set; }
 
         /// <summary>
         /// Gets the resource name.
@@ -37,13 +37,13 @@ namespace Proto.Network
         /// <summary>
         /// Gets the container object to create the resource in.
         /// </summary>
-        protected SubnetContainer UnTypedContainer { get; private set; }
+        protected PublicIpAddressContainer UnTypedContainer { get; private set; }
 
         /// <summary>
         /// Creates the resource object to send to the Azure API.
         /// </summary>
         /// <returns> The resource to create. </returns>
-        public SubnetData Build()
+        public PublicIPAddressData Build()
         {
             ThrowIfNotValid();
             OnBeforeBuild();
@@ -58,9 +58,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A response with the <see cref="ArmResponse{PublicIpAddress}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmResponse<Subnet> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmResponse<PublicIpAddress> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -76,9 +76,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{PublicIpAddress}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmResponse<Subnet>> CreateOrUpdateAsync(
+        public async Task<ArmResponse<PublicIpAddress>> CreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -96,12 +96,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> An <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> An <see cref="ArmOperation{PublicIpAddress}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmOperation<Subnet> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmOperation<PublicIpAddress> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -117,12 +117,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{PublicIpAddress}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmOperation<Subnet>> StartCreateOrUpdateAsync(
+        public async Task<ArmOperation<PublicIpAddress>> StartCreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -159,7 +159,6 @@ namespace Proto.Network
         /// </summary>
         protected virtual void OnBeforeBuild()
         {
-            Resource.Model.Name = ResourceName;
         }
 
         private static void InternalBuild()

--- a/sdk/resourcemanager/Proto.Client/network/PublicIpAddressContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/PublicIpAddressContainer.cs
@@ -42,8 +42,16 @@ namespace Proto.Network
             Credential,
             ClientOptions.Convert<NetworkManagementClientOptions>()).PublicIPAddresses;
 
-        /// <inheritdoc />
-        public override ArmResponse<PublicIpAddress> CreateOrUpdate(string name, PublicIPAddressData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a public IP address. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the public IP address. </param>
+        /// <param name="resourceDetails"> The desired public IP address configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A response with the <see cref="ArmResponse{PublicIpAddress}"/> operation for this resource. </returns>
+        /// <exception cref="ArgumentException"> Name of the public IP address cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmResponse<PublicIpAddress> CreateOrUpdate(string name, PublicIPAddressData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = Operations.StartCreateOrUpdate(Id.ResourceGroupName, name, resourceDetails, cancellationToken);
             return new PhArmResponse<PublicIpAddress, PublicIPAddress>(
@@ -51,8 +59,16 @@ namespace Proto.Network
                 n => new PublicIpAddress(Parent, new PublicIPAddressData(n)));
         }
 
-        /// <inheritdoc />
-        public override async Task<ArmResponse<PublicIpAddress>> CreateOrUpdateAsync(string name, PublicIPAddressData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a public IP address. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the public IP address. </param>
+        /// <param name="resourceDetails"> The desired public IP address configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{PublicIpAddress}"/> operation for this public IP address. </returns>
+        /// <exception cref="ArgumentException"> Name of the public IP address cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmResponse<PublicIpAddress>> CreateOrUpdateAsync(string name, PublicIPAddressData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails, cancellationToken).ConfigureAwait(false);
             return new PhArmResponse<PublicIpAddress, PublicIPAddress>(
@@ -60,16 +76,38 @@ namespace Proto.Network
                 n => new PublicIpAddress(Parent, new PublicIPAddressData(n)));
         }
 
-        /// <inheritdoc />
-        public override ArmOperation<PublicIpAddress> StartCreateOrUpdate(string name, PublicIPAddressData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a public IP address. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the public IP address. </param>
+        /// <param name="resourceDetails"> The desired public IP address configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> An <see cref="ArmOperation{PublicIpAddress}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the public IP address cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmOperation<PublicIpAddress> StartCreateOrUpdate(string name, PublicIPAddressData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<PublicIpAddress, PublicIPAddress>(
                 Operations.StartCreateOrUpdate(Id.ResourceGroupName, name, resourceDetails, cancellationToken),
                 n => new PublicIpAddress(Parent, new PublicIPAddressData(n)));
         }
 
-        /// <inheritdoc />
-        public override async Task<ArmOperation<PublicIpAddress>> StartCreateOrUpdateAsync(string name, PublicIPAddressData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a public IP address. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the public IP address. </param>
+        /// <param name="resourceDetails"> The desired public IP address configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{PublicIpAddress}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the public IP address cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmOperation<PublicIpAddress>> StartCreateOrUpdateAsync(string name, PublicIPAddressData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<PublicIpAddress, PublicIPAddress>(
                 await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails, cancellationToken).ConfigureAwait(false),
@@ -81,7 +119,7 @@ namespace Proto.Network
         /// </summary>
         /// <param name="location"> The location to create the network security group. </param>
         /// <returns> Object used to create a <see cref="PublicIpAddress"/>. </returns>
-        public ArmBuilder<ResourceGroupResourceIdentifier, PublicIpAddress, PublicIPAddressData> Construct(LocationData location = null)
+        public PublicIpAddressBuilder Construct(LocationData location = null)
         {
             var parent = GetParentResource<ResourceGroup, ResourceGroupResourceIdentifier, ResourceGroupOperations>();
             var ipAddress = new PublicIPAddress()
@@ -91,7 +129,7 @@ namespace Proto.Network
                 Location = location ?? parent.Data.Location,
             };
 
-            return new ArmBuilder<ResourceGroupResourceIdentifier, PublicIpAddress, PublicIPAddressData>(this, new PublicIPAddressData(ipAddress));
+            return new PublicIpAddressBuilder(this, new PublicIPAddressData(ipAddress));
         }
 
         /// <summary>
@@ -188,6 +226,6 @@ namespace Proto.Network
         public override async Task<ArmResponse<PublicIpAddress>> GetAsync(string publicIpAddressesName, CancellationToken cancellationToken = default)
         {
             return new PhArmResponse<PublicIpAddress, PublicIPAddress>(await Operations.GetAsync(Id.ResourceGroupName, publicIpAddressesName, cancellationToken: cancellationToken), Convertor());
-        }     
+        }
     }
 }

--- a/sdk/resourcemanager/Proto.Client/network/SubnetContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/SubnetContainer.cs
@@ -35,8 +35,16 @@ namespace Proto.Network
             Credential,
             ClientOptions.Convert<NetworkManagementClientOptions>()).Subnets;
 
-        /// <inheritdoc/>
-        public override ArmResponse<Subnet> CreateOrUpdate(string name, SubnetData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a subnet. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the subnet. </param>
+        /// <param name="resourceDetails"> The desired subnet configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <exception cref="ArgumentException"> Name of the subnet cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmResponse<Subnet> CreateOrUpdate(string name, SubnetData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = Operations.StartCreateOrUpdate(Id.ResourceGroupName, Id.Name, name, resourceDetails.Model, cancellationToken);
             return new PhArmResponse<Subnet, Azure.ResourceManager.Network.Models.Subnet>(
@@ -44,8 +52,16 @@ namespace Proto.Network
                 s => new Subnet(Parent, new SubnetData(s)));
         }
 
-        /// <inheritdoc/>
-        public override async Task<ArmResponse<Subnet>> CreateOrUpdateAsync(string name, SubnetData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a subnet. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the subnet. </param>
+        /// <param name="resourceDetails"> The desired subnet configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{Subnet}"/> operation for this subnet. </returns>
+        /// <exception cref="ArgumentException"> Name of the subnet cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmResponse<Subnet>> CreateOrUpdateAsync(string name, SubnetData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, Id.Name, name, resourceDetails.Model, cancellationToken).ConfigureAwait(false);
             return new PhArmResponse<Subnet, Azure.ResourceManager.Network.Models.Subnet>(
@@ -53,16 +69,38 @@ namespace Proto.Network
                 s => new Subnet(Parent, new SubnetData(s)));
         }
 
-        /// <inheritdoc/>
-        public override ArmOperation<Subnet> StartCreateOrUpdate(string name, SubnetData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a subnet. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the subnet. </param>
+        /// <param name="resourceDetails"> The desired subnet configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> An <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the subnet cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmOperation<Subnet> StartCreateOrUpdate(string name, SubnetData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<Subnet, Azure.ResourceManager.Network.Models.Subnet>(
                 Operations.StartCreateOrUpdate(Id.ResourceGroupName, Id.Name, name, resourceDetails.Model, cancellationToken),
                 s => new Subnet(Parent, new SubnetData(s)));
         }
 
-        /// <inheritdoc/>
-        public async override Task<ArmOperation<Subnet>> StartCreateOrUpdateAsync(string name, SubnetData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a subnet. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the subnet. </param>
+        /// <param name="resourceDetails"> The desired subnet configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the subnet cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmOperation<Subnet>> StartCreateOrUpdateAsync(string name, SubnetData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<Subnet, Azure.ResourceManager.Network.Models.Subnet>(
                 await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, Id.Name, name, resourceDetails.Model, cancellationToken).ConfigureAwait(false),
@@ -89,7 +127,7 @@ namespace Proto.Network
 
             return new SubnetBuilder(this, new SubnetData(subnet));
         }
-        
+
         /// <summary>
         /// Lists the subnets for this virtual network.
         /// </summary>
@@ -125,7 +163,7 @@ namespace Proto.Network
             return new PhArmResponse<Subnet, Azure.ResourceManager.Network.Models.Subnet>(Operations.Get(Id.ResourceGroupName, Id.Name, subnetName, cancellationToken: cancellationToken),
                 n => new Subnet(Parent, new SubnetData(n)));
         }
-        
+
         /// <inheritdoc/>
         public override async Task<ArmResponse<Subnet>> GetAsync(string subnetName, CancellationToken cancellationToken = default)
         {

--- a/sdk/resourcemanager/Proto.Client/network/VirtualNetworkBuilder.cs
+++ b/sdk/resourcemanager/Proto.Client/network/VirtualNetworkBuilder.cs
@@ -11,14 +11,14 @@ namespace Proto.Network
     /// <summary>
     /// A class representing a builder object used to create Azure resources.
     /// </summary>
-    public class SubnetBuilder
+    public class VirtualNetworkBuilder
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SubnetBuilder"/> class.
+        /// Initializes a new instance of the <see cref="VirtualNetworkBuilder"/> class.
         /// </summary>
         /// <param name="container"> The container object to create the resource in. </param>
         /// <param name="resource"> The resource to create. </param>
-        public SubnetBuilder(SubnetContainer container, SubnetData resource)
+        public VirtualNetworkBuilder(VirtualNetworkContainer container, VirtualNetworkData resource)
         {
             Resource = resource;
             UnTypedContainer = container;
@@ -27,7 +27,7 @@ namespace Proto.Network
         /// <summary>
         /// Gets the resource object to create.
         /// </summary>
-        protected SubnetData Resource { get; private set; }
+        protected VirtualNetworkData Resource { get; private set; }
 
         /// <summary>
         /// Gets the resource name.
@@ -37,13 +37,13 @@ namespace Proto.Network
         /// <summary>
         /// Gets the container object to create the resource in.
         /// </summary>
-        protected SubnetContainer UnTypedContainer { get; private set; }
+        protected VirtualNetworkContainer UnTypedContainer { get; private set; }
 
         /// <summary>
         /// Creates the resource object to send to the Azure API.
         /// </summary>
         /// <returns> The resource to create. </returns>
-        public SubnetData Build()
+        public VirtualNetworkData Build()
         {
             ThrowIfNotValid();
             OnBeforeBuild();
@@ -58,9 +58,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A response with the <see cref="ArmResponse{VirtualNetwork}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmResponse<Subnet> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmResponse<VirtualNetwork> CreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -76,9 +76,9 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{Subnet}"/> operation for this resource. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{VirtualNetwork}"/> operation for this resource. </returns>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmResponse<Subnet>> CreateOrUpdateAsync(
+        public async Task<ArmResponse<VirtualNetwork>> CreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -96,12 +96,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> An <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> An <see cref="ArmOperation{VirtualNetwork}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public ArmOperation<Subnet> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
+        public ArmOperation<VirtualNetwork> StartCreateOrUpdate(string name, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
@@ -117,12 +117,12 @@ namespace Proto.Network
         /// </summary>
         /// <param name="name"> The name of the new resource to create. </param>
         /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{Subnet}"/> that allows polling for completion of the operation. </returns>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{VirtualNetwork}"/> that allows polling for completion of the operation. </returns>
         /// <remarks>
         /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
         /// </remarks>
         /// <exception cref="ArgumentException"> Name cannot be null or a whitespace. </exception>
-        public async Task<ArmOperation<Subnet>> StartCreateOrUpdateAsync(
+        public async Task<ArmOperation<VirtualNetwork>> StartCreateOrUpdateAsync(
             string name,
             CancellationToken cancellationToken = default)
         {
@@ -159,7 +159,6 @@ namespace Proto.Network
         /// </summary>
         protected virtual void OnBeforeBuild()
         {
-            Resource.Model.Name = ResourceName;
         }
 
         private static void InternalBuild()

--- a/sdk/resourcemanager/Proto.Client/network/VirtualNetworkContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/VirtualNetworkContainer.cs
@@ -41,8 +41,16 @@ namespace Proto.Network
             Credential,
             ClientOptions.Convert<NetworkManagementClientOptions>()).VirtualNetworks;
 
-        /// <inheritdoc/>
-        public override ArmResponse<VirtualNetwork> CreateOrUpdate(string name, VirtualNetworkData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a virtual network. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the virtual network. </param>
+        /// <param name="resourceDetails"> The desired virtual network configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A response with the <see cref="ArmResponse{VirtualNetwork}"/> operation for this resource. </returns>
+        /// <exception cref="ArgumentException"> Name of the virtual network cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmResponse<VirtualNetwork> CreateOrUpdate(string name, VirtualNetworkData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = Operations.StartCreateOrUpdate(Id.ResourceGroupName, name, resourceDetails, cancellationToken);
             return new PhArmResponse<VirtualNetwork, Azure.ResourceManager.Network.Models.VirtualNetwork>(
@@ -50,8 +58,16 @@ namespace Proto.Network
                 n => new VirtualNetwork(Parent, new VirtualNetworkData(n)));
         }
 
-        /// <inheritdoc/>
-        public async override Task<ArmResponse<VirtualNetwork>> CreateOrUpdateAsync(string name, VirtualNetworkData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a virtual network. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the virtual network. </param>
+        /// <param name="resourceDetails"> The desired virtual network configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="ArmResponse{VirtualNetwork}"/> operation for this virtual network. </returns>
+        /// <exception cref="ArgumentException"> Name of the virtual network cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmResponse<VirtualNetwork>> CreateOrUpdateAsync(string name, VirtualNetworkData resourceDetails, CancellationToken cancellationToken = default)
         {
             var operation = await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails, cancellationToken).ConfigureAwait(false);
             return new PhArmResponse<VirtualNetwork, Azure.ResourceManager.Network.Models.VirtualNetwork>(
@@ -59,16 +75,38 @@ namespace Proto.Network
                 n => new VirtualNetwork(Parent, new VirtualNetworkData(n)));
         }
 
-        /// <inheritdoc/>
-        public override ArmOperation<VirtualNetwork> StartCreateOrUpdate(string name, VirtualNetworkData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a virtual network. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the virtual network. </param>
+        /// <param name="resourceDetails"> The desired virtual network configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> An <see cref="ArmOperation{VirtualNetwork}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the virtual network cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public ArmOperation<VirtualNetwork> StartCreateOrUpdate(string name, VirtualNetworkData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<VirtualNetwork, Azure.ResourceManager.Network.Models.VirtualNetwork>(
                 Operations.StartCreateOrUpdate(Id.ResourceGroupName, name, resourceDetails, cancellationToken),
                 n => new VirtualNetwork(Parent, new VirtualNetworkData(n)));
         }
 
-        /// <inheritdoc/>
-        public async override Task<ArmOperation<VirtualNetwork>> StartCreateOrUpdateAsync(string name, VirtualNetworkData resourceDetails, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// The operation to create or update a virtual network. Please note some properties can be set only during creation.
+        /// </summary>
+        /// <param name="name"> The name of the virtual network. </param>
+        /// <param name="resourceDetails"> The desired virtual network configuration. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns an <see cref="ArmOperation{VirtualNetwork}"/> that allows polling for completion of the operation. </returns>
+        /// <remarks>
+        /// <see href="https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning">Details on long running operation object.</see>
+        /// </remarks>
+        /// <exception cref="ArgumentException"> Name of the virtual network cannot be null or a whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> resourceDetails cannot be null. </exception>
+        public async Task<ArmOperation<VirtualNetwork>> StartCreateOrUpdateAsync(string name, VirtualNetworkData resourceDetails, CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<VirtualNetwork, Azure.ResourceManager.Network.Models.VirtualNetwork>(
                 await Operations.StartCreateOrUpdateAsync(Id.ResourceGroupName, name, resourceDetails, cancellationToken).ConfigureAwait(false),
@@ -81,7 +119,7 @@ namespace Proto.Network
         /// <param name="vnetCidr"> The CIDR of the resource. </param>
         /// <param name="location"> The location of the resource. </param>
         /// <returns> A builder with <see cref="VirtualNetwork"/> and <see cref="VirtualNetworkData"/>. </returns>
-        public ArmBuilder<ResourceGroupResourceIdentifier, VirtualNetwork, VirtualNetworkData> Construct(string vnetCidr, LocationData location = null)
+        public VirtualNetworkBuilder Construct(string vnetCidr, LocationData location = null)
         {
             var parent = GetParentResource<ResourceGroup, ResourceGroupResourceIdentifier, ResourceGroupOperations>();
             var vnet = new Azure.ResourceManager.Network.Models.VirtualNetwork()
@@ -91,7 +129,7 @@ namespace Proto.Network
             };
             vnet.AddressSpace.AddressPrefixes.Add(vnetCidr);
 
-            return new ArmBuilder<ResourceGroupResourceIdentifier, VirtualNetwork, VirtualNetworkData>(this, new VirtualNetworkData(vnet));
+            return new VirtualNetworkBuilder(this, new VirtualNetworkData(vnet));
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

## Problem

This PR is in order to solve the problem that the createOrUpdate operation of some resource may have different schemas in request and response, while the current `ResourceContainerBase` class assumes they are the same.

Example: https://github.com/Azure/azure-rest-api-specs/blob/e606243e5297312781dd7dbfd7ab76d2329cc088/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/storage.json#L145-L160
In the request of `StorageAccounts_Create` operation there is `StorageAccountCreateParameters`; in the response, `StorageAccount`.

## Solution

The solution is to remove the createOrUpdate methods in `ResourceContainerBase`, and let the concrete classes to have their own implementations, for example, `StorageAccountContainer` can have a `CreateOrUpdate` method that accepts type `StorageAccountCreateParameters`.
Though we can no longer enforce the consistency of the createXXX APIs by base class, we can still make sure the generated container classes to have consistent (or similar) API design and user experience.

## Changes to be made in generator

- Generate a [Resource]Builder class for each resource
- And use it to replace the ArmBuilder<> in contaienr

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
