### PR TITLE
[TA] Add None to PiiEntityDomainType and rename

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
 ## 5.1.0-beta.8 (Unreleased)
+### New features
+- Added value `None` to enum `PiiEntityDomainType` to allow user to specify no domain.
+
 ### Breaking changes
 - Renamed `StartAnalyzeBatchActions` to `StartAnalyzeActions`.
 - Renamed `AnalyzeBatchActionsOperation` to `AnalyzeActionsOperation`.
@@ -13,6 +16,7 @@
   - `RecognizeLinkedEntitiesOptions` changed to new type `RecognizeLinkedEntitiesActions`.
   - `AnalyzeSentimentOptions` changed to new type `AnalyzeSentimentActions`.
 - Renamed type `TextAnalyticsActionDetails` to `TextAnalyticsActionResult`.
+- Changed type `RecognizePiiEntitiesOptions.DomainFilter` from `PiiEntityDomainType?` to `PiiEntityDomainType`.
 
 ## 5.1.0-beta.7 (2021-05-18)
 ### New features

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -17,6 +17,7 @@
   - `AnalyzeSentimentOptions` changed to new type `AnalyzeSentimentActions`.
 - Renamed type `TextAnalyticsActionDetails` to `TextAnalyticsActionResult`.
 - Changed type `RecognizePiiEntitiesOptions.DomainFilter` from `PiiEntityDomainType?` to `PiiEntityDomainType`.
+- Renamed type `PiiEntityDomainType` to `PiiEntityDomain`.
 
 ## 5.1.0-beta.7 (2021-05-18)
 ### New features

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -557,7 +557,7 @@ namespace Azure.AI.TextAnalytics
         public string RedactedText { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.TextAnalyticsWarning> Warnings { get { throw null; } }
     }
-    public enum PiiEntityDomainType
+    public enum PiiEntityDomain
     {
         None = 0,
         ProtectedHealthInformation = 1,
@@ -623,7 +623,7 @@ namespace Azure.AI.TextAnalytics
     {
         public RecognizePiiEntitiesOptions() { }
         public System.Collections.Generic.IList<Azure.AI.TextAnalytics.PiiEntityCategory> CategoriesFilter { get { throw null; } }
-        public Azure.AI.TextAnalytics.PiiEntityDomainType DomainFilter { get { throw null; } set { } }
+        public Azure.AI.TextAnalytics.PiiEntityDomain DomainFilter { get { throw null; } set { } }
     }
     public partial class RecognizePiiEntitiesResult : Azure.AI.TextAnalytics.TextAnalyticsResult
     {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -559,7 +559,8 @@ namespace Azure.AI.TextAnalytics
     }
     public enum PiiEntityDomainType
     {
-        ProtectedHealthInformation = 0,
+        None = 0,
+        ProtectedHealthInformation = 1,
     }
     public partial class RecognizeEntitiesAction : Azure.AI.TextAnalytics.RecognizeEntitiesOptions
     {
@@ -622,7 +623,7 @@ namespace Azure.AI.TextAnalytics
     {
         public RecognizePiiEntitiesOptions() { }
         public System.Collections.Generic.IList<Azure.AI.TextAnalytics.PiiEntityCategory> CategoriesFilter { get { throw null; } }
-        public Azure.AI.TextAnalytics.PiiEntityDomainType? DomainFilter { get { throw null; } set { } }
+        public Azure.AI.TextAnalytics.PiiEntityDomainType DomainFilter { get { throw null; } set { } }
     }
     public partial class RecognizePiiEntitiesResult : Azure.AI.TextAnalytics.TextAnalyticsResult
     {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/PiiEntityDomain.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/PiiEntityDomain.cs
@@ -6,7 +6,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// The different domains of PII entities that users can filter requests by.
     /// </summary>
-    public enum PiiEntityDomainType
+    public enum PiiEntityDomain
     {
         /// <summary>
         /// Don't apply any domain filter. This is the default value.
@@ -20,14 +20,14 @@ namespace Azure.AI.TextAnalytics
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "Small extensions, good to keep here.")]
-    internal static class PiiEntityDomainTypeExtensions
+    internal static class PiiEntityDomainExtensions
     {
-        internal static string GetString(this PiiEntityDomainType type)
+        internal static string GetString(this PiiEntityDomain type)
         {
             return type switch
             {
-                PiiEntityDomainType.None => null,
-                PiiEntityDomainType.ProtectedHealthInformation => "phi",
+                PiiEntityDomain.None => null,
+                PiiEntityDomain.ProtectedHealthInformation => "phi",
                 _ => null,
             };
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/PiiEntityDomainType.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/PiiEntityDomainType.cs
@@ -9,6 +9,10 @@ namespace Azure.AI.TextAnalytics
     public enum PiiEntityDomainType
     {
         /// <summary>
+        /// Don't apply any domain filter. This is the default value.
+        /// </summary>
+        None,
+        /// <summary>
         /// Protected Health Information entities.
         /// For more information see <see href="https://aka.ms/tanerpii"/>.
         /// </summary>
@@ -22,6 +26,7 @@ namespace Azure.AI.TextAnalytics
         {
             return type switch
             {
+                PiiEntityDomainType.None => null,
                 PiiEntityDomainType.ProtectedHealthInformation => "phi",
                 _ => null,
             };

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesOptions.cs
@@ -26,7 +26,7 @@ namespace Azure.AI.TextAnalytics
         /// Filters the response entities to ones only included in the specified domain.
         /// For more information see <see href="https://aka.ms/tanerpii"/>.
         /// </summary>
-        public PiiEntityDomainType? DomainFilter { get; set; }
+        public PiiEntityDomainType DomainFilter { get; set; }
 
         /// <summary>
         /// Filters the response entities to entities that match the <see cref="PiiEntityCategory"/> specified.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesOptions.cs
@@ -26,7 +26,7 @@ namespace Azure.AI.TextAnalytics
         /// Filters the response entities to ones only included in the specified domain.
         /// For more information see <see href="https://aka.ms/tanerpii"/>.
         /// </summary>
-        public PiiEntityDomainType DomainFilter { get; set; }
+        public PiiEntityDomain DomainFilter { get; set; }
 
         /// <summary>
         /// Filters the response entities to entities that match the <see cref="PiiEntityCategory"/> specified.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -910,7 +910,7 @@ namespace Azure.AI.TextAnalytics
                     options.ModelVersion,
                     options.IncludeStatistics,
                     options.DisableServiceLogs,
-                    options.DomainFilter.HasValue ? options.DomainFilter.Value.GetString() : null,
+                    options.DomainFilter.GetString(),
                     options.StringIndexType,
                     options.CategoriesFilter.Count == 0 ? null : options.CategoriesFilter,
                     cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -977,7 +977,7 @@ namespace Azure.AI.TextAnalytics
                     options.ModelVersion,
                     options.IncludeStatistics,
                     options.DisableServiceLogs,
-                    options.DomainFilter.HasValue ? options.DomainFilter.Value.GetString() : null,
+                    options.DomainFilter.GetString(),
                     options.StringIndexType,
                     options.CategoriesFilter.Count == 0 ? null : options.CategoriesFilter,
                     cancellationToken: cancellationToken);
@@ -1145,7 +1145,7 @@ namespace Azure.AI.TextAnalytics
                     options.ModelVersion,
                     options.IncludeStatistics,
                     options.DisableServiceLogs,
-                    options.DomainFilter.HasValue ? options.DomainFilter.Value.GetString() : null,
+                    options.DomainFilter.GetString(),
                     options.StringIndexType,
                     options.CategoriesFilter.Count == 0 ? null : options.CategoriesFilter,
                     cancellationToken).ConfigureAwait(false);
@@ -1174,7 +1174,7 @@ namespace Azure.AI.TextAnalytics
                     options.ModelVersion,
                     options.IncludeStatistics,
                     options.DisableServiceLogs,
-                    options.DomainFilter.HasValue ? options.DomainFilter.Value.GetString() : null,
+                    options.DomainFilter.GetString(),
                     options.StringIndexType,
                     options.CategoriesFilter.Count == 0 ? null : options.CategoriesFilter,
                     cancellationToken);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
@@ -326,7 +326,7 @@ namespace Azure.AI.TextAnalytics
             {
                 Parameters = new PiiTaskParameters()
                 {
-                    Domain = action.DomainFilter.HasValue ? action.DomainFilter.Value.GetString() : (PiiTaskParametersDomain?)null,
+                    Domain = action.DomainFilter.GetString() ?? (PiiTaskParametersDomain?)null,
                     ModelVersion = action.ModelVersion,
                     StringIndexType = action.StringIndexType,
                     LoggingOptOut = action.DisableServiceLogs

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
@@ -415,7 +415,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() { DomainFilter = PiiEntityDomainType.ProtectedHealthInformation } },
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() { DomainFilter = PiiEntityDomain.ProtectedHealthInformation } },
                 DisplayName = "AnalyzeOperationWithPHIDomain",
             };
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
@@ -81,7 +81,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = "I work at Microsoft and my email is atest@microsoft.com";
 
-            PiiEntityCollection entities = await client.RecognizePiiEntitiesAsync(document, "en", new RecognizePiiEntitiesOptions() { DomainFilter = PiiEntityDomainType.ProtectedHealthInformation } );
+            PiiEntityCollection entities = await client.RecognizePiiEntitiesAsync(document, "en", new RecognizePiiEntitiesOptions() { DomainFilter = PiiEntityDomain.ProtectedHealthInformation } );
 
             ValidateInDocumenResult(entities, new List<string>() { "atest@microsoft.com", "Microsoft" });
         }
@@ -206,7 +206,7 @@ namespace Azure.AI.TextAnalytics.Tests
         {
             TextAnalyticsClient client = GetClient();
 
-            RecognizePiiEntitiesResultCollection results = await client.RecognizePiiEntitiesBatchAsync(s_batchDocuments, new RecognizePiiEntitiesOptions() { DomainFilter = PiiEntityDomainType.ProtectedHealthInformation });
+            RecognizePiiEntitiesResultCollection results = await client.RecognizePiiEntitiesBatchAsync(s_batchDocuments, new RecognizePiiEntitiesOptions() { DomainFilter = PiiEntityDomain.ProtectedHealthInformation });
 
             var expectedOutput = new Dictionary<string, List<string>>()
             {


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/21343

Feedback from API View so our input enums are not nullable. Note how `None` is the default value so if the user doesn't set a domain, there are no changes in the request we do to the service. This is why no re-recording was necessary.

It also Fixes: https://github.com/Azure/azure-sdk-for-net/issues/21372
Where it renames `PiiEntityDomainType` to `PiiEntityDomain` according to feedback we also got 