### PR TITLE
[TA] Rename TextAnalyticsActionDetails to TextAnalyticsActionResult

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -12,6 +12,7 @@
   - `RecognizePiiEntitiesOptions` changed to new type `RecognizePiiEntitiesActions`.
   - `RecognizeLinkedEntitiesOptions` changed to new type `RecognizeLinkedEntitiesActions`.
   - `AnalyzeSentimentOptions` changed to new type `AnalyzeSentimentActions`.
+- Renamed type `TextAnalyticsActionDetails` to `TextAnalyticsActionResult`.
 
 ## 5.1.0-beta.7 (2021-05-18)
 ### New features

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -83,7 +83,7 @@ namespace Azure.AI.TextAnalytics
     {
         public AnalyzeSentimentAction() { }
     }
-    public partial class AnalyzeSentimentActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionDetails
+    public partial class AnalyzeSentimentActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal AnalyzeSentimentActionResult() { }
         public Azure.AI.TextAnalytics.AnalyzeSentimentResultCollection Result { get { throw null; } }
@@ -226,7 +226,7 @@ namespace Azure.AI.TextAnalytics
     {
         public ExtractKeyPhrasesAction() { }
     }
-    public partial class ExtractKeyPhrasesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionDetails
+    public partial class ExtractKeyPhrasesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal ExtractKeyPhrasesActionResult() { }
         public Azure.AI.TextAnalytics.ExtractKeyPhrasesResultCollection Result { get { throw null; } }
@@ -570,7 +570,7 @@ namespace Azure.AI.TextAnalytics
     {
         public RecognizeEntitiesAction() { }
     }
-    public partial class RecognizeEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionDetails
+    public partial class RecognizeEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal RecognizeEntitiesActionResult() { }
         public Azure.AI.TextAnalytics.RecognizeEntitiesResultCollection Result { get { throw null; } }
@@ -594,7 +594,7 @@ namespace Azure.AI.TextAnalytics
     {
         public RecognizeLinkedEntitiesAction() { }
     }
-    public partial class RecognizeLinkedEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionDetails
+    public partial class RecognizeLinkedEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal RecognizeLinkedEntitiesActionResult() { }
         public Azure.AI.TextAnalytics.RecognizeLinkedEntitiesResultCollection Result { get { throw null; } }
@@ -618,7 +618,7 @@ namespace Azure.AI.TextAnalytics
     {
         public RecognizePiiEntitiesAction() { }
     }
-    public partial class RecognizePiiEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionDetails
+    public partial class RecognizePiiEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal RecognizePiiEntitiesActionResult() { }
         public Azure.AI.TextAnalytics.RecognizePiiEntitiesResultCollection Result { get { throw null; } }
@@ -697,9 +697,9 @@ namespace Azure.AI.TextAnalytics
         public Azure.AI.TextAnalytics.TextSentiment Sentiment { get { throw null; } }
         public string Text { get { throw null; } }
     }
-    public partial class TextAnalyticsActionDetails
+    public partial class TextAnalyticsActionResult
     {
-        internal TextAnalyticsActionDetails() { }
+        internal TextAnalyticsActionResult() { }
         public System.DateTimeOffset CompletedOn { get { throw null; } }
         public Azure.AI.TextAnalytics.TextAnalyticsError Error { get { throw null; } }
         public bool HasError { get { throw null; } }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentActionResult.cs
@@ -9,7 +9,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Action result class for analyze sentiment result.
     /// </summary>
-    public class AnalyzeSentimentActionResult : TextAnalyticsActionDetails
+    public class AnalyzeSentimentActionResult : TextAnalyticsActionResult
     {
         internal AnalyzeSentimentActionResult(AnalyzeSentimentResultCollection result, DateTimeOffset completedOn, TextAnalyticsErrorInternal error) : base(completedOn, error)
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesActionResult.cs
@@ -11,7 +11,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// ExtractKeyPhrasesActionResult
     /// </summary>
-    public class ExtractKeyPhrasesActionResult : TextAnalyticsActionDetails
+    public class ExtractKeyPhrasesActionResult : TextAnalyticsActionResult
     {
         internal ExtractKeyPhrasesActionResult(ExtractKeyPhrasesResultCollection result, DateTimeOffset completedOn, TextAnalyticsErrorInternal error) : base(completedOn, error)
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesActionResult.cs
@@ -11,7 +11,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// RecognizeEntitiesActionResult
     /// </summary>
-    public class RecognizeEntitiesActionResult : TextAnalyticsActionDetails
+    public class RecognizeEntitiesActionResult : TextAnalyticsActionResult
     {
         internal RecognizeEntitiesActionResult(RecognizeEntitiesResultCollection result, DateTimeOffset completedOn, TextAnalyticsErrorInternal error) : base(completedOn, error)
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesActionResult.cs
@@ -9,7 +9,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Action result class for linked entities
     /// </summary>
-    public class RecognizeLinkedEntitiesActionResult : TextAnalyticsActionDetails
+    public class RecognizeLinkedEntitiesActionResult : TextAnalyticsActionResult
     {
         internal RecognizeLinkedEntitiesActionResult(RecognizeLinkedEntitiesResultCollection result, DateTimeOffset completedOn, TextAnalyticsErrorInternal error) : base(completedOn, error)
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesActionResult.cs
@@ -11,7 +11,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// RecognizePiiEntitiesActionResults
     /// </summary>
-    public class RecognizePiiEntitiesActionResult : TextAnalyticsActionDetails
+    public class RecognizePiiEntitiesActionResult : TextAnalyticsActionResult
     {
         internal RecognizePiiEntitiesActionResult(RecognizePiiEntitiesResultCollection result, DateTimeOffset completedOn, TextAnalyticsErrorInternal error) : base(completedOn, error)
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActionResult.cs
@@ -2,20 +2,16 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using Azure.AI.TextAnalytics.Models;
 
 namespace Azure.AI.TextAnalytics
 {
     /// <summary>
-    /// Stores the details for the AnalyzeBatchActionsOperation class.
+    /// Base type for results of Text Analytics Actions executed in a set of documents.
     /// </summary>
-    public class TextAnalyticsActionDetails
+    public class TextAnalyticsActionResult
     {
-        /// <summary>
-        /// Initializes the TextAnalyticsActionDetails class by initializing CompletedOn, Error and HasError properties.
-        /// </summary>
-        internal TextAnalyticsActionDetails (DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
+        internal TextAnalyticsActionResult (DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
         {
             CompletedOn = completedOn;
             Error = error != null ? Transforms.ConvertToError(error) : default;


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/21199

Following Java and our previous `TextAnalyticsResult` base class which is used for the sync responses.