### PR TITLE
Dispose non buffered content streams

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestLogger.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestLogger.cs
@@ -48,6 +48,11 @@ namespace Azure.Core.TestFramework
 
             // If there's a request ID, use it after the category
             var message = new StringBuilder();
+            message
+                .Append("[")
+                .Append(DateTime.Now.ToString("HH:mm:ss.FFF"))
+                .Append("] ")
+                .Append(args.EventName).Append(" ");
             if (payload.TryGetValue("requestId", out var requestId))
             {
                 payload.Remove("requestId");

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -531,6 +531,7 @@ namespace Azure.Core.Pipeline
             public override void Dispose()
             {
                 _responseMessage?.Dispose();
+                DisposeContentStreamIfNotBuffered();
             }
 
             public override string ToString() => _responseMessage.ToString();

--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -274,6 +274,7 @@ namespace Azure.Core.Pipeline
             public override void Dispose()
             {
                 _originalContentStream?.Dispose();
+                DisposeContentStreamIfNotBuffered();
             }
 
             protected internal override bool TryGetHeader(string name, [NotNullWhen(true)] out string? value)

--- a/sdk/core/Azure.Core/src/Response.cs
+++ b/sdk/core/Azure.Core/src/Response.cs
@@ -131,5 +131,17 @@ namespace Azure
         {
             return $"Status: {Status}, ReasonPhrase: {ReasonPhrase}";
         }
+
+        internal void DisposeContentStreamIfNotBuffered()
+        {
+            // We want to keep the ContentStream readable
+            // even after the response is disposed but only if it's a
+            // buffered memory stream otherwise we can leave a network
+            // connection hanging open
+            if (ContentStream is not MemoryStream)
+            {
+                ContentStream?.Dispose();
+            }
+        }
     }
 }

--- a/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
@@ -261,12 +261,9 @@ namespace Azure.Core.Tests
                 using (HttpMessage message = httpPipeline.CreateMessage())
                 {
                     message.Request.Uri.Reset(testServer.Address);
-                    message.BufferResponse = false;
+                    message.BufferResponse = true;
 
                     await ExecuteRequest(message, httpPipeline);
-
-                    Assert.AreEqual(message.Response.ContentStream.CanSeek, false);
-                    Assert.Throws<InvalidOperationException>(() => { var content = message.Response.Content; });
 
                     response = message.Response;
                 }

--- a/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Microsoft.AspNetCore.Http;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
@@ -271,6 +272,50 @@ namespace Azure.Core.Tests
                 var memoryStream = new MemoryStream();
                 await response.ContentStream.CopyToAsync(memoryStream);
                 Assert.AreEqual(memoryStream.Length, bodySize);
+            }
+        }
+
+        [Test]
+        public async Task UnbufferedResponsesDisposedAfterMessageDisposed()
+        {
+            byte[] buffer = { 0 };
+
+            HttpPipeline httpPipeline = HttpPipelineBuilder.Build(GetOptions());
+
+            int bodySize = 1000;
+
+            using TestServer testServer = new TestServer(
+                async context =>
+                {
+                    for (int i = 0; i < bodySize; i++)
+                    {
+                        await context.Response.Body.WriteAsync(buffer, 0, 1);
+                    }
+                });
+
+            var requestCount = 100;
+            for (int i = 0; i < requestCount; i++)
+            {
+                Response response;
+                Mock<Stream> disposeTrackingStream = null;
+                using (HttpMessage message = httpPipeline.CreateMessage())
+                {
+                    message.Request.Uri.Reset(testServer.Address);
+                    message.BufferResponse = false;
+
+                    await ExecuteRequest(message, httpPipeline);
+
+                    response = message.Response;
+                    var originalStream = response.ContentStream;
+                    disposeTrackingStream = new Mock<Stream>();
+                    disposeTrackingStream
+                        .Setup(s=>s.Close())
+                        .Callback(originalStream.Close)
+                        .Verifiable();
+                    response.ContentStream = disposeTrackingStream.Object;
+                }
+
+                disposeTrackingStream.Verify();
             }
         }
 


### PR DESCRIPTION
Fixes a somewhat rare situation where the request is not buffered and the response stream is not extracted before the Response is disposed.

Without this fix we would not dispose the network stream if it was wrapped in some other stream (like TimeoutStream).

This was the cause of `Open50ConnectionsLive` test flakiness. One test opened 50 connections but didn't dispose the stream the other test would try to open 50 more but we would hit the connection limit.