### PR TITLE
Make TIdentifier : ResourceIdentifier in ResourceContainerBase

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceContainerBase.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceContainerBase.cs
@@ -14,7 +14,7 @@ namespace Azure.ResourceManager.Core
     /// <typeparam name="TOperations"> The type of the class containing operations for the underlying resource. </typeparam>
     /// <typeparam name="TResource"> The type of the class containing properties for the underlying resource. </typeparam>
     public abstract class ResourceContainerBase<TIdentifier, TOperations, TResource> : ContainerBase<TIdentifier, TOperations>
-        where TIdentifier : TenantResourceIdentifier
+        where TIdentifier : ResourceIdentifier
         where TOperations : ResourceOperationsBase<TIdentifier, TOperations>
         where TResource : class
     {


### PR DESCRIPTION
It doesn't seem necessary for TIdentifier to inherit TenantResourceIdentifier in ResourceContainerBase, also it blocks when the resource is sub-resource (VirtualMachineScaleSetExtensionData for example)