### PR TITLE
Pick-up propogated SetDevVersion variable.

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -41,6 +41,8 @@ stages:
       - stage: Release_${{artifact.safeName}}
         displayName: 'Release: ${{artifact.name}}'
         dependsOn: Signing
+        variables: 
+          SetDevVersion: $[stageDependencies.Build.Build.outputs['SetupVersioningProperties.SetDevVersion']]
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr'))
         jobs:
           - deployment: TagRepository


### PR DESCRIPTION
This PR depends on this ```eng/common``` change being merged in:

https://github.com/Azure/azure-sdk-tools/pull/1579

Basically I'm lifting the ```SetDevVersion``` variable out of the Build stage and making it available inside the Integration stage. We'll need to do this anywhere we set variables which are created in earlier stages.