### PR TITLE
Remove subscription id since it is not needed in test-resources.json

### DIFF
--- a/sdk/communication/test-resources.json
+++ b/sdk/communication/test-resources.json
@@ -13,10 +13,6 @@
             "defaultValue": "communication",
             "type": "string"
         },
-        "subscriptionId": {
-            "defaultValue": "[subscription().subscriptionId]",
-            "type": "string"
-        },
         "testApplicationOid": {
             "type": "string",
             "metadata": {

--- a/sdk/communication/test-resources.json
+++ b/sdk/communication/test-resources.json
@@ -85,4 +85,5 @@
             "value": "[resourceGroup().Name]"
         }
     }
+
 }

--- a/sdk/communication/test-resources.json
+++ b/sdk/communication/test-resources.json
@@ -85,5 +85,4 @@
             "value": "[resourceGroup().Name]"
         }
     }
-
 }


### PR DESCRIPTION
Remove subscription id in test-resources.json since it is not needed to be defined there