### PR TITLE
Use column types for GetObject calls

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogColumnTypes.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogColumnTypes.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.Query.Models
+{
+    internal static class LogColumnTypes
+    {
+        public const string Datetime = "datetime";
+        public const string Guid = "guid";
+        public const string Int = "int";
+        public const string Long = "long";
+        public const string Real = "real";
+        public const string String = "string";
+        public const string Timespan = "timespan";
+        public const string Decimal = "decimal";
+        public const string Bool = "bool";
+    }
+}

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogsQueryResultRow.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogsQueryResultRow.cs
@@ -14,11 +14,13 @@ namespace Azure.Monitor.Query.Models
     /// </summary>
     public class LogsQueryResultRow
     {
-        private readonly Dictionary<string, int> _columns;
+        private readonly Dictionary<string, int> _columnMap;
+        private readonly IReadOnlyList<LogsQueryResultColumn> _columns;
         private readonly JsonElement _row;
 
-        internal LogsQueryResultRow(Dictionary<string, int> columns, JsonElement row)
+        internal LogsQueryResultRow(Dictionary<string, int> columnMap, IReadOnlyList<LogsQueryResultColumn> columns, JsonElement row)
         {
+            _columnMap = columnMap;
             _columns = columns;
             _row = row;
         }
@@ -103,70 +105,70 @@ namespace Azure.Monitor.Query.Models
         /// </summary>
         /// <param name="name">The column name.</param>
         /// <returns>The <see cref="int"/> value of the column.</returns>
-        public int GetInt32(string name) => GetInt32(_columns[name]);
+        public int GetInt32(string name) => GetInt32(_columnMap[name]);
 
         /// <summary>
         /// Gets the value of the column with the specified name as <see cref="long"/>.
         /// </summary>
         /// <param name="name">The column name.</param>
         /// <returns>The <see cref="long"/> value of the column.</returns>
-        public long GetInt64(string name) => GetInt64(_columns[name]);
+        public long GetInt64(string name) => GetInt64(_columnMap[name]);
 
         /// <summary>
         /// Gets the value of the column with the specified name as <see cref="bool"/>.
         /// </summary>
         /// <param name="name">The column name.</param>
         /// <returns>The <see cref="bool"/> value of the column.</returns>
-        public bool GetBoolean(string name) => GetBoolean(_columns[name]);
+        public bool GetBoolean(string name) => GetBoolean(_columnMap[name]);
 
         /// <summary>
         /// Gets the value of the column with the specified name as <see cref="decimal"/>.
         /// </summary>
         /// <param name="name">The column name.</param>
         /// <returns>The <see cref="decimal"/> value of the column.</returns>
-        public decimal GetDecimal(string name) => GetDecimal(_columns[name]);
+        public decimal GetDecimal(string name) => GetDecimal(_columnMap[name]);
 
         /// <summary>
         /// Gets the value of the column with the specified name as <see cref="double"/>.
         /// </summary>
         /// <param name="name">The column name.</param>
         /// <returns>The <see cref="double"/> value of the column.</returns>
-        public double GetDouble(string name) => GetDouble(_columns[name]);
+        public double GetDouble(string name) => GetDouble(_columnMap[name]);
 
         /// <summary>
         /// Gets the value of the column with the specified name as <see cref="string"/>.
         /// </summary>
         /// <param name="name">The column name.</param>
         /// <returns>The <see cref="string"/> value of the column.</returns>
-        public string GetString(string name) => GetString(_columns[name]);
+        public string GetString(string name) => GetString(_columnMap[name]);
 
         /// <summary>
         /// Gets the value of the column with the specified name as <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <param name="name">The column name.</param>
         /// <returns>The <see cref="DateTimeOffset"/> value of the column.</returns>
-        public DateTimeOffset GetDateTimeOffset(string name) => GetDateTimeOffset(_columns[name]);
+        public DateTimeOffset GetDateTimeOffset(string name) => GetDateTimeOffset(_columnMap[name]);
 
         /// <summary>
         /// Gets the value of the column with the specified name as <see cref="TimeSpan"/>.
         /// </summary>
         /// <param name="name">The column name.</param>
         /// <returns>The <see cref="TimeSpan"/> value of the column.</returns>
-        public TimeSpan GetTimeSpan(string name) => GetTimeSpan(_columns[name]);
+        public TimeSpan GetTimeSpan(string name) => GetTimeSpan(_columnMap[name]);
 
         /// <summary>
         /// Gets the value of the column with the specified name as <see cref="Guid"/>.
         /// </summary>
         /// <param name="name">The column name.</param>
         /// <returns>The <see cref="Guid"/> value of the column.</returns>
-        public Guid GetGuid(string name) => GetGuid(_columns[name]);
+        public Guid GetGuid(string name) => GetGuid(_columnMap[name]);
 
         /// <summary>
         /// Returns true if the value of the column with the specified name is null, otherwise false.
         /// </summary>
         /// <param name="name">The column name.</param>
         /// <returns>True if the value is null, otherwise false.</returns>
-        public bool IsNull(string name) => IsNull(_columns[name]);
+        public bool IsNull(string name) => IsNull(_columnMap[name]);
 
         /// <summary>
         /// Gets the value of the column at the specified index as <see cref="object"/>.
@@ -175,7 +177,34 @@ namespace Azure.Monitor.Query.Models
         /// <returns>The <see cref="object"/> value of the column.</returns>
         public object GetObject(int index)
         {
+            if (IsNull(index))
+            {
+                return null;
+            }
+
             var element = _row[index];
+            switch (_columns[index].Type)
+            {
+                case LogColumnTypes.Datetime:
+                    return GetDateTimeOffset(index);
+                case LogColumnTypes.Bool:
+                    return GetBoolean(index);
+                case LogColumnTypes.Guid:
+                    return GetGuid(index);
+                case LogColumnTypes.Int:
+                    return GetInt32(index);
+                case LogColumnTypes.Long:
+                    return GetInt64(index);
+                case LogColumnTypes.Real:
+                    return GetDouble(index);
+                case LogColumnTypes.String:
+                    return GetString(index);
+                case LogColumnTypes.Timespan:
+                    return GetTimeSpan(index);
+                case LogColumnTypes.Decimal:
+                    return GetDecimal(index);
+            }
+
             switch (element.ValueKind)
             {
                 case JsonValueKind.String:
@@ -209,7 +238,7 @@ namespace Azure.Monitor.Query.Models
         /// </summary>
         /// <param name="name">The column name.</param>
         /// <returns>The <see cref="object"/> value of the column.</returns>
-        public object GetObject(string name) => GetObject(_columns[name]);
+        public object GetObject(string name) => GetObject(_columnMap[name]);
 
         /// <summary>
         /// Gets the value of the column at the specified index as <see cref="object"/>.
@@ -225,6 +254,6 @@ namespace Azure.Monitor.Query.Models
         /// <returns>The <see cref="object"/> value of the column.</returns>
         public object this[string name] => GetObject(name);
 
-        internal bool TryGetColumn(string name, out int column) => _columns.TryGetValue(name, out column);
+        internal bool TryGetColumn(string name, out int column) => _columnMap.TryGetValue(name, out column);
     }
 }

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogsQueryResultTable.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogsQueryResultTable.cs
@@ -34,7 +34,7 @@ namespace Azure.Monitor.Query.Models
 
             foreach (var row in InternalRows.EnumerateArray())
             {
-                rows.Add(new LogsQueryResultRow(columnDictionary, row));
+                rows.Add(new LogsQueryResultRow(columnDictionary, Columns, row));
             }
 
             return rows;

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/TimeSeriesElement.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/TimeSeriesElement.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 namespace Azure.Monitor.Query.Models
 {
+    // TODO: This probably be a public extensible enum
     public partial class TimeSeriesElement
     {
         private Dictionary<string,string> _metadata;

--- a/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientClientLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientClientLiveTests.cs
@@ -184,13 +184,13 @@ namespace Azure.Monitor.Query.Tests
 
             Assert.AreEqual(DateTimeOffset.Parse("2015-12-31 23:59:59.9+00:00"), row.GetDateTimeOffset("DateTime"));
             Assert.AreEqual(DateTimeOffset.Parse("2015-12-31 23:59:59.9+00:00"), row.GetDateTimeOffset(0));
-            Assert.AreEqual("2015-12-31T23:59:59.9Z", row.GetObject("DateTime"));
+            Assert.AreEqual(DateTimeOffset.Parse("2015-12-31 23:59:59.9+00:00"), row.GetObject("DateTime"));
             Assert.AreEqual(false, row.GetBoolean("Bool"));
             Assert.AreEqual(false, row.GetBoolean(1));
             Assert.AreEqual(false, row.GetObject("Bool"));
             Assert.AreEqual(Guid.Parse("74be27de-1e4e-49d9-b579-fe0b331d3642"), row.GetGuid("Guid"));
             Assert.AreEqual(Guid.Parse("74be27de-1e4e-49d9-b579-fe0b331d3642"), row.GetGuid(2));
-            Assert.AreEqual("74be27de-1e4e-49d9-b579-fe0b331d3642", row.GetObject("Guid"));
+            Assert.AreEqual(Guid.Parse("74be27de-1e4e-49d9-b579-fe0b331d3642"), row.GetObject("Guid"));
             Assert.AreEqual(12345, row.GetInt32("Int"));
             Assert.AreEqual(12345, row.GetInt32(3));
             Assert.AreEqual(12345, row.GetObject("Int"));
@@ -205,10 +205,10 @@ namespace Azure.Monitor.Query.Tests
             Assert.AreEqual("string value", row.GetObject("String"));
             Assert.AreEqual(TimeSpan.FromSeconds(10), row.GetTimeSpan("Timespan"));
             Assert.AreEqual(TimeSpan.FromSeconds(10), row.GetTimeSpan(7));
-            Assert.AreEqual("00:00:10", row.GetObject("Timespan"));
+            Assert.AreEqual(TimeSpan.FromSeconds(10),  row.GetObject("Timespan"));
             Assert.AreEqual(0.10101m, row.GetDecimal("Decimal"));
             Assert.AreEqual(0.10101m, row.GetDecimal(8));
-            Assert.AreEqual("0.10101", row.GetObject("Decimal"));
+            Assert.AreEqual(0.10101m, row.GetObject("Decimal"));
             Assert.True(row.IsNull("NullBool"));
             Assert.True(row.IsNull(9));
             Assert.IsNull(row.GetObject("NullBool"));

--- a/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientClientLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientClientLiveTests.cs
@@ -182,9 +182,10 @@ namespace Azure.Monitor.Query.Tests
 
             LogsQueryResultRow row = results.Value.PrimaryTable.Rows[0];
 
-            Assert.AreEqual(DateTimeOffset.Parse("2015-12-31 23:59:59.9+00:00"), row.GetDateTimeOffset("DateTime"));
-            Assert.AreEqual(DateTimeOffset.Parse("2015-12-31 23:59:59.9+00:00"), row.GetDateTimeOffset(0));
-            Assert.AreEqual(DateTimeOffset.Parse("2015-12-31 23:59:59.9+00:00"), row.GetObject("DateTime"));
+            var expectedDate = DateTimeOffset.Parse("2015-12-31 23:59:59.9+00:00");
+            Assert.AreEqual(expectedDate, row.GetDateTimeOffset("DateTime"));
+            Assert.AreEqual(expectedDate, row.GetDateTimeOffset(0));
+            Assert.AreEqual(expectedDate, row.GetObject("DateTime"));
             Assert.AreEqual(false, row.GetBoolean("Bool"));
             Assert.AreEqual(false, row.GetBoolean(1));
             Assert.AreEqual(false, row.GetObject("Bool"));


### PR DESCRIPTION
We can now return the same type from all methods.