### PR TITLE
Don't overbuild for Export-API

### DIFF
--- a/eng/ApiListing.targets
+++ b/eng/ApiListing.targets
@@ -1,25 +1,13 @@
 <Project>
 
   <PropertyGroup>
-    <_SupportsApiListing Condition="'$(IsShippingClientLibrary)' == 'true' AND '$(GenerateApiListingOnBuild)' == 'true'">true</_SupportsApiListing>
+    <_RefSourceOutputPath>$([System.IO.Directory]::GetParent('$(MSBuildProjectDirectory)'))/api/</_RefSourceOutputPath>
+    <GenAPIAdditionalParameters>--exclude-attributes-list "$(MSBuildThisFileDirectory)ApiListing.exclude-attributes.txt" $(GenAPIAdditionalParameters)</GenAPIAdditionalParameters>
+    <GenAPITargetPath>$(_RefSourceOutputPath)$(AssemblyName).$(TargetFramework).cs</GenAPITargetPath>
   </PropertyGroup>
 
-  <Target
-    Name="_GenerateApiListing"
-    Condition="'$(_SupportsApiListing)' == 'true' AND '$(GenerateAPIListing)' == 'true'"
-    AfterTargets="_GenerateApiListingAfterBuild"
-    DependsOnTargets="GenerateReferenceAssemblySource" />
+  <Target Name="RemoveExistingListings">
 
-  <Target 
-    Name="_GenerateApiListingAfterBuild"
-    AfterTargets="CoreBuild" 
-    Condition="'$(_SupportsApiListing)' == 'true'">
-    
-    <PropertyGroup>
-      <_RefSourceOutputPath>$([System.IO.Directory]::GetParent('$(MSBuildProjectDirectory)'))/api/</_RefSourceOutputPath>
-      <GenAPIAdditionalParameters>--exclude-attributes-list "$(MSBuildThisFileDirectory)ApiListing.exclude-attributes.txt" $(GenAPIAdditionalParameters)</GenAPIAdditionalParameters>
-      <GenAPITargetPath>$(_RefSourceOutputPath)$(AssemblyName).$(TargetFramework).cs</GenAPITargetPath>
-    </PropertyGroup>
     <ItemGroup>
       <!-- Remove all files that don't start with $(AssemblyName) and the current target -->
       <_ListingsToRemove Include="$(_RefSourceOutputPath)*" Exclude="$(_RefSourceOutputPath)$(AssemblyName).*.cs" />
@@ -29,6 +17,24 @@
     <Delete Files="@(_ListingsToRemove)" />
     <MakeDir Directories="$(_RefSourceOutputPath)"/>
   </Target>
+
+  <Target Name="_SetExportApiInnerTarget">
+    <PropertyGroup>
+      <InnerTargets>ExportApi</InnerTargets>
+    </PropertyGroup>
+  </Target>
+
+  <Target 
+    Name="ExportApiCrossTarget"
+    DependsOnTargets="_SetExportApiInnerTarget;DispatchToInnerBuilds"
+    Condition="'$(IsCrossTargetingBuild)' == 'true'" />
+
+  <Target 
+    Name="ExportApiInner"
+    DependsOnTargets="Build;RemoveExistingListings;GenerateReferenceAssemblySource"
+    Condition="'$(IsInnerBuild)' == 'true'" />
+
+  <Target Name="ExportApi" DependsOnTargets="ExportApiCrossTarget;ExportApiInner" Condition="'$(GenerateAPIListing)' == 'true'" />
 
   <Target Name="_CheckGenerateAPIListingValue" AfterTargets="Build">
     <Error

--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -66,6 +66,7 @@
     <PowerShellExe Condition="'$(PowerShellExe)' == ''">pwsh</PowerShellExe>
     <InheritDocEnabled Condition="'$(InheritDocEnabled)'=='' and '$(DesignTimeBuild)'!='true' and '$(BuildingForLiveUnitTesting)'!='true' and '$(IsShippingClientLibrary)' == true">true</InheritDocEnabled>
     <InheritDocTrimLevel>private</InheritDocTrimLevel>
+    <GenerateAPIListing Condition="'$(GenerateAPIListing)' == '' AND '$(IsShippingClientLibrary)' == 'true'">true</GenerateAPIListing>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsShippingClientLibrary)' == 'true' and '$(TF_BUILD)' == 'true'">

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -8,4 +8,4 @@ param (
 
 $servicesProj = Resolve-Path "$PSScriptRoot/../service.proj"
 
-dotnet build /p:GenerateApiListingOnBuild=true /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$ServiceDirectory" /p:SDKType=$SDKType /restore $servicesProj
+dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$ServiceDirectory" /p:SDKType=$SDKType /restore $servicesProj

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -50,6 +50,14 @@
              SkipNonexistentTargets="true" />
   </Target>
 
+  <Target Name="ExportApi">
+    <MSBuild Projects="@(ProjectReference)"
+             Targets="ExportApi"
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="false"
+             SkipNonexistentTargets="true" />
+  </Target>
+
   <Target Name="FinalBuildReferencesOutput" BeforeTargets="Build" Condition="'$(SDKType)' != 'all'">
     <Message Text="Final Build References:" Importance="high"/>
     <Message Text="  %(ProjectReference.Identity)" Importance="high"/>


### PR DESCRIPTION
Right now we build everything first and then look at whether to export API. Flip the logic so the projects that don't need the API listing are not getting built.