### PR TITLE
Updating NetworkTraversal date in CHANGELOG

### DIFF
--- a/sdk/communication/Azure.Communication.NetworkTraversal/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.NetworkTraversal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (2021-05-21)
+## 1.0.0-beta.1 (2021-05-24)
 
 This is the first release of Azure Communication Services for Network Traversal. For more information, please see the [README][read_me].
 


### PR DESCRIPTION
Updating the Azure.Communication.NetworkTraversal changelog date to reflect Public beta release.