### PR TITLE
[Storage] Weekly tests - allow only Preview subscription.

### DIFF
--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -8,6 +8,8 @@ extends:
     TimeoutInMinutes: 180
     Location: canadacentral
     Clouds: Preview
+    # Storage service enables in-preview features only in Preview subscription
+    SupportedClouds: Preview
     MatrixReplace:
       # Use dedicated storage pool in canadacentral with higher memory capacity
       - Pool=(.*)-general/$1-storage


### PR DESCRIPTION
Storage service enables in-preview features for allow-listed subscriptions. The only one used in weekly tests that's allowed is `Preview`. Thus removing other variants as they don't bring much value at this time.

The alternative is to keep marking tests to allow depending on which sub they run in. Since we don't benefit much from testing many subscriptions we'll defer this effort until absolutely necessary.