### PR TITLE
Allow null value for PatternTokenizer["flags"]

### DIFF
--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/PatternTokenizer.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/PatternTokenizer.cs
@@ -9,9 +9,9 @@ namespace Azure.Search.Documents.Indexes.Models
     public partial class PatternTokenizer
     {
         [CodeGenMember("flags")]
-        private string FlagsInternal
+        internal string FlagsInternal
         {
-            get => string.Join("|", Flags);
+            get => Flags.Count > 0 ? string.Join("|", Flags) : null;
             set
             {
                 Flags.Clear();

--- a/sdk/search/Azure.Search.Documents/tests/Models/PatternTokenizerTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Models/PatternTokenizerTests.cs
@@ -24,7 +24,13 @@ namespace Azure.Search.Documents.Tests.Models
             using JsonDocument doc = JsonDocument.Parse(stream.ToArray());
             PatternTokenizer actual = LexicalTokenizer.DeserializeLexicalTokenizer(doc.RootElement) as PatternTokenizer;
 
-            CollectionAssert.AreEqual(expected.Flags, actual?.Flags);
+            CollectionAssert.AreEqual(expected.Flags, actual.Flags);
+
+            if (expected.Flags.Count == 0)
+            {
+                Assert.IsNull(actual.FlagsInternal);
+                Assert.IsNull(expected.FlagsInternal);
+            }
         }
 
         private static IEnumerable<PatternTokenizer> RoundtripsRegexFlagsData


### PR DESCRIPTION
When there are no Flags set, we should pass null to the service.