### PR TITLE
[TA] Add action types

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -6,6 +6,12 @@
 - Renamed `AnalyzeBatchActionsOperation` to `AnalyzeActionsOperation`.
 - Renamed `AnalyzeBatchActionsResult` to `AnalyzeActionsResult`.
 - Renamed `AnalyzeBatchActionsOptions` to `AnalyzeActionsOptions`.
+- `TextAnalyticsActions` now takes `xxAction` types, instead of `xxOptions` types. Renames and types are as follow:
+  - `ExtractKeyPhrasesOptions` changed to new type `ExtractKeyPhrasesActions`.
+  - `RecognizeEntitiesOptions` changed to new type `RecognizeEntitiesActions`.
+  - `RecognizePiiEntitiesOptions` changed to new type `RecognizePiiEntitiesActions`.
+  - `RecognizeLinkedEntitiesOptions` changed to new type `RecognizeLinkedEntitiesActions`.
+  - `AnalyzeSentimentOptions` changed to new type `AnalyzeSentimentActions`.
 
 ## 5.1.0-beta.7 (2021-05-18)
 ### New features

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -558,11 +558,11 @@ This functionality allows running multiple actions in one or more documents. Act
 
     TextAnalyticsActions actions = new TextAnalyticsActions()
     {
-        ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
-        RecognizeEntitiesOptions = new List<RecognizeEntitiesOptions>() { new RecognizeEntitiesOptions() },
-        RecognizePiiEntitiesOptions = new List<RecognizePiiEntitiesOptions>() { new RecognizePiiEntitiesOptions() },
-        RecognizeLinkedEntitiesOptions = new List<RecognizeLinkedEntitiesOptions>() { new RecognizeLinkedEntitiesOptions() },
-        AnalyzeSentimentOptions = new List<AnalyzeSentimentOptions>() { new AnalyzeSentimentOptions() },
+        ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+        RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
+        RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
+        RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
+        AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
         DisplayName = "AnalyzeOperationSample"
     };
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -79,6 +79,10 @@ namespace Azure.AI.TextAnalytics
         public string ModelVersion { get { throw null; } }
         public Azure.AI.TextAnalytics.TextDocumentBatchStatistics Statistics { get { throw null; } }
     }
+    public partial class AnalyzeSentimentAction : Azure.AI.TextAnalytics.AnalyzeSentimentOptions
+    {
+        public AnalyzeSentimentAction() { }
+    }
     public partial class AnalyzeSentimentActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionDetails
     {
         internal AnalyzeSentimentActionResult() { }
@@ -217,6 +221,10 @@ namespace Azure.AI.TextAnalytics
         internal EntityDataSource() { }
         public string EntityId { get { throw null; } }
         public string Name { get { throw null; } }
+    }
+    public partial class ExtractKeyPhrasesAction : Azure.AI.TextAnalytics.ExtractKeyPhrasesOptions
+    {
+        public ExtractKeyPhrasesAction() { }
     }
     public partial class ExtractKeyPhrasesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionDetails
     {
@@ -558,6 +566,10 @@ namespace Azure.AI.TextAnalytics
     {
         ProtectedHealthInformation = 0,
     }
+    public partial class RecognizeEntitiesAction : Azure.AI.TextAnalytics.RecognizeEntitiesOptions
+    {
+        public RecognizeEntitiesAction() { }
+    }
     public partial class RecognizeEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionDetails
     {
         internal RecognizeEntitiesActionResult() { }
@@ -578,6 +590,10 @@ namespace Azure.AI.TextAnalytics
         public string ModelVersion { get { throw null; } }
         public Azure.AI.TextAnalytics.TextDocumentBatchStatistics Statistics { get { throw null; } }
     }
+    public partial class RecognizeLinkedEntitiesAction : Azure.AI.TextAnalytics.RecognizeLinkedEntitiesOptions
+    {
+        public RecognizeLinkedEntitiesAction() { }
+    }
     public partial class RecognizeLinkedEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionDetails
     {
         internal RecognizeLinkedEntitiesActionResult() { }
@@ -597,6 +613,10 @@ namespace Azure.AI.TextAnalytics
         internal RecognizeLinkedEntitiesResultCollection() : base (default(System.Collections.Generic.IList<Azure.AI.TextAnalytics.RecognizeLinkedEntitiesResult>)) { }
         public string ModelVersion { get { throw null; } }
         public Azure.AI.TextAnalytics.TextDocumentBatchStatistics Statistics { get { throw null; } }
+    }
+    public partial class RecognizePiiEntitiesAction : Azure.AI.TextAnalytics.RecognizePiiEntitiesOptions
+    {
+        public RecognizePiiEntitiesAction() { }
     }
     public partial class RecognizePiiEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionDetails
     {
@@ -687,12 +707,12 @@ namespace Azure.AI.TextAnalytics
     public partial class TextAnalyticsActions
     {
         public TextAnalyticsActions() { }
-        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.AnalyzeSentimentOptions> AnalyzeSentimentOptions { get { throw null; } set { } }
+        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.AnalyzeSentimentAction> AnalyzeSentimentActions { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
-        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.ExtractKeyPhrasesOptions> ExtractKeyPhrasesOptions { get { throw null; } set { } }
-        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.RecognizeEntitiesOptions> RecognizeEntitiesOptions { get { throw null; } set { } }
-        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.RecognizeLinkedEntitiesOptions> RecognizeLinkedEntitiesOptions { get { throw null; } set { } }
-        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.RecognizePiiEntitiesOptions> RecognizePiiEntitiesOptions { get { throw null; } set { } }
+        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.ExtractKeyPhrasesAction> ExtractKeyPhrasesActions { get { throw null; } set { } }
+        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.RecognizeEntitiesAction> RecognizeEntitiesActions { get { throw null; } set { } }
+        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.RecognizeLinkedEntitiesAction> RecognizeLinkedEntitiesActions { get { throw null; } set { } }
+        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.RecognizePiiEntitiesAction> RecognizePiiEntitiesActions { get { throw null; } set { } }
     }
     public partial class TextAnalyticsClient
     {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_AnalyzeActions.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_AnalyzeActions.md
@@ -35,11 +35,11 @@ To run multiple actions in multiple documents, call `StartAnalyzeActionsAsync` o
 
     TextAnalyticsActions actions = new TextAnalyticsActions()
     {
-        ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
-        RecognizeEntitiesOptions = new List<RecognizeEntitiesOptions>() { new RecognizeEntitiesOptions() },
-        RecognizePiiEntitiesOptions = new List<RecognizePiiEntitiesOptions>() { new RecognizePiiEntitiesOptions() },
-        RecognizeLinkedEntitiesOptions = new List<RecognizeLinkedEntitiesOptions>() { new RecognizeLinkedEntitiesOptions() },
-        AnalyzeSentimentOptions = new List<AnalyzeSentimentOptions>() { new AnalyzeSentimentOptions() },
+        ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+        RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
+        RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
+        RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
+        AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
         DisplayName = "AnalyzeOperationSample"
     };
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOptions.cs
@@ -6,7 +6,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Options that allow callers to specify details about how the operation
     /// is run and what information is returned from it by the service.
-    /// <para>For example whether to include statistics.</para>
+    /// <para>For example, whether to include statistics.</para>
     /// </summary>
     public class AnalyzeActionsOptions
     {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentAction.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Configurations that allow callers to specify details about how to execute
+    /// an Analyze Sentiment action in a set of documents.
+    /// For example execute opinion mining, set model version, and more.
+    /// </summary>
+    public class AnalyzeSentimentAction : AnalyzeSentimentOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AnalyzeSentimentAction"/>
+        /// class which allows callers to specify details about how to execute
+        /// an Analyze Sentiment action in a set of documents.
+        /// For example execute opinion mining, set model version, and more.
+        /// </summary>
+        public AnalyzeSentimentAction()
+        {
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentAction.cs
@@ -6,7 +6,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Configurations that allow callers to specify details about how to execute
     /// an Analyze Sentiment action in a set of documents.
-    /// For example execute opinion mining, set model version, and more.
+    /// For example, execute opinion mining, set model version, and more.
     /// </summary>
     public class AnalyzeSentimentAction : AnalyzeSentimentOptions
     {
@@ -14,7 +14,7 @@ namespace Azure.AI.TextAnalytics
         /// Initializes a new instance of the <see cref="AnalyzeSentimentAction"/>
         /// class which allows callers to specify details about how to execute
         /// an Analyze Sentiment action in a set of documents.
-        /// For example execute opinion mining, set model version, and more.
+        /// For example, execute opinion mining, set model version, and more.
         /// </summary>
         public AnalyzeSentimentAction()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentOptions.cs
@@ -5,14 +5,16 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// Options that allow callers to specify details about how the operation
-    /// is run. For example execute opinion mining, set model version, and whether to include statistics.
+    /// is run. For example execute opinion mining, set model version,
+    /// whether to include statistics, and more.
     /// </summary>
     public class AnalyzeSentimentOptions : TextAnalyticsRequestOptions
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AnalyzeSentimentOptions"/>
         /// class which allows callers to specify details about how the operation
-        /// is run. For example execute opinion mining, set model version, and whether to include statistics.
+        /// is run. For example execute opinion mining, set model version,
+        /// whether to include statistics, and more.
         /// </summary>
         public AnalyzeSentimentOptions()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentOptions.cs
@@ -5,7 +5,7 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// Options that allow callers to specify details about how the operation
-    /// is run. For example execute opinion mining, set model version,
+    /// is run. For example, execute opinion mining, set model version,
     /// whether to include statistics, and more.
     /// </summary>
     public class AnalyzeSentimentOptions : TextAnalyticsRequestOptions
@@ -13,7 +13,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Initializes a new instance of the <see cref="AnalyzeSentimentOptions"/>
         /// class which allows callers to specify details about how the operation
-        /// is run. For example execute opinion mining, set model version,
+        /// is run. For example, execute opinion mining, set model version,
         /// whether to include statistics, and more.
         /// </summary>
         public AnalyzeSentimentOptions()

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesAction.cs
@@ -6,7 +6,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Configurations that allow callers to specify details about how to execute
     /// an Extract KeyPhrases action in a set of documents.
-    /// For example set model version, disable service logging, and more.
+    /// For example, set model version, disable service logging, and more.
     /// </summary>
     public class ExtractKeyPhrasesAction : ExtractKeyPhrasesOptions
     {
@@ -14,7 +14,7 @@ namespace Azure.AI.TextAnalytics
         /// Initializes a new instance of the <see cref="ExtractKeyPhrasesAction"/>
         /// class which allows callers to specify details about how to execute
         /// an Extract KeyPhrases action in a set of documents.
-        /// For example set model version, disable service logging, and more.
+        /// For example, set model version, disable service logging, and more.
         /// </summary>
         public ExtractKeyPhrasesAction()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesAction.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Configurations that allow callers to specify details about how to execute
+    /// an Extract KeyPhrases action in a set of documents.
+    /// For example set model version, disable service logging, and more.
+    /// </summary>
+    public class ExtractKeyPhrasesAction : ExtractKeyPhrasesOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtractKeyPhrasesAction"/>
+        /// class which allows callers to specify details about how to execute
+        /// an Extract KeyPhrases action in a set of documents.
+        /// For example set model version, disable service logging, and more.
+        /// </summary>
+        public ExtractKeyPhrasesAction()
+        {
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesOptions.cs
@@ -5,14 +5,14 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// Options that allow callers to specify details about how the operation
-    /// is run. For example set model version, whether to include statistics, and more.
+    /// is run. For example, set model version, whether to include statistics, and more.
     /// </summary>
     public class ExtractKeyPhrasesOptions : TextAnalyticsRequestOptions
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ExtractKeyPhrasesOptions"/>
         /// class which allows callers to specify details about how the operation
-        /// is run. For example set model version, whether to include statistics, and more.
+        /// is run. For example, set model version, whether to include statistics, and more.
         /// </summary>
         public ExtractKeyPhrasesOptions()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesOptions.cs
@@ -5,14 +5,14 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// Options that allow callers to specify details about how the operation
-    /// is run. For example set model version and whether to include statistics.
+    /// is run. For example set model version, whether to include statistics, and more.
     /// </summary>
     public class ExtractKeyPhrasesOptions : TextAnalyticsRequestOptions
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ExtractKeyPhrasesOptions"/>
         /// class which allows callers to specify details about how the operation
-        /// is run. For example set model version, whether to include statistics.
+        /// is run. For example set model version, whether to include statistics, and more.
         /// </summary>
         public ExtractKeyPhrasesOptions()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesAction.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Configurations that allow callers to specify details about how to execute
+    /// a Recognize Entities action in a set of documents.
+    /// For example set model version, disable service logging, and more.
+    /// </summary>
+    public class RecognizeEntitiesAction : RecognizeEntitiesOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RecognizeEntitiesAction"/>
+        /// class which allows callers to specify details about how to execute
+        /// a Recognize Entities action in a set of documents.
+        /// For example set model version, disable service logging, and more.
+        /// </summary>
+        public RecognizeEntitiesAction()
+        {
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesAction.cs
@@ -6,7 +6,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Configurations that allow callers to specify details about how to execute
     /// a Recognize Entities action in a set of documents.
-    /// For example set model version, disable service logging, and more.
+    /// For example, set model version, disable service logging, and more.
     /// </summary>
     public class RecognizeEntitiesAction : RecognizeEntitiesOptions
     {
@@ -14,7 +14,7 @@ namespace Azure.AI.TextAnalytics
         /// Initializes a new instance of the <see cref="RecognizeEntitiesAction"/>
         /// class which allows callers to specify details about how to execute
         /// a Recognize Entities action in a set of documents.
-        /// For example set model version, disable service logging, and more.
+        /// For example, set model version, disable service logging, and more.
         /// </summary>
         public RecognizeEntitiesAction()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesOptions.cs
@@ -5,14 +5,14 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// Options that allow callers to specify details about how the operation
-    /// is run. For example set model version, whether to include statistics, and more.
+    /// is run. For example, set model version, whether to include statistics, and more.
     /// </summary>
     public class RecognizeEntitiesOptions : TextAnalyticsRequestOptions
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RecognizeEntitiesOptions"/>
         /// class which allows callers to specify details about how the operation
-        /// is run. For example set model version, whether to include statistics, and more.
+        /// is run. For example, set model version, whether to include statistics, and more.
         /// </summary>
         public RecognizeEntitiesOptions()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesOptions.cs
@@ -5,14 +5,14 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// Options that allow callers to specify details about how the operation
-    /// is run. For example set model version, whether to include statistics.
+    /// is run. For example set model version, whether to include statistics, and more.
     /// </summary>
     public class RecognizeEntitiesOptions : TextAnalyticsRequestOptions
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RecognizeEntitiesOptions"/>
         /// class which allows callers to specify details about how the operation
-        /// is run. For example set model version, whether to include statistics.
+        /// is run. For example set model version, whether to include statistics, and more.
         /// </summary>
         public RecognizeEntitiesOptions()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesAction.cs
@@ -6,7 +6,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Configurations that allow callers to specify details about how to execute
     /// a Recognize Linked Entities action in a set of documents.
-    /// For example set model version, disable service logging, and more.
+    /// For example, set model version, disable service logging, and more.
     /// </summary>
     public class RecognizeLinkedEntitiesAction : RecognizeLinkedEntitiesOptions
     {
@@ -14,7 +14,7 @@ namespace Azure.AI.TextAnalytics
         /// Initializes a new instance of the <see cref="RecognizeLinkedEntitiesAction"/>
         /// class which allows callers to specify details about how to execute
         /// a Recognize Linked Entities action in a set of documents.
-        /// For example set model version, disable service logging, and more.
+        /// For example, set model version, disable service logging, and more.
         /// </summary>
         public RecognizeLinkedEntitiesAction()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesAction.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Configurations that allow callers to specify details about how to execute
+    /// a Recognize Linked Entities action in a set of documents.
+    /// For example set model version, disable service logging, and more.
+    /// </summary>
+    public class RecognizeLinkedEntitiesAction : RecognizeLinkedEntitiesOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RecognizeLinkedEntitiesAction"/>
+        /// class which allows callers to specify details about how to execute
+        /// a Recognize Linked Entities action in a set of documents.
+        /// For example set model version, disable service logging, and more.
+        /// </summary>
+        public RecognizeLinkedEntitiesAction()
+        {
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesOptions.cs
@@ -1,20 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-
 namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// Options that allow callers to specify details about how the operation
-    /// is run. For example set model version or whether to include statistics.
+    /// is run. For example set model version, whether to include statistics, and more.
     /// </summary>
     public class RecognizeLinkedEntitiesOptions : TextAnalyticsRequestOptions
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RecognizeLinkedEntitiesOptions"/>
         /// class which allows callers to specify details about how the operation
-        /// is run. For example set model version or whether to include statistics.
+        /// is run. For example set model version, whether to include statistics, and more.
         /// </summary>
         public RecognizeLinkedEntitiesOptions()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesOptions.cs
@@ -5,14 +5,14 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// Options that allow callers to specify details about how the operation
-    /// is run. For example set model version, whether to include statistics, and more.
+    /// is run. For example, set model version, whether to include statistics, and more.
     /// </summary>
     public class RecognizeLinkedEntitiesOptions : TextAnalyticsRequestOptions
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RecognizeLinkedEntitiesOptions"/>
         /// class which allows callers to specify details about how the operation
-        /// is run. For example set model version, whether to include statistics, and more.
+        /// is run. For example, set model version, whether to include statistics, and more.
         /// </summary>
         public RecognizeLinkedEntitiesOptions()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesAction.cs
@@ -6,7 +6,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Configurations that allow callers to specify details about how to execute
     /// a Recognize PII Entities action in a set of documents.
-    /// For example set model version, filter the response entities by a given
+    /// For example, set model version, filter the response entities by a given
     /// domain filter, and more.
     /// </summary>
     public class RecognizePiiEntitiesAction : RecognizePiiEntitiesOptions
@@ -15,7 +15,7 @@ namespace Azure.AI.TextAnalytics
         /// Initializes a new instance of the <see cref="RecognizePiiEntitiesAction"/>
         /// class which allows callers to specify details about how to execute
         /// a Recognize PII Entities action in a set of documents.
-        /// For example set model version, filter the response entities by a given
+        /// For example, set model version, filter the response entities by a given
         /// domain filter, and more.
         /// </summary>
         public RecognizePiiEntitiesAction()

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesAction.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Configurations that allow callers to specify details about how to execute
+    /// a Recognize PII Entities action in a set of documents.
+    /// For example set model version, filter the response entities by a given
+    /// domain filter, and more.
+    /// </summary>
+    public class RecognizePiiEntitiesAction : RecognizePiiEntitiesOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RecognizePiiEntitiesAction"/>
+        /// class which allows callers to specify details about how to execute
+        /// a Recognize PII Entities action in a set of documents.
+        /// For example set model version, filter the response entities by a given
+        /// domain filter, and more.
+        /// </summary>
+        public RecognizePiiEntitiesAction()
+        {
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesOptions.cs
@@ -8,7 +8,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Options that allow callers to specify details about how the operation
     /// is run. For example set model version, whether to include statistics,
-    /// and filter the response entities by a given domain filter.
+    /// filter the response entities by a given domain filter, and more.
     /// </summary>
     public class RecognizePiiEntitiesOptions : TextAnalyticsRequestOptions
     {
@@ -16,7 +16,7 @@ namespace Azure.AI.TextAnalytics
         /// Initializes a new instance of the <see cref="RecognizePiiEntitiesOptions"/>
         /// class which allows callers to specify details about how the operation
         /// is run. For example set model version, whether to include statistics,
-        /// and filter the response entities by a given domain filter.
+        /// filter the response entities by a given domain filter, and more.
         /// </summary>
         public RecognizePiiEntitiesOptions()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesOptions.cs
@@ -7,7 +7,7 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// Options that allow callers to specify details about how the operation
-    /// is run. For example set model version, whether to include statistics,
+    /// is run. For example, set model version, whether to include statistics,
     /// filter the response entities by a given domain filter, and more.
     /// </summary>
     public class RecognizePiiEntitiesOptions : TextAnalyticsRequestOptions
@@ -15,7 +15,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Initializes a new instance of the <see cref="RecognizePiiEntitiesOptions"/>
         /// class which allows callers to specify details about how the operation
-        /// is run. For example set model version, whether to include statistics,
+        /// is run. For example, set model version, whether to include statistics,
         /// filter the response entities by a given domain filter, and more.
         /// </summary>
         public RecognizePiiEntitiesOptions()

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActions.cs
@@ -9,33 +9,33 @@ namespace Azure.AI.TextAnalytics
     public class TextAnalyticsActions
     {
         /// <summary>
-        /// Optional display name for the analysis operation.
+        /// Optional display name for the operation.
         /// </summary>
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// Extract KeyPhrases actions configurations.
+        /// Extract KeyPhrases actions.
         /// </summary>
-        public IReadOnlyCollection<ExtractKeyPhrasesOptions> ExtractKeyPhrasesOptions { get; set; }
+        public IReadOnlyCollection<ExtractKeyPhrasesAction> ExtractKeyPhrasesActions { get; set; }
 
         /// <summary>
-        /// Recognize Entities actions configurations.
+        /// Recognize Entities actions.
         /// </summary>
-        public IReadOnlyCollection<RecognizeEntitiesOptions> RecognizeEntitiesOptions { get; set; }
+        public IReadOnlyCollection<RecognizeEntitiesAction> RecognizeEntitiesActions { get; set; }
 
         /// <summary>
-        /// Recognize PII Entities actions configurations.
+        /// Recognize PII Entities actions.
         /// </summary>
-        public IReadOnlyCollection<RecognizePiiEntitiesOptions> RecognizePiiEntitiesOptions { get; set; }
+        public IReadOnlyCollection<RecognizePiiEntitiesAction> RecognizePiiEntitiesActions { get; set; }
 
         /// <summary>
-        /// Recognize Linked Entities actions configurations.
+        /// Recognize Linked Entities actions.
         /// </summary>
-        public IReadOnlyCollection<RecognizeLinkedEntitiesOptions> RecognizeLinkedEntitiesOptions { get; set; }
+        public IReadOnlyCollection<RecognizeLinkedEntitiesAction> RecognizeLinkedEntitiesActions { get; set; }
 
         /// <summary>
-        /// Analyze Sentiment actions configurations.
+        /// Analyze Sentiment actions.
         /// </summary>
-        public IReadOnlyCollection<AnalyzeSentimentOptions> AnalyzeSentimentOptions { get; set; }
+        public IReadOnlyCollection<AnalyzeSentimentAction> AnalyzeSentimentActions { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -2860,25 +2860,25 @@ namespace Azure.AI.TextAnalytics
 
             options ??= new AnalyzeActionsOptions();
 
-            if (actions.RecognizePiiEntitiesOptions != null)
+            if (actions.RecognizePiiEntitiesActions != null)
             {
-                tasks.EntityRecognitionPiiTasks = Transforms.ConvertFromPiiEntityOptionsToTasks(actions.RecognizePiiEntitiesOptions);
+                tasks.EntityRecognitionPiiTasks = Transforms.ConvertFromRecognizePiiEntitiesActionsToTasks(actions.RecognizePiiEntitiesActions);
             }
-            if (actions.RecognizeEntitiesOptions != null)
+            if (actions.RecognizeEntitiesActions != null)
             {
-                tasks.EntityRecognitionTasks = Transforms.ConvertFromEntityOptionsToTasks(actions.RecognizeEntitiesOptions);
+                tasks.EntityRecognitionTasks = Transforms.ConvertFromRecognizeEntitiesActionsToTasks(actions.RecognizeEntitiesActions);
             }
-            if (actions.ExtractKeyPhrasesOptions != null)
+            if (actions.ExtractKeyPhrasesActions != null)
             {
-                tasks.KeyPhraseExtractionTasks = Transforms.ConvertFromKeyPhrasesOptionsToTasks(actions.ExtractKeyPhrasesOptions);
+                tasks.KeyPhraseExtractionTasks = Transforms.ConvertFromExtractKeyPhrasesActionsToTasks(actions.ExtractKeyPhrasesActions);
             }
-            if (actions.RecognizeLinkedEntitiesOptions != null)
+            if (actions.RecognizeLinkedEntitiesActions != null)
             {
-                tasks.EntityLinkingTasks = Transforms.ConvertFromEntityLinkingOptionsToTasks(actions.RecognizeLinkedEntitiesOptions);
+                tasks.EntityLinkingTasks = Transforms.ConvertFromRecognizeLinkedEntitiesActionsToTasks(actions.RecognizeLinkedEntitiesActions);
             }
-            if (actions.AnalyzeSentimentOptions != null)
+            if (actions.AnalyzeSentimentActions != null)
             {
-                tasks.SentimentAnalysisTasks = Transforms.ConvertFromAnalyzeSentimentOptionsToTasks(actions.AnalyzeSentimentOptions);
+                tasks.SentimentAnalysisTasks = Transforms.ConvertFromAnalyzeSentimentActionsToTasks(actions.AnalyzeSentimentActions);
             }
 
             AnalyzeBatchInput analyzeDocumentInputs = new AnalyzeBatchInput(batchInput, tasks) { DisplayName = actions.DisplayName };
@@ -2908,25 +2908,25 @@ namespace Azure.AI.TextAnalytics
 
             options ??= new AnalyzeActionsOptions();
 
-            if (actions.RecognizePiiEntitiesOptions != null)
+            if (actions.RecognizePiiEntitiesActions != null)
             {
-                tasks.EntityRecognitionPiiTasks = Transforms.ConvertFromPiiEntityOptionsToTasks(actions.RecognizePiiEntitiesOptions);
+                tasks.EntityRecognitionPiiTasks = Transforms.ConvertFromRecognizePiiEntitiesActionsToTasks(actions.RecognizePiiEntitiesActions);
             }
-            if (actions.RecognizeEntitiesOptions != null)
+            if (actions.RecognizeEntitiesActions != null)
             {
-                tasks.EntityRecognitionTasks = Transforms.ConvertFromEntityOptionsToTasks(actions.RecognizeEntitiesOptions);
+                tasks.EntityRecognitionTasks = Transforms.ConvertFromRecognizeEntitiesActionsToTasks(actions.RecognizeEntitiesActions);
             }
-            if (actions.ExtractKeyPhrasesOptions != null)
+            if (actions.ExtractKeyPhrasesActions != null)
             {
-                tasks.KeyPhraseExtractionTasks = Transforms.ConvertFromKeyPhrasesOptionsToTasks(actions.ExtractKeyPhrasesOptions);
+                tasks.KeyPhraseExtractionTasks = Transforms.ConvertFromExtractKeyPhrasesActionsToTasks(actions.ExtractKeyPhrasesActions);
             }
-            if (actions.RecognizeLinkedEntitiesOptions != null)
+            if (actions.RecognizeLinkedEntitiesActions != null)
             {
-                tasks.EntityLinkingTasks = Transforms.ConvertFromEntityLinkingOptionsToTasks(actions.RecognizeLinkedEntitiesOptions);
+                tasks.EntityLinkingTasks = Transforms.ConvertFromRecognizeLinkedEntitiesActionsToTasks(actions.RecognizeLinkedEntitiesActions);
             }
-            if (actions.AnalyzeSentimentOptions != null)
+            if (actions.AnalyzeSentimentActions != null)
             {
-                tasks.SentimentAnalysisTasks = Transforms.ConvertFromAnalyzeSentimentOptionsToTasks(actions.AnalyzeSentimentOptions);
+                tasks.SentimentAnalysisTasks = Transforms.ConvertFromAnalyzeSentimentActionsToTasks(actions.AnalyzeSentimentActions);
             }
 
             AnalyzeBatchInput analyzeDocumentInputs = new AnalyzeBatchInput(batchInput, tasks) { DisplayName = actions.DisplayName };

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsRequestOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsRequestOptions.cs
@@ -6,14 +6,15 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Options that allow callers to specify details about how the operation
     /// is run and what information is returned from it by the service.
-    /// <para>For example set model version, and whether to include statistics.</para>
+    /// <para>For example set model version, whether to include statistics,
+    /// and more.</para>
     /// </summary>
     public class TextAnalyticsRequestOptions
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TextAnalyticsRequestOptions"/>
         /// class which allows callers to specify details about how the operation
-        /// is run. For example set model version, and whether to include statistics.
+        /// is run. For example set model version, whether to include statistics, and more.
         /// </summary>
         public TextAnalyticsRequestOptions()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsRequestOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsRequestOptions.cs
@@ -6,7 +6,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Options that allow callers to specify details about how the operation
     /// is run and what information is returned from it by the service.
-    /// <para>For example set model version, whether to include statistics,
+    /// <para>For example, set model version, whether to include statistics,
     /// and more.</para>
     /// </summary>
     public class TextAnalyticsRequestOptions
@@ -14,7 +14,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Initializes a new instance of the <see cref="TextAnalyticsRequestOptions"/>
         /// class which allows callers to specify details about how the operation
-        /// is run. For example set model version, whether to include statistics, and more.
+        /// is run. For example, set model version, whether to include statistics, and more.
         /// </summary>
         public TextAnalyticsRequestOptions()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
@@ -320,128 +320,128 @@ namespace Azure.AI.TextAnalytics
 
         #region Analyze Operation
 
-        internal static PiiTask ConvertToPiiTask(RecognizePiiEntitiesOptions option)
+        internal static PiiTask ConvertToPiiTask(RecognizePiiEntitiesAction action)
         {
             return new PiiTask()
             {
                 Parameters = new PiiTaskParameters()
                 {
-                    Domain = option.DomainFilter.HasValue ? option.DomainFilter.Value.GetString() : (PiiTaskParametersDomain?)null,
-                    ModelVersion = option.ModelVersion,
-                    StringIndexType = option.StringIndexType,
-                    LoggingOptOut = option.DisableServiceLogs
+                    Domain = action.DomainFilter.HasValue ? action.DomainFilter.Value.GetString() : (PiiTaskParametersDomain?)null,
+                    ModelVersion = action.ModelVersion,
+                    StringIndexType = action.StringIndexType,
+                    LoggingOptOut = action.DisableServiceLogs
                     // Categories are not enabled because of https://github.com/Azure/azure-sdk-for-net/issues/19237
                 }
             };
         }
 
-        internal static EntityLinkingTask ConvertToLinkedEntitiesTask(RecognizeLinkedEntitiesOptions option)
+        internal static EntityLinkingTask ConvertToLinkedEntitiesTask(RecognizeLinkedEntitiesAction action)
         {
             return new EntityLinkingTask()
             {
                 Parameters = new EntityLinkingTaskParameters()
                 {
-                    ModelVersion = option.ModelVersion,
-                    StringIndexType = option.StringIndexType,
-                    LoggingOptOut = option.DisableServiceLogs
+                    ModelVersion = action.ModelVersion,
+                    StringIndexType = action.StringIndexType,
+                    LoggingOptOut = action.DisableServiceLogs
                 }
             };
         }
 
-        internal static EntitiesTask ConvertToEntitiesTask(RecognizeEntitiesOptions option)
+        internal static EntitiesTask ConvertToEntitiesTask(RecognizeEntitiesAction action)
         {
             return new EntitiesTask()
             {
                 Parameters = new EntitiesTaskParameters()
                 {
-                    ModelVersion = option.ModelVersion,
-                    StringIndexType = option.StringIndexType,
-                    LoggingOptOut = option.DisableServiceLogs
+                    ModelVersion = action.ModelVersion,
+                    StringIndexType = action.StringIndexType,
+                    LoggingOptOut = action.DisableServiceLogs
                 }
             };
         }
 
-        internal static KeyPhrasesTask ConvertToKeyPhrasesTask(ExtractKeyPhrasesOptions option)
+        internal static KeyPhrasesTask ConvertToKeyPhrasesTask(ExtractKeyPhrasesAction action)
         {
             return new KeyPhrasesTask()
             {
                 Parameters = new KeyPhrasesTaskParameters()
                 {
-                    ModelVersion = option.ModelVersion,
-                    LoggingOptOut = option.DisableServiceLogs
+                    ModelVersion = action.ModelVersion,
+                    LoggingOptOut = action.DisableServiceLogs
                 }
             };
         }
 
-        internal static SentimentAnalysisTask ConvertToSentimentAnalysisTask(AnalyzeSentimentOptions option)
+        internal static SentimentAnalysisTask ConvertToSentimentAnalysisTask(AnalyzeSentimentAction action)
         {
             return new SentimentAnalysisTask()
             {
                 Parameters = new SentimentAnalysisTaskParameters()
                 {
-                    ModelVersion = option.ModelVersion,
-                    StringIndexType = option.StringIndexType,
-                    LoggingOptOut = option.DisableServiceLogs,
-                    OpinionMining = option.IncludeOpinionMining
+                    ModelVersion = action.ModelVersion,
+                    StringIndexType = action.StringIndexType,
+                    LoggingOptOut = action.DisableServiceLogs,
+                    OpinionMining = action.IncludeOpinionMining
                 }
             };
         }
 
-        internal static IList<EntityLinkingTask> ConvertFromEntityLinkingOptionsToTasks(IReadOnlyCollection<RecognizeLinkedEntitiesOptions> recognizeLinkedEntityOptions)
+        internal static IList<EntityLinkingTask> ConvertFromRecognizeLinkedEntitiesActionsToTasks(IReadOnlyCollection<RecognizeLinkedEntitiesAction> recognizeLinkedEntitiesActions)
         {
             List<EntityLinkingTask> list = new List<EntityLinkingTask>();
 
-            foreach (RecognizeLinkedEntitiesOptions option in recognizeLinkedEntityOptions)
+            foreach (RecognizeLinkedEntitiesAction action in recognizeLinkedEntitiesActions)
             {
-                list.Add(ConvertToLinkedEntitiesTask(option));
+                list.Add(ConvertToLinkedEntitiesTask(action));
             }
 
             return list;
         }
 
-        internal static IList<EntitiesTask> ConvertFromEntityOptionsToTasks(IReadOnlyCollection<RecognizeEntitiesOptions> recognizeEntitiesOptions)
+        internal static IList<EntitiesTask> ConvertFromRecognizeEntitiesActionsToTasks(IReadOnlyCollection<RecognizeEntitiesAction> recognizeEntitiesActions)
         {
             List<EntitiesTask> list = new List<EntitiesTask>();
 
-            foreach (RecognizeEntitiesOptions option in recognizeEntitiesOptions)
+            foreach (RecognizeEntitiesAction action in recognizeEntitiesActions)
             {
-                list.Add(ConvertToEntitiesTask(option));
+                list.Add(ConvertToEntitiesTask(action));
             }
 
             return list;
         }
 
-        internal static IList<KeyPhrasesTask> ConvertFromKeyPhrasesOptionsToTasks(IReadOnlyCollection<ExtractKeyPhrasesOptions> extractKeyPhrasesOptions)
+        internal static IList<KeyPhrasesTask> ConvertFromExtractKeyPhrasesActionsToTasks(IReadOnlyCollection<ExtractKeyPhrasesAction> extractKeyPhrasesActions)
         {
             List<KeyPhrasesTask> list = new List<KeyPhrasesTask>();
 
-            foreach (ExtractKeyPhrasesOptions option in extractKeyPhrasesOptions)
+            foreach (ExtractKeyPhrasesAction action in extractKeyPhrasesActions)
             {
-                list.Add(ConvertToKeyPhrasesTask(option));
+                list.Add(ConvertToKeyPhrasesTask(action));
             }
 
             return list;
         }
 
-        internal static IList<PiiTask> ConvertFromPiiEntityOptionsToTasks(IReadOnlyCollection<RecognizePiiEntitiesOptions> recognizePiiEntityOptions)
+        internal static IList<PiiTask> ConvertFromRecognizePiiEntitiesActionsToTasks(IReadOnlyCollection<RecognizePiiEntitiesAction> recognizePiiEntitiesActions)
         {
             List <PiiTask> list = new List<PiiTask>();
 
-            foreach (RecognizePiiEntitiesOptions option in recognizePiiEntityOptions)
+            foreach (RecognizePiiEntitiesAction action in recognizePiiEntitiesActions)
             {
-                list.Add(ConvertToPiiTask(option));
+                list.Add(ConvertToPiiTask(action));
             }
 
             return list;
         }
 
-        internal static IList<SentimentAnalysisTask> ConvertFromAnalyzeSentimentOptionsToTasks(IReadOnlyCollection<AnalyzeSentimentOptions> analyzeSentimentOptions)
+        internal static IList<SentimentAnalysisTask> ConvertFromAnalyzeSentimentActionsToTasks(IReadOnlyCollection<AnalyzeSentimentAction> analyzeSentimentActions)
         {
             List<SentimentAnalysisTask> list = new List<SentimentAnalysisTask>();
 
-            foreach (AnalyzeSentimentOptions option in analyzeSentimentOptions)
+            foreach (AnalyzeSentimentAction action in analyzeSentimentActions)
             {
-                list.Add(ConvertToSentimentAnalysisTask(option));
+                list.Add(ConvertToSentimentAnalysisTask(action));
             }
 
             return list;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
@@ -39,7 +39,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
             };
 
             AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(batchDocuments, batchActions);
@@ -62,7 +62,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
             };
 
             AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(batchConvenienceDocuments, batchActions, "en");
@@ -120,7 +120,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
                 DisplayName = "AnalyzeOperationWithLanguageTest"
             };
 
@@ -173,11 +173,11 @@ namespace Azure.AI.TextAnalytics.Tests
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
-                RecognizeEntitiesOptions = new List<RecognizeEntitiesOptions>() { new RecognizeEntitiesOptions() },
-                RecognizePiiEntitiesOptions = new List<RecognizePiiEntitiesOptions>() { new RecognizePiiEntitiesOptions() },
-                RecognizeLinkedEntitiesOptions = new List<RecognizeLinkedEntitiesOptions>() { new RecognizeLinkedEntitiesOptions() },
-                AnalyzeSentimentOptions = new List<AnalyzeSentimentOptions>() { new AnalyzeSentimentOptions() },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+                RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
+                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
                 DisplayName = "AnalyzeOperationWithMultipleTasks"
             };
 
@@ -300,7 +300,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
                 DisplayName = "AnalyzeOperationWithPagination",
             };
 
@@ -351,10 +351,10 @@ namespace Azure.AI.TextAnalytics.Tests
             };
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>()
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>()
                 {
-                    new ExtractKeyPhrasesOptions(),
-                    new ExtractKeyPhrasesOptions()
+                    new ExtractKeyPhrasesAction(),
+                    new ExtractKeyPhrasesAction()
                     {
                         ModelVersion = "InvalidVersion"
                     }
@@ -379,9 +379,9 @@ namespace Azure.AI.TextAnalytics.Tests
             };
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>()
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>()
                 {
-                    new ExtractKeyPhrasesOptions()
+                    new ExtractKeyPhrasesAction()
                 }
             };
 
@@ -415,7 +415,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                RecognizePiiEntitiesOptions = new List<RecognizePiiEntitiesOptions>() { new RecognizePiiEntitiesOptions() { DomainFilter = PiiEntityDomainType.ProtectedHealthInformation } },
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() { DomainFilter = PiiEntityDomainType.ProtectedHealthInformation } },
                 DisplayName = "AnalyzeOperationWithPHIDomain",
             };
 
@@ -462,7 +462,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
                 DisplayName = "AnalyzeOperationTest",
             };
 
@@ -500,11 +500,11 @@ namespace Azure.AI.TextAnalytics.Tests
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() { DisableServiceLogs = true } },
-                RecognizeEntitiesOptions = new List<RecognizeEntitiesOptions>() { new RecognizeEntitiesOptions() { DisableServiceLogs = true } },
-                RecognizePiiEntitiesOptions = new List<RecognizePiiEntitiesOptions>() { new RecognizePiiEntitiesOptions() { DisableServiceLogs = false } },
-                RecognizeLinkedEntitiesOptions = new List<RecognizeLinkedEntitiesOptions>() { new RecognizeLinkedEntitiesOptions() { DisableServiceLogs = true } },
-                AnalyzeSentimentOptions = new List<AnalyzeSentimentOptions>() { new AnalyzeSentimentOptions() { DisableServiceLogs = true } },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() { DisableServiceLogs = true } },
+                RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() { DisableServiceLogs = true } },
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() { DisableServiceLogs = false } },
+                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() { DisableServiceLogs = true } },
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() { DisableServiceLogs = true } },
             };
 
             AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(batchConvenienceDocuments, batchActions);
@@ -548,7 +548,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                AnalyzeSentimentOptions = new List<AnalyzeSentimentOptions>() { new AnalyzeSentimentOptions() { IncludeOpinionMining = true } },
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() { IncludeOpinionMining = true } },
                 DisplayName = "AnalyzeOperationWithOpinionMining",
             };
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
@@ -677,14 +677,14 @@ namespace Azure.AI.TextAnalytics.Tests
                 "Elon Musk is the CEO of SpaceX and Tesla."
             };
 
-            var options = new ExtractKeyPhrasesOptions()
+            var actions = new ExtractKeyPhrasesAction()
             {
                 DisableServiceLogs = true
             };
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { options },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { actions },
             };
 
             await client.StartAnalyzeActionsAsync(documents, batchActions);
@@ -715,14 +715,14 @@ namespace Azure.AI.TextAnalytics.Tests
                 "Elon Musk is the CEO of SpaceX and Tesla."
             };
 
-            var options = new RecognizeEntitiesOptions()
+            var actions = new RecognizeEntitiesAction()
             {
                 DisableServiceLogs = true
             };
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                RecognizeEntitiesOptions = new List<RecognizeEntitiesOptions>() { options },
+                RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { actions },
             };
 
             await client.StartAnalyzeActionsAsync(documents, batchActions);
@@ -753,14 +753,14 @@ namespace Azure.AI.TextAnalytics.Tests
                 "Elon Musk is the CEO of SpaceX and Tesla."
             };
 
-            var options = new RecognizeLinkedEntitiesOptions()
+            var actions = new RecognizeLinkedEntitiesAction()
             {
                 DisableServiceLogs = true
             };
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                RecognizeLinkedEntitiesOptions = new List<RecognizeLinkedEntitiesOptions>() { options },
+                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { actions },
             };
 
             await client.StartAnalyzeActionsAsync(documents, batchActions);
@@ -791,14 +791,14 @@ namespace Azure.AI.TextAnalytics.Tests
                 "Elon Musk is the CEO of SpaceX and Tesla."
             };
 
-            var options = new RecognizePiiEntitiesOptions()
+            var actions = new RecognizePiiEntitiesAction()
             {
                 DisableServiceLogs = true
             };
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                RecognizePiiEntitiesOptions = new List<RecognizePiiEntitiesOptions>() { options },
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { actions },
             };
 
             await client.StartAnalyzeActionsAsync(documents, batchActions);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperation.cs
@@ -47,11 +47,11 @@ namespace Azure.AI.TextAnalytics.Samples
 
             TextAnalyticsActions actions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
-                RecognizeEntitiesOptions = new List<RecognizeEntitiesOptions>() { new RecognizeEntitiesOptions() },
-                RecognizePiiEntitiesOptions = new List<RecognizePiiEntitiesOptions>() { new RecognizePiiEntitiesOptions() },
-                RecognizeLinkedEntitiesOptions = new List<RecognizeLinkedEntitiesOptions>() { new RecognizeLinkedEntitiesOptions() },
-                AnalyzeSentimentOptions = new List<AnalyzeSentimentOptions>() { new AnalyzeSentimentOptions() },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+                RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
+                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
                 DisplayName = "AnalyzeOperationSample"
             };
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationAsync.cs
@@ -47,11 +47,11 @@ namespace Azure.AI.TextAnalytics.Samples
 
             TextAnalyticsActions actions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
-                RecognizeEntitiesOptions = new List<RecognizeEntitiesOptions>() { new RecognizeEntitiesOptions() },
-                RecognizePiiEntitiesOptions = new List<RecognizePiiEntitiesOptions>() { new RecognizePiiEntitiesOptions() },
-                RecognizeLinkedEntitiesOptions = new List<RecognizeLinkedEntitiesOptions>() { new RecognizeLinkedEntitiesOptions() },
-                AnalyzeSentimentOptions = new List<AnalyzeSentimentOptions>() { new AnalyzeSentimentOptions() },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+                RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
+                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
                 DisplayName = "AnalyzeOperationSample"
             };
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenience.cs
@@ -40,11 +40,11 @@ namespace Azure.AI.TextAnalytics.Samples
 
             TextAnalyticsActions actions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
-                RecognizeEntitiesOptions = new List<RecognizeEntitiesOptions>() { new RecognizeEntitiesOptions() },
-                RecognizePiiEntitiesOptions = new List<RecognizePiiEntitiesOptions>() { new RecognizePiiEntitiesOptions() },
-                RecognizeLinkedEntitiesOptions = new List<RecognizeLinkedEntitiesOptions>() { new RecognizeLinkedEntitiesOptions() },
-                AnalyzeSentimentOptions = new List<AnalyzeSentimentOptions>() { new AnalyzeSentimentOptions() },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+                RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
+                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
                 DisplayName = "AnalyzeOperationSample"
             };
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenienceAsync.cs
@@ -41,11 +41,11 @@ namespace Azure.AI.TextAnalytics.Samples
 
             TextAnalyticsActions actions = new TextAnalyticsActions()
             {
-                ExtractKeyPhrasesOptions = new List<ExtractKeyPhrasesOptions>() { new ExtractKeyPhrasesOptions() },
-                RecognizeEntitiesOptions = new List<RecognizeEntitiesOptions>() { new RecognizeEntitiesOptions() },
-                RecognizePiiEntitiesOptions = new List<RecognizePiiEntitiesOptions>() { new RecognizePiiEntitiesOptions() },
-                RecognizeLinkedEntitiesOptions = new List<RecognizeLinkedEntitiesOptions>() { new RecognizeLinkedEntitiesOptions() },
-                AnalyzeSentimentOptions = new List<AnalyzeSentimentOptions>() { new AnalyzeSentimentOptions() },
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+                RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
+                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
                 DisplayName = "AnalyzeOperationSample"
             };
 


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/21174

Note: In .NET and Java we decided to re-utilize the `xxOptions` types in our `xxAction` types. We understand that `showStats` doesn't apply per task in analyze, but are ok with the comprise.
Most architects are ok with this idea. If later on, we get different feedback from them, then we will remove that relationship.

API view: https://apiview.dev/Assemblies/Review/b196a5e53fa2441f92e3b1accefa35e7?diffRevisionId=9ea988d3cd3841ad96244d4f095b1c36&doc=False&diffOnly=False