### PR TITLE
Remove EnableAPICompat from released packages and update common dependency as package

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -74,6 +74,7 @@
     <PackageReference Update="Microsoft.CSharp" Version="4.5.0" />
 
     <!-- Azure SDK packages -->
+    <PackageReference Update="Azure.Communication.Common" Version="1.0.0" />
     <PackageReference Update="Azure.Core" Version="1.13.0" />
     <PackageReference Update="Azure.Core.Amqp" Version="1.1.0-beta.1" Condition="'$(HasReleaseVersion)' == 'false'"/>
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.10" />

--- a/sdk/communication/Azure.Communication.Chat/src/Azure.Communication.Chat.csproj
+++ b/sdk/communication/Azure.Communication.Chat/src/Azure.Communication.Chat.csproj
@@ -30,7 +30,7 @@
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Azure.Communication.Common\src\Azure.Communication.Common.csproj" />
+    <PackageReference Include="Azure.Communication.Common" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />

--- a/sdk/communication/Azure.Communication.Chat/src/Azure.Communication.Chat.csproj
+++ b/sdk/communication/Azure.Communication.Chat/src/Azure.Communication.Chat.csproj
@@ -12,7 +12,6 @@
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Communication Chat Service;Microsoft;Azure;Azure Communication Service;Azure Communication Chat Service;Chat;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <EnableApiCompat>false</EnableApiCompat>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />

--- a/sdk/communication/Azure.Communication.Common/src/Azure.Communication.Common.csproj
+++ b/sdk/communication/Azure.Communication.Common/src/Azure.Communication.Common.csproj
@@ -11,7 +11,6 @@
     <PackageTags>Microsoft Azure Communication Service;Microsoft;Azure;Azure Communication Service;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Azure.Communication</RootNamespace>
-    <EnableApiCompat>false</EnableApiCompat>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />

--- a/sdk/communication/Azure.Communication.Identity/src/Azure.Communication.Identity.csproj
+++ b/sdk/communication/Azure.Communication.Identity/src/Azure.Communication.Identity.csproj
@@ -34,7 +34,7 @@
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Azure.Communication.Common\src\Azure.Communication.Common.csproj" />
+    <PackageReference Include="Azure.Communication.Common" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />

--- a/sdk/communication/Azure.Communication.Identity/src/Azure.Communication.Identity.csproj
+++ b/sdk/communication/Azure.Communication.Identity/src/Azure.Communication.Identity.csproj
@@ -11,7 +11,6 @@
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Communication Identity Service;Microsoft;Azure;Azure Communication Service;Azure Communication Identity Service;Identity;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <EnableApiCompat>false</EnableApiCompat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/Azure.Communication.PhoneNumbers.csproj
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/Azure.Communication.PhoneNumbers.csproj
@@ -10,7 +10,6 @@
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Communication Phone Numbers Service;Microsoft;Azure;Azure Communication Service;Azure Communication Phone Numbers Service;Phone Numbers;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <EnableApiCompat>false</EnableApiCompat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/communication/Azure.Communication.Sms/src/Azure.Communication.Sms.csproj
+++ b/sdk/communication/Azure.Communication.Sms/src/Azure.Communication.Sms.csproj
@@ -11,7 +11,6 @@
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Communication Sms Service;Microsoft;Azure;Azure Communication Service;Azure Communication Sms Service;Sms;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <EnableApiCompat>false</EnableApiCompat>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is actually a no-op the actual compatibility is now driven through ApiCompatVersion which is managed automatically