### PR TITLE
[Storage] Release blobs with latest commons.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 12.8.2 (2020-04-27)
+- This release contains bug fixes to improve quality.
+
 ## 12.8.1 (2021-03-29)
 - Fixed bug where ClientDiagnostics's DiagnosticListener was leaking resources.
 

--- a/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure.Storage.Blobs client library</AssemblyTitle>
-    <Version>12.8.1</Version>
+    <Version>12.8.2</Version>
     <ApiCompatVersion>12.7.0</ApiCompatVersion>
     <DefineConstants>BlobSDK;$(DefineConstants)</DefineConstants>
     <PackageTags>Microsoft Azure Storage Blobs;Microsoft;Azure;Blobs;Blob;Storage;StorageScalable;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
Releasing blobs with updated Commons. Note that Commons 12.7.2 has already shipped, so won't be released again but it has proper version in this branch (this branch has been created from Commons 12.7.2 tag).