### PR TITLE
[Event Grid Client] Overview README

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -150,6 +150,7 @@ known_content_issues:
   - ['sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/README.md', 'azure-sdk-tools/issues/404']
   - ['sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/README.md','azure-sdk-tools/issues/404']
   - ['sdk/extensions/Microsoft.Extensions.Azure/README.md','#5499']
+  - ['sdk/eventgrid/README.md','azure-sdk-tools/issues/42']
   - ['sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/README.md', '#15423']
   - ['sdk/eventhub/README.md','azure-sdk-tools/issues/42']
   - ['sdk/search/README.md','azure-sdk-tools/issues/42']

--- a/sdk/eventgrid/README.md
+++ b/sdk/eventgrid/README.md
@@ -1,0 +1,35 @@
+# Azure Event Grid libraries for .NET
+
+Azure Event Grid allows you to build applications with event-based architectures. The Event Grid service fully manages all routing of events from any source, to any destination, for any application. Azure service events and custom events can be published directly to the service, where the events can then be filtered and sent to various recipients, such as built-in handlers or custom webhooks. To learn more about Azure Event Grid: [What is Event Grid?](https://docs.microsoft.com/azure/event-grid/overview)
+
+## Libraries for data access
+
+The current generation of the Azure Event Grid client library uses the package name `Azure.Messaging.EventGrid`.  Microsoft recommends using `Azure.Messaging.EventGrid` for new applications.  If you are unable to upgrade existing applications, then Microsoft recommends using version 3.2 or higher of the previous package, `Microsoft.Azure.EventGrid`.
+
+### `Azure.Messaging.EventGrid`
+
+This package is the current generation client library and is of the Azure SDK for .NET. The source code is available on [GitHub](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventgrid/Azure.Messaging.EventGrid).
+
+Use the following packages to publish and consume events from Event Grid:
+
+| Nuget Package | Reference | Samples |
+|--------------------------------------|---------------------------------------------------------------|-------------------------------------------------------------------------------|
+| [Azure.Messaging.EventGrid](https://www.nuget.org/packages/Azure.Messaging.EventGrid)  |  [API Reference for Azure.Messaging.EventGrid](https://docs.microsoft.com/dotnet/api/azure.messaging.eventgrid?view=azure-dotnet)  |  [Samples for Azure.Messaging.EventGrid](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventgrid/Azure.Messaging.EventGrid/samples) |
+
+### `Microsoft.Azure.EventGrid`
+
+The source code for the previous generation client library, `Microsoft.Azure.EventGrid` is available on [GitHub](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventgrid/Microsoft.Azure.EventGrid).
+
+Use the following legacy packages to publish and consume events from Event Grid:
+
+| Nuget Package | Reference | Samples |
+|--------------------------------------|---------------------------------------------------------------|-------------------------------------------------------------------------------|
+| [Microsoft.Azure.EventGrid](https://www.nuget.org/packages/Microsoft.Azure.EventGrid)  |  [API Reference for Microsoft.Azure.EventGrid](https://docs.microsoft.com/dotnet/api/microsoft.azure.eventgrid?view=azure-dotnet)  |  [Samples for Azure.Messaging.EventGrid](https://github.com/Azure-Samples/event-grid-dotnet-publish-consume-events/tree/master/)  |
+
+## Libraries for resource management
+
+Use the following library to work with the Azure Event Grid resource provider:
+
+| Nuget Package | Reference |
+|--------------------------------------|---------------------------------------------------------------|
+| [Microsoft.Azure.Management.EventGrid](https://www.nuget.org/packages/Microsoft.Azure.Management.EventGrid)  | [API Reference for Microsoft.Azure.Management.EventGrid](https://docs.microsoft.com/dotnet/api/overview/azure/eventgrid/management?view=azure-dotnet)  |

--- a/sdk/eventhub/README.md
+++ b/sdk/eventhub/README.md
@@ -4,11 +4,11 @@ Azure Event Hubs is a highly scalable publish-subscribe service that can ingest 
 
 ## Libraries for data access
 
-The current generation of the Azure Event Hubs client library uses versions 5.0.1 and above.  Microsoft recommends using version 5.2 or higher for new applications.  If you are unable to existing applications to version 5.x, then Microsoft recommends using version 4.1 or higher.
+The current generation of the Azure Event Hubs client library uses package names that follow the pattern `Azure.Messaging.EventHubs.*`.  Microsoft recommends using the `Azure.Messaging.EventHubs` family of packages for  for new applications.  If you are unable to existing applications, then Microsoft recommends using version 4.1 or higher of the legacy Event Hubs packages, `Microsoft.Azure.EventHubs.*`
 
-### Version 5.x
+### `Azure.Messaging.EventHubs`
 
-The version 5.x client libraries are part of the Azure SDK for .NET. The source code for the Azure Event Hubs client libraries is available on [GitHub](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub).
+These packages are the current generation of client libraries for Event Hubs and are part of the Azure SDK for .NET. The source code is available on [GitHub](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub).
 
 Use the following packages to publish and consume events from Event Hubs:
 
@@ -17,9 +17,9 @@ Use the following packages to publish and consume events from Event Hubs:
 | [Azure.Messaging.EventHubs](https://www.nuget.org/packages/Azure.Messaging.EventHubs)  |  [API Reference for Azure.Messaging.EventHubs](https://docs.microsoft.com/dotnet/api/azure.messaging.eventhubs?view=azure-dotnet)  |  [Samples for Azure.Messaging.EventHubs](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Azure.Messaging.EventHubs/samples)  |
 | [Azure.Messaging.EventHubs.Processor](https://www.nuget.org/packages/Azure.Messaging.EventHubs.Processor)  |  [API Reference for Azure.Messaging.EventHubs.Processor](https://docs.microsoft.com/dotnet/api/azure.messaging.eventhubs?view=azure-dotnet)  |  [Samples for Azure.Messaging.EventHubs.Processor](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples)  |
 
-### Version 4.x
+### `Microsoft.Azure.EventHubs`
 
-The source code for version 4.x of the Azure Event Hubs client libraries is available on [GitHub](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub).
+These packages are the legacy generation of client libraries for Event Hubs.  The source code is available on [GitHub](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub).
 
 Use the following legacy packages to publish and consume events from Event Hubs:
 


### PR DESCRIPTION
# Summary

The focus of these changes is to add the overview content as a README in the root of the SDK directory, which will be used by the MS Docs site to as the landing page: [Azure Event Grid libraries for .NET - Azure for .NET Developers](https://docs.microsoft.com/dotnet/api/overview/azure/eventgrid).

# Related and References

- [Overview page for Event Grid ref docs show older packages (#21125)](https://github.com/Azure/azure-sdk-for-net/issues/21125)
- [Event Hubs Overview README](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/README.md)
- [Key Vault Overview (no README)](https://docs.microsoft.com/dotnet/api/overview/azure/key-vault?view=azure-dotnet)