### PR TITLE
API updates to support function level autocomplete

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/api/Microsoft.Azure.WebJobs.Extensions.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/api/Microsoft.Azure.WebJobs.Extensions.ServiceBus.netstandard2.0.cs
@@ -39,21 +39,20 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
     {
         public MessageProcessor(Azure.Messaging.ServiceBus.ServiceBusProcessor processor) { }
         protected internal Azure.Messaging.ServiceBus.ServiceBusProcessor Processor { get { throw null; } }
-        public virtual System.Threading.Tasks.Task<bool> BeginProcessingMessageAsync(Microsoft.Azure.WebJobs.ServiceBus.ServiceBusMessageActions messageActions, Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public virtual System.Threading.Tasks.Task CompleteProcessingMessageAsync(Microsoft.Azure.WebJobs.ServiceBus.ServiceBusMessageActions messageActions, Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, Microsoft.Azure.WebJobs.Host.Executors.FunctionResult result, System.Threading.CancellationToken cancellationToken) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task<bool> BeginProcessingMessageAsync(Microsoft.Azure.WebJobs.ServiceBus.ServiceBusMessageActions messageActions, Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Threading.CancellationToken cancellationToken) { throw null; }
+        protected internal virtual System.Threading.Tasks.Task CompleteProcessingMessageAsync(Microsoft.Azure.WebJobs.ServiceBus.ServiceBusMessageActions messageActions, Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, Microsoft.Azure.WebJobs.Host.Executors.FunctionResult result, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public partial class MessagingProvider
     {
-        protected MessagingProvider() { }
         public MessagingProvider(Microsoft.Extensions.Options.IOptions<Microsoft.Azure.WebJobs.ServiceBus.ServiceBusOptions> options) { }
-        public virtual Azure.Messaging.ServiceBus.ServiceBusReceiver CreateBatchMessageReceiver(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath) { throw null; }
-        public virtual Azure.Messaging.ServiceBus.ServiceBusClient CreateClient(string connectionString) { throw null; }
-        public virtual Azure.Messaging.ServiceBus.ServiceBusClient CreateClient(string fullyQualifiedNamespace, Azure.Core.TokenCredential credential) { throw null; }
-        public virtual Microsoft.Azure.WebJobs.ServiceBus.MessageProcessor CreateMessageProcessor(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath) { throw null; }
-        public virtual Azure.Messaging.ServiceBus.ServiceBusSender CreateMessageSender(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath) { throw null; }
-        public virtual Azure.Messaging.ServiceBus.ServiceBusProcessor CreateProcessor(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath) { throw null; }
-        public virtual Microsoft.Azure.WebJobs.ServiceBus.SessionMessageProcessor CreateSessionMessageProcessor(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath) { throw null; }
-        public virtual Azure.Messaging.ServiceBus.ServiceBusSessionProcessor CreateSessionProcessor(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath) { throw null; }
+        protected internal virtual Azure.Messaging.ServiceBus.ServiceBusReceiver CreateBatchMessageReceiver(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath, Azure.Messaging.ServiceBus.ServiceBusReceiverOptions options) { throw null; }
+        protected internal virtual Azure.Messaging.ServiceBus.ServiceBusClient CreateClient(string fullyQualifiedNamespace, Azure.Core.TokenCredential credential, Azure.Messaging.ServiceBus.ServiceBusClientOptions options) { throw null; }
+        protected internal virtual Azure.Messaging.ServiceBus.ServiceBusClient CreateClient(string connectionString, Azure.Messaging.ServiceBus.ServiceBusClientOptions options) { throw null; }
+        protected internal virtual Microsoft.Azure.WebJobs.ServiceBus.MessageProcessor CreateMessageProcessor(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath, Azure.Messaging.ServiceBus.ServiceBusProcessorOptions options) { throw null; }
+        protected internal virtual Azure.Messaging.ServiceBus.ServiceBusSender CreateMessageSender(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath) { throw null; }
+        protected internal virtual Azure.Messaging.ServiceBus.ServiceBusProcessor CreateProcessor(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath, Azure.Messaging.ServiceBus.ServiceBusProcessorOptions options) { throw null; }
+        protected internal virtual Microsoft.Azure.WebJobs.ServiceBus.SessionMessageProcessor CreateSessionMessageProcessor(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath, Azure.Messaging.ServiceBus.ServiceBusSessionProcessorOptions options) { throw null; }
+        protected internal virtual Azure.Messaging.ServiceBus.ServiceBusSessionProcessor CreateSessionProcessor(Azure.Messaging.ServiceBus.ServiceBusClient client, string entityPath, Azure.Messaging.ServiceBus.ServiceBusSessionProcessorOptions options) { throw null; }
     }
     public enum ServiceBusEntityType
     {
@@ -77,9 +76,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public System.Func<Azure.Messaging.ServiceBus.ProcessErrorEventArgs, System.Threading.Tasks.Task> ExceptionHandler { get { throw null; } set { } }
         public Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { throw null; } set { } }
         public System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } set { } }
+        public int MaxBatchSize { get { throw null; } set { } }
         public int MaxConcurrentCalls { get { throw null; } set { } }
         public int MaxConcurrentSessions { get { throw null; } set { } }
-        public int MaxMessages { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
         public System.TimeSpan? SessionIdleTimeout { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusTransportType TransportType { get { throw null; } set { } }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusClientFactory.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusClientFactory.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.WebJobs.ServiceBus;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using System;
+using Microsoft.Extensions.Options;
 using Constants = Microsoft.Azure.WebJobs.ServiceBus.Constants;
 
 namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config
@@ -18,16 +19,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config
         private readonly IConfiguration _configuration;
         private readonly AzureComponentFactory _componentFactory;
         private readonly MessagingProvider _messagingProvider;
+        private readonly ServiceBusOptions _options;
 
         public ServiceBusClientFactory(
             IConfiguration configuration,
             AzureComponentFactory componentFactory,
             MessagingProvider messagingProvider,
-            AzureEventSourceLogForwarder logForwarder)
+            AzureEventSourceLogForwarder logForwarder,
+            IOptions<ServiceBusOptions> options)
         {
             _configuration = configuration;
             _componentFactory = componentFactory;
             _messagingProvider = messagingProvider;
+            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
             logForwarder.Start();
         }
 
@@ -35,8 +39,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config
         {
             var connectionInfo = ResolveConnectionInformation(connection);
 
-            return connectionInfo.ConnectionString != null ? _messagingProvider.CreateClient(connectionInfo.ConnectionString)
-            : _messagingProvider.CreateClient(connectionInfo.FullyQualifiedNamespace, connectionInfo.Credential);
+            return connectionInfo.ConnectionString != null ? _messagingProvider.CreateClient(connectionInfo.ConnectionString, _options.ToClientOptions())
+            : _messagingProvider.CreateClient(connectionInfo.FullyQualifiedNamespace, connectionInfo.Credential, _options.ToClientOptions());
         }
 
         internal ServiceBusAdministrationClient CreateAdministrationClient(string connection)

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// Gets or sets the maximum number of messages that will be passed to each function call. This only applies for functions that receive
         /// a batch of messages. The default value is 1000.
         /// </summary>
-        public int MaxMessages { get; set; } = 1000;
+        public int MaxBatchSize { get; set; } = 1000;
 
         /// <summary>
         /// Gets or sets the maximum amount of time to wait for a message to be received for the
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 { nameof(MaxAutoLockRenewalDuration), MaxAutoLockRenewalDuration },
                 { nameof(MaxConcurrentCalls), MaxConcurrentCalls },
                 { nameof(MaxConcurrentSessions), MaxConcurrentSessions },
-                { nameof(MaxMessages), MaxMessages },
+                { nameof(MaxBatchSize), MaxBatchSize },
                 { nameof(SessionIdleTimeout), SessionIdleTimeout.ToString() ?? string.Empty }
             };
 
@@ -210,6 +210,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 MaxAutoLockRenewalDuration = MaxAutoLockRenewalDuration,
                 MaxConcurrentSessions = MaxConcurrentSessions,
                 SessionIdleTimeout = SessionIdleTimeout
+            };
+
+        internal ServiceBusReceiverOptions ToReceiverOptions() =>
+            new ServiceBusReceiverOptions
+            {
+                PrefetchCount = PrefetchCount
             };
 
         internal ServiceBusClientOptions ToClientOptions() =>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/MessageProcessor.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/MessageProcessor.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <param name="message">The <see cref="ServiceBusReceivedMessage"/> to process.</param>
         /// <param name="cancellationToken">A cancellation token that will be cancelled when the processor is shutting down.</param>
         /// <returns>A <see cref="Task"/> that returns true if the message processing should continue, false otherwise.</returns>
-        public virtual Task<bool> BeginProcessingMessageAsync(ServiceBusMessageActions messageActions, ServiceBusReceivedMessage message, CancellationToken cancellationToken)
+        protected internal virtual Task<bool> BeginProcessingMessageAsync(ServiceBusMessageActions messageActions, ServiceBusReceivedMessage message, CancellationToken cancellationToken)
         {
             return Task.FromResult<bool>(true);
         }
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <param name="result">The <see cref="FunctionResult"/> from the job invocation.</param>
         /// <param name="cancellationToken">A cancellation token that will be cancelled when the processor is shutting down.</param>
         /// <returns>A <see cref="Task"/> that will complete the message processing.</returns>
-        public virtual Task CompleteProcessingMessageAsync(ServiceBusMessageActions messageActions, ServiceBusReceivedMessage message, FunctionResult result, CancellationToken cancellationToken)
+        protected internal virtual Task CompleteProcessingMessageAsync(ServiceBusMessageActions messageActions, ServiceBusReceivedMessage message, FunctionResult result, CancellationToken cancellationToken)
         {
             if (message is null)
             {

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/MessagingProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/MessagingProvider.cs
@@ -6,14 +6,14 @@ using System.Collections.Concurrent;
 using Azure.Core;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
-using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
     /// <summary>
     /// This class provides factory methods for the creation of instances
-    /// used for ServiceBus message processing.
+    /// used for Service Bus message processing. It can be overriden to customize
+    /// any of the client creation methods.
     /// </summary>
     public class MessagingProvider
     {
@@ -23,46 +23,91 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         private readonly ConcurrentDictionary<string, ServiceBusReceiver> _messageReceiverCache = new();
         private readonly ConcurrentDictionary<string, ServiceBusClient> _clientCache = new();
 
-        protected MessagingProvider()
-        {
-        }
-
+        /// <summary>
+        /// Initializes a new instance of <see cref="MessagingProvider"/>.
+        /// This is called by the Functions runtime as part of start up.
+        /// </summary>
+        /// <param name="options">The options that are used to configure the client instances.</param>
+        /// <exception cref="ArgumentNullException">The options instance is null.</exception>
         public MessagingProvider(IOptions<ServiceBusOptions> options)
         {
             Options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         }
 
-        public virtual ServiceBusClient CreateClient(string connectionString)
+        /// <summary>
+        /// Creates a <see cref="ServiceBusClient"/> to use for communicating with the service.
+        /// </summary>
+        /// <param name="connectionString">The connection string to use for connecting to the
+        /// Service Bus namespace.</param>
+        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
+        /// constructor.</param>
+        /// <returns>The client that will be used by the extension for communicating with the service.</returns>
+        protected internal virtual ServiceBusClient CreateClient(string connectionString, ServiceBusClientOptions options)
         {
             Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+            Argument.AssertNotNull(options, nameof(options));
 
             return _clientCache.GetOrAdd(
                 connectionString,
-                (_) => new ServiceBusClient(connectionString, Options.ToClientOptions()));
+                (_) => new ServiceBusClient(connectionString, options));
         }
 
-        public virtual ServiceBusClient CreateClient(string fullyQualifiedNamespace, TokenCredential credential)
+        /// <summary>
+        /// Creates a <see cref="ServiceBusClient"/> to use for communicating with the service.
+        /// </summary>
+        /// <param name="fullyQualifiedNamespace">The connection string to use for connecting to the
+        /// Service Bus namespace.</param>
+        /// <param name="credential">The Azure managed identity credential to use for authorization.
+        /// Access controls may be specified by the Service Bus namespace.</param>
+        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
+        /// constructor.</param>
+        /// <returns>The client that will be used by the extension for communicating with the service.</returns>
+        protected internal virtual ServiceBusClient CreateClient(string fullyQualifiedNamespace, TokenCredential credential, ServiceBusClientOptions options)
         {
             Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
             Argument.AssertNotNull(credential, nameof(credential));
+            Argument.AssertNotNull(options, nameof(options));
 
             return _clientCache.GetOrAdd(
                 fullyQualifiedNamespace,
-                (_) => new ServiceBusClient(fullyQualifiedNamespace, credential, Options.ToClientOptions()));
+                (_) => new ServiceBusClient(fullyQualifiedNamespace, credential, options));
         }
 
-        public virtual MessageProcessor CreateMessageProcessor(ServiceBusClient client, string entityPath)
+        /// <summary>
+        /// Creates a <see cref="MessageProcessor"/> instance that will be used to process messages.
+        /// </summary>
+        /// <param name="client">The client that is being used to communicate with the service.</param>
+        /// <param name="entityPath">The path to the Service Bus entity that is being received from.</param>
+        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
+        /// constructor.</param>
+        /// <returns>A message processor that will be used by the extension.</returns>
+        protected internal virtual MessageProcessor CreateMessageProcessor(ServiceBusClient client, string entityPath, ServiceBusProcessorOptions options)
         {
             Argument.AssertNotNull(client, nameof(client));
             Argument.AssertNotNullOrEmpty(entityPath, nameof(entityPath));
+            Argument.AssertNotNull(options, nameof(options));
 
-            return new MessageProcessor(CreateProcessor(client, entityPath));
+            return new MessageProcessor(CreateProcessor(client, entityPath, options));
         }
 
-        public virtual ServiceBusProcessor CreateProcessor(ServiceBusClient client, string entityPath)
+        /// <summary>
+        /// Creates a <see cref="ServiceBusProcessor"/> instance that will be used to receive messages from the entity.
+        /// </summary>
+        /// <param name="client">The client that is being used to communicate with the service.</param>
+        /// <param name="entityPath">The path to the Service Bus entity that is being received from.</param>
+        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
+        /// constructor.</param>
+        /// <remarks>This method is called for functions that bind to a single message.</remarks>
+        /// <returns>A <see cref="ServiceBusProcessor"/> that will be used by the extension.</returns>
+        protected internal virtual ServiceBusProcessor CreateProcessor(ServiceBusClient client, string entityPath, ServiceBusProcessorOptions options)
         {
             Argument.AssertNotNull(client, nameof(client));
             Argument.AssertNotNullOrEmpty(entityPath, nameof(entityPath));
+            Argument.AssertNotNull(options, nameof(options));
 
             // processors cannot be shared across listeners since there is a limit of 1 event handler in the Service Bus SDK.
 
@@ -71,18 +116,25 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             {
                 // entityPath for a subscription is "{TopicName}/Subscriptions/{SubscriptionName}"
                 ServiceBusEntityPathHelper.ParseTopicAndSubscription(entityPath, out string topic, out string subscription);
-                processor = client.CreateProcessor(topic, subscription, Options.ToProcessorOptions());
+                processor = client.CreateProcessor(topic, subscription, options);
             }
             else
             {
                 // entityPath for a queue is "{QueueName}"
-                processor = client.CreateProcessor(entityPath, Options.ToProcessorOptions());
+                processor = client.CreateProcessor(entityPath, options);
             }
             processor.ProcessErrorAsync += Options.ExceptionReceivedHandler;
             return processor;
         }
 
-        public virtual ServiceBusSender CreateMessageSender(ServiceBusClient client, string entityPath)
+        /// <summary>
+        /// Creates a <see cref="ServiceBusSender"/> that will be used to send messages to the queue
+        /// or topic.
+        /// </summary>
+        /// <param name="client">The client that is being used to communicate with the service.</param>
+        /// <param name="entityPath">The path to the Service Bus entity that is being received from.</param>
+        /// <returns>A sender that the extension will use to send messages.</returns>
+        protected internal virtual ServiceBusSender CreateMessageSender(ServiceBusClient client, string entityPath)
         {
             Argument.AssertNotNull(client, nameof(client));
             Argument.AssertNotNullOrEmpty(entityPath, nameof(entityPath));
@@ -90,43 +142,70 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             return _messageSenderCache.GetOrAdd(entityPath, client.CreateSender(entityPath));
         }
 
-        public virtual ServiceBusReceiver CreateBatchMessageReceiver(ServiceBusClient client, string entityPath)
+        /// <summary>
+        /// Creates a <see cref="ServiceBusReceiver"/> that will be used to receive a batch of messages.
+        /// </summary>
+        /// <param name="client">The client that is being used to communicate with the service.</param>
+        /// <param name="entityPath">The path to the Service Bus entity that is being received from.</param>
+        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
+        /// constructor.</param>
+        /// <remarks>This method is called for functions that bind to multiple messages.</remarks>
+        /// <returns>A receiver that will be used by the extension to receive a batch of messages.</returns>
+        protected internal virtual ServiceBusReceiver CreateBatchMessageReceiver(ServiceBusClient client, string entityPath, ServiceBusReceiverOptions options)
         {
             Argument.AssertNotNull(client, nameof(client));
             Argument.AssertNotNullOrEmpty(entityPath, nameof(entityPath));
+            Argument.AssertNotNull(options, nameof(options));
 
-            return _messageReceiverCache.GetOrAdd(entityPath, (_) => client.CreateReceiver(
-                entityPath,
-                new ServiceBusReceiverOptions
-                {
-                    PrefetchCount = Options.PrefetchCount
-                }));
+            return _messageReceiverCache.GetOrAdd(entityPath, (_) => client.CreateReceiver(entityPath, options));
         }
 
-        public virtual SessionMessageProcessor CreateSessionMessageProcessor(ServiceBusClient client, string entityPath)
+        /// <summary>
+        /// Creates a <see cref="SessionMessageProcessor"/> instance that will be used to process messages.
+        /// </summary>
+        /// <param name="client">The client that is being used to communicate with the service.</param>
+        /// <param name="entityPath">The path to the Service Bus entity that is being received from.</param>
+        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
+        /// constructor.</param>
+        /// <returns>A message processor that will be used by the extension.</returns>
+        protected internal virtual SessionMessageProcessor CreateSessionMessageProcessor(ServiceBusClient client, string entityPath, ServiceBusSessionProcessorOptions options)
         {
             Argument.AssertNotNull(client, nameof(client));
             Argument.AssertNotNullOrEmpty(entityPath, nameof(entityPath));
+            Argument.AssertNotNull(options, nameof(options));
 
-            return new SessionMessageProcessor(CreateSessionProcessor(client, entityPath));
+            return new SessionMessageProcessor(CreateSessionProcessor(client, entityPath, options));
         }
 
-        public virtual ServiceBusSessionProcessor CreateSessionProcessor(ServiceBusClient client, string entityPath)
+        /// <summary>
+        /// Creates a <see cref="ServiceBusProcessor"/> instance that will be used to receive messages from the entity.
+        /// </summary>
+        /// <param name="client">The client that is being used to communicate with the service.</param>
+        /// <param name="entityPath">The path to the Service Bus entity that is being received from.</param>
+        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
+        /// constructor.</param>
+        /// <remarks>This method is called for functions that bind to a single message.</remarks>
+        /// <returns>A <see cref="ServiceBusProcessor"/> that will be used by the extension.</returns>
+        protected internal virtual ServiceBusSessionProcessor CreateSessionProcessor(ServiceBusClient client, string entityPath, ServiceBusSessionProcessorOptions options)
         {
             Argument.AssertNotNull(client, nameof(client));
             Argument.AssertNotNullOrEmpty(entityPath, nameof(entityPath));
+            Argument.AssertNotNull(options, nameof(options));
 
             ServiceBusSessionProcessor processor;
             if (ServiceBusEntityPathHelper.ParseEntityType(entityPath) == ServiceBusEntityType.Topic)
             {
                 // entityPath for a subscription is "{TopicName}/Subscriptions/{SubscriptionName}"
                 ServiceBusEntityPathHelper.ParseTopicAndSubscription(entityPath, out string topic, out string subscription);
-                processor = client.CreateSessionProcessor(topic, subscription, Options.ToSessionProcessorOptions());
+                processor = client.CreateSessionProcessor(topic, subscription, options);
             }
             else
             {
                 // entityPath for a queue is "{QueueName}"
-                processor = client.CreateSessionProcessor(entityPath, Options.ToSessionProcessorOptions());
+                processor = client.CreateSessionProcessor(entityPath, options);
             }
             processor.ProcessErrorAsync += Options.ExceptionReceivedHandler;
             return processor;

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/MessagingProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/MessagingProvider.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// </summary>
         /// <param name="client">The client that is being used to communicate with the service.</param>
         /// <param name="entityPath">The path to the Service Bus entity that is being received from.</param>
-        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// <param name="options">The set of options to use for configuring the processor. These options are
         /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
         /// constructor.</param>
         /// <returns>A message processor that will be used by the extension.</returns>
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// </summary>
         /// <param name="client">The client that is being used to communicate with the service.</param>
         /// <param name="entityPath">The path to the Service Bus entity that is being received from.</param>
-        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// <param name="options">The set of options to use for configuring the processor. These options are
         /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
         /// constructor.</param>
         /// <remarks>This method is called for functions that bind to a single message.</remarks>
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// </summary>
         /// <param name="client">The client that is being used to communicate with the service.</param>
         /// <param name="entityPath">The path to the Service Bus entity that is being received from.</param>
-        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// <param name="options">The set of options to use for configuring the receiver. These options are
         /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
         /// constructor.</param>
         /// <remarks>This method is called for functions that bind to multiple messages.</remarks>
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// </summary>
         /// <param name="client">The client that is being used to communicate with the service.</param>
         /// <param name="entityPath">The path to the Service Bus entity that is being received from.</param>
-        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// <param name="options">The set of options to use for configuring the processor. These options are
         /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
         /// constructor.</param>
         /// <returns>A message processor that will be used by the extension.</returns>
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// </summary>
         /// <param name="client">The client that is being used to communicate with the service.</param>
         /// <param name="entityPath">The path to the Service Bus entity that is being received from.</param>
-        /// <param name="options">The set of options to use for configuring the client. These options are
+        /// <param name="options">The set of options to use for configuring the processor. These options are
         /// computed from the <see cref="ServiceBusOptions"/> passed to the <see cref="MessagingProvider"/>
         /// constructor.</param>
         /// <remarks>This method is called for functions that bind to a single message.</remarks>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Bindings/ServiceBusAttributeBindingProviderTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Bindings/ServiceBusAttributeBindingProviderTests.cs
@@ -31,7 +31,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
             Mock<INameResolver> mockResolver = new Mock<INameResolver>(MockBehavior.Strict);
             ServiceBusOptions config = new ServiceBusOptions();
             var messagingProvider = new MessagingProvider(new OptionsWrapper<ServiceBusOptions>(config));
-            var factory = new ServiceBusClientFactory(_configuration, new Mock<AzureComponentFactory>().Object, messagingProvider, new AzureEventSourceLogForwarder(new NullLoggerFactory()));
+            var factory = new ServiceBusClientFactory(
+                _configuration,
+                new Mock<AzureComponentFactory>().Object,
+                messagingProvider,
+                new AzureEventSourceLogForwarder(new NullLoggerFactory()),
+                new OptionsWrapper<ServiceBusOptions>(config));
             _provider = new ServiceBusAttributeBindingProvider(mockResolver.Object, messagingProvider, factory);
         }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Bindings/ServiceBusTriggerAttributeBindingProviderTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Bindings/ServiceBusTriggerAttributeBindingProviderTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
 
             Mock<IConverterManager> convertManager = new Mock<IConverterManager>(MockBehavior.Default);
             var provider = new MessagingProvider(new OptionsWrapper<ServiceBusOptions>(options));
-            var factory = new ServiceBusClientFactory(configuration, new Mock<AzureComponentFactory>().Object, provider, new AzureEventSourceLogForwarder(new NullLoggerFactory()));
+            var factory = new ServiceBusClientFactory(configuration, new Mock<AzureComponentFactory>().Object, provider, new AzureEventSourceLogForwarder(new NullLoggerFactory()), new OptionsWrapper<ServiceBusOptions>(options));
             _provider = new ServiceBusTriggerAttributeBindingProvider(mockResolver.Object, options, provider, NullLoggerFactory.Instance, convertManager.Object, factory);
         }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusClientFactoryTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusClientFactoryTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Tests.Config
                 new KeyValuePair<string, string>("ConnectionStrings:" + Constants.DefaultConnectionStringName, defaultConnectionString),
                 new KeyValuePair<string, string>(Constants.DefaultConnectionSettingStringName, defaultConnectionSettingString));
 
-            var mockProvider = new Mock<MessagingProvider>();
+            var mockProvider = new Mock<MessagingProvider>(new OptionsWrapper<ServiceBusOptions>(new ServiceBusOptions()));
             mockProvider.Setup(
                 p => p.CreateClient(expectedValue, It.IsAny<ServiceBusClientOptions>()))
                 .Returns(Mock.Of<ServiceBusClient>());

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusClientFactoryTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusClientFactoryTests.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.Tests.Config
 {
@@ -32,10 +33,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Tests.Config
 
             var mockProvider = new Mock<MessagingProvider>();
             mockProvider.Setup(
-                p => p.CreateClient(expectedValue))
+                p => p.CreateClient(expectedValue, It.IsAny<ServiceBusClientOptions>()))
                 .Returns(Mock.Of<ServiceBusClient>());
 
-            var factory = new ServiceBusClientFactory(configuration, Mock.Of<AzureComponentFactory>(), mockProvider.Object, new AzureEventSourceLogForwarder(new NullLoggerFactory()));
+            var factory = new ServiceBusClientFactory(configuration, Mock.Of<AzureComponentFactory>(), mockProvider.Object, new AzureEventSourceLogForwarder(new NullLoggerFactory()), new OptionsWrapper<ServiceBusOptions>(new ServiceBusOptions()));
             if (expectedValue == null)
             {
                 Assert.That(

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusListenerTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusListenerTests.cs
@@ -50,13 +50,13 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             _mockMessageProcessor = new Mock<MessageProcessor>(MockBehavior.Strict, processor);
 
             _mockMessagingProvider = new Mock<MessagingProvider>(new OptionsWrapper<ServiceBusOptions>(config));
-            _mockClientFactory = new Mock<ServiceBusClientFactory>(configuration, Mock.Of<AzureComponentFactory>(), _mockMessagingProvider.Object, new AzureEventSourceLogForwarder(new NullLoggerFactory()));
+            _mockClientFactory = new Mock<ServiceBusClientFactory>(configuration, Mock.Of<AzureComponentFactory>(), _mockMessagingProvider.Object, new AzureEventSourceLogForwarder(new NullLoggerFactory()), new OptionsWrapper<ServiceBusOptions>(new ServiceBusOptions()));
             _mockMessagingProvider
-                .Setup(p => p.CreateMessageProcessor(It.IsAny<ServiceBusClient>(), _entityPath))
+                .Setup(p => p.CreateMessageProcessor(It.IsAny<ServiceBusClient>(), _entityPath, It.IsAny<ServiceBusProcessorOptions>()))
                 .Returns(_mockMessageProcessor.Object);
 
             _mockMessagingProvider
-                    .Setup(p => p.CreateBatchMessageReceiver(It.IsAny<ServiceBusClient>(), _entityPath))
+                    .Setup(p => p.CreateBatchMessageReceiver(It.IsAny<ServiceBusClient>(), _entityPath, default))
                     .Returns(receiver);
 
             _loggerFactory = new LoggerFactory();

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
@@ -51,15 +51,20 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>(_connection, _testConnection));
 
             _serviceBusOptions = new ServiceBusOptions();
-            _mockProvider = new Mock<MessagingProvider>(new OptionsWrapper<ServiceBusOptions>(new ServiceBusOptions()));
-            _mockClientFactory = new Mock<ServiceBusClientFactory>(configuration, Mock.Of<AzureComponentFactory>(), _mockProvider.Object, new AzureEventSourceLogForwarder(new NullLoggerFactory()));
+            _mockProvider = new Mock<MessagingProvider>(new OptionsWrapper<ServiceBusOptions>(_serviceBusOptions));
+            _mockClientFactory = new Mock<ServiceBusClientFactory>(
+                configuration,
+                 Mock.Of<AzureComponentFactory>(),
+                _mockProvider.Object,
+                new AzureEventSourceLogForwarder(new NullLoggerFactory()),
+                new OptionsWrapper<ServiceBusOptions>(_serviceBusOptions));
 
             _mockProvider
-                .Setup(p => p.CreateMessageProcessor(_client, _entityPath))
+                .Setup(p => p.CreateMessageProcessor(_client, _entityPath, It.IsAny<ServiceBusProcessorOptions>()))
                 .Returns(_mockMessageProcessor.Object);
 
             _mockProvider
-                .Setup(p => p.CreateClient(_testConnection))
+                .Setup(p => p.CreateClient(_testConnection, It.IsAny<ServiceBusClientOptions>()))
                 .Returns(_client);
 
             _loggerFactory = new LoggerFactory();
@@ -131,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
         {
             // MessagingEntityNotFoundException
             _mockProvider
-                .Setup(p => p.CreateBatchMessageReceiver(_client, _entityPath))
+                .Setup(p => p.CreateBatchMessageReceiver(_client, _entityPath, It.IsAny<ServiceBusReceiverOptions>()))
                 .Throws(new ServiceBusException("", reason: ServiceBusFailureReason.MessagingEntityNotFound));
 
             ServiceBusListener listener = CreateListener();
@@ -149,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
 
             // UnauthorizedAccessException
             _mockProvider
-                .Setup(p => p.CreateBatchMessageReceiver(_client, _entityPath))
+                .Setup(p => p.CreateBatchMessageReceiver(_client, _entityPath, It.IsAny<ServiceBusReceiverOptions>()))
                 .Throws(new UnauthorizedAccessException(""));
             listener = CreateListener();
 
@@ -168,7 +173,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
 
             // Generic Exception
             _mockProvider
-                .Setup(p => p.CreateBatchMessageReceiver(_client, _entityPath))
+                .Setup(p => p.CreateBatchMessageReceiver(_client, _entityPath, It.IsAny<ServiceBusReceiverOptions>()))
                 .Throws(new Exception("Uh oh"));
             listener = CreateListener();
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/MessagingProviderTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/MessagingProviderTests.cs
@@ -22,18 +22,18 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
         public void CreateMessageReceiver_ReturnsExpectedReceiver()
         {
             var options = new ServiceBusOptions();
-            var configuration = CreateConfiguration(new KeyValuePair<string, string>("connection", _defaultConnection));
 
             var provider = new MessagingProvider(new OptionsWrapper<ServiceBusOptions>(options));
+            var receiverOptions = options.ToReceiverOptions();
 
-            var receiver = provider.CreateBatchMessageReceiver(_client, "entityPath");
+            var receiver = provider.CreateBatchMessageReceiver(_client, "entityPath", receiverOptions);
             Assert.AreEqual("entityPath", receiver.EntityPath);
 
-            var receiver2 = provider.CreateBatchMessageReceiver(_client, "entityPath");
+            var receiver2 = provider.CreateBatchMessageReceiver(_client, "entityPath", receiverOptions);
             Assert.AreSame(receiver, receiver2);
 
             options.PrefetchCount = 100;
-            receiver = provider.CreateBatchMessageReceiver(_client, "entityPath1");
+            receiver = provider.CreateBatchMessageReceiver(_client, "entityPath1", options.ToReceiverOptions());
             Assert.AreEqual(100, receiver.PrefetchCount);
         }
 
@@ -41,21 +41,43 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
         public void CreateProcessor_ReturnsExpectedProcessor()
         {
             var options = new ServiceBusOptions();
-            var configuration = CreateConfiguration(new KeyValuePair<string, string>("connection", _defaultConnection));
             var provider = new MessagingProvider(new OptionsWrapper<ServiceBusOptions>(options));
+            var processorOptions = options.ToProcessorOptions();
 
-            var processor = provider.CreateProcessor(_client, "entityPath");
+            var processor = provider.CreateProcessor(_client, "entityPath", processorOptions);
             Assert.AreEqual("entityPath", processor.EntityPath);
 
-            var processor2 = provider.CreateProcessor(_client, "entityPath");
+            var processor2 = provider.CreateProcessor(_client, "entityPath", processorOptions);
             Assert.AreNotSame(processor, processor2);
 
             options.PrefetchCount = 100;
             options.MaxConcurrentCalls = 5;
             options.MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(30);
-            processor = provider.CreateProcessor(_client, "entityPath1");
+            processor = provider.CreateProcessor(_client, "entityPath1", options.ToProcessorOptions());
             Assert.AreEqual(options.PrefetchCount, processor.PrefetchCount);
             Assert.AreEqual(options.MaxConcurrentCalls, processor.MaxConcurrentCalls);
+            Assert.AreEqual(options.MaxAutoLockRenewalDuration, processor.MaxAutoLockRenewalDuration);
+        }
+
+        [Test]
+        public void CreateSessionProcessor_ReturnsExpectedProcessor()
+        {
+            var options = new ServiceBusOptions();
+            var provider = new MessagingProvider(new OptionsWrapper<ServiceBusOptions>(options));
+            var processorOptions = options.ToSessionProcessorOptions();
+
+            var processor = provider.CreateSessionProcessor(_client, "entityPath", processorOptions);
+            Assert.AreEqual("entityPath", processor.EntityPath);
+
+            var processor2 = provider.CreateSessionProcessor(_client, "entityPath", processorOptions);
+            Assert.AreNotSame(processor, processor2);
+
+            options.PrefetchCount = 100;
+            options.MaxConcurrentSessions = 5;
+            options.MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(30);
+            processor = provider.CreateSessionProcessor(_client, "entityPath1", options.ToSessionProcessorOptions());
+            Assert.AreEqual(options.PrefetchCount, processor.PrefetchCount);
+            Assert.AreEqual(options.MaxConcurrentSessions, processor.MaxConcurrentSessions);
             Assert.AreEqual(options.MaxAutoLockRenewalDuration, processor.MaxAutoLockRenewalDuration);
         }
 


### PR DESCRIPTION
The main change here is to update the MessagingProvider methods to accept the relevant option bags for each type in support of https://github.com/Azure/azure-sdk-for-net/issues/21124. This helps because it will allow customizing the options that gets passed into the provider by taking into account the ServiceBusTriggerAttribute properties when calling from the ServiceBusListener. This was only technically necessary for the processor methods, but added it to all methods that have a corresponding options type for consistency.

I also updated the MessagingProvider and MessageProcessor methods to be protected as they do not need to be public for the expected usage scenarios.