### PR TITLE
[Storage] Unsupported headers - proposal 3 - option bags.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
@@ -1120,6 +1120,14 @@ namespace Azure.Storage.Blobs.Models
         public GetBlobTagResult() { }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } }
     }
+    public partial class GetBlockListOptions
+    {
+        public GetBlockListOptions() { }
+        public Azure.Storage.Blobs.Models.BlockListTypes BlockListTypes { get { throw null; } set { } }
+        public string LeaseId { get { throw null; } set { } }
+        public string Snapshot { get { throw null; } set { } }
+        public string TagConditions { get { throw null; } set { } }
+    }
     public enum LeaseDurationType
     {
         Infinite = 0,
@@ -1450,8 +1458,16 @@ namespace Azure.Storage.Blobs.Specialized
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>> CommitBlockListAsync(System.Collections.Generic.IEnumerable<string> base64BlockIds, Azure.Storage.Blobs.Models.BlobHttpHeaders httpHeaders = null, System.Collections.Generic.IDictionary<string, string> metadata = null, Azure.Storage.Blobs.Models.BlobRequestConditions conditions = null, Azure.Storage.Blobs.Models.AccessTier? accessTier = default(Azure.Storage.Blobs.Models.AccessTier?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>> CommitBlockListAsync(System.Collections.Generic.IEnumerable<string> base64BlockIds, Azure.Storage.Blobs.Models.CommitBlockListOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         protected static Azure.Storage.Blobs.Specialized.BlockBlobClient CreateClient(System.Uri blobUri, Azure.Storage.Blobs.BlobClientOptions options, Azure.Core.Pipeline.HttpPipeline pipeline) { throw null; }
+        public virtual Azure.Response<Azure.Storage.Blobs.Models.BlockList> GetBlockList() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public virtual Azure.Response<Azure.Storage.Blobs.Models.BlockList> GetBlockList(Azure.Storage.Blobs.Models.BlockListTypes blockListTypes = Azure.Storage.Blobs.Models.BlockListTypes.All, string snapshot = null, Azure.Storage.Blobs.Models.BlobRequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Storage.Blobs.Models.BlockList> GetBlockList(Azure.Storage.Blobs.Models.GetBlockListOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Storage.Blobs.Models.BlockList> GetBlockList(System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlockList>> GetBlockListAsync() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlockList>> GetBlockListAsync(Azure.Storage.Blobs.Models.BlockListTypes blockListTypes = Azure.Storage.Blobs.Models.BlockListTypes.All, string snapshot = null, Azure.Storage.Blobs.Models.BlobRequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlockList>> GetBlockListAsync(Azure.Storage.Blobs.Models.GetBlockListOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlockList>> GetBlockListAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual System.IO.Stream OpenWrite(bool overwrite, Azure.Storage.Blobs.Models.BlockBlobOpenWriteOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<System.IO.Stream> OpenWriteAsync(bool overwrite, Azure.Storage.Blobs.Models.BlockBlobOpenWriteOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Storage.Blobs.Models.BlobDownloadInfo> Query(string querySqlExpression, Azure.Storage.Blobs.Models.BlobQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -1924,7 +1924,199 @@ namespace Azure.Storage.Blobs.Specialized
 
         #region GetBlockList
         /// <summary>
-        /// The <see cref="GetBlockList"/> operation operation retrieves
+        /// The operation operation retrieves
+        /// the list of blocks that have been uploaded as part of a block blob.
+        /// There are two block lists maintained for a blob.  The Committed
+        /// Block list has blocks that have been successfully committed to a
+        /// given blob with <see cref="CommitBlockList(IEnumerable{string}, CommitBlockListOptions, CancellationToken)"/>.
+        /// The Uncommitted Block list has blocks that have been uploaded for a
+        /// blob using <see cref="StageBlock"/>, but that have not yet
+        /// been committed.  These blocks are stored in Azure in association
+        /// with a blob, but do not yet form part of the blob.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Response{BlockList}"/> describing requested
+        /// block list.
+        /// </returns>
+        /// <remarks>
+        /// A <see cref="RequestFailedException"/> will be thrown if
+        /// a failure occurs.
+        /// </remarks>
+        public virtual Response<BlockList> GetBlockList() =>
+            GetBlockListInternal(
+                BlockListTypes.All,
+                default,
+                default,
+                false, // async
+                default)
+                .EnsureCompleted();
+
+        /// <summary>
+        /// The operation operation retrieves
+        /// the list of blocks that have been uploaded as part of a block blob.
+        /// There are two block lists maintained for a blob.  The Committed
+        /// Block list has blocks that have been successfully committed to a
+        /// given blob with <see cref="CommitBlockListAsync(IEnumerable{string}, CommitBlockListOptions, CancellationToken)"/>.
+        /// The Uncommitted Block list has blocks that have been uploaded for a
+        /// blob using <see cref="StageBlockAsync"/>, but that have not yet
+        /// been committed.  These blocks are stored in Azure in association
+        /// with a blob, but do not yet form part of the blob.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Response{BlockList}"/> describing requested
+        /// block list.
+        /// </returns>
+        /// <remarks>
+        /// A <see cref="RequestFailedException"/> will be thrown if
+        /// a failure occurs.
+        /// </remarks>
+        public virtual async Task<Response<BlockList>> GetBlockListAsync() =>
+            await GetBlockListInternal(
+                BlockListTypes.All,
+                default,
+                default,
+                true, // async
+                default)
+                .ConfigureAwait(false);
+
+        /// <summary>
+        /// The operation operation retrieves
+        /// the list of blocks that have been uploaded as part of a block blob.
+        /// There are two block lists maintained for a blob.  The Committed
+        /// Block list has blocks that have been successfully committed to a
+        /// given blob with <see cref="CommitBlockList(IEnumerable{string}, CommitBlockListOptions, CancellationToken)"/>.
+        /// The Uncommitted Block list has blocks that have been uploaded for a
+        /// blob using <see cref="StageBlock"/>, but that have not yet
+        /// been committed.  These blocks are stored in Azure in association
+        /// with a blob, but do not yet form part of the blob.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// Optional <see cref="CancellationToken"/> to propagate
+        /// notifications that the operation should be cancelled.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Response{BlockList}"/> describing requested
+        /// block list.
+        /// </returns>
+        /// <remarks>
+        /// A <see cref="RequestFailedException"/> will be thrown if
+        /// a failure occurs.
+        /// </remarks>
+        public virtual Response<BlockList> GetBlockList(
+            CancellationToken cancellationToken) =>
+            GetBlockListInternal(
+                BlockListTypes.All,
+                default,
+                default,
+                false, // async
+                cancellationToken)
+                .EnsureCompleted();
+
+        /// <summary>
+        /// The operation operation retrieves
+        /// the list of blocks that have been uploaded as part of a block blob.
+        /// There are two block lists maintained for a blob.  The Committed
+        /// Block list has blocks that have been successfully committed to a
+        /// given blob with <see cref="CommitBlockListAsync(IEnumerable{string}, CommitBlockListOptions, CancellationToken)"/>.
+        /// The Uncommitted Block list has blocks that have been uploaded for a
+        /// blob using <see cref="StageBlockAsync"/>, but that have not yet
+        /// been committed.  These blocks are stored in Azure in association
+        /// with a blob, but do not yet form part of the blob.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// Optional <see cref="CancellationToken"/> to propagate
+        /// notifications that the operation should be cancelled.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Response{BlockList}"/> describing requested
+        /// block list.
+        /// </returns>
+        /// <remarks>
+        /// A <see cref="RequestFailedException"/> will be thrown if
+        /// a failure occurs.
+        /// </remarks>
+        public virtual async Task<Response<BlockList>> GetBlockListAsync(
+            CancellationToken cancellationToken) =>
+            await GetBlockListInternal(
+                BlockListTypes.All,
+                default,
+                default,
+                true, // async
+                cancellationToken)
+                .ConfigureAwait(false);
+
+        /// <summary>
+        /// The operation operation retrieves
+        /// the list of blocks that have been uploaded as part of a block blob.
+        /// There are two block lists maintained for a blob.  The Committed
+        /// Block list has blocks that have been successfully committed to a
+        /// given blob with <see cref="CommitBlockList(IEnumerable{string}, CommitBlockListOptions, CancellationToken)"/>.
+        /// The Uncommitted Block list has blocks that have been uploaded for a
+        /// blob using <see cref="StageBlock"/>, but that have not yet
+        /// been committed.  These blocks are stored in Azure in association
+        /// with a blob, but do not yet form part of the blob.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="cancellationToken">
+        /// Optional <see cref="CancellationToken"/> to propagate
+        /// notifications that the operation should be cancelled.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Response{BlockList}"/> describing requested
+        /// block list.
+        /// </returns>
+        /// <remarks>
+        /// A <see cref="RequestFailedException"/> will be thrown if
+        /// a failure occurs.
+        /// </remarks>
+        public virtual Response<BlockList> GetBlockList(
+            GetBlockListOptions options,
+            CancellationToken cancellationToken = default) =>
+            GetBlockListInternal(
+                options.BlockListTypes,
+                options.Snapshot,
+                new BlobRequestConditions() { LeaseId = options.LeaseId, TagConditions = options.TagConditions },
+                false, // async
+                cancellationToken)
+                .EnsureCompleted();
+
+        /// <summary>
+        /// The operation operation retrieves
+        /// the list of blocks that have been uploaded as part of a block blob.
+        /// There are two block lists maintained for a blob.  The Committed
+        /// Block list has blocks that have been successfully committed to a
+        /// given blob with <see cref="CommitBlockListAsync(IEnumerable{string}, CommitBlockListOptions, CancellationToken)"/>.
+        /// The Uncommitted Block list has blocks that have been uploaded for a
+        /// blob using <see cref="StageBlockAsync"/>, but that have not yet
+        /// been committed.  These blocks are stored in Azure in association
+        /// with a blob, but do not yet form part of the blob.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="cancellationToken">
+        /// Optional <see cref="CancellationToken"/> to propagate
+        /// notifications that the operation should be cancelled.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Response{BlockList}"/> describing requested
+        /// block list.
+        /// </returns>
+        /// <remarks>
+        /// A <see cref="RequestFailedException"/> will be thrown if
+        /// a failure occurs.
+        /// </remarks>
+        public virtual async Task<Response<BlockList>> GetBlockListAsync(
+            GetBlockListOptions options,
+            CancellationToken cancellationToken = default) =>
+            await GetBlockListInternal(
+                options.BlockListTypes,
+                options.Snapshot,
+                new BlobRequestConditions() { LeaseId = options.LeaseId, TagConditions = options.TagConditions },
+                true, // async
+                cancellationToken)
+                .ConfigureAwait(false);
+
+        /// <summary>
+        /// The operation operation retrieves
         /// the list of blocks that have been uploaded as part of a block blob.
         /// There are two block lists maintained for a blob.  The Committed
         /// Block list has blocks that have been successfully committed to a
@@ -1961,6 +2153,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Response<BlockList> GetBlockList(
             BlockListTypes blockListTypes = BlockListTypes.All,
             string snapshot = default,
@@ -1975,7 +2168,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .EnsureCompleted();
 
         /// <summary>
-        /// The <see cref="GetBlockListAsync"/> operation operation retrieves
+        /// The operation operation retrieves
         /// the list of blocks that have been uploaded as part of a block blob.
         /// There are two block lists maintained for a blob.  The Committed
         /// Block list has blocks that have been successfully committed to a
@@ -2012,6 +2205,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual async Task<Response<BlockList>> GetBlockListAsync(
             BlockListTypes blockListTypes = BlockListTypes.All,
             string snapshot = default,

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlockList.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlockList.cs
@@ -8,8 +8,7 @@ using Azure.Storage.Blobs.Specialized;
 namespace Azure.Storage.Blobs.Models
 {
     /// <summary>
-    /// A block blob's <see cref="BlockList"/> returned from
-    /// <see cref="BlockBlobClient.GetBlockListAsync"/>.
+    /// A block blob's <see cref="BlockList"/>.
     /// </summary>
     public partial class BlockList
     {
@@ -29,9 +28,7 @@ namespace Azure.Storage.Blobs.Models
         public ETag ETag { get; internal set; }
 
         /// <summary>
-        /// The media type of the body of the response. For the
-        /// <see cref=" Specialized.BlockBlobClient.GetBlockListAsync"/>
-        /// operation this is 'application/xml'.
+        /// The media type of the body of the response.
         /// </summary>
         public string ContentType { get; internal set; }
 

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlockListOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlockListOptions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Storage.Blobs.Models
+{
+    /// <summary>
+    /// TODO.
+    /// </summary>
+    public class GetBlockListOptions : IRequestConditions.ITags, IRequestConditions.ILeaseId
+    {
+        ///<inheritdoc/>
+        public string TagConditions { get; set; }
+
+        ///<inheritdoc/>
+        public string LeaseId { get; set; }
+
+        /// <summary>
+        /// Specifies whether to return the list of committed blocks, the
+        /// list of uncommitted blocks, or both lists together.  If you omit
+        /// this parameter, Get Block List returns the list of committed blocks.
+        /// </summary>
+        public BlockListTypes BlockListTypes { get; set; } = BlockListTypes.All;
+
+        /// <summary>
+        /// Optionally specifies the blob snapshot to retrieve the block list
+        /// from. For more information on working with blob snapshots, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
+        /// </summary>
+        public string Snapshot { get; set; }
+    }
+}

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/Internal/BlobRequestConditionsInternals.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/Internal/BlobRequestConditionsInternals.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Storage.Blobs.Models
+{
+#pragma warning disable SA1649 // File name should match first type name
+    internal interface IRequestConditions
+    {
+        internal interface ILeaseId
+        {
+            /// <summary>
+            /// Optionally limit requests to resources with an active lease
+            /// matching this Id.
+            /// </summary>
+            public string LeaseId { get; set; }
+        }
+
+        internal interface ITags
+        {
+            /// <summary>
+            /// Optional SQL statement to apply to the Tags of the Blob.
+            /// </summary>
+            public string TagConditions { get; set; }
+        }
+
+        internal interface IIfModifiedSince
+        {
+            /// <summary>
+            /// Optionally limit requests to resources that have only been
+            /// modified since this point in time.
+            /// </summary>
+            public DateTimeOffset? IfModifiedSince { get; set; }
+        }
+
+        internal interface IIfUnmodifiedSince
+        {
+            /// <summary>
+            /// Optionally limit requests to resources that have remained
+            /// unmodified.
+            /// </summary>
+            public DateTimeOffset? IfUnmodifiedSince { get; set; }
+        }
+
+        internal interface IIfMatch
+        {
+            /// <summary>
+            /// Optionally limit requests to resources that have a matching ETag.
+            /// </summary>
+            public ETag? IfMatch { get; set; }
+        }
+
+        internal interface IIfNoneMatch
+        {
+            /// <summary>
+            /// Optionally limit requests to resources that do not match the ETag.
+            /// </summary>
+            public ETag? IfNoneMatch { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
In this PR: handle unsupported headers by blending request conditions with option bag.

Pros:
- model maps 1:1 with service capabilities
- evolution of APIs is decoupled
- There's no type explosion (assuming that we want to have DoFoo(mandatoryParams) and DoFoo(mandatoryParams, optionsBag) anyway).

Cons:
- not easy to draw the line between request conditions and api specific parameters (should request condition properties have common prefix?)