### PR TITLE
[Event Hubs Client] Test Configuration Adjustments

### DIFF
--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -57,7 +57,7 @@
     },
     "perTestExecutionLimitMinutes": {
       "type": "string",
-      "defaultValue": "10",
+      "defaultValue": "15",
       "metadata": {
         "description": "The maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung."
       }

--- a/sdk/eventhub/tests.data.yml
+++ b/sdk/eventhub/tests.data.yml
@@ -7,4 +7,5 @@ extends:
     ServiceDirectory: eventhub
     SDKType: data
     TimeoutInMinutes: 240
-    Clouds: 'Public,UsGov,China,Canary'
+    Clouds: 'Public,Canary'
+    SupportedClouds: 'Public,UsGov,China,Canary'

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -7,4 +7,5 @@ extends:
     ServiceDirectory: eventhub
     SDKType: client
     TimeoutInMinutes: 240
-    Clouds: 'Public,UsGov,China,Canary'
+    Clouds: 'Public,Canary'
+    SupportedClouds: 'Public,UsGov,China,Canary'


### PR DESCRIPTION
# Summary

The focus of these changes is to adjust the clouds used for nightly and manual test runs, reverting to the Public and Canary clouds.  Weekly runs will include the UsGov and China sovereign clouds as well.   After discussion, this aligns with the configuration that the engineering team intended.

Due to the China cloud performing slowly during runs, we've seen some tests start to exceed the previous execution time cap; this cap has been increased to reduce flakiness in weekly runs.  I'll continue to monitor and adjust as we learn more about test stability and performance in the sovereign clouds.

# References and Related

- [Wiki: Configuring Tests](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/389/Configuring-Tests?anchor=configuring-test-environments)