### PR TITLE
[MetricsAdvisor] Re-enabled GetHooksAsync sample

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample04_HookCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample04_HookCrudOperations.cs
@@ -122,7 +122,6 @@ namespace Azure.AI.MetricsAdvisor.Samples
         }
 
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/20677")]
         public async Task GetHooksAsync()
         {
             string endpoint = MetricsAdvisorUri;


### PR DESCRIPTION
Service bug has been fixed.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/20677.