### PR TITLE
Update ContentRange.cs due to large 2gb+ file transfers causing exception

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Models/ContentRange.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/ContentRange.cs
@@ -130,14 +130,14 @@ namespace Azure.Storage.Blobs.Models
                 {
                     blobSizeIndex = 3;
 
-                    start = int.Parse(tokens[1], CultureInfo.InvariantCulture);
-                    end = int.Parse(tokens[2], CultureInfo.InvariantCulture);
+                    start = long.Parse(tokens[1], CultureInfo.InvariantCulture);
+                    end = long.Parse(tokens[2], CultureInfo.InvariantCulture);
                 }
 
                 var rawSize = tokens[blobSizeIndex];
                 if (rawSize != WildcardMarker)
                 {
-                    size = int.Parse(rawSize, CultureInfo.InvariantCulture);
+                    size = long.Parse(rawSize, CultureInfo.InvariantCulture);
                 }
 
                 return new ContentRange(unit, start, end, size);

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -788,6 +788,6 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual((long)Int32.MaxValue + 1, contentRange.Size);
             Assert.AreEqual(0, contentRange.Start);
             Assert.AreEqual((long)Int32.MaxValue + 1, contentRange.End);
-        }        
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -780,5 +780,14 @@ namespace Azure.Storage.Blobs.Test
             // Assert
             Assert.IsFalse(blobEncrypted.CanGenerateSasUri);
         }
+        [Test]
+        public void CanParseLargeContentRange()
+        {
+            long compareValue = (long)Int32.MaxValue + 1; //Increase max int32 by one
+            ContentRange contentRange = ContentRange.Parse($"bytes 0 {compareValue} {compareValue}");
+            Assert.AreEqual((long)Int32.MaxValue + 1, contentRange.Size);
+            Assert.AreEqual(0, contentRange.Start);
+            Assert.AreEqual((long)Int32.MaxValue + 1, contentRange.End);
+        }        
     }
 }


### PR DESCRIPTION
When using client side encryption for large files transfers you get an exception when downloading a large file from blob storage. Specifically file size greater then max int32 value 2147483647.
The exception occurs during first stream access. Since long values are expected the string parsing should have been done with long.Parse(). Once changed the issue goes away.
 Exception Message : System.OverflowException: Value was either too large or too small for an Int32.
   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
   at Azure.Storage.Blobs.Models.ContentRange.Parse(String headerValue)
   at Azure.Storage.Blobs.BlobClientSideDecryptor.<DecryptInternal>d__2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [x] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [x] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
