### PR TITLE
[TSI] Stabilize an Aggregate  test

### DIFF
--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsQueryAggregateSeriesTests.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/tests/TimeSeriesInsightsQueryAggregateSeriesTests.cs
@@ -239,16 +239,14 @@ namespace Azure.IoT.TimeSeriesInsights.Tests
                         TimeSpan.FromSeconds(5),
                         queryAggregateSeriesRequestOptions);
 
-                    var countFound = false;
+                    long? totalCount = 0;
                     await foreach (TimeSeriesPoint point in queryAggregateSeriesPages.GetResultsAsync())
                     {
-                        if ((long?)point.GetValue("Count") == 30)
-                        {
-                            countFound = true;
-                        }
+                        var currentCount = (long?)point.GetValue("Count");
+                        totalCount += currentCount;
                     }
 
-                    countFound.Should().BeTrue();
+                    totalCount.Should().Be(30);
 
                     return null;
                 }, MaxNumberOfRetries, s_retryDelay);


### PR DESCRIPTION
Because this test fetches aggregate data by bin timeslots, not all results might land up on a single time slot. Rather, they could be spread across many time slots. Hence, ensure that the total count is correct.