### PR TITLE
Move code coverage steps into shared template. Enable live test opt-in

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -43,12 +43,15 @@ jobs:
       - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
         parameters:
           AgentImage: $(OSVmImage)
+
       - ${{ each step in parameters.TestSetupSteps }}:
         - ${{ each pair in step }}:
             ${{ pair.key }}: ${{ pair.value }}
+
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
         parameters:
           NuGetCacheKey: Test
+
       - script: >-
           dotnet test eng/service.proj --filter "(TestCategory!=Manually) & (TestCategory!=Live)" --framework $(TestTargetFramework)
           --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
@@ -59,6 +62,7 @@ jobs:
           /p:Configuration=$(BuildConfiguration) $(ConvertToProjectReferenceOption)
           /p:CollectCoverage=$(CollectCoverage) /p:CodeCoverageDirectory=$(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}
         displayName: "Build & Test ($(TestTargetFramework))"
+
       - task: PublishTestResults@2
         condition: always()
         displayName: "Publish Results ($(TestTargetFramework))"
@@ -67,18 +71,5 @@ jobs:
           testRunTitle: "$(OSName) $(TestTargetFramework)"
           testResultsFormat: "VSTest"
           mergeTestResults: true
-      - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
-        condition: and(succeededOrFailed(), eq(variables['CollectCoverage'], 'true'), eq(variables['coverage.collected'], 'true'))
-        displayName: Generate Code Coverage Reports
-        inputs:
-          reports: $(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}\**\coverage.cobertura.xml
-          targetdir: $(Build.ArtifactStagingDirectory)\coverage
-          reporttypes: Cobertura
-          filefilters: +$(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}\**
-          verbosity: Verbose
-      - task: PublishCodeCoverageResults@1
-        condition: and(succeededOrFailed(), eq(variables['CollectCoverage'], 'true'), eq(variables['coverage.collected'], 'true'))
-        displayName: Publish Code Coverage Reports
-        inputs:
-          codeCoverageTool: Cobertura
-          summaryFileLocation: $(Build.ArtifactStagingDirectory)\coverage\Cobertura.xml
+
+      - template: ../steps/code-coverage.yml

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -141,21 +141,6 @@ jobs:
           testResultsFormat: "VSTest"
           mergeTestResults: true
 
-      - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
-        condition: and(succeededOrFailed(), eq(variables['CollectCoverage'], 'true'), eq(variables['coverage.collected'], 'true'))
-        displayName: Generate Code Coverage Reports
-        inputs:
-          reports: $(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}\**\coverage.cobertura.xml
-          targetdir: $(Build.ArtifactStagingDirectory)\coverage
-          reporttypes: Cobertura
-          filefilters: +$(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}\**
-          verbosity: Verbose
-
-      - task: PublishCodeCoverageResults@1
-        condition: and(succeededOrFailed(), eq(variables['CollectCoverage'], 'true'), eq(variables['coverage.collected'], 'true'))
-        displayName: Publish Code Coverage Reports
-        inputs:
-          codeCoverageTool: Cobertura
-          summaryFileLocation: $(Build.ArtifactStagingDirectory)\coverage\Cobertura.xml
+      - template: ../steps/code-coverage.yml
 
       - ${{ parameters.PostSteps }}

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -81,7 +81,10 @@ stages:
           - ${{ each config in parameters.AdditionalMatrixConfigs }}:
             -  ${{ config }}
         MatrixFilters: ${{ parameters.MatrixFilters }}
-        MatrixReplace: ${{ parameters.MatrixReplace }}
+        MatrixReplace:
+          - CollectCoverage=.*/true
+          - ${{ each replacement in parameters.MatrixReplace }}:
+            - ${{ replacement }}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -37,9 +37,9 @@
           }
       },
       "TestMode": {
-          "netcoreapp21_Coverage_Record": {
+          "netcoreapp21_Coverage_or_Record": {
               "SupportsRecording": true,
-              "CollectCoverage": true,
+              "CollectCoverage": false,
               "TestTargetFramework": "netcoreapp2.1"
           },
           "net5.0": {

--- a/eng/pipelines/templates/steps/code-coverage.yml
+++ b/eng/pipelines/templates/steps/code-coverage.yml
@@ -1,0 +1,16 @@
+steps:
+  - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
+    condition: and(succeededOrFailed(), eq(variables['CollectCoverage'], 'true'), eq(variables['coverage.collected'], 'true'))
+    displayName: Generate Code Coverage Reports
+    inputs:
+      reports: $(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}\**\coverage.cobertura.xml
+      targetdir: $(Build.ArtifactStagingDirectory)\coverage
+      reporttypes: Cobertura
+      filefilters: +$(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}\**
+      verbosity: Verbose
+  - task: PublishCodeCoverageResults@1
+    condition: and(succeededOrFailed(), eq(variables['CollectCoverage'], 'true'), eq(variables['coverage.collected'], 'true'))
+    displayName: Publish Code Coverage Reports
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: $(Build.ArtifactStagingDirectory)\coverage\Cobertura.xml

--- a/sdk/communication/Azure.Communication.Sms/tests.yml
+++ b/sdk/communication/Azure.Communication.Sms/tests.yml
@@ -11,6 +11,8 @@ extends:
           - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
           - $(sub-config-communication-services-cloud-test-resources-net)
+        MatrixReplace:
+          - CollectCoverage=.*/true
       Int:
         SubscriptionConfigurations:
           - $(sub-config-communication-int-test-resources-common)


### PR DESCRIPTION
This PR re-works code coverage inclusion to be a little more flexible. Additionally, it allows opt-in of coverage results in the live tests where desired (for example, the azure communication services team wants live test coverage for select clouds).