### PR TITLE
Add missing credential type to DefaultAzureCredential class XML doc

### DIFF
--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -21,6 +21,7 @@ namespace Azure.Identity
     /// <item><description><see cref="VisualStudioCredential"/></description></item>
     /// <item><description><see cref="VisualStudioCodeCredential"/></description></item>
     /// <item><description><see cref="AzureCliCredential"/></description></item>
+    /// <item><description><see cref="AzurePowerShellCredential"/></description></item>
     /// <item><description><see cref="InteractiveBrowserCredential"/></description></item>
     /// </list>
     /// Consult the documentation of these credential types for more information on how they attempt authentication.


### PR DESCRIPTION
Update the XML docs for the `DefaultAzureCredential` class so that `AzurePowerShellCredential` is listed as a credential type to be attempted.