### PR TITLE
[Event Hubs Processor] Validate at Startup

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Azure.Messaging.EventHubs.Processor.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Azure.Messaging.EventHubs.Processor.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{797FF941-76FD-45FD-AC17-A73DFE2BA621}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs", "..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj", "{D82CC3DD-E6CC-4688-BDA8-16E7A303C35B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,12 +31,17 @@ Global
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D82CC3DD-E6CC-4688-BDA8-16E7A303C35B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D82CC3DD-E6CC-4688-BDA8-16E7A303C35B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D82CC3DD-E6CC-4688-BDA8-16E7A303C35B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D82CC3DD-E6CC-4688-BDA8-16E7A303C35B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
+		{D82CC3DD-E6CC-4688-BDA8-16E7A303C35B} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {44BD3BD5-61DF-464D-8627-E00B0BC4B3A3}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -13,7 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" />
+    <!-- RETURN TO PACAKGE REFERENCE -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
+    <!-- PackageReference Include="Azure.Messaging.EventHubs" /-->
+    <!-- END RETURN TO PACKAGE REFERENCE -->
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
@@ -178,5 +178,26 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                 WriteEvent(25, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
             }
         }
+
+        /// <summary>
+        ///   Indicates that the process of cleaning up after startup validation has experienced an exception.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(26, Level = EventLevel.Error, Message = "An exception occurred while attempting to perform cleanup after validating the processor configuration and permissions during startup for processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Error Message: '{4}'")]
+        public virtual void ValidationCleanupError(string identifier,
+                                                   string eventHubName,
+                                                   string consumerGroup,
+                                                   string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(26, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -11,12 +11,11 @@ using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Diagnostics;
 using Azure.Messaging.EventHubs.Primitives;
 using Azure.Messaging.EventHubs.Processor.Diagnostics;
-using Azure.Messaging.EventHubs.Tests;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Processor.Tests
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of tests for validating the diagnostics instrumentation

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -13,7 +14,9 @@ using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Primitives;
 using Azure.Messaging.EventHubs.Processor;
 using Azure.Messaging.EventHubs.Processor.Diagnostics;
+using Azure.Storage;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Moq;
 using NUnit.Framework;
 
@@ -385,6 +388,103 @@ namespace Azure.Messaging.EventHubs.Tests
 
             assertStartProcessing();
             assertStartProcessing();
+
+            await processorClient.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
+            cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessorClient.StartProcessingAsync" />
+        ///   and <see cref="EventProcessorClient.StartProcessing" /> methods.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StartProcessingValidatesBlobsCanBeWritten(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+
+            var capturedException = default(Exception);
+            var expectedException = new AccessViolationException("Stop violating my access!");
+            var mockContainerClient = new Mock<BlobContainerClient>();
+            var mockBlobClient = new MockBlobClient("dummy") { UploadException = expectedException };
+
+            mockContainerClient
+                .Setup(client => client.GetBlobClient(It.IsAny<string>()))
+                .Returns(mockBlobClient);
+
+            var processorClient = new TestEventProcessorClient(mockContainerClient.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
+            processorClient.ProcessEventAsync += eventArgs => Task.CompletedTask;
+            processorClient.ProcessErrorAsync += eventArgs => Task.CompletedTask;
+
+            try
+            {
+                if (async)
+                {
+                    await processorClient.StartProcessingAsync(cancellationSource.Token);
+                }
+                else
+                {
+                    processorClient.StartProcessing(cancellationSource.Token);
+                }
+            }
+            catch (Exception ex)
+            {
+                capturedException = ex;
+            }
+
+            Assert.That(capturedException, Is.Not.Null, "An exception should have been thrown.");
+            Assert.That(capturedException, Is.InstanceOf<AggregateException>(), "A validation exception should be surfaced as an AggregateException.");
+            Assert.That(((AggregateException)capturedException).InnerExceptions.Count, Is.EqualTo(1), "There should have been a single validation exception.");
+
+            var innerException = ((AggregateException)capturedException).InnerExceptions.First();
+            Assert.That(innerException, Is.SameAs(expectedException), "The source of the validation exception should have been exposed.");
+            Assert.That(processorClient.IsRunning, Is.False, "The processor should not be running after a validation exception.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessorClient.StartProcessingAsync" />
+        ///   and <see cref="EventProcessorClient.StartProcessing" /> methods.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StartProcessingLogsWhenValidationCleanupFails(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var expectedException = new AccessViolationException("Stop violating my access!");
+            var mockLogger = new Mock<EventProcessorClientEventSource>();
+            var mockContainerClient = new Mock<BlobContainerClient>();
+            var mockBlobClient = new MockBlobClient("dummy") { DeleteException = expectedException };
+
+            mockContainerClient
+                .Setup(client => client.GetBlobClient(It.IsAny<string>()))
+                .Returns(mockBlobClient);
+
+            var processorClient = new TestEventProcessorClient(mockContainerClient.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
+
+            processorClient.Logger = mockLogger.Object;
+            processorClient.ProcessEventAsync += eventArgs => Task.CompletedTask;
+            processorClient.ProcessErrorAsync += eventArgs => Task.CompletedTask;
+
+            if (async)
+            {
+                Assert.That(async () => await processorClient.StartProcessingAsync(cancellationSource.Token), Throws.Nothing);
+            }
+            else
+            {
+                Assert.That(() => processorClient.StartProcessing(cancellationSource.Token), Throws.Nothing);
+            }
+
+            mockLogger.Verify(log => log.ValidationCleanupError(
+                processorClient.Identifier,
+                processorClient.EventHubName,
+                processorClient.ConsumerGroup, expectedException.Message),
+            Times.Once);
 
             await processorClient.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
             cancellationSource.Cancel();
@@ -1072,31 +1172,33 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="EventProcessorClient.ListCheckpointsAsync" />
+        ///   Verifies functionality of the <see cref="EventProcessorClient.GetCheckpointAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
-        public async Task ListCheckpointsDelegatesToTheStorageManager()
+        public async Task GetCheckpointAsyncDelegatesToTheStorageManager()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
+            var partitionId = "5";
             var mockStorageManager = new Mock<StorageManager>();
             var processorClient = new TestEventProcessorClient(mockStorageManager.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
 
             mockStorageManager
-                .Setup(storage => storage.ListCheckpointsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(default(IEnumerable<EventProcessorCheckpoint>));
+                .Setup(storage => storage.GetCheckpointAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(default(EventProcessorCheckpoint));
 
-            await processorClient.InvokeListCheckpointsAsync(cancellationSource.Token);
+            await processorClient.InvokeGetCheckpointAsync(partitionId, cancellationSource.Token);
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             mockStorageManager
-                .Verify(storage => storage.ListCheckpointsAsync(
+                .Verify(storage => storage.GetCheckpointAsync(
                     processorClient.FullyQualifiedNamespace,
                     processorClient.EventHubName,
                     processorClient.ConsumerGroup,
+                    partitionId,
                     It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -1104,12 +1206,12 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="EventProcessorClient.ListCheckpointsAsync" />
+        ///   Verifies functionality of the <see cref="EventProcessorClient.GetCheckpointAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
-        public async Task ListCheckpointsIncludesInitializeEventHandlerStartingPositionWhenNoNaturalCheckpointExists()
+        public async Task GetCheckpointIncludesInitializeEventHandlerStartingPositionWhenNoNaturalCheckpointExists()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
@@ -1120,15 +1222,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockStorageManager = new Mock<StorageManager>();
             var processorClient = new TestEventProcessorClient(mockStorageManager.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), options);
 
-            var sourceCheckpoints = new[]
-            {
-                new EventProcessorCheckpoint { PartitionId = "7", StartingPosition = EventPosition.FromOffset(111) },
-                new EventProcessorCheckpoint { PartitionId = "4", StartingPosition = EventPosition.FromOffset(222) }
-            };
-
             mockStorageManager
-                .Setup(storage => storage.ListCheckpointsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(sourceCheckpoints);
+                .Setup(storage => storage.GetCheckpointAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(default(EventProcessorCheckpoint));
 
             processorClient.PartitionInitializingAsync += eventArgs =>
             {
@@ -1139,26 +1235,22 @@ namespace Azure.Messaging.EventHubs.Tests
             await processorClient.InvokeOnInitializingPartitionAsync(new TestEventProcessorPartition(partitionId), cancellationSource.Token);
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
-            var checkpoints = (await processorClient.InvokeListCheckpointsAsync(cancellationSource.Token))?.ToList();
+            var checkpoint = await processorClient.InvokeGetCheckpointAsync(partitionId, cancellationSource.Token);
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
-            Assert.That(checkpoints, Is.Not.Null, "A set of checkpoints should have been returned.");
-            Assert.That(checkpoints.Count, Is.EqualTo(sourceCheckpoints.Length + 1), "The source checkpoints and the initialized partition should have been in the set.");
-
-            var partitionCheckpoint = checkpoints.SingleOrDefault(checkpoint => checkpoint.PartitionId == partitionId);
-            Assert.That(partitionCheckpoint, Is.Not.Null, "A checkpoint for the initialized partition should have been injected.");
-            Assert.That(partitionCheckpoint.StartingPosition, Is.EqualTo(startingPosition), "The injected checkpoint should have respected the value that the initialization event handler set.");
+            Assert.That(checkpoint, Is.Not.Null, "A checkpoint should have been injected for the partition.");
+            Assert.That(checkpoint.StartingPosition, Is.EqualTo(startingPosition), "The injected checkpoint should have respected the value that the initialization event handler set.");
 
             cancellationSource.Cancel();
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="EventProcessorClient.ListCheckpointsAsync" />
+        ///   Verifies functionality of the <see cref="EventProcessorClient.GetCheckpointAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
-        public async Task ListCheckpointsPrefersNaturalCheckpointOverInitializeEventHandlerStartingPosition()
+        public async Task GetCheckpointPrefersNaturalCheckpointOverInitializeEventHandlerStartingPosition()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
@@ -1170,16 +1262,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockStorageManager = new Mock<StorageManager>();
             var processorClient = new TestEventProcessorClient(mockStorageManager.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), options);
 
-            var sourceCheckpoints = new[]
-            {
-                new EventProcessorCheckpoint { PartitionId = "7", StartingPosition = EventPosition.FromOffset(111) },
-                new EventProcessorCheckpoint { PartitionId = "4", StartingPosition = EventPosition.FromOffset(222) },
-                new EventProcessorCheckpoint { PartitionId = partitionId, StartingPosition = checkpointStartingPosition }
-            };
-
             mockStorageManager
-                .Setup(storage => storage.ListCheckpointsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(sourceCheckpoints);
+                .Setup(storage => storage.GetCheckpointAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), partitionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventProcessorCheckpoint { PartitionId = partitionId, StartingPosition = checkpointStartingPosition });
 
             processorClient.PartitionInitializingAsync += eventArgs =>
             {
@@ -1190,15 +1275,42 @@ namespace Azure.Messaging.EventHubs.Tests
             await processorClient.InvokeOnInitializingPartitionAsync(new TestEventProcessorPartition(partitionId), cancellationSource.Token);
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
-            var checkpoints = (await processorClient.InvokeListCheckpointsAsync(cancellationSource.Token))?.ToList();
+            var checkpoint = await processorClient.InvokeGetCheckpointAsync(partitionId, cancellationSource.Token);
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
-            Assert.That(checkpoints, Is.Not.Null, "A set of checkpoints should have been returned.");
-            Assert.That(checkpoints.Count, Is.EqualTo(sourceCheckpoints.Length), "The source checkpoints should have been in the set.");
+            Assert.That(checkpoint, Is.Not.Null, "A checkpoints should have been found for the partition.");
+            Assert.That(checkpoint.StartingPosition, Is.EqualTo(checkpointStartingPosition), "The natural checkpoint should have respected the value that the initialization event handler set.");
 
-            var partitionCheckpoint = checkpoints.SingleOrDefault(checkpoint => checkpoint.PartitionId == partitionId);
-            Assert.That(partitionCheckpoint, Is.Not.Null, "A checkpoint for the initialized partition should exist naturally.");
-            Assert.That(partitionCheckpoint.StartingPosition, Is.EqualTo(checkpointStartingPosition), "The natural checkpoint should have respected the value that the initialization event handler set.");
+            cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessorClient.GetCheckpointAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetCheckpointReturnsNaturalCheckpointsWhenNoInitializeEventHandlerIsRegistered()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var partitionId = "0";
+            var options = new EventProcessorOptions { DefaultStartingPosition = EventPosition.Latest };
+            var mockStorageManager = new Mock<StorageManager>();
+            var processorClient = new TestEventProcessorClient(mockStorageManager.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), options);
+
+            mockStorageManager
+                .Setup(storage => storage.GetCheckpointAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(default(EventProcessorCheckpoint));
+
+            await processorClient.InvokeOnInitializingPartitionAsync(new TestEventProcessorPartition(partitionId), cancellationSource.Token);
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            var checkpoint = await processorClient.InvokeGetCheckpointAsync(partitionId, cancellationSource.Token);
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            Assert.That(checkpoint, Is.Null,  "No handler was registered for the partition; no checkpoint should have been injected.");
 
             cancellationSource.Cancel();
         }
@@ -1209,38 +1321,19 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ListCheckpointsReturnsNaturalCheckpointsWhenNoInitializeEventHandlerIsRegistered()
+        public void ListCheckpointsIsDeprecatedAndThrows()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
-            var partitionId = "0";
-            var options = new EventProcessorOptions { DefaultStartingPosition = EventPosition.Latest };
             var mockStorageManager = new Mock<StorageManager>();
-            var processorClient = new TestEventProcessorClient(mockStorageManager.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), options);
-
-            var sourceCheckpoints = new[]
-            {
-                new EventProcessorCheckpoint { PartitionId = "7", StartingPosition = EventPosition.FromOffset(111) },
-                new EventProcessorCheckpoint { PartitionId = "4", StartingPosition = EventPosition.FromOffset(222) }
-            };
+            var processorClient = new TestEventProcessorClient(mockStorageManager.Object, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), Mock.Of<EventHubConnection>(), default);
 
             mockStorageManager
                 .Setup(storage => storage.ListCheckpointsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(sourceCheckpoints);
+                .ReturnsAsync(default(IEnumerable<EventProcessorCheckpoint>));
 
-            await processorClient.InvokeOnInitializingPartitionAsync(new TestEventProcessorPartition(partitionId), cancellationSource.Token);
-            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-
-            var checkpoints = (await processorClient.InvokeListCheckpointsAsync(cancellationSource.Token))?.ToList();
-            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-
-            Assert.That(checkpoints, Is.Not.Null, "A set of checkpoints should have been returned.");
-            Assert.That(checkpoints.Count, Is.EqualTo(sourceCheckpoints.Length), "The source checkpoints should have been in the set.");
-
-            var partitionCheckpoint = checkpoints.SingleOrDefault(checkpoint => checkpoint.PartitionId == partitionId);
-            Assert.That(partitionCheckpoint, Is.Null, "No handler was registered for the partition; no checkpoint should have been injected.");
-
+            Assert.That(async () => await processorClient.InvokeListCheckpointsAsync(cancellationSource.Token), Throws.InstanceOf<InvalidOperationException>());
             cancellationSource.Cancel();
         }
 
@@ -1535,11 +1628,23 @@ namespace Azure.Messaging.EventHubs.Tests
                 InjectedConnection = connection;
             }
 
+            internal TestEventProcessorClient(BlobContainerClient containerClient,
+                                              string consumerGroup,
+                                              string fullyQualifiedNamespace,
+                                              string eventHubName,
+                                              TokenCredential credential,
+                                              EventHubConnection connection,
+                                              EventProcessorClientOptions options) : base(containerClient, consumerGroup, fullyQualifiedNamespace, eventHubName, credential, options)
+            {
+                InjectedConnection = connection;
+            }
+
             public Task InvokeOnProcessingEventBatchAsync(IEnumerable<EventData> events, EventProcessorPartition partition, CancellationToken cancellationToken) => base.OnProcessingEventBatchAsync(events, partition, cancellationToken);
             public Task InvokeOnProcessingErrorAsync(Exception exception, EventProcessorPartition partition, string operationDescription, CancellationToken cancellationToken) => base.OnProcessingErrorAsync(exception, partition, operationDescription, cancellationToken);
             public Task InvokeOnInitializingPartitionAsync(EventProcessorPartition partition, CancellationToken cancellationToken) => base.OnInitializingPartitionAsync(partition, cancellationToken);
             public Task InvokeOnPartitionProcessingStoppedAsync(EventProcessorPartition partition, ProcessingStoppedReason reason, CancellationToken cancellationToken) => base.OnPartitionProcessingStoppedAsync(partition, reason, cancellationToken);
             public Task<IEnumerable<EventProcessorCheckpoint>> InvokeListCheckpointsAsync(CancellationToken cancellationToken) => base.ListCheckpointsAsync(cancellationToken);
+            public Task<EventProcessorCheckpoint> InvokeGetCheckpointAsync(string partitionId, CancellationToken cancellationToken) => base.GetCheckpointAsync(partitionId, cancellationToken);
             public Task<IEnumerable<EventProcessorPartitionOwnership>> InvokeListOwnershipAsync(CancellationToken cancellationToken) => base.ListOwnershipAsync(cancellationToken);
             public Task<IEnumerable<EventProcessorPartitionOwnership>> InvokeClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership, CancellationToken cancellationToken) => base.ClaimOwnershipAsync(desiredOwnership, cancellationToken);
             protected override EventHubConnection CreateConnection() => InjectedConnection;
@@ -1552,6 +1657,70 @@ namespace Azure.Messaging.EventHubs.Tests
         public class TestEventProcessorPartition : EventProcessorPartition
         {
             public TestEventProcessorPartition(string partitionId) { PartitionId = partitionId; }
+        }
+
+        /// <summary>
+        ///   A mock <see cref="BlobClient" /> used for testing purposes.
+        /// </summary>
+        ///
+        public class MockBlobClient : BlobClient
+        {
+            public override string Name { get; }
+            public Exception UploadException;
+            public Exception DeleteException;
+
+            public MockBlobClient(string blobName)
+            {
+                Name = blobName;
+            }
+
+            public override Task<Response<BlobContentInfo>> UploadAsync(Stream content, BlobHttpHeaders httpHeaders = null, IDictionary<string, string> metadata = null, BlobRequestConditions conditions = null, IProgress<long> progressHandler = null, AccessTier? accessTier = null, StorageTransferOptions transferOptions = default, CancellationToken cancellationToken = default)
+            {
+                if (UploadException != null)
+                {
+                    throw UploadException;
+                }
+
+                return Task.FromResult(
+                    Response.FromValue(
+                        BlobsModelFactory.BlobContentInfo(new ETag("etag"), new DateTimeOffset(2015, 10, 27, 00, 00, 00, 00, TimeSpan.Zero), Array.Empty<byte>(), string.Empty, 0L),
+                        Mock.Of<Response>()));
+            }
+
+            public override Response<BlobContentInfo> Upload(Stream content, BlobHttpHeaders httpHeaders = null, IDictionary<string, string> metadata = null, BlobRequestConditions conditions = null, IProgress<long> progressHandler = null, AccessTier? accessTier = null, StorageTransferOptions transferOptions = default, CancellationToken cancellationToken = default)
+            {
+                if (UploadException != null)
+                {
+                    throw UploadException;
+                }
+
+                return Response.FromValue(
+                    BlobsModelFactory.BlobContentInfo(new ETag("etag"), new DateTimeOffset(2015, 10, 27, 00, 00, 00, 00, TimeSpan.Zero), Array.Empty<byte>(), string.Empty, 0L),
+                    Mock.Of<Response>());
+            }
+
+            public override Task<Response<bool>> DeleteIfExistsAsync(DeleteSnapshotsOption snapshotsOption = DeleteSnapshotsOption.None, BlobRequestConditions conditions = null, CancellationToken cancellationToken = default)
+            {
+                if (DeleteException != null)
+                {
+                    throw DeleteException;
+                }
+
+                return Task.FromResult(Response.FromValue(true, Mock.Of<Response>()));
+            }
+
+            public override Response<bool> DeleteIfExists(DeleteSnapshotsOption snapshotsOption = DeleteSnapshotsOption.None, BlobRequestConditions conditions = null, CancellationToken cancellationToken = default)
+            {
+                if (DeleteException != null)
+                {
+                    throw DeleteException;
+                }
+
+                return Response.FromValue(true, Mock.Of<Response>());
+            }
+
+            public override Task<Response<BlobProperties>> GetPropertiesAsync(BlobRequestConditions conditions = null, CancellationToken cancellationToken = default) =>
+                 Task.FromResult(Response.FromValue(Mock.Of<BlobProperties>(), Mock.Of<Response>()));
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -736,5 +736,16 @@ namespace Azure.Messaging.EventHubs
                 return ResourceManager.GetString("IdempotentAlreadyPublished", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The ListCheckpointsAsync method has been superseded by GetCheckpointAsync and should no longer be called..
+        /// </summary>
+        internal static string ListCheckpointsAsyncObsolete
+        {
+            get
+            {
+                return ResourceManager.GetString("ListCheckpointsAsyncObsolete", resourceCulture);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -297,4 +297,7 @@
   <data name="IdempotentAlreadyPublished" xml:space="preserve">
     <value>These events have already been successfully published.  When idempotent publishing is enabled, events that were acknowledged by the Event Hubs service may not be published again.</value>
   </data>
+  <data name="ListCheckpointsAsyncObsolete" xml:space="preserve">
+    <value>The ListCheckpointsAsync method has been superseded by GetCheckpointAsync and should no longer be called.</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
@@ -78,6 +78,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(Mock.Of<SettableTransportConsumer>());
 
+             mockProcessor
+                .Setup(processor => processor.ValidateStartupAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
             Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Running), "The processor should not fault if a load balancing cycle fails.");
 
@@ -130,6 +134,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockProcessor
                 .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(Mock.Of<SettableTransportConsumer>());
+
+            mockProcessor
+                .Setup(processor => processor.ValidateStartupAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
 
             await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
             Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Running), "The processor should not fault if a load balancing cycle fails.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
@@ -48,6 +48,12 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(processor => processor.CreateConnection())
                 .Throws(expectedException);
 
+            mockProcessor
+                .Setup(processor => processor.ValidateStartupAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             // Delay the return from the error handler by slightly longer than cancellation is triggered in
             // order to validate that the handler call does not block or delay other processor operations.
 
@@ -97,6 +103,12 @@ namespace Azure.Messaging.EventHubs.Tests
             mockProcessor
                 .Setup(processor => processor.CreateConnection())
                 .Throws(expectedException);
+
+            mockProcessor
+                .Setup(processor => processor.ValidateStartupAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
 
             mockLogger
                 .Setup(log => log.EventProcessorTaskError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))


### PR DESCRIPTION
# Summary

The focus of these changes is to introduce validation for configuration and permissions errors that would prevent an event processor from being able to recover without intervention.  For example, an incorrect connection string or the inability to write to the storage container would be detected.

Validation is performed in an unobtrusive way intended to avoid delaying the processor's ability to begin taking ownership of partitions while ensuring that host applications are made aware of fatal problems within the scope of the Start call, rather than having to rely on the error handler.

Also included in these changes is retiring of the `ListCheckpointsAsync` implementation, which was deprecated in favor of `GetCheckpointAsync` previously, though tests were not properly updated to reflect the change.

# References and Related

- [Event Processor Client: Eagerly Validate Connections at Startup (#19301)](https://github.com/Azure/azure-sdk-for-net/issues/19301)
- [[Design Discussion] Should the Event Processors Eagerly Validate Connections at Startup (#18552)](https://github.com/Azure/azure-sdk-for-net/issues/18552)