### PR TITLE
Do not fallback to older Nuget cache

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -92,6 +92,7 @@
     <PackageReference Update="Microsoft.Azure.Amqp" Version="2.4.13" />
     <PackageReference Update="Microsoft.Identity.Client" Version="4.30.1" />
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.4" />
+
     <!-- TODO: Make sure this package is arch-board approved -->
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
 

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -19,8 +19,5 @@ steps:
   - task: Cache@2
     inputs:
       key: 'nuget | "$(Agent.OS)" | $(Build.SourcesDirectory)/eng/Packages.Data.props | ${{parameters.NuGetCacheKey}}'
-      restoreKeys: |
-        nuget | "$(Agent.OS)" | $(Build.SourcesDirectory)/eng/Packages.Data.props
-        nuget | "$(Agent.OS)"
       path: $(NUGET_PACKAGES)
     displayName: Cache NuGet packages


### PR DESCRIPTION
If we do we just keep adding packages to it resulting in a larger and larger cache size.
