### PR TITLE
[FR] Improve docstrings

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormLine.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormLine.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace Azure.AI.FormRecognizer.Models
 {
     /// <summary>
-    /// Represents a line of text  and its appearance.
+    /// Represents a line of text and its appearance.
     /// </summary>
     public class FormLine : FormElement
     {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -32,8 +32,8 @@ namespace Azure.AI.FormRecognizer
         /// <remarks>
         /// Both the <paramref name="endpoint"/> URI string and the <paramref name="credential"/> <c>string</c> key
         /// can be found in the Azure Portal.
+        /// For more information see <see href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"> here</see>.
         /// </remarks>
-        /// <seealso href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"/>
         public FormRecognizerClient(Uri endpoint, AzureKeyCredential credential)
             : this(endpoint, credential, new FormRecognizerClientOptions())
         {
@@ -48,8 +48,8 @@ namespace Azure.AI.FormRecognizer
         /// <remarks>
         /// Both the <paramref name="endpoint"/> URI string and the <paramref name="credential"/> <c>string</c> key
         /// can be found in the Azure Portal.
+        /// For more information see <see href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"> here</see>.
         /// </remarks>
-        /// <seealso href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"/>
         public FormRecognizerClient(Uri endpoint, AzureKeyCredential credential, FormRecognizerClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
@@ -68,8 +68,8 @@ namespace Azure.AI.FormRecognizer
         /// <param name="credential">A credential used to authenticate to an Azure Service.</param>
         /// <remarks>
         /// The <paramref name="endpoint"/> URI string can be found in the Azure Portal.
+        /// For more information see <see href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"> here</see>.
         /// </remarks>
-        /// <seealso href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"/>
         public FormRecognizerClient(Uri endpoint, TokenCredential credential)
             : this(endpoint, credential, new FormRecognizerClientOptions())
         {
@@ -83,8 +83,8 @@ namespace Azure.AI.FormRecognizer
         /// <param name="options">A set of options to apply when configuring the client.</param>
         /// <remarks>
         /// The <paramref name="endpoint"/> URI string can be found in the Azure Portal.
+        /// For more information see <see href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"> here</see>.
         /// </remarks>
-        /// <seealso href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"/>
         public FormRecognizerClient(Uri endpoint, TokenCredential credential, FormRecognizerClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
@@ -278,7 +278,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more receipts.
-        /// <para>See <a href="https://aka.ms/formrecognizer/receiptfields"/> for a list of available fields on a receipt.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/receiptfields">receipt fields</see> for a list of available fields on a receipt.</para>
         /// </summary>
         /// <param name="receipt">The stream containing the one or more receipts to recognize values from.</param>
         /// <param name="recognizeReceiptsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -319,7 +319,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more receipts.
-        /// <para>See <a href="https://aka.ms/formrecognizer/receiptfields"/> for a list of available fields on a receipt.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/receiptfields">receipt fields</see> for a list of available fields on a receipt.</para>
         /// </summary>
         /// <param name="receipt">The stream containing the one or more receipts to recognize values from.</param>
         /// <param name="recognizeReceiptsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -360,7 +360,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more receipts.
-        /// <para>See <a href="https://aka.ms/formrecognizer/receiptfields"/> for a list of available fields on a receipt.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/receiptfields">receipt fields</see> for a list of available fields on a receipt.</para>
         /// </summary>
         /// <param name="receiptUri">The absolute URI of the remote file to recognize values from.</param>
         /// <param name="recognizeReceiptsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -399,7 +399,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more receipts.
-        /// <para>See <a href="https://aka.ms/formrecognizer/receiptfields"/> for a list of available fields on a receipt.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/receiptfields">receipt fields</see> for a list of available fields on a receipt.</para>
         /// </summary>
         /// <param name="receiptUri">The absolute URI of the remote file to recognize values from.</param>
         /// <param name="recognizeReceiptsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -442,7 +442,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more business cards.
-        /// <para>See <a href="https://aka.ms/formrecognizer/businesscardfields"/> for a list of available fields on a business card.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/businesscardfields">business card fields</see> for a list of available fields on a business card.</para>
         /// </summary>
         /// <param name="businessCard">The stream containing the one or more business cards to recognize values from.</param>
         /// <param name="recognizeBusinessCardsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -486,7 +486,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more business cards.
-        /// <para>See <a href="https://aka.ms/formrecognizer/businesscardfields"/> for a list of available fields on a business card.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/businesscardfields">business card fields</see> for a list of available fields on a business card.</para>
         /// </summary>
         /// <param name="businessCard">The stream containing the one or more business cards to recognize values from.</param>
         /// <param name="recognizeBusinessCardsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -530,7 +530,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more business cards.
-        /// <para>See <a href="https://aka.ms/formrecognizer/businesscardfields"/> for a list of available fields on a business card.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/businesscardfields">business card fields</see> for a list of available fields on a business card.</para>
         /// </summary>
         /// <param name="businessCardUri">The absolute URI of the remote file to recognize values from.</param>
         /// <param name="recognizeBusinessCardsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -572,7 +572,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more business cards.
-        /// <para>See <a href="https://aka.ms/formrecognizer/businesscardfields"/> for a list of available fields on a business card.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/businesscardfields">business card fields</see> for a list of available fields on a business card.</para>
         /// </summary>
         /// <param name="businessCardUri">The absolute URI of the remote file to recognize values from.</param>
         /// <param name="recognizeBusinessCardsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -618,7 +618,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more invoices.
-        /// <para>See <a href="https://aka.ms/formrecognizer/invoicefields"/> for a list of available fields on an invoice.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/invoicefields">invoice fields</see> for a list of available fields on an invoice.</para>
         /// </summary>
         /// <param name="invoice">The stream containing the one or more invoices to recognize values from.</param>
         /// <param name="recognizeInvoicesOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -662,7 +662,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more invoices.
-        /// <para>See <a href="https://aka.ms/formrecognizer/invoicefields"/> for a list of available fields on an invoice.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/invoicefields">invoice fields</see> for a list of available fields on an invoice.</para>
         /// </summary>
         /// <param name="invoice">The stream containing the one or more invoices to recognize values from.</param>
         /// <param name="recognizeInvoicesOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -706,7 +706,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more invoices.
-        /// <para>See <a href="https://aka.ms/formrecognizer/invoicefields"/> for a list of available fields on an invoice.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/invoicefields">invoice fields</see> for a list of available fields on an invoice.</para>
         /// </summary>
         /// <param name="invoiceUri">The absolute URI of the remote file to recognize values from.</param>
         /// <param name="recognizeInvoicesOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -748,7 +748,7 @@ namespace Azure.AI.FormRecognizer
 
         /// <summary>
         /// Recognizes values from one or more invoices.
-        /// <para>See <a href="https://aka.ms/formrecognizer/invoicefields"/> for a list of available fields on an invoice.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/invoicefields">invoice fields</see> for a list of available fields on an invoice.</para>
         /// </summary>
         /// <param name="invoiceUri">The absolute URI of the remote file to recognize values from.</param>
         /// <param name="recognizeInvoicesOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -794,7 +794,7 @@ namespace Azure.AI.FormRecognizer
         /// <summary>
         /// Analyze identity documents using optical character recognition (OCR) and a prebuilt model trained on identity documents
         /// to extract key information from passports and US driver licenses.
-        /// <para>See <a href="https://aka.ms/formrecognizer/iddocumentfields"/> for a list of available fields on an identity document.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/iddocumentfields">identity document fields</see> for a list of available fields on an identity document.</para>
         /// </summary>
         /// <param name="identityDocument">The stream containing the one or more identity documents to recognize values from.</param>
         /// <param name="recognizeIdentityDocumentsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -838,7 +838,7 @@ namespace Azure.AI.FormRecognizer
         /// <summary>
         /// Analyze identity documents using optical character recognition (OCR) and a prebuilt model trained on identity documents
         /// to extract key information from passports and US driver licenses.
-        /// <para>See <a href="https://aka.ms/formrecognizer/iddocumentfields"/> for a list of available fields on an identity document.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/iddocumentfields">identity document fields</see> for a list of available fields on an identity document.</para>
         /// </summary>
         /// <param name="identityDocument">The stream containing the one or more identity documents to recognize values from.</param>
         /// <param name="recognizeIdentityDocumentsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -882,7 +882,7 @@ namespace Azure.AI.FormRecognizer
         /// <summary>
         /// Analyze identity documents using optical character recognition (OCR) and a prebuilt model trained on identity documents
         /// to extract key information from passports and US driver licenses.
-        /// <para>See <a href="https://aka.ms/formrecognizer/iddocumentfields"/> for a list of available fields on an identity document.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/iddocumentfields">identity document fields</see> for a list of available fields on an identity document.</para>
         /// </summary>
         /// <param name="identityDocumentUri">The absolute URI of the remote file to recognize values from.</param>
         /// <param name="recognizeIdentityDocumentsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the
@@ -924,7 +924,7 @@ namespace Azure.AI.FormRecognizer
         /// <summary>
         /// Analyze identity documents using optical character recognition (OCR) and a prebuilt model trained on identity documents
         /// to extract key information from passports and US driver licenses.
-        /// <para>See <a href="https://aka.ms/formrecognizer/iddocumentfields"/> for a list of available fields on an identity document.</para>
+        /// <para>See <see href="https://aka.ms/formrecognizer/iddocumentfields">identity document fields</see> for a list of available fields on an identity document.</para>
         /// </summary>
         /// <param name="identityDocumentUri">The absolute URI of the remote file to recognize values from.</param>
         /// <param name="recognizeIdentityDocumentsOptions">A set of options available for configuring the recognize request. For example, specify the content type of the

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
@@ -43,8 +43,8 @@ namespace Azure.AI.FormRecognizer.Training
         /// <remarks>
         /// Both the <paramref name="endpoint"/> URI string and the <paramref name="credential"/> <c>string</c> key
         /// can be found in the Azure Portal.
+        /// For more information see <see href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"> here</see>.
         /// </remarks>
-        /// <seealso href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"/>
         public FormTrainingClient(Uri endpoint, AzureKeyCredential credential)
             : this(endpoint, credential, new FormRecognizerClientOptions())
         {
@@ -59,8 +59,8 @@ namespace Azure.AI.FormRecognizer.Training
         /// <remarks>
         /// Both the <paramref name="endpoint"/> URI string and the <paramref name="credential"/> <c>string</c> key
         /// can be found in the Azure Portal.
+        /// For more information see <see href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"> here</see>.
         /// </remarks>
-        /// <seealso href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"/>
         public FormTrainingClient(Uri endpoint, AzureKeyCredential credential, FormRecognizerClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
@@ -80,8 +80,8 @@ namespace Azure.AI.FormRecognizer.Training
         /// <param name="credential">A credential used to authenticate to an Azure Service.</param>
         /// <remarks>
         /// The <paramref name="endpoint"/> URI string can be found in the Azure Portal.
+        /// For more information see <see href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"> here</see>.
         /// </remarks>
-        /// <seealso href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"/>
         public FormTrainingClient(Uri endpoint, TokenCredential credential)
             : this(endpoint, credential, new FormRecognizerClientOptions())
         {
@@ -95,8 +95,8 @@ namespace Azure.AI.FormRecognizer.Training
         /// <param name="options">A set of options to apply when configuring the client.</param>
         /// <remarks>
         /// The <paramref name="endpoint"/> URI string can be found in the Azure Portal.
+        /// For more information see <see href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"> here</see>.
         /// </remarks>
-        /// <seealso href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md#authenticate-a-form-recognizer-client"/>
         public FormTrainingClient(Uri endpoint, TokenCredential credential, FormRecognizerClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
@@ -114,7 +114,7 @@ namespace Azure.AI.FormRecognizer.Training
         /// Trains a model from a collection of custom forms in a blob storage container.
         /// </summary>
         /// <param name="trainingFilesUri">An externally accessible Azure storage blob container Uri.
-        /// For more information see <a href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data"/>.</param>
+        /// For more information see <see href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data">here</see>.</param>
         /// <param name="useTrainingLabels">If <c>true</c>, corresponding labeled files must exist in the blob container. If <c>false</c>, the model will be trained from forms only.</param>
         /// <param name="modelName">An optional, user-defined name to associate with the model.
         /// <remarks>
@@ -161,7 +161,7 @@ namespace Azure.AI.FormRecognizer.Training
         /// Trains a model from a collection of custom forms in a blob storage container.
         /// </summary>
         /// <param name="trainingFilesUri">An externally accessible Azure storage blob container Uri.
-        /// For more information see <a href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data"/>.</param>
+        /// For more information see <see href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data">here</see>.</param>
         /// <param name="useTrainingLabels">If <c>true</c>, corresponding labeled files must exist in the blob container. If <c>false</c>, the model will be trained from forms only.</param>
         /// <param name="modelName">An optional, user-defined name to associate with the model.
         /// <remarks>
@@ -207,7 +207,7 @@ namespace Azure.AI.FormRecognizer.Training
         /// Trains a model from a collection of custom forms in a blob storage container.
         /// </summary>
         /// <param name="trainingFilesUri">An externally accessible Azure storage blob container Uri.
-        /// For more information see <a href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data"/>.</param>
+        /// For more information see <see href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data">here</see>.</param>
         /// <param name="useTrainingLabels">If <c>true</c>, corresponding labeled files must exist in the blob container. If <c>false</c>, the model will be trained from forms only.</param>
         /// <param name="trainingOptions">A set of options available for configuring the training request. For example, set a filter to apply
         /// to the documents in the source path for training.</param>
@@ -248,7 +248,7 @@ namespace Azure.AI.FormRecognizer.Training
         /// Trains a model from a collection of custom forms in a blob storage container.
         /// </summary>
         /// <param name="trainingFilesUri">An externally accessible Azure storage blob container Uri.
-        /// For more information see <a href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data"/>.</param>
+        /// For more information see <see href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data">here</see>.</param>
         /// <param name="useTrainingLabels">If <c>true</c>, corresponding labeled files must exist in the blob container. If <c>false</c>, the model will be trained from forms only.</param>
         /// <param name="trainingOptions">A set of options available for configuring the training request. For example, set a filter to apply
         /// to the documents in the source path for training.</param>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeBusinessCardsOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeBusinessCardsOptions.cs
@@ -48,7 +48,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <a href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</a>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
         /// </para>
         /// </summary>
         public IList<string> Pages { get; } = new List<string>();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOptions.cs
@@ -57,7 +57,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <a href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</a>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
         /// </para>
         /// </summary>
         /// <remarks>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOptions.cs
@@ -42,7 +42,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <a href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</a>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
         /// </para>
         /// </summary>
         /// <remarks>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeIdentityDocumentsOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeIdentityDocumentsOptions.cs
@@ -42,7 +42,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <a href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</a>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
         /// </para>
         /// </summary>
         public IList<string> Pages { get; } = new List<string>();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeInvoicesOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeInvoicesOptions.cs
@@ -48,7 +48,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <a href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</a>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
         /// </para>
         /// </summary>
         public IList<string> Pages { get; } = new List<string>();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOptions.cs
@@ -51,7 +51,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <a href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</a>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
         /// </para>
         /// </summary>
         /// <remarks>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DisposableTrainedModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DisposableTrainedModel.cs
@@ -16,7 +16,7 @@ namespace Azure.AI.FormRecognizer.Tests
     /// <remarks>
     /// Please note that models can also be trained using a graphical user interface
     /// such as the Form Recognizer Labeling Tool found here:
-    /// <a href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/label-tool"/>.
+    /// <see href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/label-tool"/>.
     /// </remarks>
     public class DisposableTrainedModel : IAsyncDisposable
     {


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/20845

- For constructors, the `See Also` section is not displayed in MS docs, so adding that information into remarks.  i.e. [here](https://docs.microsoft.com/en-us/dotnet/api/azure.ai.formrecognizer.formrecognizerclient.-ctor?view=azure-dotnet#Azure_AI_FormRecognizer_FormRecognizerClient__ctor)
- Links should use the tag `<see>` or `<seealso>` according to context and not `<a>` so updating that.