### PR TITLE
Fix null ref exception in Listener

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -278,10 +278,13 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                         {
                             try
                             {
-                                receiver = await sessionClient.AcceptNextSessionAsync(_entityPath, new ServiceBusSessionReceiverOptions
-                                {
-                                    PrefetchCount = _serviceBusOptions.PrefetchCount
-                                }).ConfigureAwait(false);
+                                receiver = await sessionClient.AcceptNextSessionAsync(
+                                    _entityPath,
+                                    new ServiceBusSessionReceiverOptions
+                                    {
+                                        PrefetchCount = _serviceBusOptions.PrefetchCount
+                                    },
+                                    cancellationToken).ConfigureAwait(false);
                             }
                             catch (ServiceBusException ex)
                             when (ex.Reason == ServiceBusFailureReason.ServiceTimeout)
@@ -292,9 +295,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                         }
 
                         IReadOnlyList<ServiceBusReceivedMessage> messages =
-                            await receiver.ReceiveMessagesAsync(_serviceBusOptions.MaxBatchSize).ConfigureAwait(false);
+                            await receiver.ReceiveMessagesAsync(
+                                _serviceBusOptions.MaxBatchSize,
+                                cancellationToken: cancellationToken)
+                                .ConfigureAwait(false);
 
-                        if (messages != null)
+                        if (messages.Count > 0)
                         {
                             ServiceBusReceivedMessage[] messagesArray = messages.ToArray();
                             ServiceBusTriggerInput input = ServiceBusTriggerInput.CreateBatch(messagesArray);
@@ -321,7 +327,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                                     List<Task> completeTasks = new List<Task>();
                                     foreach (ServiceBusReceivedMessage message in messagesArray)
                                     {
-                                        completeTasks.Add(receiver.CompleteMessageAsync(message));
+                                        completeTasks.Add(receiver.CompleteMessageAsync(message, cancellationToken));
                                     }
                                     await Task.WhenAll(completeTasks).ConfigureAwait(false);
                                 }
@@ -330,7 +336,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                                     List<Task> abandonTasks = new List<Task>();
                                     foreach (ServiceBusReceivedMessage message in messagesArray)
                                     {
-                                        abandonTasks.Add(receiver.AbandonMessageAsync(message));
+                                        abandonTasks.Add(receiver.AbandonMessageAsync(message, cancellationToken: cancellationToken));
                                     }
                                     await Task.WhenAll(abandonTasks).ConfigureAwait(false);
                                 }
@@ -341,7 +347,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                             // Close the session and release the session lock after draining all messages for the accepted session.
                             if (_isSessionsEnabled)
                             {
-                                await receiver.CloseAsync().ConfigureAwait(false);
+                                // Use CancellationToken.None to attempt to close the receiver even when shutting down
+                                await receiver.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                             }
                         }
                     }
@@ -359,7 +366,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                             // Attempt to close the session and release session lock to accept a new session on the next loop iteration
                             try
                             {
-                                await receiver.CloseAsync().ConfigureAwait(false);
+                                // Use CancellationToken.None to attempt to close the receiver even when shutting down
+                                await receiver.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                             }
                             catch
                             {

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/MessageProcessor.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/MessageProcessor.cs
@@ -66,8 +66,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 throw new ArgumentNullException(nameof(result));
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
-
             if (!result.Succeeded)
             {
                 // if the invocation failed, we must propagate the

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/SessionMessageProcessor.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/SessionMessageProcessor.cs
@@ -58,8 +58,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 throw new ArgumentNullException(nameof(result));
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
-
             if (!result.Succeeded)
             {
                 // if the invocation failed, we must propagate the

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         {
             var host = BuildHost<ServiceBusMultipleMessagesTestJob_BindToJObject_RespectsCustomJsonSettings>(
                 configurationDelegate: host =>
-                    host.ConfigureDefaultTestHost<ServiceBusMultipleMessagesTestJob_BindToJObject_RespectsCustomJsonSettings>(b =>
+                    host.ConfigureWebJobs(b =>
                     {
                         b.AddServiceBus(options =>
                         {

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -450,8 +450,9 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.AreEqual("E2E-SBQueue2SBQueue-SBQueue2SBTopic-topic-1", _resultMessage1);
             Assert.AreEqual("E2E-SBQueue2SBQueue-SBQueue2SBTopic-topic-2", _resultMessage2);
 
+            AssertNoLoggedErrors(host);
+
             IEnumerable<LogMessage> logMessages = host.GetTestLoggerProvider().GetAllLogMessages();
-            Assert.False(logMessages.Any(p => p.Level == LogLevel.Error));
 
             // Filter out Azure SDK and custom processor logs for easier validation.
             logMessages = logMessages.Where(

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Test]
         public async Task ServiceBusSessionQueue_OrderGuaranteed()
         {
-            var (jobHost, host) = BuildSessionHost<ServiceBusSessionsTestJobs1>();
-            using (jobHost)
+            var host = BuildSessionHost<ServiceBusSessionsTestJobs1>();
+            using (host)
             {
                 await WriteQueueMessage("message1", "test-session1");
                 await WriteQueueMessage("message2", "test-session1");
@@ -50,15 +50,15 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     StringAssert.StartsWith("message" + i++, logMessage.FormattedMessage);
                 }
 
-                await jobHost.StopAsync();
+                await host.StopAsync();
             }
         }
 
         [Test]
         public async Task ServiceBusSessionTopicSubscription_OrderGuaranteed()
         {
-            var (jobHost, host) = BuildSessionHost<ServiceBusSessionsTestJobs1>();
-            using (jobHost)
+            var host = BuildSessionHost<ServiceBusSessionsTestJobs1>();
+            using (host)
             {
                 await WriteTopicMessage("message1", "test-session1");
                 await WriteTopicMessage("message2", "test-session1");
@@ -77,17 +77,17 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     StringAssert.StartsWith("message" + i++, logMessage.FormattedMessage);
                 }
 
-                await jobHost.StopAsync();
+                await host.StopAsync();
             }
         }
 
         [Test]
         public async Task ServiceBusSessionQueue_DifferentHosts_DifferentSessions()
         {
-            var (jobHost1, host1) = BuildSessionHost<ServiceBusSessionsTestJobs1>(true);
-            var (jobHost2, host2) = BuildSessionHost<ServiceBusSessionsTestJobs2>(true);
-            using (jobHost1)
-            using (jobHost2)
+            var host1 = BuildSessionHost<ServiceBusSessionsTestJobs1>(true);
+            var host2 = BuildSessionHost<ServiceBusSessionsTestJobs2>(true);
+            using (host1)
+            using (host2)
             {
                 await WriteQueueMessage("message1", "test-session1");
                 await WriteQueueMessage("message1", "test-session2");
@@ -137,18 +137,18 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     Assert.AreEqual(sessionId2, m.FormattedMessage[m.FormattedMessage.Length - 1]);
                 }
 
-                await jobHost1.StopAsync();
-                await jobHost2.StopAsync();
+                await host1.StopAsync();
+                await host2.StopAsync();
             }
         }
 
         [Test]
         public async Task ServiceBusSessionSub_DifferentHosts_DifferentSessions()
         {
-            var (jobHost1, host1) = BuildSessionHost<ServiceBusSessionsTestJobs1>(true);
-            var (jobHost2, host2) = BuildSessionHost<ServiceBusSessionsTestJobs2>(true);
-            using (jobHost1)
-            using (jobHost2)
+            var host1 = BuildSessionHost<ServiceBusSessionsTestJobs1>(true);
+            var host2 = BuildSessionHost<ServiceBusSessionsTestJobs2>(true);
+            using (host1)
+            using (host2)
             {
                 await WriteTopicMessage("message1", "test-session1");
                 await WriteTopicMessage("message1", "test-session2");
@@ -199,16 +199,16 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     Assert.AreEqual(sessionId2, m.FormattedMessage[m.FormattedMessage.Length - 1]);
                 }
 
-                await jobHost1.StopAsync();
-                await jobHost2.StopAsync();
+                await host1.StopAsync();
+                await host2.StopAsync();
             }
         }
 
         [Test]
         public async Task ServiceBusSessionQueue_SessionLocks()
         {
-            var (jobHost, host) = BuildSessionHost<ServiceBusSessionsTestJobs1>(addCustomProvider: true);
-            using (jobHost)
+            var host = BuildSessionHost<ServiceBusSessionsTestJobs1>(addCustomProvider: true);
+            using (host)
             {
                 await WriteQueueMessage("message1", "test-session1");
                 await WriteQueueMessage("message1", "test-session2");
@@ -247,15 +247,15 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                             logMessages[5].FormattedMessage[logMessages[0].FormattedMessage.Length - 1]);
                     }
                 }
-                await jobHost.StopAsync();
+                await host.StopAsync();
             }
         }
 
         [Test]
         public async Task ServiceBusSessionSub_SessionLocks()
         {
-            var (jobHost, host) = BuildSessionHost<ServiceBusSessionsTestJobs1>(addCustomProvider: true);
-            using (jobHost)
+            var host = BuildSessionHost<ServiceBusSessionsTestJobs1>(addCustomProvider: true);
+            using (host)
             {
                 await WriteTopicMessage("message1", "test-session1");
                 await WriteTopicMessage("message1", "test-session2");
@@ -295,7 +295,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     }
                 }
 
-                await jobHost.StopAsync();
+                await host.StopAsync();
             }
         }
 
@@ -366,7 +366,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
          * Helper functions
          */
 
-        private (JobHost JobHost, IHost Host) BuildSessionHost<T>(bool addCustomProvider = false, bool autoComplete = true)
+        private IHost BuildSessionHost<T>(bool addCustomProvider = false, bool autoComplete = true)
         {
             return BuildHost<T>(builder =>
                 builder.ConfigureWebJobs(b =>
@@ -397,8 +397,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 await WriteTopicMessage(DrainingTopicMessageBody, _drainModeSessionId);
             }
-            var (jobHost, host) = BuildSessionHost<T>(false, false);
-            using (jobHost)
+            var host = BuildSessionHost<T>(false, false);
+            using (host)
             {
                 // Wait to ensure function invocatoin has started before draining messages
                 Assert.True(_drainValidationPreDelay.WaitOne(SBTimeoutMills));
@@ -409,7 +409,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 // Validate that function execution was allowed to complete
                 Assert.True(_drainValidationPostDelay.WaitOne(DrainWaitTimeoutMills + SBTimeoutMills));
-                await jobHost.StopAsync();
+                await host.StopAsync();
             }
         }
 
@@ -425,12 +425,12 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 await WriteQueueMessage("{'Name': 'Test1', 'Value': 'Value'}", "sessionId");
                 await WriteQueueMessage("{'Name': 'Test2', 'Value': 'Value'}", "sessionId");
             }
-            var (jobHost, host) = BuildSessionHost<T>(true);
-            using (jobHost)
+            var host = BuildSessionHost<T>(true);
+            using (host)
             {
                 bool result = _waitHandle1.WaitOne(SBTimeoutMills);
                 Assert.True(result);
-                await jobHost.StopAsync();
+                await host.StopAsync();
             }
         }
 
@@ -444,8 +444,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 await WriteTopicMessage(DrainingTopicMessageBody, _drainModeSessionId);
             }
-            var (jobHost, host) = BuildSessionHost<T>(false, false);
-            using (jobHost)
+            var host = BuildSessionHost<T>(false, false);
+            using (host)
             {
                 // Wait to ensure function invocatoin has started before draining messages
                 Assert.True(_drainValidationPreDelay.WaitOne(SBTimeoutMills));
@@ -456,7 +456,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 // Validate that function execution was allowed to complete
                 Assert.True(_drainValidationPostDelay.WaitOne(DrainWaitTimeoutMills + SBTimeoutMills));
-                await jobHost.StopAsync();
+                await host.StopAsync();
             }
         }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -51,7 +51,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 }
 
                 await jobHost.StopAsync();
-                AssertNoLoggedErrors(host);
             }
         }
 
@@ -79,7 +78,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 }
 
                 await jobHost.StopAsync();
-                AssertNoLoggedErrors(host);
             }
         }
 
@@ -141,8 +139,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 await jobHost1.StopAsync();
                 await jobHost2.StopAsync();
-                AssertNoLoggedErrors(host1);
-                AssertNoLoggedErrors(host2);
             }
         }
 
@@ -205,8 +201,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 await jobHost1.StopAsync();
                 await jobHost2.StopAsync();
-                AssertNoLoggedErrors(host1);
-                AssertNoLoggedErrors(host2);
             }
         }
 
@@ -254,7 +248,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     }
                 }
                 await jobHost.StopAsync();
-                AssertNoLoggedErrors(host);
             }
         }
 
@@ -303,7 +296,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 }
 
                 await jobHost.StopAsync();
-                AssertNoLoggedErrors(host);
             }
         }
 
@@ -439,7 +431,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 bool result = _waitHandle1.WaitOne(SBTimeoutMills);
                 Assert.True(result);
                 await jobHost.StopAsync();
-                AssertNoLoggedErrors(host);
             }
         }
 
@@ -466,7 +457,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 // Validate that function execution was allowed to complete
                 Assert.True(_drainValidationPostDelay.WaitOne(DrainWaitTimeoutMills + SBTimeoutMills));
                 await jobHost.StopAsync();
-                AssertNoLoggedErrors(host);
             }
         }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 }
 
                 await jobHost.StopAsync();
+                AssertNoLoggedErrors(host);
             }
         }
 
@@ -78,6 +79,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 }
 
                 await jobHost.StopAsync();
+                AssertNoLoggedErrors(host);
             }
         }
 
@@ -139,6 +141,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 await jobHost1.StopAsync();
                 await jobHost2.StopAsync();
+                AssertNoLoggedErrors(host1);
+                AssertNoLoggedErrors(host2);
             }
         }
 
@@ -201,6 +205,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 await jobHost1.StopAsync();
                 await jobHost2.StopAsync();
+                AssertNoLoggedErrors(host1);
+                AssertNoLoggedErrors(host2);
             }
         }
 
@@ -248,6 +254,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     }
                 }
                 await jobHost.StopAsync();
+                AssertNoLoggedErrors(host);
             }
         }
 
@@ -296,6 +303,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 }
 
                 await jobHost.StopAsync();
+                AssertNoLoggedErrors(host);
             }
         }
 
@@ -425,12 +433,13 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 await WriteQueueMessage("{'Name': 'Test1', 'Value': 'Value'}", "sessionId");
                 await WriteQueueMessage("{'Name': 'Test2', 'Value': 'Value'}", "sessionId");
             }
-            var (jobHost, _) = BuildSessionHost<T>(true);
+            var (jobHost, host) = BuildSessionHost<T>(true);
             using (jobHost)
             {
                 bool result = _waitHandle1.WaitOne(SBTimeoutMills);
                 Assert.True(result);
                 await jobHost.StopAsync();
+                AssertNoLoggedErrors(host);
             }
         }
 
@@ -457,6 +466,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 // Validate that function execution was allowed to complete
                 Assert.True(_drainValidationPostDelay.WaitOne(DrainWaitTimeoutMills + SBTimeoutMills));
                 await jobHost.StopAsync();
+                AssertNoLoggedErrors(host);
             }
         }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,6 +16,7 @@ using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using static Azure.Messaging.ServiceBus.Tests.ServiceBusScope;
 
@@ -214,6 +216,13 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 messageObj.SessionId = sessionId;
             }
             await sender.SendMessageAsync(messageObj);
+        }
+
+        internal static void AssertNoLoggedErrors(IHost host)
+        {
+            var logs = host.GetTestLoggerProvider().GetAllLogMessages();
+            var errors = logs.Where(p => p.Level == LogLevel.Error);
+            Assert.IsEmpty(errors, string.Join(",", errors.Select(e => e.FormattedMessage)));
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             await _topicScope.DisposeAsync();
         }
 
-        protected (JobHost JobHost, IHost Host) BuildHost<TJobClass>(
+        protected IHost BuildHost<TJobClass>(
             Action<IHostBuilder> configurationDelegate = null,
             bool startHost = true,
             bool useTokenCredential = false)
@@ -167,8 +167,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 host.StartAsync().GetAwaiter().GetResult();
             }
 
-            JobHost jobHost = host.GetJobHost();
-            return (jobHost, host);
+            return host;
         }
 
         internal async Task WriteQueueMessage(string message, string sessionId = null, string connectionString = default, string queueName = default)


### PR DESCRIPTION
- Fix null ref exception in listener (https://github.com/Azure/azure-sdk-for-net/issues/21359)
- Pass cancellation token to SB methods in listener
- Add checks for logged errors in tests
- Remove unnecessary ThrowIfCancellationRequested from processor Complete method