### PR TITLE
Make AzureKeyVaultConfigurationProvider case insensitive again

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
+## 1.2.1 (2021-05-18)
 
+### Changes
+
+#### Key Bug Fixes
+
+- Fixes an issues where keys returned from `AzureKeyVaultConfigurationProvider` were case sensitive. 
 
 ## 1.1.0 (2021-05-14)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
@@ -4,7 +4,7 @@
     <Description>Azure Key Vault configuration provider implementation for Microsoft.Extensions.Configuration.</Description>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);azure;keyvault</PackageTags>
-    <Version>1.2.0-beta.1</Version>
+    <Version>1.2.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.0</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0001;AZC0102</NoWarn>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
@@ -61,7 +61,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
                 }
             }
 
-            return data.ToDictionary(d => d.Key, v => v.Value.Value);
+            return data.ToDictionary(d => d.Key, v => v.Value.Value, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
@@ -438,6 +438,26 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
                 Assert.AreEqual("Value1", provider.Get("Section:Secret1"));
             }
         }
+        [Test]
+        public void ReturnsCaseInsensitiveDictionary()
+        {
+            var client = new Mock<SecretClient>();
+            SetPages(client,
+                new[]
+                {
+                    CreateSecret("Section--Secret1", "Value1")
+                }
+            );
+
+            // Act
+            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object,  new AzureKeyVaultConfigurationOptions() { Manager = new KeyVaultSecretManager() }))
+            {
+                provider.Load();
+
+                // Assert
+                Assert.AreEqual("Value1", provider.Get("section:secret1"));
+            }
+        }
 
         [Test]
         public void HandleCollisions()


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/21117

It's a bad regression, prepare for a patch.