### PR TITLE
Add spell check for changed files

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -25,9 +25,13 @@
   ],
   // cspell is not case sensitive
   // Sort words alphabetically to make this list easier to use
-  "words": [],
+  "words": ["azsdk", "pwsh"],
   "overrides": [
-    { "filename": "**/sdk/formrecognizer/**/*.cs", "words": ["ZhHant"] }
+    { "filename": "**/sdk/formrecognizer/**/*.cs", "words": ["ZhHant"] },
+    {
+      "filename": "**/eng/pipelines/templates/jobs/ci.yml",
+      "words": ["warnaserror"]
+    }
   ],
   "allowCompoundWords": true
 }

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -103,6 +103,7 @@ jobs:
       name: azsdk-pool-mms-ubuntu-1804-general
       vmImage: MMSUbuntu18.04
     steps:
+      - task: /eng/common/pipelines/templates/steps/check-spelling.yml
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
         inputs:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -103,7 +103,7 @@ jobs:
       name: azsdk-pool-mms-ubuntu-1804-general
       vmImage: MMSUbuntu18.04
     steps:
-      - task: /eng/common/pipelines/templates/steps/check-spelling.yml
+      - template: /eng/common/pipelines/templates/steps/check-spelling.yml
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
         inputs:


### PR DESCRIPTION
Example spelling error warning: 

![image](https://user-images.githubusercontent.com/2158838/116761539-ce083900-a9cc-11eb-90b1-331d092534be.png)

Adding this in does not block the build or turn the build yellow/red. Additional information at: https://aka.ms/azsdk/engsys/spellcheck