### PR TITLE
Decrease polling frequency for Key Vault tests

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/OperationInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/OperationInterceptor.cs
@@ -69,8 +69,8 @@ namespace Azure.Core.TestFramework
                 var interval = (TimeSpan) invocationArguments[0];
                 if (interval < TimeSpan.FromSeconds(1))
                 {
-                    throw new InvalidOperationException($"Fast polling interval of {interval} detected in playback mode." +
-                                                        $"Please use the default WaitForCompletion()." +
+                    throw new InvalidOperationException($"Fast polling interval of {interval} detected in playback mode. " +
+                                                        $"Please use the default WaitForCompletion(). " +
                                                         $"The test framework would automatically reduce the interval in playback.");
                 }
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AdministrationTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AdministrationTestBase.cs
@@ -46,7 +46,7 @@ namespace Azure.Security.KeyVault.Administration.Tests
         /// </summary>
         protected TimeSpan PollingInterval => Recording.Mode == RecordedTestMode.Playback
             ? TimeSpan.Zero
-            : TimeSpan.FromSeconds(2);
+            : KeyVaultTestEnvironment.DefaultPollingInterval;
 
         [TearDown]
         public virtual async Task Cleanup()
@@ -85,7 +85,7 @@ namespace Azure.Security.KeyVault.Administration.Tests
 
             if (Mode != RecordedTestMode.Playback)
             {
-                await Task.Delay(delay ?? TimeSpan.FromSeconds(1));
+                await Task.Delay(delay ?? KeyVaultTestEnvironment.DefaultPollingInterval);
             }
             else if (playbackDelay != null)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/BackupRestoreTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/BackupRestoreTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
+using Azure.Security.KeyVault.Tests;
 using Azure.Storage;
 using Azure.Storage.Sas;
 using NUnit.Framework;
@@ -53,7 +54,7 @@ namespace Azure.Security.KeyVault.Administration.Tests
 
         // The service polls every second, so wait a bit to make sure the operation appears completed.
         protected async Task WaitForOperationAsync() =>
-            await DelayAsync(TimeSpan.FromSeconds(2));
+            await DelayAsync(KeyVaultTestEnvironment.DefaultPollingInterval);
 
         private string GenerateSasToken()
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -3,6 +3,7 @@
 
 using Azure.Core.TestFramework;
 using Azure.Security.KeyVault.Keys.Cryptography;
+using Azure.Security.KeyVault.Tests;
 using NUnit.Framework;
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.Pkcs;
@@ -242,7 +243,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
                 RegisterForCleanup(certName);
 
                 using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
-                TimeSpan pollingInterval = TimeSpan.FromSeconds((Mode == RecordedTestMode.Playback) ? 0 : 2);
+                TimeSpan pollingInterval = Mode == RecordedTestMode.Playback ? TimeSpan.Zero : KeyVaultTestEnvironment.DefaultPollingInterval;
 
                 while (!operation.HasCompleted)
                 {
@@ -335,7 +336,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             // Need to call the real async wait method or the sync version of this test fails because it's using the instrumented Client directly.
             using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
-            TimeSpan pollingInterval = TimeSpan.FromSeconds((Mode == RecordedTestMode.Playback) ? 0 : 2);
+            TimeSpan pollingInterval = Mode == RecordedTestMode.Playback ? TimeSpan.Zero : KeyVaultTestEnvironment.DefaultPollingInterval;
 
             await operation.WaitForCompletionAsync(pollingInterval, cts.Token);
 
@@ -892,7 +893,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CertificateOperation operation = await Client.StartCreateCertificateAsync(name, policy);
             RegisterForCleanup(name);
 
-            await WaitForCompletion(operation, TimeSpan.FromSeconds(5));
+            await WaitForCompletion(operation, KeyVaultTestEnvironment.DefaultPollingInterval);
 
             // Sign data remotely.
             byte[] plaintext = Encoding.UTF8.GetBytes(nameof(DownloadECDsaCertificateSignRemoteVerifyLocal));
@@ -944,7 +945,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CertificateOperation operation = await Client.StartCreateCertificateAsync(name, policy);
             RegisterForCleanup(name);
 
-            await WaitForCompletion(operation, TimeSpan.FromSeconds(5));
+            await WaitForCompletion(operation, KeyVaultTestEnvironment.DefaultPollingInterval);
 
             // Download the certificate and sign data locally.
             byte[] plaintext = Encoding.UTF8.GetBytes(nameof(DownloadECDsaCertificateSignRemoteVerifyLocal));

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -32,6 +32,9 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 {
     public partial class CertificateClientLiveTests : CertificatesTestBase
     {
+        // The service sends back a Retry-After header of 10s anyway.
+        private static readonly TimeSpan DefaultCertificateOperationPollingInterval = TimeSpan.FromSeconds(10);
+
         private static MethodInfo s_clearCacheMethod;
 
         public CertificateClientLiveTests(bool isAsync, CertificateClientOptions.ServiceVersion serviceVersion)
@@ -94,6 +97,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             RegisterForCleanup(certName);
 
             CertificateOperation getOperation = await Client.GetCertificateOperationAsync(certName);
+            getOperation = InstrumentOperation(getOperation);
 
             Assert.IsNotNull(getOperation);
         }
@@ -124,7 +128,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
 
             OperationCanceledException ex = Assert.ThrowsAsync<OperationCanceledException>(
-                async () => await WaitForCompletion(operation),
+                async () => await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default),
                 $"Expected exception {nameof(OperationCanceledException)} not thrown. Operation status: {operation?.Properties?.Status}, error: {operation?.Properties?.Error?.Message}");
 
             Assert.AreEqual("The operation was canceled so no value is available.", ex.Message);
@@ -156,7 +160,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
 
             OperationCanceledException ex = Assert.ThrowsAsync<OperationCanceledException>(
-                async () => await WaitForCompletion(operation),
+                async () => await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default),
                 $"Expected exception {nameof(OperationCanceledException)} not thrown. Operation status: {operation?.Properties?.Status}, error: {operation?.Properties?.Error?.Message}");
             Assert.AreEqual("The operation was canceled so no value is available.", ex.Message);
 
@@ -179,7 +183,8 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             await operation.DeleteAsync();
 
-            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForCompletion(operation));
+            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default));
             Assert.AreEqual("The operation was deleted so no value is available.", ex.Message);
 
             Assert.IsTrue(operation.HasCompleted);
@@ -209,7 +214,8 @@ namespace Azure.Security.KeyVault.Certificates.Tests
                 Assert.Inconclusive("The create operation completed before it could be canceled.");
             }
 
-            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForCompletion(operation));
+            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default));
             Assert.AreEqual("The operation was deleted so no value is available.", ex.Message);
 
             Assert.IsTrue(operation.HasCompleted);
@@ -239,6 +245,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
                 certificatePolicy.IssuerName = issuerName;
 
                 operation = await Client.StartCreateCertificateAsync(certName, certificatePolicy);
+                operation = InstrumentOperation(operation);
 
                 RegisterForCleanup(certName);
 
@@ -305,7 +312,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             RegisterForCleanup(certName);
 
-            await WaitForCompletion(operation);
+            await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
 
             KeyVaultCertificateWithPolicy certificateWithPolicy = await Client.GetCertificateAsync(certName);
 
@@ -359,7 +366,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             RegisterForCleanup(certName);
 
-            KeyVaultCertificateWithPolicy original = await WaitForCompletion(operation);
+            KeyVaultCertificateWithPolicy original = await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
             CertificateProperties originalProperties = original.Properties;
             Assert.IsTrue(originalProperties.Enabled);
             Assert.IsEmpty(originalProperties.Tags);
@@ -385,7 +392,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateOperation operation = await Client.StartCreateCertificateAsync(certName, DefaultPolicy);
 
-            KeyVaultCertificateWithPolicy original = await WaitForCompletion(operation);
+            KeyVaultCertificateWithPolicy original = await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
 
             Assert.NotNull(original);
 
@@ -552,7 +559,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual(csrInfo.Subject.ToString(), serverCertificate.Subject);
             Assert.AreEqual(serverCertificateName, mergedServerCertificate.Name);
 
-            KeyVaultCertificateWithPolicy completedServerCertificate = await WaitForCompletion(operation);
+            KeyVaultCertificateWithPolicy completedServerCertificate = await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
 
             Assert.AreEqual(mergedServerCertificate.Name, completedServerCertificate.Name);
             CollectionAssert.AreEqual(mergedServerCertificate.Cer, completedServerCertificate.Cer);
@@ -694,7 +701,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateOperation operation = await Client.StartCreateCertificateAsync(certName, certificatePolicy);
 
-            KeyVaultCertificateWithPolicy original = await WaitForCompletion(operation);
+            KeyVaultCertificateWithPolicy original = await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
 
             Assert.NotNull(original);
 
@@ -717,7 +724,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateOperation operation = await Client.StartCreateCertificateAsync(certName, certificatePolicy);
 
-            KeyVaultCertificateWithPolicy original = await WaitForCompletion(operation);
+            KeyVaultCertificateWithPolicy original = await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
 
             Assert.NotNull(original);
 
@@ -767,7 +774,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CertificateOperation operation = await Client.StartCreateCertificateAsync(name, policy);
             RegisterForCleanup(name);
 
-            await WaitForCompletion(operation);
+            await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
 
             KeyVaultCertificate certificate = await Client.GetCertificateAsync(name);
 
@@ -809,7 +816,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CertificateOperation operation = await Client.StartCreateCertificateAsync(name, policy);
             RegisterForCleanup(name);
 
-            await WaitForCompletion(operation);
+            await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
 
             KeyVaultCertificate certificate = await Client.GetCertificateAsync(name);
             string version = certificate.Properties.Version;
@@ -824,7 +831,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             policy.Exportable = false;
             operation = await Client.StartCreateCertificateAsync(name, policy);
 
-            await WaitForCompletion(operation);
+            await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
 
             certificate = await Client.GetCertificateAsync(name);
             Assert.AreNotEqual(version, certificate.Properties.Version);
@@ -862,7 +869,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CertificateOperation operation = await Client.StartCreateCertificateAsync(name, policy);
             RegisterForCleanup(name);
 
-            await WaitForCompletion(operation);
+            await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
 
             using X509Certificate2 x509certificate = await Client.DownloadCertificateAsync(name);
             Assert.IsFalse(x509certificate.HasPrivateKey);
@@ -893,7 +900,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CertificateOperation operation = await Client.StartCreateCertificateAsync(name, policy);
             RegisterForCleanup(name);
 
-            await WaitForCompletion(operation, KeyVaultTestEnvironment.DefaultPollingInterval);
+            await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
 
             // Sign data remotely.
             byte[] plaintext = Encoding.UTF8.GetBytes(nameof(DownloadECDsaCertificateSignRemoteVerifyLocal));
@@ -945,7 +952,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CertificateOperation operation = await Client.StartCreateCertificateAsync(name, policy);
             RegisterForCleanup(name);
 
-            await WaitForCompletion(operation, KeyVaultTestEnvironment.DefaultPollingInterval);
+            await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
 
             // Download the certificate and sign data locally.
             byte[] plaintext = Encoding.UTF8.GetBytes(nameof(DownloadECDsaCertificateSignRemoteVerifyLocal));

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateOperationTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateOperationTests.cs
@@ -304,7 +304,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
         private async ValueTask<KeyVaultCertificateWithPolicy> WaitForOperationAsync(CertificateOperation operation)
         {
-            return await operation.WaitForCompletionAsync();
+            return await operation.WaitForCompletionAsync(TimeSpan.Zero, default);
         }
 
         public class MockCredential : TokenCredential

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
@@ -202,13 +202,6 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
         }
 
-        protected async Task<KeyVaultCertificateWithPolicy> WaitForCompletion(CertificateOperation operation, TimeSpan? pollingInterval = null)
-        {
-            // Service sends Retry-After header of 10s, so no reason to poll more frequently.
-            pollingInterval ??= TimeSpan.FromSeconds(10);
-            return await operation.WaitForCompletionAsync(pollingInterval.Value, default).TimeoutAfter(TimeSpan.FromMinutes(2));
-        }
-
         protected Task WaitForDeletedCertificate(string name)
         {
             if (Mode == RecordedTestMode.Playback)

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
@@ -20,7 +20,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
     [NonParallelizable]
     public abstract class CertificatesTestBase : RecordedTestBase<KeyVaultTestEnvironment>
     {
-        protected readonly TimeSpan PollingInterval = TimeSpan.FromSeconds(5);
+        protected readonly TimeSpan PollingInterval = KeyVaultTestEnvironment.DefaultPollingInterval;
         private readonly CertificateClientOptions.ServiceVersion _serviceVersion;
 
         public CertificateClient Client { get; set; }
@@ -204,8 +204,9 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
         protected async Task<KeyVaultCertificateWithPolicy> WaitForCompletion(CertificateOperation operation, TimeSpan? pollingInterval = null)
         {
-            pollingInterval ??= TimeSpan.FromSeconds(1);
-            return await operation.WaitForCompletionAsync(pollingInterval.Value, default).TimeoutAfter(TimeSpan.FromMinutes(1));
+            // Service sends Retry-After header of 10s, so no reason to poll more frequently.
+            pollingInterval ??= TimeSpan.FromSeconds(10);
+            return await operation.WaitForCompletionAsync(pollingInterval.Value, default).TimeoutAfter(TimeSpan.FromMinutes(2));
         }
 
         protected Task WaitForDeletedCertificate(string name)

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
@@ -649,7 +649,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             DeletedKey deletedKey = operation.Value;
 
             // Wait a little longer since live tests are failing with only a 2s delay.
-            await WaitForDeletedKey(keyName, TimeSpan.FromSeconds(5));
+            await WaitForDeletedKey(keyName, KeyVaultTestEnvironment.DefaultPollingInterval);
 
             DeletedKey polledSecret = await Client.GetDeletedKeyAsync(keyName);
 
@@ -910,7 +910,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             {
                 // WaitForDeletedKey disables recording, so we can wait concurrently.
                 // Wait a little longer for deleting keys since tests occasionally fail after max attempts.
-                deletingKeys.Add(WaitForDeletedKey(deletedKey.Name, delay: TimeSpan.FromSeconds(5)));
+                deletingKeys.Add(WaitForDeletedKey(deletedKey.Name, delay: KeyVaultTestEnvironment.DefaultPollingInterval));
             }
 
             await Task.WhenAll(deletingKeys);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
@@ -21,7 +21,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
     {
         protected TimeSpan PollingInterval => Recording.Mode == RecordedTestMode.Playback
             ? TimeSpan.Zero
-            : TimeSpan.FromSeconds(2);
+            : KeyVaultTestEnvironment.DefaultPollingInterval;
 
         public KeyClient Client { get; private set; }
 
@@ -260,7 +260,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             using (Recording.DisableRecording())
             {
-                delay ??= TimeSpan.FromSeconds(5);
+                delay ??= KeyVaultTestEnvironment.DefaultPollingInterval;
                 return TestRetryHelper.RetryAsync(async () => await Client.GetDeletedKeyAsync(name), delay: delay.Value);
             }
         }
@@ -274,7 +274,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             using (Recording.DisableRecording())
             {
-                delay ??= TimeSpan.FromSeconds(5);
+                delay ??= KeyVaultTestEnvironment.DefaultPollingInterval;
                 return TestRetryHelper.RetryAsync(async () => {
                     try
                     {

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretsTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretsTestBase.cs
@@ -18,7 +18,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
     [NonParallelizable]
     public abstract class SecretsTestBase : RecordedTestBase<KeyVaultTestEnvironment>
     {
-        protected readonly TimeSpan PollingInterval = TimeSpan.FromSeconds(10);
+        protected readonly TimeSpan PollingInterval = KeyVaultTestEnvironment.DefaultPollingInterval;
         private readonly SecretClientOptions.ServiceVersion _serviceVersion;
 
         public SecretClient Client { get; set; }

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/KeyVaultTestEnvironment.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/KeyVaultTestEnvironment.cs
@@ -19,6 +19,11 @@ namespace Azure.Security.KeyVault.Tests
         private const string StorageUriFormat = "https://{0}.blob.core.windows.net";
 
         /// <summary>
+        /// Gets the default polling interval to use in tests.
+        /// </summary>
+        public static TimeSpan DefaultPollingInterval { get; } = TimeSpan.FromSeconds(5);
+
+        /// <summary>
         /// Gets the URI to Key Vault.
         /// </summary>
         public string KeyVaultUrl => GetRecordedVariable("AZURE_KEYVAULT_URL");


### PR DESCRIPTION
Resolves #20735. Also fixes some slow Certificates mock tests.
