### PR TITLE
Restore MacOS agent usage in test platform matrix (revert #20198)

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -81,12 +81,7 @@ stages:
           - ${{ each config in parameters.AdditionalMatrixConfigs }}:
             -  ${{ config }}
         MatrixFilters: ${{ parameters.MatrixFilters }}
-        MatrixReplace:
-          # Temporarily replace macOS agents with ubuntu agents because of ongoing pool capacity issues
-          - Pool=Azure.Pipelines/azsdk-pool-mms-ubuntu-1804-general
-          - OsVmImage=macOS-10.15/MMSUbuntu18.04
-          - ${{ each replacement in parameters.MatrixReplace }}:
-            - ${{ replacement }}
+        MatrixReplace: ${{ parameters.MatrixReplace }}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -12,10 +12,6 @@
       "windows-2019": {
           "OSVmImage": "MMS2019",
           "Pool": "azsdk-pool-mms-win-2019-general"
-      },
-      "macOS-10.15": {
-          "OSVmImage": "macOS-10.15",
-          "Pool": "Azure Pipelines"
       }
     },
     "TestTargetFramework": [

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -12,6 +12,10 @@
       "windows-2019": {
           "OSVmImage": "MMS2019",
           "Pool": "azsdk-pool-mms-win-2019-general"
+      },
+      "macOS-10.15": {
+          "OSVmImage": "macOS-10.15",
+          "Pool": "Azure Pipelines"
       }
     },
     "TestTargetFramework": [


### PR DESCRIPTION
Azure Pipelines macOS agent capacity seems to be restored now (https://status.dev.azure.com/_event/233282345).