### PR TITLE
[Service Bus] Populate TransportType

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -115,6 +115,10 @@ namespace Azure.Messaging.ServiceBus
         /// If the connection string specifies a specific entity name, any subsequent calls to
         /// <see cref="CreateSender(string)"/>, <see cref="CreateReceiver(string)"/>,
         /// <see cref="CreateProcessor(string)"/> etc. must still specify the same entity name.
+        ///
+        /// The connection string will recognize and apply properties populated by the
+        /// Azure portal such as Endpoint, SharedAccessKeyName, SharedAccessKey, and EntityPath.
+        /// Other values will be ignored; to configure the processor, please use the <see cref="ServiceBusClientOptions" />.
         /// </remarks>
         public ServiceBusClient(string connectionString) :
             this(connectionString, new ServiceBusClientOptions())
@@ -134,6 +138,10 @@ namespace Azure.Messaging.ServiceBus
         /// If the connection string specifies a specific entity name, any subsequent calls to
         /// <see cref="CreateSender(string)"/>, <see cref="CreateReceiver(string)"/>,
         /// <see cref="CreateProcessor(string)"/> etc. must still specify the same entity name.
+        ///
+        /// The connection string will recognize and apply properties populated by the
+        /// Azure portal such as Endpoint, SharedAccessKeyName, SharedAccessKey, and EntityPath.
+        /// Other values will be ignored; to configure the processor, please use the <see cref="ServiceBusClientOptions" />.
         /// </remarks>
         public ServiceBusClient(string connectionString, ServiceBusClientOptions options)
         {
@@ -142,6 +150,7 @@ namespace Azure.Messaging.ServiceBus
             Logger.ClientCreateStart(typeof(ServiceBusClient), FullyQualifiedNamespace);
             Identifier = DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
             Plugins = _options.Plugins;
+            TransportType = _options.TransportType;
             Logger.ClientCreateComplete(typeof(ServiceBusClient), Identifier);
         }
 
@@ -218,14 +227,15 @@ namespace Azure.Messaging.ServiceBus
             object credential,
             ServiceBusClientOptions options)
         {
-            _options = options?.Clone() ?? new ServiceBusClientOptions();
             Logger.ClientCreateStart(typeof(ServiceBusClient), fullyQualifiedNamespace);
+            _options = options?.Clone() ?? new ServiceBusClientOptions();
             Identifier = DiagnosticUtilities.GenerateIdentifier(fullyQualifiedNamespace);
             Connection = ServiceBusConnection.CreateWithCredential(
                 fullyQualifiedNamespace,
                 credential,
                 _options);
             Plugins = _options.Plugins;
+            TransportType = _options.TransportType;
             Logger.ClientCreateComplete(typeof(ServiceBusClient), Identifier);
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Client
 {
+    [TestFixture]
     public class ServiceBusClientTests
     {
         /// <summary>
@@ -266,10 +267,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         /// </summary>
         ///
         [Test]
-        public void ConstructorWithTokenCredentialArgumentsValidatesOptions()
+        public void ConstructorWithTokenCredentialValidatesOptions()
         {
             var token = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
             var invalidOptions = new ServiceBusClientOptions { TransportType = ServiceBusTransportType.AmqpTcp, WebProxy = Mock.Of<IWebProxy>() };
+
             Assert.That(() => new ServiceBusClient("fullyQualifiedNamespace", Mock.Of<TokenCredential>(), invalidOptions), Throws.InstanceOf<ArgumentException>(), "The expanded argument constructor should validate client options");
         }
 
@@ -279,11 +281,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         /// </summary>
         ///
         [Test]
-        public void ConstructorWithSharedKeyCredentialArgumentsValidatesOptions()
+        public void ConstructorWithSharedKeyCredentialValidatesOptions()
         {
             var token = new AzureNamedKeyCredential("key", "value");
             var invalidOptions = new ServiceBusClientOptions { TransportType = ServiceBusTransportType.AmqpTcp, WebProxy = Mock.Of<IWebProxy>() };
-            Assert.That(() => new ServiceBusClient("fullyQualifiedNamespace", Mock.Of<TokenCredential>(), invalidOptions), Throws.InstanceOf<ArgumentException>(), "The expanded argument constructor should validate client options");
+
+            Assert.That(() => new ServiceBusClient("fullyQualifiedNamespace", token, invalidOptions), Throws.InstanceOf<ArgumentException>(), "The expanded argument constructor should validate client options");
         }
 
         /// <summary>
@@ -292,12 +295,74 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         /// </summary>
         ///
         [Test]
-        public void ConstructorWithSasCredentialArgumentsValidatesOptions()
+        public void ConstructorWithSasCredentialValidatesOptions()
         {
             var signature = new SharedAccessSignature("sb://fake.thing.com", "fakeKey", "fakeValue");
             var token = new AzureSasCredential(signature.Value);
             var invalidOptions = new ServiceBusClientOptions { TransportType = ServiceBusTransportType.AmqpTcp, WebProxy = Mock.Of<IWebProxy>() };
-            Assert.That(() => new ServiceBusClient("fullyQualifiedNamespace", Mock.Of<TokenCredential>(), invalidOptions), Throws.InstanceOf<ArgumentException>(), "The expanded argument constructor should validate client options");
+
+            Assert.That(() => new ServiceBusClient("fullyQualifiedNamespace", token, invalidOptions), Throws.InstanceOf<ArgumentException>(), "The expanded argument constructor should validate client options");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="ServiceBusClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorWithConnectionStringSetsTransportTypeFromOptions()
+        {
+            var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
+            var options = new ServiceBusClientOptions { TransportType = ServiceBusTransportType.AmqpWebSockets };
+            var client = new ServiceBusClient(fakeConnection, options);
+
+            Assert.That(client.TransportType, Is.EqualTo(options.TransportType));
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="ServiceBusClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorWithTokenCredentialSetsTransportTypeFromOptions()
+        {
+            var token = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
+            var options = new ServiceBusClientOptions { TransportType = ServiceBusTransportType.AmqpWebSockets };
+            var client = new ServiceBusClient("fullyQualifiedNamespace", Mock.Of<TokenCredential>(), options);
+
+            Assert.That(client.TransportType, Is.EqualTo(options.TransportType));
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="ServiceBusClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorWithSharedKeyCredentialSetsTransportTypeFromOptions()
+        {
+            var token = new AzureNamedKeyCredential("key", "value");
+            var options = new ServiceBusClientOptions { TransportType = ServiceBusTransportType.AmqpWebSockets };
+            var client = new ServiceBusClient("fullyQualifiedNamespace", token, options);
+
+            Assert.That(client.TransportType, Is.EqualTo(options.TransportType));
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="ServiceBusClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorWithSasCredentialSetsTransportTypeFromOptions()
+        {
+            var signature = new SharedAccessSignature("sb://fake.thing.com", "fakeKey", "fakeValue");
+            var token = new AzureSasCredential(signature.Value);
+            var options = new ServiceBusClientOptions { TransportType = ServiceBusTransportType.AmqpWebSockets };
+            var client = new ServiceBusClient("fullyQualifiedNamespace", token, options);
+
+            Assert.That(client.TransportType, Is.EqualTo(options.TransportType));
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to populate the `TransportType` property on the `ServiceBusClient` at construction.  Previously, the requested `TransportType` was honored but was nor correctly reflected in the property.   Messaging to clarify connection string semantics is also included, as are some test fixes.

# References and Related

- [ServiceBusTransportType is always AmqpTcp (#20910)](https://github.com/Azure/azure-sdk-for-net/issues/20910)
