### PR TITLE
Add ServiceBusAdministrationClient to the migration docs for service bus SDK

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -6,19 +6,21 @@ Familiarity with the v4 client library is assumed. For those new to the Service 
 
 ## Table of contents
 
-- [Migration benefits](#migration-benefits)
-- [General changes](#general-changes)
-  - [Package and namespaces](#package-and-namespaces)
-  - [Client hierarchy](#client-hierarchy)
-  - [Client constructors](#client-constructors)
-  - [Creating sender and receiver](#creating-sender-and-receiver)
-  - [Sending messages](#sending-messages)
-  - [Receiving messages](#receiving-messages)
-  - [Working with sessions](#working-with-sessions)
-- [Migration samples](#migration-samples)
-  - [Sending and receiving a message](#sending-and-receiving-a-message)
-  - [Sending and receiving a batch of messages](#sending-and-receiving-a-batch-of-messages)
-- [Additional samples](#additional-samples)
+- [Guide for migrating to Azure.Messaging.ServiceBus from Microsoft.Azure.ServiceBus](#guide-for-migrating-to-azuremessagingservicebus-from-microsoftazureservicebus)
+  - [Table of contents](#table-of-contents)
+  - [Migration benefits](#migration-benefits)
+  - [General changes](#general-changes)
+    - [Package and namespaces](#package-and-namespaces)
+    - [Client hierarchy](#client-hierarchy)
+    - [Client constructors](#client-constructors)
+    - [Creating sender and receiver](#creating-sender-and-receiver)
+    - [Sending messages](#sending-messages)
+    - [Receiving messages](#receiving-messages)
+    - [Working with sessions](#working-with-sessions)
+  - [Migration samples](#migration-samples)
+    - [Sending and receiving a message](#sending-and-receiving-a-message)
+    - [Sending and receiving a batch of messages](#sending-and-receiving-a-batch-of-messages)
+  - [Additional samples](#additional-samples)
 
 ## Migration benefits
 
@@ -50,6 +52,7 @@ In the interest of simplifying the API surface we've made a single top level cli
 |-------------------------------------------------------|-----------------------------------------------------------------|--------|
 | `new QueueClient()` or `new TopicClient()` or `new SubscriptionClient()` or `new SessionClient()`  | `new ServiceBusClient()`                      | [Authenticate with connection string](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs#L177) |
 | `new QueueClient(..., ITokenProvider)` or `new TopicClient(..., ITokenProvider)` or `new SubscriptionClient(..., ITokenProvider)` or `new SessionClient(..., ITokenProvider)`  | `new ServiceBusClient(..., TokenCredential)` | [Authenticate with client secret credential](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs#L165)
+| `new ManagementClient(...)` | `new ServiceBusAdministrationClient(...)` | [Create subscription with connection string](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample08_Administration.cs)
 
 ### Creating sender and receiver
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample08_Administration.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample08_Administration.md
@@ -1,0 +1,40 @@
+## Using the administration client
+
+This sample aims to demonstrate how to create a subscription on an existing topic.
+
+### Create the subscription
+
+```C# Snippet:CreateAdministrationClient
+string connectionString = "<connection_string>";
+
+string topicName = "<topic_name>";
+string subscriptionName = "<subscription_name>";
+
+// create a client from a connection string
+ServiceBusAdministrationClient client = new ServiceBusAdministrationClient(connectionString);
+
+// check if the topic exists before creating the subscription
+
+
+bool topicExists = await client.TopicExistsAsync();
+
+if (!topicExists) {
+    // handle errors
+    return;
+}
+
+bool subscriptionExists = await client.SubscriptionExistsAsync(topicName, subscriptionName);
+
+if (!subscriptionExists) {
+    await client.CreateSubscriptionAsync(new CreateSubscriptionOptions(topicName, subscriptionName)
+    {
+        // subscription options such as:
+        // Max delivery count
+        // Retry policy
+        // Batching options
+        // Forwarding options
+    });
+}
+
+return;
+```


### PR DESCRIPTION
fixes #21186

Documentation changes only for example code to demonstrate the usage of the `ServiceBusAdministrationClient` over the deprecated `ManagementClient`
