### PR TITLE
[Event Hubs Client] Move Partition Initialization to the Background

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -774,18 +774,16 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="identifier">A unique name used to identify the event processor.</param>
         /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
-        /// <param name="eventPosition">The description of the <see cref="EventPosition" /> used as the starting point for processing.</param>
         ///
-        [Event(39, Level = EventLevel.Verbose, Message = "Completed starting to process partition '{0}' using processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Starting at position: {4}.")]
+        [Event(39, Level = EventLevel.Verbose, Message = "Completed starting to process partition '{0}' using processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.")]
         public virtual void EventProcessorPartitionProcessingStartComplete(string partitionId,
                                                                            string identifier,
                                                                            string eventHubName,
-                                                                           string consumerGroup,
-                                                                           string eventPosition)
+                                                                           string consumerGroup)
         {
             if (IsEnabled())
             {
-                WriteEvent(39, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, eventPosition ?? string.Empty);
+                WriteEvent(39, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
@@ -492,7 +492,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
 
             mockLogger
-                .Setup(log => log.EventProcessorPartitionProcessingStartComplete(secondPartition, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(log => log.EventProcessorPartitionProcessingStartComplete(secondPartition, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Callback(() => completionSource.TrySetResult(true));
 
             mockLoadBalancer
@@ -540,15 +540,15 @@ namespace Azure.Messaging.EventHubs.Tests
             mockProcessor
                 .Verify(processor => processor.CreatePartitionProcessor(
                     It.Is<EventProcessorPartition>(value => value.PartitionId == firstPartiton),
-                    options.DefaultStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
                 Times.Once);
 
             mockProcessor
                 .Verify(processor => processor.CreatePartitionProcessor(
                     It.Is<EventProcessorPartition>(value => value.PartitionId == secondPartition),
-                    options.DefaultStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
                 Times.Once);
 
             await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
@@ -582,7 +582,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
 
             mockLogger
-                .Setup(log => log.EventProcessorPartitionProcessingStartComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(log => log.EventProcessorPartitionProcessingStartComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Callback(() =>
                 {
                     if (Interlocked.Increment(ref startProcessingCalls) >= expectedProcessingCalls)
@@ -728,11 +728,11 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockProcessor
                 .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Callback(() => startCompletionSource.TrySetResult(true))
                 .Returns(Mock.Of<TransportConsumer>());
 
             mockProcessor
-                .Setup(processor => processor.CreatePartitionProcessor(It.IsAny<EventProcessorPartition>(), It.IsAny<EventPosition>(), It.IsAny<CancellationTokenSource>()))
-                .Callback(() => startCompletionSource.TrySetResult(true))
+                .Setup(processor => processor.CreatePartitionProcessor(It.IsAny<EventProcessorPartition>(), It.IsAny<CancellationTokenSource>(), It.IsAny<EventPosition?>()))
                 .CallBase();
 
             mockProcessor
@@ -862,15 +862,15 @@ namespace Azure.Messaging.EventHubs.Tests
             mockProcessor
                 .Verify(processor => processor.CreatePartitionProcessor(
                     It.Is<EventProcessorPartition>(value => value.PartitionId == firstPartiton),
-                    options.DefaultStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
                 Times.Once);
 
             mockProcessor
                 .Verify(processor => processor.CreatePartitionProcessor(
                     It.Is<EventProcessorPartition>(value => value.PartitionId == secondPartition),
-                    options.DefaultStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
                 Times.Once);
 
             await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
@@ -925,8 +925,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConsumer.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreatePartitionProcessor(It.IsAny<EventProcessorPartition>(), It.IsAny<EventPosition>(), It.IsAny<CancellationTokenSource>()))
-                .Returns((EventProcessorPartition partition, EventPosition position, CancellationTokenSource source) =>
+                .Setup(processor => processor.CreatePartitionProcessor(It.IsAny<EventProcessorPartition>(), It.IsAny<CancellationTokenSource>(), It.IsAny<EventPosition?>()))
+                .Returns((EventProcessorPartition partition, CancellationTokenSource source, EventPosition? overridePosition) =>
                 {
                     if (firstProcessorCreate)
                     {
@@ -947,8 +947,8 @@ namespace Azure.Messaging.EventHubs.Tests
             mockProcessor
                 .Verify(processor => processor.CreatePartitionProcessor(
                     It.Is<EventProcessorPartition>(value => value.PartitionId == partitionId),
-                    options.DefaultStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
                 Times.Exactly(2));
 
             await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
@@ -995,14 +995,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockProcessor
                 .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
-                .Returns(Mock.Of<TransportConsumer>());
-
-            mockProcessor
-                .Setup(processor => processor.CreatePartitionProcessor(It.IsAny<EventProcessorPartition>(), It.IsAny<EventPosition>(), It.IsAny<CancellationTokenSource>()))
-                .Returns((EventProcessorPartition partition, EventPosition position, CancellationTokenSource cancellation) =>
-                {
-                    return new EventProcessor<EventProcessorPartition>.PartitionProcessor(Task.Delay(Timeout.Infinite, cancellation.Token), partition, () => default, cancellation);
-                })
+                .Returns(Mock.Of<TransportConsumer>())
                 .Callback(() => completionSource.TrySetResult(true));
 
             mockProcessor
@@ -1017,10 +1010,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             mockProcessor
-                .Verify(processor => processor.CreatePartitionProcessor(
-                    It.Is<EventProcessorPartition>(value => value.PartitionId == partitionId),
-                    expectedStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                .Verify(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), expectedStartingPosition, mockConnection.Object, It.IsAny<EventProcessorOptions>()),
                 Times.Once);
 
             await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
@@ -1088,8 +1078,8 @@ namespace Azure.Messaging.EventHubs.Tests
             mockProcessor
                 .Verify(processor => processor.CreatePartitionProcessor(
                     It.Is<CustomPartition>(value => ((value.PartitionId == partitionId) && (value.Description == expectedDescription))),
-                    options.DefaultStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
                 Times.Once);
 
             mockProcessor
@@ -1171,15 +1161,14 @@ namespace Azure.Messaging.EventHubs.Tests
                     partitionId,
                     mockProcessor.Object.Identifier,
                     mockProcessor.Object.EventHubName,
-                    mockProcessor.Object.ConsumerGroup,
-                    options.DefaultStartingPosition.ToString()),
+                    mockProcessor.Object.ConsumerGroup),
                  Times.Once);
 
             mockProcessor
                 .Verify(processor => processor.CreatePartitionProcessor(
                     It.Is<EventProcessorPartition>(value => value.PartitionId == partitionId),
-                    options.DefaultStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
                 Times.Once);
 
             await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
@@ -1237,8 +1226,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Mock.Of<TransportConsumer>());
 
             mockProcessor
-                .Setup(processor => processor.CreatePartitionProcessor(It.IsAny<EventProcessorPartition>(), It.IsAny<EventPosition>(), It.IsAny<CancellationTokenSource>()))
-                .Returns((EventProcessorPartition partition, EventPosition position, CancellationTokenSource cancellation) =>
+                .Setup(processor => processor.CreatePartitionProcessor(It.IsAny<EventProcessorPartition>(), It.IsAny<CancellationTokenSource>(), It.IsAny<EventPosition?>()))
+                .Returns((EventProcessorPartition partition, CancellationTokenSource cancellation, EventPosition? overridePosition) =>
                 {
                     if (firstProcessorCreate)
                     {
@@ -1269,15 +1258,14 @@ namespace Azure.Messaging.EventHubs.Tests
                     partitionId,
                     mockProcessor.Object.Identifier,
                     mockProcessor.Object.EventHubName,
-                    mockProcessor.Object.ConsumerGroup,
-                    options.DefaultStartingPosition.ToString()),
+                    mockProcessor.Object.ConsumerGroup),
                  Times.Exactly(2));
 
             mockProcessor
                 .Verify(processor => processor.CreatePartitionProcessor(
                     It.Is<EventProcessorPartition>(value => value.PartitionId == partitionId),
-                    options.DefaultStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
                 Times.Exactly(2));
 
             await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
@@ -1331,8 +1319,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Mock.Of<TransportConsumer>());
 
             mockProcessor
-                .Setup(processor => processor.CreatePartitionProcessor(It.IsAny<EventProcessorPartition>(), It.IsAny<EventPosition>(), It.IsAny<CancellationTokenSource>()))
-                .Returns((EventProcessorPartition partition, EventPosition position, CancellationTokenSource cancellation) =>
+                .Setup(processor => processor.CreatePartitionProcessor(It.IsAny<EventProcessorPartition>(), It.IsAny<CancellationTokenSource>(), It.IsAny<EventPosition?>()))
+                .Returns((EventProcessorPartition partition, CancellationTokenSource cancellation, EventPosition? overridePosition) =>
                 {
                     if (firstProcessorCreate)
                     {
@@ -1368,8 +1356,8 @@ namespace Azure.Messaging.EventHubs.Tests
             mockProcessor
                 .Verify(processor => processor.CreatePartitionProcessor(
                     It.Is<EventProcessorPartition>(value => value.PartitionId == partitionId),
-                    options.DefaultStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
                 Times.Exactly(2));
 
             await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
@@ -1455,8 +1443,8 @@ namespace Azure.Messaging.EventHubs.Tests
             mockProcessor
                 .Verify(processor => processor.CreatePartitionProcessor(
                     It.Is<EventProcessorPartition>(value => value.PartitionId == partitionId),
-                    options.DefaultStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
                 Times.Once);
 
             cancellationSource.Cancel();
@@ -1532,8 +1520,8 @@ namespace Azure.Messaging.EventHubs.Tests
             mockProcessor
                 .Verify(processor => processor.CreatePartitionProcessor(
                     It.Is<EventProcessorPartition>(value => value.PartitionId == partitionId),
-                    options.DefaultStartingPosition,
-                    It.IsAny<CancellationTokenSource>()),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
                 Times.Once);
 
             cancellationSource.Cancel();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -142,7 +142,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.Cancel();
 
             var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
-            Assert.That(() => mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource), Throws.InstanceOf<TaskCanceledException>());
+            Assert.That(() => mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest), Throws.InstanceOf<TaskCanceledException>());
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
             Assert.That(partitionProcessor.CancellationSource, Is.SameAs(cancellationSource));
 
             cancellationSource.Cancel();
@@ -210,7 +210,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
 
             var lastEventProperties = partitionProcessor.ReadLastEnqueuedEventProperties();
@@ -244,7 +244,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(default(TransportConsumer))
                 .Callback(() => completionSource.TrySetResult(true));
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -290,7 +290,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -349,7 +349,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(badMockConsumer.Object)
                 .Returns(mockConsumer.Object);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -405,7 +405,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(connection => connection.CreateTransportConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<uint?>(), It.IsAny<long?>()))
                 .Returns(mockConsumer.Object);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -461,7 +461,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
                 .Returns(Task.CompletedTask);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -515,7 +515,7 @@ namespace Azure.Messaging.EventHubs.Tests
                  .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
                  .Returns(Task.CompletedTask);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -564,7 +564,7 @@ namespace Azure.Messaging.EventHubs.Tests
                  .Returns(Task.CompletedTask)
                  .Callback(() => completionSource.TrySetResult(true));
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -610,7 +610,7 @@ namespace Azure.Messaging.EventHubs.Tests
                .Callback(() => completionSource.TrySetResult(true))
                .Returns(Task.CompletedTask);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource);
             Assert.That(async () => await partitionProcessor.ProcessingTask, Throws.Exception.EqualTo(expectedException), "The processing task should fail.");
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
@@ -673,7 +673,7 @@ namespace Azure.Messaging.EventHubs.Tests
                .Callback(() => errorCompletion.TrySetResult(true))
                .Returns(Task.CompletedTask);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
             var completionSources = Task.WhenAll(receiveCompletion.Task, errorCompletion.Task);
 
             await Task.WhenAny(completionSources, Task.Delay(Timeout.Infinite, cancellationSource.Token));
@@ -737,7 +737,7 @@ namespace Azure.Messaging.EventHubs.Tests
                .Setup(log => log.EventProcessorPartitionProcessingError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                .Callback(() => errorCompletion.TrySetResult(true));
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
             var completionSources = Task.WhenAll(receiveCompletion.Task, errorCompletion.Task);
 
             await Task.WhenAny(completionSources, Task.Delay(Timeout.Infinite, cancellationSource.Token));
@@ -801,7 +801,7 @@ namespace Azure.Messaging.EventHubs.Tests
                .Callback(() => errorCompletion.TrySetResult(true))
                .Returns(Task.CompletedTask);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
             var completionSources = Task.WhenAll(receiveCompletion.Task, errorCompletion.Task);
 
             await Task.WhenAny(completionSources, Task.Delay(Timeout.Infinite, cancellationSource.Token));
@@ -849,7 +849,7 @@ namespace Azure.Messaging.EventHubs.Tests
                  .Callback(() => completionSource.TrySetResult(true))
                  .Throws(expectedException);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -910,7 +910,7 @@ namespace Azure.Messaging.EventHubs.Tests
                  .Callback(() => completionSource.TrySetResult(true))
                  .Throws(expectedException);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -970,7 +970,7 @@ namespace Azure.Messaging.EventHubs.Tests
                  .Callback(() => completionSource.TrySetResult(true))
                  .Throws(developerException);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -1021,7 +1021,7 @@ namespace Azure.Messaging.EventHubs.Tests
                  .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
                  .Returns(Task.CompletedTask);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -1073,7 +1073,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(badMockConsumer.Object)
                 .Returns(mockConsumer.Object);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -1134,7 +1134,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     return mockConsumer.Object;
                 });
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, initialStartingPosition, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, initialStartingPosition);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -1191,7 +1191,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -1241,7 +1241,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -1290,7 +1290,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -1355,7 +1355,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     return mockConsumer.Object;
                 });
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
@@ -1424,7 +1424,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     return mockConsumer.Object;
                 });
 
-            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, EventPosition.Earliest, cancellationSource);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, EventPosition.Earliest);
 
             await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");


### PR DESCRIPTION
# Summary

The focus of these changes is to o refactor partition initialization into the background task responsible for processing the partition. Because failures would still be surfaced through the error handler mechanism and the flow for recovering would follow the existing partition processing failure, there should be no change to usage patterns nor visible behavioral changes.

# References and Related

- [Event Processor: Move Partition Initialization into a Background Task (#18544)](https://github.com/Azure/azure-sdk-for-net/issues/18544)