### PR TITLE
[TA] Enable multiversion

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.1.0-beta.8 (Unreleased)
 ### New features
+- Added support for service version `3.0`. This can be specified in the `TextAnalyticsClientOptions` object under the `ServiceVersion` enum. By default the SDK targets latest supported service version.
 - Added value `None` to enum `PiiEntityDomainType` to allow user to specify no domain.
 
 ### Breaking changes

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -24,8 +24,7 @@ dotnet add package Azure.AI.TextAnalytics
 This table shows the relationship between SDK versions and supported API versions of the service:
 
 |SDK version|Supported API version of service
-|-|-
-
+|-|- |
 |5.1.0-beta.7 (latest Beta) | 3.0, 3.1-preview.5
 |5.0.0 (latest GA) | 3.0
 |1.0.0, 1.0.1 | 3.0

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -19,6 +19,16 @@ Install the Azure Text Analytics client library for .NET with [NuGet][nuget]:
 ```PowerShell
 dotnet add package Azure.AI.TextAnalytics
 ```
+> Note: This version of the client library defaults to the `v3.1-preview.5` version of the service.
+
+This table shows the relationship between SDK versions and supported API versions of the service:
+
+|SDK version|Supported API version of service
+|-|-
+|1.0.0 | 3.0
+|1.0.1 | 3.0
+|5.0.0 (latest GA) | 3.0
+|5.1.0-beta.7 (latest Beta) | 3.0, 3.1-preview.5
 
 ### Prerequisites
 * An [Azure subscription][azure_sub].

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -25,10 +25,10 @@ This table shows the relationship between SDK versions and supported API version
 
 |SDK version|Supported API version of service
 |-|-
-|1.0.0 | 3.0
-|1.0.1 | 3.0
-|5.0.0 (latest GA) | 3.0
+
 |5.1.0-beta.7 (latest Beta) | 3.0, 3.1-preview.5
+|5.0.0 (latest GA) | 3.0
+|1.0.0, 1.0.1 | 3.0
 
 ### Prerequisites
 * An [Azure subscription][azure_sub].

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentOptions.cs
@@ -32,6 +32,9 @@ namespace Azure.AI.TextAnalytics
         /// will contain the result of this analysis.
         /// <para>Only available for service version v3.1-preview and up.</para>
         /// </summary>
+        /// <remarks>
+        /// This property only has value for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         public bool? IncludeOpinionMining { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/TextAnalyticsRestClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/TextAnalyticsRestClient.cs
@@ -20,6 +20,7 @@ namespace Azure.AI.TextAnalytics
     internal partial class TextAnalyticsRestClient
     {
         private string endpoint;
+        private string apiVersion;
         private ClientDiagnostics _clientDiagnostics;
         private HttpPipeline _pipeline;
 
@@ -27,15 +28,21 @@ namespace Azure.AI.TextAnalytics
         /// <param name="clientDiagnostics"> The handler for diagnostic messaging in the client. </param>
         /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
         /// <param name="endpoint"> Supported Cognitive Services endpoints (protocol and hostname, for example: https://westus.api.cognitive.microsoft.com). </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/> is null. </exception>
-        public TextAnalyticsRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint)
+        /// <param name="apiVersion"> Text Analytics API version (for example: v3.0). </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/> or <paramref name="apiVersion"/> is null. </exception>
+        public TextAnalyticsRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "v3.1")
         {
             if (endpoint == null)
             {
                 throw new ArgumentNullException(nameof(endpoint));
             }
+            if (apiVersion == null)
+            {
+                throw new ArgumentNullException(nameof(apiVersion));
+            }
 
             this.endpoint = endpoint;
+            this.apiVersion = apiVersion;
             _clientDiagnostics = clientDiagnostics;
             _pipeline = pipeline;
         }
@@ -47,7 +54,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/analyze", false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json, text/json");
@@ -102,7 +110,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/analyze/jobs/", false);
             uri.AppendPath(jobId, true);
             if (showStats != null)
@@ -189,7 +198,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/entities/health/jobs/", false);
             uri.AppendPath(jobId, true);
             if (top != null)
@@ -264,7 +274,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/entities/health/jobs/", false);
             uri.AppendPath(jobId, true);
             request.Uri = uri;
@@ -313,7 +324,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/entities/health/jobs", false);
             if (modelVersion != null)
             {
@@ -395,7 +407,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/entities/recognition/general", false);
             if (modelVersion != null)
             {
@@ -491,7 +504,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/entities/recognition/pii", false);
             if (modelVersion != null)
             {
@@ -605,7 +619,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/entities/linking", false);
             if (modelVersion != null)
             {
@@ -701,7 +716,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/keyPhrases", false);
             if (modelVersion != null)
             {
@@ -791,7 +807,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/languages", false);
             if (modelVersion != null)
             {
@@ -881,7 +898,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/sentiment", false);
             if (modelVersion != null)
             {
@@ -983,7 +1001,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/entities/health/jobs/", false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
@@ -1052,7 +1071,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendPath("/analyze/jobs/", false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
@@ -1121,7 +1141,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json, text/json");
@@ -1189,7 +1210,8 @@ namespace Azure.AI.TextAnalytics
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(endpoint, false);
-            uri.AppendRaw("/text/analytics/v3.1-preview.5", false);
+            uri.AppendRaw("/text/analytics/", false);
+            uri.AppendRaw(apiVersion, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json, text/json");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntity.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntity.cs
@@ -62,8 +62,10 @@ namespace Azure.AI.TextAnalytics
 
         /// <summary> Bing Entity Search API unique identifier of the recognized entity.
         /// Use in conjunction with the Bing Entity Search API to fetch additional relevant information.
-        /// This property is only available for service v3.1-preview and up.
         /// </summary>
+        /// <remarks>
+        /// This property only has value for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         [CodeGenMember("BingId")]
         public string BingEntitySearchApiId { get; }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -66,7 +66,7 @@ namespace Azure.AI.TextAnalytics
             _options = options;
 
             var pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, DefaultCognitiveScope));
-            _serviceRestClient = new TextAnalyticsRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri);
+            _serviceRestClient = new TextAnalyticsRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri, TextAnalyticsClientOptions.GetVersionString(options.Version));
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace Azure.AI.TextAnalytics
             _options = options;
 
             var pipeline = HttpPipelineBuilder.Build(options, new AzureKeyCredentialPolicy(credential, AuthorizationHeader));
-            _serviceRestClient = new TextAnalyticsRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri);
+            _serviceRestClient = new TextAnalyticsRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri, TextAnalyticsClientOptions.GetVersionString(options.Version));
         }
 
         #region Detect Language
@@ -877,6 +877,9 @@ namespace Azure.AI.TextAnalytics
         /// <para>For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.</para>
         /// </summary>
+        /// <remarks>
+        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         /// <param name="document">The document to analyze.</param>
         /// <param name="language">The language that the document is written in.
         /// If unspecified, this value will be set to the default language in
@@ -944,6 +947,9 @@ namespace Azure.AI.TextAnalytics
         /// <para>For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.</para>
         /// </summary>
+        /// <remarks>
+        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         /// <param name="document">The document to analyze.</param>
         /// <param name="language">The language that the document is written in.
         /// If unspecified, this value will be set to the default language in
@@ -1011,6 +1017,9 @@ namespace Azure.AI.TextAnalytics
         /// <para>For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.</para>
         /// </summary>
+        /// <remarks>
+        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         /// <param name="documents">The documents to analyze.</param>
         /// <param name="language">The language that the document is written in.
         /// If unspecified, this value will be set to the default language in
@@ -1047,6 +1056,9 @@ namespace Azure.AI.TextAnalytics
         /// <para>For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.</para>
         /// </summary>
+        /// <remarks>
+        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         /// <param name="documents">The documents to analyze.</param>
         /// <param name="language">The language that the document is written in.
         /// If unspecified, this value will be set to the default language in
@@ -1083,6 +1095,9 @@ namespace Azure.AI.TextAnalytics
         /// <para>For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.</para>
         /// </summary>
+        /// <remarks>
+        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         /// <param name="documents">The documents to analyze.</param>
         /// <param name="options">The additional configurable <see cref="RecognizePiiEntitiesOptions"/> that may be passed when
         /// recognizing PII entities. Options include entity domain filters, model version, and more.</param>
@@ -1114,6 +1129,9 @@ namespace Azure.AI.TextAnalytics
         /// <para>For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.</para>
         /// </summary>
+        /// <remarks>
+        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         /// <param name="documents">The documents to analyze.</param>
         /// <param name="options">The additional configurable <see cref="RecognizePiiEntitiesOptions"/> that may be passed when
         /// recognizing PII entities. Options include entity domain filters, model version, and more.</param>
@@ -2577,11 +2595,14 @@ namespace Azure.AI.TextAnalytics
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.
         /// For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.
-        /// <remarks><para>
+        /// <remarks>
+        /// <para>Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.</para>
+        /// <para>
         /// Note: In order to use this functionality, request to access public preview is required.
         /// Azure Active Directory (AAD) is not currently supported. For more information see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/how-tos/text-analytics-for-health?tabs=ner#request-access-to-the-public-preview"/>.
-        /// </para></remarks>
+        /// </para>
+        /// </remarks>
         /// </summary>
         /// <param name="documents">The documents to analyze.</param>
         /// <param name="language">The language that the document is written in.</param>
@@ -2607,11 +2628,14 @@ namespace Azure.AI.TextAnalytics
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.
         /// For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.
-        /// <remarks><para>
+        /// <remarks>
+        /// <para>Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.</para>
+        /// <para>
         /// Note: In order to use this functionality, request to access public preview is required.
         /// Azure Active Directory (AAD) is not currently supported. For more information see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/how-tos/text-analytics-for-health?tabs=ner#request-access-to-the-public-preview"/>.
-        /// </para></remarks>
+        /// </para>
+        /// </remarks>
         /// </summary>
         /// <param name="documents">The documents to analyze.</param>
         /// <param name="language">The language that the document is written in.
@@ -2644,11 +2668,14 @@ namespace Azure.AI.TextAnalytics
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.
         /// For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.
-        /// <remarks><para>
+        /// <remarks>
+        /// <para>Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.</para>
+        /// <para>
         /// Note: In order to use this functionality, request to access public preview is required.
         /// Azure Active Directory (AAD) is not currently supported. For more information see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/how-tos/text-analytics-for-health?tabs=ner#request-access-to-the-public-preview"/>.
-        /// </para></remarks>
+        /// </para>
+        /// </remarks>
         /// </summary>
         /// <param name="documents">The documents to analyze.</param>
         /// <param name="options">The additional configurable options<see cref="AnalyzeHealthcareEntitiesOptions"/></param>
@@ -2674,11 +2701,14 @@ namespace Azure.AI.TextAnalytics
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.
         /// For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.
-        /// <remarks><para>
+        /// <remarks>
+        /// <para>Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.</para>
+        /// <para>
         /// Note: In order to use this functionality, request to access public preview is required.
         /// Azure Active Directory (AAD) is not currently supported. For more information see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/how-tos/text-analytics-for-health?tabs=ner#request-access-to-the-public-preview"/>.
-        /// </para></remarks>
+        /// </para>
+        /// </remarks>
         /// </summary>
         /// <param name="documents">The documents to analyze.</param>
         /// <param name="options">The additional configurable options<see cref="AnalyzeHealthcareEntitiesOptions"/></param>
@@ -2763,6 +2793,9 @@ namespace Azure.AI.TextAnalytics
         /// For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.
         /// </summary>
+        /// <remarks>
+        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         /// <param name="documents">The list of documents to analyze.</param>
         /// <param name="language">The language that the document is written in.</param>
         /// <param name="actions"> The different actions to pass as arguments. <see cref="TextAnalyticsActions"/>
@@ -2788,6 +2821,9 @@ namespace Azure.AI.TextAnalytics
         /// For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.
         /// </summary>
+        /// <remarks>
+        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         /// <param name="documents">The list of documents to analyze.</param>
         /// <param name="actions"> The different actions to pass as arguments. <see cref="TextAnalyticsActions"/>
         /// You can use it to have multiple actions to analyze as well as multiple action item per each individual action.
@@ -2813,6 +2849,9 @@ namespace Azure.AI.TextAnalytics
         /// For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.
         /// </summary>
+        /// <remarks>
+        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         /// <param name="documents">The list of documents to analyze.</param>
         /// <param name="actions"> The different actions to pass as arguments. <see cref="TextAnalyticsActions"/>
         /// You can use it to have multiple actions to analyze as well as multiple action item per each individual action.
@@ -2837,6 +2876,9 @@ namespace Azure.AI.TextAnalytics
         /// For document length limits, maximum batch size, and supported text encoding, see
         /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits"/>.
         /// </summary>
+        /// <remarks>
+        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         /// <param name="documents">The list of documents to analyze.</param>
         /// <param name="actions"> The different actions to pass as arguments. <see cref="TextAnalyticsActions"/>
         /// You can use it to have multiple actions to analyze as well as multiple action item per each individual action.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClientOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClientOptions.cs
@@ -69,14 +69,14 @@ namespace Azure.AI.TextAnalytics
             this.ConfigureLogging();
         }
 
-        internal string GetVersionString()
+        internal static string GetVersionString(ServiceVersion version)
         {
-            return Version switch
+            return version switch
             {
                 ServiceVersion.V3_0 => "v3.0",
                 ServiceVersion.V3_1_Preview_5 => "v3.1-preview.5",
 
-                _ => throw new ArgumentException($"Version {Version} not supported."),
+                _ => throw new ArgumentException($"Version {version} not supported."),
             };
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsRequestOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsRequestOptions.cs
@@ -53,6 +53,9 @@ namespace Azure.AI.TextAnalytics
         /// This means, Text Analytics service logs your input text for 48 hours, solely to allow for troubleshooting issues.
         /// Setting this property to true, disables input logging and may limit our ability to investigate issues that occur.
         /// </summary>
+        /// <remarks>
+        /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5"/> and up.
+        /// </remarks>
         public bool? DisableServiceLogs { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/autorest.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/autorest.md
@@ -21,6 +21,29 @@ directive:
     $["x-accessibility"] = "internal"
 ```
 
+### Make the API version parameterized so we generate a multi-versioned API
+
+This should be fixed in the swagger, but we're working around it locally for now.
+``` yaml
+directive:
+- from: swagger-document
+  where: $["x-ms-parameterized-host"]
+  transform: >
+    $.hostTemplate = "{Endpoint}/text/analytics/{apiVersion}";
+    $.parameters.push({
+      "name": "apiVersion",
+      "description": "Text Analytics API version (for example: v3.0).",
+      "x-ms-parameter-location": "client",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "v3.1"
+      ],
+      "in": "path",
+      "x-ms-skip-url-encoding": true
+    });
+```
+
 ### Add nullable annotations
 This is to guarantee that we don't introduce breaking changes now that we autogerate the code.
 ``` yaml

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
@@ -10,9 +10,13 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Tests
 {
+    [ClientTestFixture(TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
     public class AnalyzeOperationTests : TextAnalyticsClientLiveTestBase
     {
-        public AnalyzeOperationTests(bool isAsync) : base(isAsync) { }
+        public AnalyzeOperationTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync, serviceVersion)
+        {
+        }
 
         private static List<string> batchConvenienceDocuments = new List<string>
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
@@ -12,7 +12,10 @@ namespace Azure.AI.TextAnalytics.Tests
 {
     public class AnalyzeSentimentTests : TextAnalyticsClientLiveTestBase
     {
-        public AnalyzeSentimentTests(bool isAsync) : base(isAsync) { }
+        public AnalyzeSentimentTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync, serviceVersion)
+        {
+        }
 
         private const string singleEnglish = "That was the best day of my life!";
         private const string singleSpanish = "El mejor test del mundo!";
@@ -74,6 +77,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
         public async Task AnalyzeSentimentWithOpinionMining()
         {
             TextAnalyticsClient client = GetClient();
@@ -86,6 +90,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
         public async Task AnalyzeSentimentWithOpinionMiningEmpty()
         {
             TextAnalyticsClient client = GetClient();
@@ -98,6 +103,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
         public async Task AnalyzeSentimentWithOpinionMiningNegated()
         {
             TextAnalyticsClient client = GetClient();
@@ -156,6 +162,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
         public async Task AnalyzeSentimentBatchConvenienceWithOpinionMiningTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -333,6 +340,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
         public async Task AnalyzeSentimentBatchWithOpinionMiningTest()
         {
             TextAnalyticsClient client = GetClient();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/DetectLanguageTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/DetectLanguageTests.cs
@@ -11,7 +11,17 @@ namespace Azure.AI.TextAnalytics.Tests
 {
     public class DetectLanguageTests : TextAnalyticsClientLiveTestBase
     {
-        public DetectLanguageTests(bool isAsync) : base(isAsync) { }
+        /// <summary>
+        /// The version of the REST API to test against.  This will be passed
+        /// to the .ctor via ClientTestFixture's values.
+        /// </summary>
+        private readonly TextAnalyticsClientOptions.ServiceVersion _serviceVersion;
+
+        public DetectLanguageTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync, serviceVersion)
+        {
+            _serviceVersion = serviceVersion;
+        }
 
         private const string SingleEnglish = "This is written in English.";
         private const string SingleSpanish = "Este documento está en español";
@@ -100,7 +110,7 @@ namespace Azure.AI.TextAnalytics.Tests
         [RecordedTest]
         public async Task DetectLanguageWithNoneDefaultCountryHintTest()
         {
-            var options = new TextAnalyticsClientOptions()
+            var options = new TextAnalyticsClientOptions(_serviceVersion)
             {
                 DefaultCountryHint = DetectLanguageInput.None
             };

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractKeyPhrasesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractKeyPhrasesTests.cs
@@ -12,7 +12,10 @@ namespace Azure.AI.TextAnalytics.Tests
 {
     public class ExtractKeyPhrasesTests : TextAnalyticsClientLiveTestBase
     {
-        public ExtractKeyPhrasesTests(bool isAsync) : base(isAsync) { }
+        public ExtractKeyPhrasesTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync, serviceVersion)
+        {
+        }
 
         private const string SingleEnglish = "My cat might need to see a veterinarian.";
         private const string SingleSpanish = "Mi perro está en el veterinario";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsClientLiveTestBase.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsClientLiveTestBase.cs
@@ -6,10 +6,21 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.TextAnalytics.Tests
 {
+    [ClientTestFixture(
+    TextAnalyticsClientOptions.ServiceVersion.V3_0,
+    TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
     public class TextAnalyticsClientLiveTestBase : RecordedTestBase<TextAnalyticsTestEnvironment>
     {
-        public TextAnalyticsClientLiveTestBase(bool isAsync) : base(isAsync)
+        /// <summary>
+        /// The version of the REST API to test against.  This will be passed
+        /// to the .ctor via ClientTestFixture's values.
+        /// </summary>
+        private readonly TextAnalyticsClientOptions.ServiceVersion _serviceVersion;
+
+        public TextAnalyticsClientLiveTestBase(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync)
         {
+            _serviceVersion = serviceVersion;
             Sanitizer = new TextAnalyticsRecordedTestSanitizer();
         }
 
@@ -19,7 +30,7 @@ namespace Azure.AI.TextAnalytics.Tests
             bool useTokenCredential = default)
         {
             var endpoint = new Uri(TestEnvironment.Endpoint);
-            options ??= new TextAnalyticsClientOptions();
+            options ??= new TextAnalyticsClientOptions(_serviceVersion);
 
             if (useTokenCredential)
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
@@ -12,7 +12,10 @@ namespace Azure.AI.TextAnalytics.Tests
 {
     public class RecognizeEntitiesTests : TextAnalyticsClientLiveTestBase
     {
-        public RecognizeEntitiesTests(bool isAsync) : base(isAsync) { }
+        public RecognizeEntitiesTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync, serviceVersion)
+        {
+        }
 
         private const string EnglishDocument1 = "Microsoft was founded by Bill Gates and Paul Allen.";
         private const string EnglishDocument2 = "My cat and my dog might need to see a veterinarian.";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeHealthcareEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeHealthcareEntitiesTests.cs
@@ -10,9 +10,13 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Tests
 {
+    [ClientTestFixture(TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
     public class RecognizeHealthcareEntitiesTests : TextAnalyticsClientLiveTestBase
     {
-        public RecognizeHealthcareEntitiesTests(bool isAsync) : base(isAsync) { }
+        public RecognizeHealthcareEntitiesTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync, serviceVersion)
+        {
+        }
 
         private static List<string> s_batchConvenienceDocuments = new List<string>
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeLinkedEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeLinkedEntitiesTests.cs
@@ -12,7 +12,10 @@ namespace Azure.AI.TextAnalytics.Tests
 {
     public class RecognizeLinkedEntitiesTests : TextAnalyticsClientLiveTestBase
     {
-        public RecognizeLinkedEntitiesTests(bool isAsync) : base(isAsync) { }
+        public RecognizeLinkedEntitiesTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync, serviceVersion)
+        {
+        }
 
         private const string EnglishDocument1 = "Microsoft was founded by Bill Gates and Paul Allen.";
         private const string EnglishDocument2 = "Pike place market is my favorite Seattle attraction.";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
@@ -10,9 +10,13 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Tests
 {
+    [ClientTestFixture(TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
     public class RecognizePiiEntitiesTests : TextAnalyticsClientLiveTestBase
     {
-        public RecognizePiiEntitiesTests(bool isAsync) : base(isAsync) { }
+        public RecognizePiiEntitiesTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync, serviceVersion)
+        {
+        }
 
         private const string EnglishDocument1 = "A developer with SSN 859-98-0987 whose phone number is 800-102-1100 is building tools with our APIs. They work at Microsoft";
         private const string EnglishDocument2 = "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -11,9 +11,13 @@ namespace Azure.AI.TextAnalytics.Tests
 {
     public class TextAnalyticsClientLiveTests : TextAnalyticsClientLiveTestBase
     {
-        public TextAnalyticsClientLiveTests(bool isAsync) : base(isAsync) { }
+        public TextAnalyticsClientLiveTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync, serviceVersion)
+        {
+        }
 
         [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
         public async Task TextWithEmoji()
         {
             TextAnalyticsClient client = GetClient();
@@ -28,6 +32,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
         public async Task TextWithStringIndexType()
         {
             TextAnalyticsClient client = GetClient();
@@ -51,6 +56,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
         public async Task TextWithDiacriticsNFC()
         {
             TextAnalyticsClient client = GetClient();
@@ -65,6 +71,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_5)]
         public async Task TextInKoreanNFC()
         {
             TextAnalyticsClient client = GetClient();


### PR DESCRIPTION
Enable multi-version support.
- Adds a transform to swagger (service is adding this to swagger, so when it is merged I will delete the transform)
- Adds tests fixture so we can test `v3.0` and `v3.1-preview5` with the current SDK version
- Add information about different versions in Readme
- Methods and properties affected by version have docs updated

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/20858