### PR TITLE
Remove perf and stress from new ci.yml files

### DIFF
--- a/sdk/farmbeats/ci.yml
+++ b/sdk/farmbeats/ci.yml
@@ -20,9 +20,6 @@ pr:
     - release/*
   paths:
     include:
-    - common/Perf/
-    - common/PerfStressShared/
-    - common/Stress/
     - sdk/farmbeats/
 
 extends:

--- a/sdk/purview/ci.yml
+++ b/sdk/purview/ci.yml
@@ -20,9 +20,6 @@ pr:
     - release/*
   paths:
     include:
-    - common/Perf/
-    - common/PerfStressShared/
-    - common/Stress/
     - sdk/purview/
 
 extends:

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -20,10 +20,12 @@ pr:
     - release/*
   paths:
     include:
+    - sdk/template/
+    # The following paths should only be included in template/ci.yml, and removed from any other
+    # SDKs which copy this file.
     - common/Perf/
     - common/PerfStressShared/
     - common/Stress/
-    - sdk/template/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/webpubsub/ci.yml
+++ b/sdk/webpubsub/ci.yml
@@ -20,9 +20,6 @@ pr:
     - release/*
   paths:
     include:
-    - common/Perf/
-    - common/PerfStressShared/
-    - common/Stress/
     - sdk/webpubsub/
 
 extends:


### PR DESCRIPTION
- Perf and stress paths should only be included in template/ci.yml, and removed from any other SDKs which copy this file

