### PR TITLE
Increase Key Vault live test timeout

### DIFF
--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -5,7 +5,7 @@ extends:
   parameters:
     ServiceDirectory: keyvault
     MaxParallel: 5
-    TimeoutInMinutes: 180
+    TimeoutInMinutes: 240
     SupportedClouds: 'Public,UsGov,China,Canary'
     CloudConfig:
       Public:


### PR DESCRIPTION
Recent change to call Key Vault less to reduce costs increased duration.
Been getting timeouts lately.
