### PR TITLE
Enable Form Recognizer cilent to authenticate with token credential in USGOV and China

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Constants.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Constants.cs
@@ -14,10 +14,10 @@ namespace Azure.AI.FormRecognizer
 
         public const string OperationLocationHeader = "Operation-Location";
 
-        public static string DefaultCognitiveScope = getDefaultCognitiveScope(Environment.GetEnvironmentVariable("AZURE_AUTHORITY_HOST"));
+        public static string DefaultCognitiveScope = GetDefaultCognitiveScope(Environment.GetEnvironmentVariable("AZURE_AUTHORITY_HOST"));
 
         public const float DefaultConfidenceValue = 1.0f;
-        internal static string getDefaultCognitiveScope(string authorityHost)
+        internal static string GetDefaultCognitiveScope(string authorityHost)
         {
             switch (authorityHost)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Constants.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Constants.cs
@@ -1,16 +1,35 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using System;
 
 namespace Azure.AI.FormRecognizer
 {
     internal static class Constants
     {
+        private const string AzurePublicCloud = "https://login.microsoftonline.com/";
+        private const string AzureChina = "https://login.microsoftonline.cn/";
+        private const string AzureGovernment = "https://login.microsoftonline.us/";
+
         public const string AuthorizationHeader = "Ocp-Apim-Subscription-Key";
 
         public const string OperationLocationHeader = "Operation-Location";
 
-        public const string DefaultCognitiveScope = "https://cognitiveservices.azure.com/.default";
+        public static string DefaultCognitiveScope = getDefaultCognitiveScope(Environment.GetEnvironmentVariable("AZURE_AUTHORITY_HOST"));
 
         public const float DefaultConfidenceValue = 1.0f;
+        internal static string getDefaultCognitiveScope(string authorityHost)
+        {
+            switch (authorityHost)
+            {
+                case AzurePublicCloud:
+                    return "https://cognitiveservices.azure.com/.default";
+                case AzureChina:
+                    return "https://cognitiveservices.azure.cn/.default";
+                case AzureGovernment:
+                    return "https://cognitiveservices.azure.us/.default";
+                default:
+                    return "https://cognitiveservices.azure.com/.default";
+            }
+        }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -541,7 +541,24 @@ namespace Azure.AI.FormRecognizer.Tests
             var sourceClient = CreateFormTrainingClient();
             var targetClient = CreateFormTrainingClient();
             var resourceId = TestEnvironment.TargetResourceId;
-            var wrongRegion = TestEnvironment.TargetResourceRegion == "westcentralus" ? "eastus2" : "westcentralus";
+            var regionA = "regionA";
+            var regionB = "regionB";
+            switch (TestEnvironment.AuthorityHostUrl)
+            {
+                case "https://login.microsoftonline.com/":
+                    regionA = "westcentralus";
+                    regionB = "eastus2";
+                    break;
+                case "https://login.microsoftonline.us/":
+                    regionA = "usgovarizona";
+                    regionB = "usgovvirginia";
+                    break;
+                case "https://login.chinacloudapi.cn/":
+                    regionA = "chinaeast2";
+                    regionB = "chinanorth";
+                    break;
+            }
+            var wrongRegion = TestEnvironment.TargetResourceRegion == regionA ? regionB : regionA;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: true);
             CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceId, wrongRegion);


### PR DESCRIPTION
1.Fix Issue https://github.com/Azure/azure-sdk-for-net/issues/17192
2.The scope is hard code leading to only work well in the public cloud.
![image](https://user-images.githubusercontent.com/81678720/117754669-61ebc780-b24d-11eb-8de3-458e4d03c0f6.png)
Remove hardcoded value and enable Form Recognizer tests in `UsGov` and `China` clouds

@jongio  ,  @maririos for notification.
