### PR TITLE
Add INT testing in sdk pipelines

### DIFF
--- a/sdk/communication/Azure.Communication.Chat/tests.yml
+++ b/sdk/communication/Azure.Communication.Chat/tests.yml
@@ -11,7 +11,11 @@ extends:
           - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
-    Clouds: Public
+      Int:
+        SubscriptionConfigurations:
+          - $(sub-config-communication-int-test-resources-common)
+          - $(sub-config-communication-int-test-resources-net)
+    Clouds: Public,Int
     EnvVars:
       # SKIP_PHONENUMBER_LIVE_TESTS skips certain phone number tests such as purchase and release
       SKIP_PHONENUMBER_LIVE_TESTS: TRUE

--- a/sdk/communication/Azure.Communication.Identity/tests.yml
+++ b/sdk/communication/Azure.Communication.Identity/tests.yml
@@ -11,7 +11,11 @@ extends:
           - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
-    Clouds: Public
+      Int:
+        SubscriptionConfigurations:
+          - $(sub-config-communication-int-test-resources-common)
+          - $(sub-config-communication-int-test-resources-net)
+    Clouds: Public,Int
     EnvVars:
       # SKIP_PHONENUMBER_LIVE_TESTS skips certain phone number tests such as purchase and release
       SKIP_PHONENUMBER_LIVE_TESTS: TRUE

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests.yml
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests.yml
@@ -11,7 +11,11 @@ extends:
           - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
-    Clouds: Public
+      Int:
+        SubscriptionConfigurations:
+          - $(sub-config-communication-int-test-resources-common)
+          - $(sub-config-communication-int-test-resources-net)
+    Clouds: Public,Int
     EnvVars:
       # SKIP_PHONENUMBER_LIVE_TESTS skips certain phone number tests such as purchase and release
       SKIP_PHONENUMBER_LIVE_TESTS: TRUE

--- a/sdk/communication/Azure.Communication.Sms/tests.yml
+++ b/sdk/communication/Azure.Communication.Sms/tests.yml
@@ -11,7 +11,11 @@ extends:
           - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
-    Clouds: Public
+      Int:
+        SubscriptionConfigurations:
+          - $(sub-config-communication-int-test-resources-common)
+          - $(sub-config-communication-int-test-resources-net)
+    Clouds: Public,Int
     EnvVars:
       # SKIP_PHONENUMBER_LIVE_TESTS skips certain phone number tests such as purchase and release
       SKIP_PHONENUMBER_LIVE_TESTS: TRUE

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTestBase.cs
@@ -14,6 +14,16 @@ namespace Azure.Communication.Sms.Tests
         public SmsClientLiveTestBase(bool isAsync) : base(isAsync)
             => Sanitizer = new SmsClientRecordedTestSanitizer();
 
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            if (TestEnvironment.ShouldIgnoreSMSTests)
+            {
+                Assert.Ignore("SMS tests are skipped " +
+                    "because sms package is not included in the TEST_PACKAGES_ENABLED variable");
+            }
+        }
+
         public SmsClient CreateSmsClient()
         {
             var connectionString = TestEnvironment.LiveTestStaticConnectionString;


### PR DESCRIPTION
Add INT sub config 
Add INT to Clouds so that we run live test in both Prod and INT.
