### PR TITLE
Don't log task canceled exceptions as errors when stopping processor.

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -139,9 +139,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="identifier">The identifier for the sender.</param>
         /// <param name="sessionId">The session ID to receive messages for.</param>
         /// <param name="isSessionReceiver">Whether or not this is a sessionful receiver link.</param>
+        /// <param name="isProcessor">Whether or not the receiver is being created for a processor.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the
-        /// open link operation. Only applicable for session receivers.</param>
-        ///
+        ///     open link operation. Only applicable for session receivers.</param>
         /// <returns>A <see cref="TransportReceiver" /> configured in the requested manner.</returns>
         public override TransportReceiver CreateReceiver(
             string entityPath,
@@ -151,6 +151,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             string identifier,
             string sessionId,
             bool isSessionReceiver,
+            bool isProcessor,
             CancellationToken cancellationToken)
         {
             Argument.AssertNotDisposed(_closed, nameof(AmqpClient));
@@ -165,6 +166,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 identifier,
                 sessionId,
                 isSessionReceiver,
+                isProcessor,
                 cancellationToken
             );
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -276,7 +276,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="isProcessor">Whether or not the receiver is being created for a processor.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         /// <returns>List of messages received. Returns an empty list if no message is found.</returns>
-        public override async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveMessagesAsync(int maxMessages,
+        public override async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveMessagesAsync(
+            int maxMessages,
             TimeSpan? maxWaitTime,
             bool isProcessor,
             CancellationToken cancellationToken)
@@ -1405,7 +1406,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <summary>
         /// Opens an AMQP link for use with receiver operations.
         /// </summary>
-        /// <param name="isProcessor"></param>
+        /// <param name="isProcessor">Whether or not the receiver is being created for a processor.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         public override async Task OpenLinkAsync(bool isProcessor, CancellationToken cancellationToken)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -111,20 +111,20 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// </summary>
         ///
         /// <param name="entityPath">The name of the Service Bus entity from which events will be consumed.</param>
-        /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         /// <param name="receiveMode">The <see cref="ServiceBusReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.</param>
+        /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         /// <param name="connectionScope">The AMQP connection context for operations .</param>
         /// <param name="retryPolicy">The retry policy to consider when an operation fails.</param>
         /// <param name="identifier">The identifier for the sender.</param>
         /// <param name="sessionId">The session ID to receive messages for.</param>
         /// <param name="isSessionReceiver">Whether or not this is a sessionful receiver link.</param>
+        /// <param name="isProcessor">Whether or not the receiver is being created for a processor.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the
         /// open link operation. Only applicable for session receivers.</param>
         ///
         /// <remarks>
         /// As an internal type, this class performs only basic sanity checks against its arguments.  It
         /// is assumed that callers are trusted and have performed deep validation.
-        ///
         /// Any parameters passed are assumed to be owned by this instance and safe to mutate or dispose;
         /// creation of clones or otherwise protecting the parameters is assumed to be the purview of the
         /// caller.
@@ -138,6 +138,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             string identifier,
             string sessionId,
             bool isSessionReceiver,
+            bool isProcessor,
             CancellationToken cancellationToken)
         {
             Argument.AssertNotNullOrEmpty(entityPath, nameof(entityPath));
@@ -160,6 +161,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                         prefetchCount: prefetchCount,
                         receiveMode: receiveMode,
                         isSessionReceiver: isSessionReceiver,
+                        isProcessor: isProcessor,
                         identifier: identifier,
                         // The cancellationToken will always be CancellationToken.None for non-session receivers
                         // it is okay to register the user provided cancellationToken from the AcceptNextSessionAsync call in
@@ -189,6 +191,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             uint prefetchCount,
             ServiceBusReceiveMode receiveMode,
             bool isSessionReceiver,
+            bool isProcessor,
             string identifier,
             CancellationToken cancellationToken)
         {
@@ -208,8 +211,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 if (isSessionReceiver)
                 {
                     SessionLockedUntil = link.Settings.Properties.TryGetValue<long>(
-                        AmqpClientConstants.LockedUntilUtc, out var lockedUntilUtcTicks) ?
-                        new DateTime(lockedUntilUtcTicks, DateTimeKind.Utc)
+                        AmqpClientConstants.LockedUntilUtc, out var lockedUntilUtcTicks)
+                        ? new DateTime(lockedUntilUtcTicks, DateTimeKind.Utc)
                         : DateTime.MinValue;
 
                     var source = (Source)link.Settings.Source;
@@ -231,6 +234,20 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 ServiceBusEventSource.Log.CreateReceiveLinkComplete(_identifier, SessionId);
                 link.Closed += OnReceiverLinkClosed;
                 return link;
+            }
+            catch (TimeoutException)
+                when (isSessionReceiver)
+            {
+                // When this occurs during accepting a session, it will be logged from
+                // ServiceBusSessionReceiver.CreateSessionReceiverAsync so it would be redundant
+                // to log here.
+                throw;
+            }
+            catch (TaskCanceledException)
+                when (isProcessor)
+            {
+                // do not log this as the processor is shutting down
+                throw;
             }
             catch (Exception ex)
             {
@@ -254,15 +271,14 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <summary>
         /// Receives a list of <see cref="ServiceBusReceivedMessage" /> from the entity using <see cref="ServiceBusReceiveMode"/> mode.
         /// </summary>
-        ///
         /// <param name="maxMessages">The maximum number of messages that will be received.</param>
         /// <param name="maxWaitTime">An optional <see cref="TimeSpan"/> specifying the maximum time to wait for the first message before returning an empty list if no messages have been received.</param>
+        /// <param name="isProcessor">Whether or not the receiver is being created for a processor.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
         /// <returns>List of messages received. Returns an empty list if no message is found.</returns>
-        public override async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveMessagesAsync(
-            int maxMessages,
+        public override async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveMessagesAsync(int maxMessages,
             TimeSpan? maxWaitTime,
+            bool isProcessor,
             CancellationToken cancellationToken)
         {
             return await _retryPolicy.RunOperation(static async (value, timeout, token) =>
@@ -285,12 +301,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///
         /// <param name="maxMessages">The maximum number of messages to receive.</param>
         /// <param name="maxWaitTime">An optional <see cref="TimeSpan"/> specifying the maximum time to wait for the first message before returning an empty list if no messages have been received.
-        /// If not specified, the <see cref="ServiceBusRetryOptions.TryTimeout"/> will be used.</param>
+        ///     If not specified, the <see cref="ServiceBusRetryOptions.TryTimeout"/> will be used.</param>
         /// <param name="timeout">The per-try timeout specified in the RetryOptions.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
         /// <returns>The list of <see cref="ServiceBusMessage" /> from the Service Bus entity this receiver is associated with. If no messages are present, an empty list is returned.</returns>
-        ///
         private async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveMessagesAsyncInternal(
             int maxMessages,
             TimeSpan? maxWaitTime,
@@ -895,7 +909,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// Each subsequent call fetches the subsequent message in the entity.
         /// Unlike a received message, peeked message will not have lock token associated with it,
         /// and hence it cannot be Completed/Abandoned/Deferred/Deadlettered/Renewed.
-        /// Also, unlike <see cref="ReceiveMessagesAsync(int, TimeSpan?, CancellationToken)"/>, this method will fetch even Deferred messages (but not Deadlettered message)
+        /// Also, unlike <see cref="ReceiveMessagesAsync"/>, this method will fetch even Deferred messages (but not Deadlettered message)
         /// </remarks>
         /// <returns></returns>
         public override async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekMessagesAsync(
@@ -1391,11 +1405,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <summary>
         /// Opens an AMQP link for use with receiver operations.
         /// </summary>
-        ///
+        /// <param name="isProcessor"></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
-        public override async Task OpenLinkAsync(CancellationToken cancellationToken)
+        public override async Task OpenLinkAsync(bool isProcessor, CancellationToken cancellationToken)
         {
             _ = await _retryPolicy.RunOperation(
                 static async (receiveLink, timeout, _) =>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportClient.cs
@@ -47,14 +47,14 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         public abstract TransportSender CreateSender(string entityPath, ServiceBusRetryPolicy retryPolicy, string identifier);
 
-        public abstract TransportReceiver CreateReceiver(
-            string entityPath,
+        public abstract TransportReceiver CreateReceiver(string entityPath,
             ServiceBusRetryPolicy retryPolicy,
             ServiceBusReceiveMode receiveMode,
             uint prefetchCount,
             string identifier,
             string sessionId,
             bool isSessionReceiver,
+            bool isProcessor,
             CancellationToken cancellationToken);
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -39,16 +39,16 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <summary>
         /// Receives a set of <see cref="ServiceBusReceivedMessage" /> from the entity using <see cref="ServiceBusReceiveMode"/> mode.
         /// </summary>
-        ///
         /// <param name="maximumMessageCount">The maximum number of messages that will be received.</param>
         /// <param name="maxWaitTime">An optional <see cref="TimeSpan"/> specifying the maximum time to wait for the first message before returning an empty list if no messages have been received.
-        /// If not specified, the <see cref="ServiceBusRetryOptions.TryTimeout"/> will be used.</param>
+        ///     If not specified, the <see cref="ServiceBusRetryOptions.TryTimeout"/> will be used.</param>
+        /// <param name="isProcessor"></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
         /// <returns>List of messages received. Returns an empty list if no message is found.</returns>
         public abstract Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveMessagesAsync(
             int maximumMessageCount,
             TimeSpan? maxWaitTime,
+            bool isProcessor,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -61,11 +61,10 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <summary>
         /// Opens an AMQP link for use with receiver operations.
         /// </summary>
-        ///
+        /// <param name="isProcessor"></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
-        public abstract Task OpenLinkAsync(CancellationToken cancellationToken);
+        public abstract Task OpenLinkAsync(bool isProcessor, CancellationToken cancellationToken);
 
         /// <summary>
         /// Completes a <see cref="ServiceBusReceivedMessage"/>. This will delete the message from the service.
@@ -117,7 +116,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// The first call to PeekBatchBySequenceAsync(long, int, CancellationToken) fetches the first active message for this receiver. Each subsequent call
         /// fetches the subsequent message in the entity.
         /// Unlike a received message, peeked message will not have lock token associated with it, and hence it cannot be Completed/Abandoned/Deferred/Deadlettered/Renewed.
-        /// Also, unlike <see cref="ReceiveMessagesAsync(int, TimeSpan?, CancellationToken)"/>, this method will fetch even Deferred messages (but not Deadlettered messages).
+        /// Also, unlike <see cref="ReceiveMessagesAsync"/>, this method will fetch even Deferred messages (but not Deadlettered messages).
         /// </remarks>
         /// <returns></returns>
         public abstract Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekMessagesAsync(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -42,7 +42,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <param name="maximumMessageCount">The maximum number of messages that will be received.</param>
         /// <param name="maxWaitTime">An optional <see cref="TimeSpan"/> specifying the maximum time to wait for the first message before returning an empty list if no messages have been received.
         ///     If not specified, the <see cref="ServiceBusRetryOptions.TryTimeout"/> will be used.</param>
-        /// <param name="isProcessor"></param>
+        /// <param name="isProcessor">Whether or not the receiver is being created for a processor.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         /// <returns>List of messages received. Returns an empty list if no message is found.</returns>
         public abstract Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveMessagesAsync(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -61,7 +61,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <summary>
         /// Opens an AMQP link for use with receiver operations.
         /// </summary>
-        /// <param name="isProcessor"></param>
+        /// <param name="isProcessor">Whether or not the receiver is part of a processor.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         public abstract Task OpenLinkAsync(bool isProcessor, CancellationToken cancellationToken);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -19,8 +19,8 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
     /// </summary>
     ///
     /// <remarks>
-    ///   When defining Start/Stop tasks, it is highly recommended that the
-    ///   the StopEvent.Id must be exactly StartEvent.Id + 1.
+    ///   When defining Start/Complete tasks, it is highly recommended that the
+    ///   the CompleteEvent.Id must be exactly StartEvent.Id + 1.
     /// </remarks>
     [EventSource(Name = EventSourceName)]
     internal class ServiceBusEventSource : EventSource
@@ -191,6 +191,9 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         internal const int RequestAuthorizationExceptionEvent = 107;
 
         internal const int ProcessorClientClosedExceptionEvent = 108;
+        internal const int ProcessorAcceptSessionTimeoutEvent = 109;
+        internal const int ProcessorStoppingReceiveCanceledEvent = 110;
+        internal const int ProcessorStoppingAcceptSessionCanceledEvent = 111;
 
         #endregion
         // add new event numbers here incrementing from previous
@@ -842,6 +845,36 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             if (IsEnabled())
             {
                 WriteEvent(ProcessorClientClosedExceptionEvent, identifier);
+            }
+        }
+
+        [Event(ProcessorStoppingReceiveCanceledEvent, Level = EventLevel.Verbose, Message = "A receive operation was cancelled while stopping the processor. (Identifier '{0}'). Error Message: '{1}'")]
+        public void ProcessorStoppingReceiveCanceled(string identifier, string exception)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ProcessorStoppingReceiveCanceledEvent, identifier, exception);
+            }
+        }
+
+        [Event(ProcessorStoppingAcceptSessionCanceledEvent, Level = EventLevel.Verbose, Message = "An accept session operation was cancelled while stopping the processor. (Namespace '{0}', Entity path '{1}'). Error Message: '{2}'")]
+        public void ProcessorStoppingAcceptSessionCanceled(string fullyQualifiedNamespace, string entityPath, string exception)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ProcessorStoppingAcceptSessionCanceledEvent, fullyQualifiedNamespace, entityPath, exception);
+            }
+        }
+        
+        [Event(ProcessorAcceptSessionTimeoutEvent, Level = EventLevel.Verbose, Message = "The processor accept session call timed out. It will be tried again. (Namespace '{0}', Entity path '{1}'). Error Message: '{2}'")]
+        public virtual void ProcessorAcceptSessionTimeout(
+            string fullyQualifiedNamespace,
+            string entityPath,
+            string exception)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ProcessorAcceptSessionTimeoutEvent, fullyQualifiedNamespace, entityPath, exception);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -865,7 +865,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                 WriteEvent(ProcessorStoppingAcceptSessionCanceledEvent, fullyQualifiedNamespace, entityPath, exception);
             }
         }
-        
+
         [Event(ProcessorAcceptSessionTimeoutEvent, Level = EventLevel.Verbose, Message = "The processor accept session call timed out. It will be tried again. (Namespace '{0}', Entity path '{1}'). Error Message: '{2}'")]
         public virtual void ProcessorAcceptSessionTimeout(
             string fullyQualifiedNamespace,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusConnection.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusConnection.cs
@@ -240,6 +240,7 @@ namespace Azure.Messaging.ServiceBus
             string identifier,
             string sessionId,
             bool isSessionReceiver,
+            bool isProcessor,
             CancellationToken cancellationToken) =>
                 _innerClient.CreateReceiver(
                     entityPath,
@@ -249,6 +250,7 @@ namespace Azure.Messaging.ServiceBus
                     identifier,
                     sessionId,
                     isSessionReceiver,
+                    isProcessor,
                     cancellationToken);
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -85,12 +85,12 @@ namespace Azure.Messaging.ServiceBus
                 while (!cancellationToken.IsCancellationRequested && !Processor.Connection.IsClosed)
                 {
                     errorSource = ServiceBusErrorSource.Receive;
-#pragma warning disable CA1826 // Do not use Enumerable methods on indexable collections
-                    ServiceBusReceivedMessage message = (await Receiver.ReceiveMessagesAsync(
+                    IReadOnlyList<ServiceBusReceivedMessage> messages = await Receiver.ReceiveMessagesAsync(
                         maxMessages: 1,
                         maxWaitTime: _maxReceiveWaitTime,
-                        isProcessor: true, cancellationToken: cancellationToken).ConfigureAwait(false)).FirstOrDefault();
-#pragma warning restore CA1826 // Do not use Enumerable methods on indexable collections
+                        isProcessor: true,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                    ServiceBusReceivedMessage message = messages.Count == 0 ? null : messages[0];
                     if (message == null)
                     {
                         continue;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
@@ -51,6 +52,7 @@ namespace Azure.Messaging.ServiceBus
                 connection: Processor.Connection,
                 entityPath: Processor.EntityPath,
                 isSessionEntity: false,
+                isProcessor: true,
                 plugins: _plugins,
                 options: _receiverOptions);
             _scopeFactory = scopeFactory;
@@ -83,9 +85,12 @@ namespace Azure.Messaging.ServiceBus
                 while (!cancellationToken.IsCancellationRequested && !Processor.Connection.IsClosed)
                 {
                     errorSource = ServiceBusErrorSource.Receive;
-                    ServiceBusReceivedMessage message = await Receiver.ReceiveMessageAsync(
-                        _maxReceiveWaitTime,
-                        cancellationToken).ConfigureAwait(false);
+#pragma warning disable CA1826 // Do not use Enumerable methods on indexable collections
+                    ServiceBusReceivedMessage message = (await Receiver.ReceiveMessagesAsync(
+                        maxMessages: 1,
+                        maxWaitTime: _maxReceiveWaitTime,
+                        isProcessor: true, cancellationToken: cancellationToken).ConfigureAwait(false)).FirstOrDefault();
+#pragma warning restore CA1826 // Do not use Enumerable methods on indexable collections
                     if (message == null)
                     {
                         continue;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -261,13 +261,12 @@ namespace Azure.Messaging.ServiceBus
                 while (!_sessionCancellationSource.Token.IsCancellationRequested)
                 {
                     errorSource = ServiceBusErrorSource.Receive;
-                    // ReSharper disable once CA1826
-#pragma warning disable CA1826 // Do not use Enumerable methods on indexable collections
-                    ServiceBusReceivedMessage message = (await _receiver.ReceiveMessagesAsync(
+                    IReadOnlyList<ServiceBusReceivedMessage> messages = await Receiver.ReceiveMessagesAsync(
                         maxMessages: 1,
                         maxWaitTime: _maxReceiveWaitTime,
-                        isProcessor: true, cancellationToken: _sessionCancellationSource.Token).ConfigureAwait(false)).FirstOrDefault();
-#pragma warning restore CA1826 // Do not use Enumerable methods on indexable collections
+                        isProcessor: true,
+                        cancellationToken: _sessionCancellationSource.Token).ConfigureAwait(false);
+                    ServiceBusReceivedMessage message = messages.Count == 0 ? null : messages[0];
                     if (message == null)
                     {
                         // Break out of the loop to allow a new session to

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -123,9 +123,9 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="plugins">The plugins to apply to incoming messages.</param>
         /// <param name="options">A set of options to apply when configuring the consumer.</param>
         /// <param name="sessionId">An optional session Id to scope the receiver to. If not specified,
-        /// the next available session returned from the service will be used.</param>
+        ///     the next available session returned from the service will be used.</param>
+        /// <param name="isProcessor"></param>
         /// <param name="cancellationToken">The cancellation token to use when opening the receiver link.</param>
-        ///
         internal ServiceBusReceiver(
             ServiceBusConnection connection,
             string entityPath,
@@ -133,6 +133,7 @@ namespace Azure.Messaging.ServiceBus
             IList<ServiceBusPlugin> plugins,
             ServiceBusReceiverOptions options,
             string sessionId = default,
+            bool isProcessor = default,
             CancellationToken cancellationToken = default)
         {
             Type type = GetType();
@@ -166,6 +167,7 @@ namespace Azure.Messaging.ServiceBus
                     identifier: Identifier,
                     sessionId: sessionId,
                     isSessionReceiver: IsSessionReceiver,
+                    isProcessor: isProcessor,
                     cancellationToken: cancellationToken);
                 _scopeFactory = new EntityScopeFactory(EntityPath, FullyQualifiedNamespace);
                 _plugins = plugins;
@@ -228,9 +230,16 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns>List of messages received. Returns an empty list if no message is found.</returns>
         public virtual async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveMessagesAsync(
-           int maxMessages,
-           TimeSpan? maxWaitTime = default,
-           CancellationToken cancellationToken = default)
+            int maxMessages,
+            TimeSpan? maxWaitTime = default,
+            CancellationToken cancellationToken = default) =>
+            await ReceiveMessagesAsync(maxMessages, maxWaitTime, false, cancellationToken).ConfigureAwait(false);
+
+        internal async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveMessagesAsync(
+            int maxMessages,
+            TimeSpan? maxWaitTime,
+            bool isProcessor,
+            CancellationToken cancellationToken)
         {
             Argument.AssertAtLeast(maxMessages, 1, nameof(maxMessages));
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
@@ -261,8 +270,16 @@ namespace Azure.Messaging.ServiceBus
                 messages = await InnerReceiver.ReceiveMessagesAsync(
                     maxMessages,
                     maxWaitTime,
+                    isProcessor,
                     cancellationToken).ConfigureAwait(false);
                 await ApplyPlugins(messages).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException ex)
+                when (isProcessor)
+            {
+                Logger.ProcessorStoppingReceiveCanceled(Identifier, ex.ToString());
+                scope.Failed(ex);
+                throw;
             }
             catch (Exception exception)
             {
@@ -457,12 +474,11 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Opens an AMQP link for use with receiver operations.
         /// </summary>
-        ///
+        /// <param name="isProcessor"></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
-        internal async Task OpenLinkAsync(CancellationToken cancellationToken) =>
-            await InnerReceiver.OpenLinkAsync(cancellationToken).ConfigureAwait(false);
+        internal async Task OpenLinkAsync(bool isProcessor, CancellationToken cancellationToken) =>
+            await InnerReceiver.OpenLinkAsync(isProcessor, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Completes a <see cref="ServiceBusReceivedMessage"/>. This will delete the message from the service.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -124,7 +124,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="options">A set of options to apply when configuring the consumer.</param>
         /// <param name="sessionId">An optional session Id to scope the receiver to. If not specified,
         ///     the next available session returned from the service will be used.</param>
-        /// <param name="isProcessor"></param>
+        /// <param name="isProcessor">Whether or not the receiver is being created for a processor.</param>
         /// <param name="cancellationToken">The cancellation token to use when opening the receiver link.</param>
         internal ServiceBusReceiver(
             ServiceBusConnection connection,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -76,7 +76,7 @@ namespace Azure.Messaging.ServiceBus
                 throw;
             }
             catch (TaskCanceledException exception)
-            when (isProcessor)
+                when (isProcessor)
             {
                 receiver.Logger.ProcessorStoppingAcceptSessionCanceled(receiver.FullyQualifiedNamespace, entityPath, exception.ToString());
                 throw;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -37,25 +37,25 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         public virtual DateTimeOffset SessionLockedUntil => InnerReceiver.SessionLockedUntil;
 
-        /// <summary>
-        /// Creates a session receiver which can be used to interact with all messages with the same sessionId.
-        /// </summary>
-        ///
-        /// <param name="entityPath">The name of the specific queue to associate the receiver with.</param>
-        /// <param name="connection">The <see cref="ServiceBusConnection" /> connection to use for communication with the Service Bus service.</param>
-        /// <param name="plugins">The set of plugins to apply to incoming messages.</param>
-        /// <param name="options">A set of options to apply when configuring the receiver.</param>
-        /// <param name="sessionId">The Session Id to receive from or null to receive from the next available session.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
-        ///<returns>Returns a new instance of the <see cref="ServiceBusSessionReceiver"/> class.</returns>
+        ///  <summary>
+        ///  Creates a session receiver which can be used to interact with all messages with the same sessionId.
+        ///  </summary>
+        ///  <param name="entityPath">The name of the specific queue to associate the receiver with.</param>
+        ///  <param name="connection">The <see cref="ServiceBusConnection" /> connection to use for communication with the Service Bus service.</param>
+        ///  <param name="plugins">The set of plugins to apply to incoming messages.</param>
+        ///  <param name="options">A set of options to apply when configuring the receiver.</param>
+        ///  <param name="sessionId">The Session Id to receive from or null to receive from the next available session.</param>
+        ///  <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///  <param name="isProcessor">True if called from the session processor.</param>
+        ///  <returns>Returns a new instance of the <see cref="ServiceBusSessionReceiver"/> class.</returns>
         internal static async Task<ServiceBusSessionReceiver> CreateSessionReceiverAsync(
             string entityPath,
             ServiceBusConnection connection,
             IList<ServiceBusPlugin> plugins,
             ServiceBusSessionReceiverOptions options,
             string sessionId,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            bool isProcessor = false)
         {
             var receiver = new ServiceBusSessionReceiver(
                 connection: connection,
@@ -63,10 +63,23 @@ namespace Azure.Messaging.ServiceBus
                 plugins: plugins,
                 options: options,
                 cancellationToken: cancellationToken,
-                sessionId: sessionId);
+                sessionId: sessionId,
+                isProcessor: isProcessor);
             try
             {
-                await receiver.OpenLinkAsync(cancellationToken).ConfigureAwait(false);
+                await receiver.OpenLinkAsync(isProcessor, cancellationToken).ConfigureAwait(false);
+            }
+            catch (ServiceBusException e)
+                when (e.Reason == ServiceBusFailureReason.ServiceTimeout && isProcessor)
+            {
+                receiver.Logger.ProcessorAcceptSessionTimeout(receiver.FullyQualifiedNamespace, entityPath, e.ToString());
+                throw;
+            }
+            catch (TaskCanceledException exception)
+            when (isProcessor)
+            {
+                receiver.Logger.ProcessorStoppingAcceptSessionCanceled(receiver.FullyQualifiedNamespace, entityPath, exception.ToString());
+                throw;
             }
             catch (Exception ex)
             {
@@ -87,14 +100,16 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="options">A set of options to apply when configuring the consumer.</param>
         /// <param name="cancellationToken">The cancellation token to use when opening the receiver link.</param>
         /// <param name="sessionId">An optional session Id to receive from.</param>
+        /// <param name="isProcessor"></param>
         internal ServiceBusSessionReceiver(
             ServiceBusConnection connection,
             string entityPath,
             IList<ServiceBusPlugin> plugins,
             ServiceBusSessionReceiverOptions options,
             CancellationToken cancellationToken,
-            string sessionId = default) :
-            base(connection, entityPath, true, plugins, options?.ToReceiverOptions(), sessionId, cancellationToken)
+            string sessionId = default,
+            bool isProcessor = false) :
+            base(connection, entityPath, true, plugins, options?.ToReceiverOptions(), sessionId, isProcessor, cancellationToken)
         {
             _connection = connection;
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
@@ -49,10 +49,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 prefetchCount: 0,
                 connectionScope: Mock.Of<AmqpConnectionScope>(),
                 retryPolicy: Mock.Of<ServiceBusRetryPolicy>(),
-                sessionId: default,
                 identifier: "someIdentifier",
-                isSessionReceiver: default,
-                cancellationToken: CancellationToken.None),
+                sessionId: default,
+                isSessionReceiver: default, isProcessor: false, cancellationToken: CancellationToken.None),
                 Throws.InstanceOf<ArgumentException>());
         }
 
@@ -71,7 +70,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 retryPolicy: Mock.Of<ServiceBusRetryPolicy>(),
                 identifier: "someIdentifier",
                 sessionId: default,
-                isSessionReceiver: default,
+                isSessionReceiver: default, isProcessor: false,
                 cancellationToken: CancellationToken.None),
             Throws.InstanceOf<ArgumentNullException>());
         }
@@ -91,7 +90,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 retryPolicy: null,
                 identifier: "someIdentifier",
                 sessionId: default,
-                isSessionReceiver: default,
+                isSessionReceiver: default, isProcessor: false,
                 cancellationToken: CancellationToken.None),
             Throws.InstanceOf<ArgumentNullException>());
         }
@@ -127,7 +126,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default,
+                default, false,
                 cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
@@ -169,10 +168,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default,
+                default, false,
                 cancellationSource.Token), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.GeneralError));
 
             mockScope
@@ -225,10 +224,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default,
+                default, false,
                 cancellationSource.Token), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.ServiceTimeout));
 
             mockScope
@@ -289,10 +288,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default,
+                default, false,
                 cancellationSource.Token), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.ServiceBusy));
             mockScope
                 .Verify(scope => scope.OpenReceiverLinkAsync(
@@ -348,10 +347,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(exception);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default,
+                default, false,
                 cancellationSource.Token), Throws.InstanceOf<ArgumentNullException>());
 
             mockScope
@@ -403,10 +402,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(exception);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default,
+                default, false,
                 cancellationSource.Token), Throws.InstanceOf<ArgumentException>());
 
             mockScope
@@ -458,10 +457,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                    It.IsAny<CancellationToken>()))
                .Throws(exception);
 
-            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, CancellationToken.None);
+            var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default,
+                default, false,
                 cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
 
             mockScope
@@ -486,7 +485,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 Mock.Of<ServiceBusRetryPolicy>(),
                 "someIdentifier",
                 default,
-                default,
+                default, false,
                 default);
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
@@ -51,7 +51,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 retryPolicy: Mock.Of<ServiceBusRetryPolicy>(),
                 identifier: "someIdentifier",
                 sessionId: default,
-                isSessionReceiver: default, isProcessor: false, cancellationToken: CancellationToken.None),
+                isSessionReceiver: default,
+                isProcessor: false,
+                cancellationToken: CancellationToken.None),
                 Throws.InstanceOf<ArgumentException>());
         }
 
@@ -70,7 +72,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 retryPolicy: Mock.Of<ServiceBusRetryPolicy>(),
                 identifier: "someIdentifier",
                 sessionId: default,
-                isSessionReceiver: default, isProcessor: false,
+                isSessionReceiver: default,
+                isProcessor: false,
                 cancellationToken: CancellationToken.None),
             Throws.InstanceOf<ArgumentNullException>());
         }
@@ -90,7 +93,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 retryPolicy: null,
                 identifier: "someIdentifier",
                 sessionId: default,
-                isSessionReceiver: default, isProcessor: false,
+                isSessionReceiver: default,
+                isProcessor: false,
                 cancellationToken: CancellationToken.None),
             Throws.InstanceOf<ArgumentNullException>());
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
@@ -130,7 +130,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default, false,
+                default,
+                false,
                 cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
@@ -175,7 +176,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default, false,
+                default,
+                false,
                 cancellationSource.Token), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.GeneralError));
 
             mockScope
@@ -231,7 +233,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default, false,
+                default,
+                false,
                 cancellationSource.Token), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.ServiceTimeout));
 
             mockScope
@@ -295,7 +298,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default, false,
+                default,
+                false,
                 cancellationSource.Token), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.ServiceBusy));
             mockScope
                 .Verify(scope => scope.OpenReceiverLinkAsync(
@@ -354,7 +358,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default, false,
+                default,
+                false,
                 cancellationSource.Token), Throws.InstanceOf<ArgumentNullException>());
 
             mockScope
@@ -409,7 +414,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default, false,
+                default,
+                false,
                 cancellationSource.Token), Throws.InstanceOf<ArgumentException>());
 
             mockScope
@@ -464,7 +470,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             var receiver = new AmqpReceiver(entityName, ServiceBusReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession, false, CancellationToken.None);
             Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
-                default, false,
+                default,
+                false,
                 cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
 
             mockScope
@@ -489,7 +496,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 Mock.Of<ServiceBusRetryPolicy>(),
                 "someIdentifier",
                 default,
-                default, false,
+                default,
+                false,
                 default);
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -391,7 +391,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))
             {
-                await using var client = CreateNoRetryClient();
+                await using var client = CreateNoRetryClient(5);
                 await using var processor = client.CreateSessionProcessor(scope.QueueName);
 
                 processor.ProcessMessageAsync += args => Task.CompletedTask;
@@ -400,7 +400,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 await processor.StartProcessingAsync();
 
                 // wait twice as long as the try timeout to ensure that the Accept session will timeout
-                await Task.Delay(TimeSpan.FromSeconds(20));
+                await Task.Delay(TimeSpan.FromSeconds(10));
 
                 await processor.StopProcessingAsync();
 
@@ -416,7 +416,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
-                await using var client = CreateNoRetryClient();
+                await using var client = CreateNoRetryClient(5);
                 await using var processor = client.CreateProcessor(scope.QueueName);
 
                 processor.ProcessMessageAsync += args => Task.CompletedTask;
@@ -425,7 +425,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 await processor.StartProcessingAsync();
 
                 // wait twice as long as the try timeout to ensure that the Accept session will timeout
-                await Task.Delay(TimeSpan.FromSeconds(20));
+                await Task.Delay(TimeSpan.FromSeconds(10));
 
                 await processor.StopProcessingAsync();
 
@@ -440,7 +440,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))
             {
-                await using var client = CreateNoRetryClient();
+                await using var client = CreateNoRetryClient(5);
                 await using var processor = client.CreateSessionProcessor(
                     scope.QueueName,
                     new ServiceBusSessionProcessorOptions
@@ -455,7 +455,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 await processor.StartProcessingAsync();
 
                 // wait twice as long as the try timeout to ensure that the Accept session will timeout
-                await Task.Delay(TimeSpan.FromSeconds(20));
+                await Task.Delay(TimeSpan.FromSeconds(10));
 
                 await processor.StopProcessingAsync();
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -385,5 +385,84 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 _listener.SingleEventById(ServiceBusEventSource.ProcessorClientClosedExceptionEvent);
             }
         }
+
+        [Test]
+        public async Task DoesNotLogAcceptSessionTimeoutAsError()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))
+            {
+                await using var client = CreateNoRetryClient();
+                await using var processor = client.CreateSessionProcessor(scope.QueueName);
+
+                processor.ProcessMessageAsync += args => Task.CompletedTask;
+                processor.ProcessErrorAsync += args => Task.CompletedTask;
+
+                await processor.StartProcessingAsync();
+
+                // wait twice as long as the try timeout to ensure that the Accept session will timeout
+                await Task.Delay(TimeSpan.FromSeconds(20));
+
+                await processor.StopProcessingAsync();
+
+                Assert.False(_listener.EventsById(ServiceBusEventSource.CreateReceiveLinkExceptionEvent).Any());
+                Assert.False(_listener.EventsById(ServiceBusEventSource.ClientCreateExceptionEvent).Any());
+                Assert.True(_listener.EventsById(ServiceBusEventSource.ProcessorAcceptSessionTimeoutEvent).Any());
+                Assert.True(_listener.EventsById(ServiceBusEventSource.ProcessorStoppingAcceptSessionCanceledEvent).Any());
+            }
+        }
+
+        [Test]
+        public async Task StoppingProcessorDoesNotLogTaskCanceledExceptions()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = CreateNoRetryClient();
+                await using var processor = client.CreateProcessor(scope.QueueName);
+
+                processor.ProcessMessageAsync += args => Task.CompletedTask;
+                processor.ProcessErrorAsync += args => Task.CompletedTask;
+
+                await processor.StartProcessingAsync();
+
+                // wait twice as long as the try timeout to ensure that the Accept session will timeout
+                await Task.Delay(TimeSpan.FromSeconds(20));
+
+                await processor.StopProcessingAsync();
+
+                Assert.False(_listener.EventsById(ServiceBusEventSource.CreateReceiveLinkExceptionEvent).Any());
+                Assert.False(_listener.EventsById(ServiceBusEventSource.ClientCreateExceptionEvent).Any());
+                Assert.True(_listener.EventsById(ServiceBusEventSource.ProcessorStoppingReceiveCanceledEvent).Any());
+            }
+        }
+
+        [Test]
+        public async Task StoppingSessionProcessorDoesNotLogTaskCanceledExceptions()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))
+            {
+                await using var client = CreateNoRetryClient();
+                await using var processor = client.CreateSessionProcessor(
+                    scope.QueueName,
+                    new ServiceBusSessionProcessorOptions
+                {
+                    // specify a session so that we can establish the link without sending messages
+                    SessionIds = { "sessionId "}
+                });
+
+                processor.ProcessMessageAsync += args => Task.CompletedTask;
+                processor.ProcessErrorAsync += args => Task.CompletedTask;
+
+                await processor.StartProcessingAsync();
+
+                // wait twice as long as the try timeout to ensure that the Accept session will timeout
+                await Task.Delay(TimeSpan.FromSeconds(20));
+
+                await processor.StopProcessingAsync();
+
+                Assert.False(_listener.EventsById(ServiceBusEventSource.CreateReceiveLinkExceptionEvent).Any());
+                Assert.False(_listener.EventsById(ServiceBusEventSource.ClientCreateExceptionEvent).Any());
+                Assert.True(_listener.EventsById(ServiceBusEventSource.ProcessorStoppingReceiveCanceledEvent).Any());
+            }
+        }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -328,7 +328,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             mockTransportReceiver.Setup(
                 transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     1,
-                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<TimeSpan?>(), false,
                     It.IsAny<CancellationToken>()))
                 .Returns(
                 Task.FromResult((IReadOnlyList<ServiceBusReceivedMessage>)
@@ -377,7 +377,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             mockTransportReceiver.Setup(
                 transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     maxMessages,
-                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<TimeSpan?>(), false,
                     It.IsAny<CancellationToken>()))
                 .Returns(
                 Task.FromResult((IReadOnlyList<ServiceBusReceivedMessage>)
@@ -432,7 +432,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             mockTransportReceiver.Setup(
                 transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     1,
-                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<TimeSpan?>(), false,
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
             var receiver = new ServiceBusReceiver(
@@ -1190,6 +1190,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     1,
                     It.IsAny<TimeSpan?>(),
+                    true,
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult((IReadOnlyList<ServiceBusReceivedMessage>) new List<ServiceBusReceivedMessage>() { new ServiceBusReceivedMessage() }));
             var processor = new ServiceBusProcessor(mockConnection.Object, "queueName", false, new ServiceBusPlugin[] { }, new ServiceBusProcessorOptions
@@ -1279,6 +1280,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     It.IsAny<uint>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
+                    It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     CancellationToken.None))
                 .Returns(mockTransportReceiver.Object);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -328,7 +328,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             mockTransportReceiver.Setup(
                 transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     1,
-                    It.IsAny<TimeSpan?>(), false,
+                    It.IsAny<TimeSpan?>(),
+                    false,
                     It.IsAny<CancellationToken>()))
                 .Returns(
                 Task.FromResult((IReadOnlyList<ServiceBusReceivedMessage>)
@@ -377,7 +378,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             mockTransportReceiver.Setup(
                 transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     maxMessages,
-                    It.IsAny<TimeSpan?>(), false,
+                    It.IsAny<TimeSpan?>(),
+                    false,
                     It.IsAny<CancellationToken>()))
                 .Returns(
                 Task.FromResult((IReadOnlyList<ServiceBusReceivedMessage>)
@@ -432,7 +434,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             mockTransportReceiver.Setup(
                 transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     1,
-                    It.IsAny<TimeSpan?>(), false,
+                    It.IsAny<TimeSpan?>(),
+                    false,
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
             var receiver = new ServiceBusReceiver(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
@@ -12,16 +12,18 @@ namespace Azure.Messaging.ServiceBus.Tests
     [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
     public abstract class ServiceBusLiveTestBase : ServiceBusTestBase
     {
+        private const int DefaultTryTimeout = 10;
+
         public ServiceBusTestEnvironment TestEnvironment { get; } = ServiceBusTestEnvironment.Instance;
 
-        protected ServiceBusClient CreateNoRetryClient()
+        protected ServiceBusClient CreateNoRetryClient(int tryTimeout = DefaultTryTimeout)
         {
             var options =
                 new ServiceBusClientOptions
                 {
                     RetryOptions = new ServiceBusRetryOptions
                     {
-                        TryTimeout = TimeSpan.FromSeconds(10),
+                        TryTimeout = TimeSpan.FromSeconds(tryTimeout),
                         MaxRetries = 0
                     }
                 };
@@ -30,19 +32,20 @@ namespace Azure.Messaging.ServiceBus.Tests
                 options);
         }
 
-        protected ServiceBusClient CreateClient(int tryTimeout = 15)
+        protected ServiceBusClient CreateClient(int tryTimeout = DefaultTryTimeout)
         {
-            var retryOptions = new ServiceBusRetryOptions();
-            if (tryTimeout != default)
-            {
-                retryOptions.TryTimeout = TimeSpan.FromSeconds(tryTimeout);
-            }
-            return new ServiceBusClient(
-                TestEnvironment.ServiceBusConnectionString,
+            var options =
                 new ServiceBusClientOptions
                 {
-                    RetryOptions = retryOptions
-                });
+                    RetryOptions = new ServiceBusRetryOptions
+                    {
+                        TryTimeout = TimeSpan.FromSeconds(tryTimeout),
+                        MaxRetries = 0
+                    }
+                };
+            return new ServiceBusClient(
+                TestEnvironment.ServiceBusConnectionString,
+                options);
         }
 
         protected static async Task SendMessagesAsync(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.ServiceBus.Tests
     [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
     public abstract class ServiceBusLiveTestBase : ServiceBusTestBase
     {
-        private const int DefaultTryTimeout = 10;
+        private const int DefaultTryTimeout = 15;
 
         public ServiceBusTestEnvironment TestEnvironment { get; } = ServiceBusTestEnvironment.Instance;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestBase.cs
@@ -85,8 +85,8 @@ namespace Azure.Messaging.ServiceBus.Tests
         {
             var mockTransportReceiver = new Mock<TransportReceiver>();
             mockTransportReceiver
-                .Setup(receiver => receiver.ReceiveMessagesAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
-                .Returns(async (int maximumMessageCount, TimeSpan? maxWaitTime, CancellationToken cancellationToken) =>
+                .Setup(receiver => receiver.ReceiveMessagesAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns(async (int maximumMessageCount, TimeSpan? maxWaitTime, bool isProcessor, CancellationToken cancellationToken) =>
                 {
                     await Task.Delay(Timeout.Infinite, cancellationToken);
                     throw new NotImplementedException();
@@ -102,6 +102,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     It.IsAny<uint>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
+                    It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(mockTransportReceiver.Object);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Primitives/ServiceBusConnectionTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Primitives/ServiceBusConnectionTests.cs
@@ -538,7 +538,10 @@ namespace Azure.Messaging.ServiceBus.Tests
                 return Task.CompletedTask;
             }
 
-            public override TransportReceiver CreateReceiver(string entityPath, ServiceBusRetryPolicy retryPolicy, ServiceBusReceiveMode receiveMode, uint prefetchCount, string identifier, string sessionId, bool isSessionReceiver, CancellationToken cancellationToken)
+            public override TransportReceiver CreateReceiver(string entityPath, ServiceBusRetryPolicy retryPolicy,
+                ServiceBusReceiveMode receiveMode, uint prefetchCount, string identifier, string sessionId, bool isSessionReceiver,
+                bool isProcessor,
+                CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
@@ -423,7 +423,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
         [TestCase(true, false)]
         [TestCase(false, false)]
         [TestCase(false, true)]
-        public async Task TransactionGroupReceivesFirst(bool partitioned, bool enableSessions)
+        public async Task CrossEntityTransactionReceivesFirst(bool partitioned, bool enableSessions)
         {
             await using var client = CreateCrossEntityTxnClient();
             await using var queueA = await ServiceBusScope.CreateWithQueue(enablePartitioning: partitioned, enableSession: enableSessions);
@@ -471,7 +471,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
 
        [Test]
        [Ignore("Send claims are not available for the topic. Leaving for now in case this is supported in the future.")]
-        public async Task TransactionGroupReceivesFirstRollbackSubscription()
+        public async Task CrossEntityTransactionReceivesFirstRollbackSubscription()
         {
             await using var client = CreateCrossEntityTxnClient();
             await using var topicA = await ServiceBusScope.CreateWithTopic(enablePartitioning: false, enableSession: false);
@@ -530,7 +530,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
         }
 
         [Test]
-        public async Task TransactionGroupReceivesFirstRollback()
+        public async Task CrossEntityTransactionReceivesFirstRollback()
         {
             await using var client = CreateCrossEntityTxnClient();
             await using var queueA = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false);
@@ -588,7 +588,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
         }
 
         [Test]
-        public async Task TransactionGroupFirstOperationTransacted()
+        public async Task CrossEntityTransactionFirstOperationTransacted()
         {
             await using var client = CreateCrossEntityTxnClient();
             await using var queueA = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false);
@@ -609,7 +609,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
         [Test]
         [TestCase(true, false)]
         [TestCase(false, true)]
-        public async Task TransactionGroupSendsFirst(bool partitioned, bool enableSessions)
+        public async Task CrossEntityTransactionSendsFirst(bool partitioned, bool enableSessions)
         {
             await using var client = CreateCrossEntityTxnClient();
             await using var queueA = await ServiceBusScope.CreateWithQueue(enablePartitioning: partitioned, enableSession: enableSessions);
@@ -700,7 +700,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
         }
 
         [Test]
-        public async Task TransactionGroupSendsFirstRollback()
+        public async Task CrossEntityTransactionSendsFirstRollback()
         {
             await using var client = CreateCrossEntityTxnClient();
             await using var queueA = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false);
@@ -771,7 +771,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
         }
 
         [Test]
-        public async Task TransactionGroupProcessorRollback()
+        public async Task CrossEntityTransactionProcessorRollback()
         {
             await using var client = CreateCrossEntityTxnClient();
             await using var queueA = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false);
@@ -816,7 +816,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
         }
 
         [Test]
-        public async Task TransactionGroupProcessor()
+        public async Task CrossEntityTransactionProcessor()
         {
             await using var client = CreateCrossEntityTxnClient();
             await using var noTxClient = CreateClient();
@@ -867,7 +867,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
         }
 
         [Test]
-        public async Task TransactionGroupSessionProcessorRollback()
+        public async Task CrossEntityTransactionSessionProcessorRollback()
         {
             await using var client = CreateCrossEntityTxnClient();
             await using var queueA = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true);
@@ -910,7 +910,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
         }
 
         [Test]
-        public async Task TransactionGroupSessionProcessor()
+        public async Task CrossEntityTransactionSessionProcessor()
         {
             await using var client = CreateCrossEntityTxnClient();
             await using var queueA = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true);

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -14,7 +14,8 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Sources" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" />
+<!--    Uncomment once ServiceBus version containing https://github.com/Azure/azure-sdk-for-net/pull/20940 is released-->
+<!--    <PackageReference Include="Azure.Messaging.ServiceBus" />-->
   </ItemGroup>
 
   <ItemGroup>
@@ -27,5 +28,10 @@
     <Compile Include="..\..\Azure.Messaging.ServiceBus\src\Resources.Designer.cs" LinkBase="Shared" />
     <Compile Include="..\..\..\extensions\Microsoft.Azure.WebJobs.Extensions.Clients\src\Shared\WebJobsConfigurationExtensions.cs" LinkBase="Shared" />
 
+  </ItemGroup>
+
+  <ItemGroup>
+<!--    Remove once ServiceBus version containing https://github.com/Azure/azure-sdk-for-net/pull/20940 is released-->
+    <ProjectReference Include="..\..\Azure.Messaging.ServiceBus\src\Azure.Messaging.ServiceBus.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -357,14 +357,13 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.AreEqual("E2E-SBQueue2SBQueue-SBQueue2SBTopic-topic-1", _resultMessage1);
             Assert.AreEqual("E2E-SBQueue2SBQueue-SBQueue2SBTopic-topic-2", _resultMessage2);
 
-            IEnumerable<LogMessage> logMessages = host.GetTestLoggerProvider()
-                // Filter out Azure SDK and custom processor logs for easier validation. Intentionally do the error check after as the
-                // Service Bus SDK currently logs errors when stopping the processor.
-                .GetAllLogMessages().Where(m =>
-                    !m.Category.StartsWith("Azure.") &&
-                    m.Category != CustomMessagingProvider.CustomMessagingCategory);
-
+            IEnumerable<LogMessage> logMessages = host.GetTestLoggerProvider().GetAllLogMessages();
             Assert.False(logMessages.Any(p => p.Level == LogLevel.Error));
+
+            // Filter out Azure SDK and custom processor logs for easier validation.
+            logMessages = logMessages.Where(
+                m => !m.Category.StartsWith("Azure.") &&
+                     m.Category != CustomMessagingProvider.CustomMessagingCategory);
 
             string[] consoleOutputLines = logMessages
                 .Where(p => p.FormattedMessage != null)

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             // Filter out Azure SDK and custom processor logs for easier validation.
             logMessages = logMessages.Where(
-                m => !m.Category.StartsWith("Azure.") &&
+                m => !m.Category.StartsWith("Azure.", StringComparison.InvariantCulture) &&
                      m.Category != CustomMessagingProvider.CustomMessagingCategory);
 
             string[] consoleOutputLines = logMessages

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.False(logMessages.Any(p => p.Level == LogLevel.Error));
 
             // Filter out Azure SDK and custom processor logs for easier validation.
-            return logMessages.Where(m => !m.Category.StartsWith("Azure.", StringComparison.InvariantCultureIgnoreCase)).ToList();
+            return logMessages.Where(m => !m.Category.StartsWith("Azure.", StringComparison.InvariantCulture)).ToList();
         }
 
         [Test]

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -301,12 +301,11 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         private static List<LogMessage> GetLogMessages(IHost host)
         {
-            List<LogMessage> logMessages = host.GetTestLoggerProvider().GetAllLogMessages()
-                // Filter out Azure SDK and custom processor logs for easier validation. Intentionally do the error check after as the
-                // Service Bus SDK currently logs errors when stopping the processor. See https://github.com/Azure/azure-sdk-for-net/issues/19098#issuecomment-813126915
-                .Where(m => !m.Category.StartsWith("Azure.", StringComparison.InvariantCultureIgnoreCase)).ToList();
+            IEnumerable<LogMessage> logMessages = host.GetTestLoggerProvider().GetAllLogMessages();
             Assert.False(logMessages.Any(p => p.Level == LogLevel.Error));
-            return logMessages;
+
+            // Filter out Azure SDK and custom processor logs for easier validation.
+            return logMessages.Where(m => !m.Category.StartsWith("Azure.", StringComparison.InvariantCultureIgnoreCase)).ToList();
         }
 
         [Test]


### PR DESCRIPTION
Also, don't log service timeout exceptions as errors when accepting sessions in processor.

Addresses https://github.com/Azure/azure-sdk-for-net/issues/19098