### PR TITLE
Prepare Communication packages for Patch Release

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -74,7 +74,7 @@
     <PackageReference Update="Microsoft.CSharp" Version="4.5.0" />
 
     <!-- Azure SDK packages -->
-    <PackageReference Update="Azure.Communication.Common" Version="1.0.0" />
+    <PackageReference Update="Azure.Communication.Common" Version="1.0.1" />
     <PackageReference Update="Azure.Core" Version="1.14.0" />
     <PackageReference Update="Azure.Core.Amqp" Version="1.1.0-beta.1" Condition="'$(HasReleaseVersion)' == 'false'"/>
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.12" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -74,7 +74,7 @@
     <PackageReference Update="Microsoft.CSharp" Version="4.5.0" />
 
     <!-- Azure SDK packages -->
-    <PackageReference Update="Azure.Communication.Common" Version="1.0.1" />
+    <PackageReference Update="Azure.Communication.Common" Version="1.0.0" />
     <PackageReference Update="Azure.Core" Version="1.14.0" />
     <PackageReference Update="Azure.Core.Amqp" Version="1.1.0-beta.1" Condition="'$(HasReleaseVersion)' == 'false'"/>
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.12" />

--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
+## 1.0.1 (2021-05-25)
+- Dependency versions updated.
 
 ## 1.0.0 (2021-03-29)
 Updated `Azure.Communication.Common` version.

--- a/sdk/communication/Azure.Communication.Common/src/Azure.Communication.Common.csproj
+++ b/sdk/communication/Azure.Communication.Common/src/Azure.Communication.Common.csproj
@@ -5,7 +5,7 @@
       For this release, see notes - https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/communication/Azure.Communication.Common/README.md and https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/communication/Azure.Communication.Common/CHANGELOG.md.
     </Description>
     <AssemblyTitle>Azure Communication Services Common</AssemblyTitle>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.0.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Communication Service;Microsoft;Azure;Azure Communication Service;Communication;$(PackageCommonTags)</PackageTags>

--- a/sdk/communication/Azure.Communication.Identity/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Identity/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
+## 1.0.1 (2021-05-25)
+- Dependency versions updated.
 
 ## 1.0.0 (2021-03-29)
 Updated `Azure.Communication.Identity` version.

--- a/sdk/communication/Azure.Communication.Identity/src/Azure.Communication.Identity.csproj
+++ b/sdk/communication/Azure.Communication.Identity/src/Azure.Communication.Identity.csproj
@@ -6,7 +6,7 @@
       Microsoft Azure Communication Identity quickstart - https://docs.microsoft.com/azure/communication-services/quickstarts/access-tokens?pivots=programming-language-csharp
     </Description>
     <AssemblyTitle>Azure Communication Identity Service</AssemblyTitle>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.0.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Communication Identity Service;Microsoft;Azure;Azure Communication Service;Azure Communication Identity Service;Identity;Communication;$(PackageCommonTags)</PackageTags>

--- a/sdk/communication/Azure.Communication.PhoneNumbers/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
-## 1.0.1 (Unreleased)
+## 1.0.1 (2021-05-25)
+- Dependency versions updated.
 
 ## 1.0.0 (2021-04-26)
 Updated `Azure.Communication.PhoneNumbers` version.

--- a/sdk/communication/Azure.Communication.Sms/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Sms/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
+## 1.0.1 (2021-05-25)
+- Dependency versions updated.
 
 ## 1.0.0 (2021-03-29)
 Updated `Azure.Communication.Sms` version.

--- a/sdk/communication/Azure.Communication.Sms/src/Azure.Communication.Sms.csproj
+++ b/sdk/communication/Azure.Communication.Sms/src/Azure.Communication.Sms.csproj
@@ -6,7 +6,7 @@
       Microsoft Azure Communication Sms quickstart - https://docs.microsoft.com/azure/communication-services/quickstarts/telephony-sms/send?pivots=programming-language-csharp
     </Description>
     <AssemblyTitle>Azure Communication Sms Service</AssemblyTitle>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.0.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Communication Sms Service;Microsoft;Azure;Azure Communication Service;Azure Communication Sms Service;Sms;Communication;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
* Preparing for the patch release that updates the Azure.Core dependency (>=1.14) that contains the .NET security fix
* Chat already released a patch with the update so that is not needed anymore