### PR TITLE
Update test results titles to include service directory and cloud names

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -137,7 +137,7 @@ jobs:
         displayName: "Publish Results ($(TestTargetFramework))"
         inputs:
           testResultsFiles: "**/*.trx"
-          testRunTitle: "$(TestTargetFramework)"
+          testRunTitle: "${{ parameters.ServiceDirectory }} ${{ parameters.CloudConfig.Cloud }} $(Agent.JobName)"
           testResultsFormat: "VSTest"
           mergeTestResults: true
 


### PR DESCRIPTION
When testing with multiple clouds, it can be hard to tell from the coverage view which failures come from which cloud and/or job.