### PR TITLE
[Event Hubs Client] Capture Unobserved AMQP Link Close Errors

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 5.5.0-beta.1 (Unreleased)
 
-## 5.5.0-beta.1 (Unreleased)
-
 ### Acknowledgments
 
 Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
@@ -14,7 +12,15 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 #### New Features
 
--  When stopping, the `EventProcessorClient` will now attempt to force-close the connection to the Event Hubs service to abort in-process read operations blocked on their timeout.  This should significantly help reduce the amount of time the processor takes to stop in many scenarios. _(Based on a community prototype contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_
+-  When stopping, the `EventProcessorClient` will now attempt to force-close the connection to the Event Hubs service to abort in-process read operations blocked on their timeout.  This should significantly help reduce the amount of time the processor takes to stop in many scenarios. _(Based on a community prototype contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_  
+
+- When the `EventProcessorClient` detects a partition being stolen outside of a load balancing cycle, it will immediately surrender ownership rather than waiting for a load balancing cycle to confirm the ownership change.  This will help reduce event duplication from overlapping ownership of processors.
+
+#### Key Bug Fixes
+
+- The `EventProcessorClient` will now properly respect another another consumer stealing ownership of a partition when the service forcibly terminates the active link in the background.  Previously, the client did not observe the error directly and attempted to recover the faulted link which reasserted ownership and caused the partition to "bounce" between owners until a load balancing cycle completed.
+
+- The  `EventProcessorClient` will now be less aggressive when considering whether or not to steal a partition, doing so only when it will correct an imbalance and preferring the status quo when the overall distribution would not change.  This will help reduce event duplication due to partitions moving between owners.
 
 ## 5.4.1 (2021-05-11)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/PartitionLoadBalancer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/PartitionLoadBalancer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -99,7 +100,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///   The set of partition ownership the associated event processor owns.  Partition ids are used as keys.
         /// </summary>
         ///
-        private Dictionary<string, EventProcessorPartitionOwnership> InstanceOwnership { get; set; } = new Dictionary<string, EventProcessorPartitionOwnership>();
+        private ConcurrentDictionary<string, EventProcessorPartitionOwnership> InstanceOwnership { get; set; } = new ConcurrentDictionary<string, EventProcessorPartitionOwnership>();
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="PartitionLoadBalancer" /> class.
@@ -298,6 +299,16 @@ namespace Azure.Messaging.EventHubs.Primitives
         }
 
         /// <summary>
+        ///   Allows reporting that a partition was stolen by another event consumer causing ownership
+        ///   to be considered relinquished until the next load balancing cycle reconciles with persisted
+        ///   state.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition that was stolen.</param>
+        ///
+        public virtual void ReportPartitionStolen(string partitionId) => InstanceOwnership.TryRemove(partitionId, out _);
+
+        /// <summary>
         ///   Finds and tries to claim an ownership if this processor instance is eligible to increase its ownership list.
         /// </summary>
         ///
@@ -389,9 +400,11 @@ namespace Azure.Messaging.EventHubs.Primitives
                     }
                 }
 
-                // If this processor has less than the minimum or any other processor has more than the maximum, then we need to steal a partition.
+                // If this processor has less than the minimum or it has less than the maximum at the same time another processor has more than the
+                // maximum, then we need to steal a partition.
 
-                if ((ownedPartitionsCount < minimumOwnedPartitionsCount) || (partitionsOwnedByProcessorWithGreaterThanMaximumOwnedPartitionsCount.Count > 0))
+                if ((ownedPartitionsCount < minimumOwnedPartitionsCount)
+                    || (ownedPartitionsCount < maximumOwnedPartitionsCount && partitionsOwnedByProcessorWithGreaterThanMaximumOwnedPartitionsCount.Count > 0))
                 {
                     Logger.ShouldStealPartition(OwnerIdentifier);
 
@@ -476,7 +489,7 @@ namespace Azure.Messaging.EventHubs.Primitives
 
                 foreach (var oldOwnership in ownershipToRenew)
                 {
-                    InstanceOwnership.Remove(oldOwnership.PartitionId);
+                    InstanceOwnership.TryRemove(oldOwnership.PartitionId, out _);
                 }
 
                 foreach (var newOwnership in newOwnerships)
@@ -520,7 +533,6 @@ namespace Azure.Messaging.EventHubs.Primitives
                                                                                                                             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-
             Logger.ClaimOwnershipStart(partitionId);
 
             // We need the eTag from the most recent ownership of this partition, even if it's expired.  We want to keep the offset and

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -367,6 +367,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         public override int GetHashCode() { throw null; }
         protected abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorCheckpoint>> ListCheckpointsAsync(System.Threading.CancellationToken cancellationToken);
         protected abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ListOwnershipAsync(System.Threading.CancellationToken cancellationToken);
+        protected virtual System.Threading.Tasks.Task<string[]> ListPartitionIdsAsync(Azure.Messaging.EventHubs.EventHubConnection connection, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected virtual System.Threading.Tasks.Task OnInitializingPartitionAsync(TPartition partition, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected virtual System.Threading.Tasks.Task OnPartitionProcessingStoppedAsync(TPartition partition, Azure.Messaging.EventHubs.Processor.ProcessingStoppedReason reason, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected abstract System.Threading.Tasks.Task OnProcessingErrorAsync(System.Exception exception, TPartition partition, string operationDescription, System.Threading.CancellationToken cancellationToken);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -182,6 +182,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                     {
                         link.Session?.SafeClose();
                         link.SafeClose();
+                        EventHubsEventSource.Log.FaultTolerantAmqpObjectClose(nameof(RequestResponseAmqpLink), "", EventHubName, "", "", link.TerminalException?.Message);
                     });
             }
             finally
@@ -438,6 +439,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="invalidateConsumerWhenPartitionStolen">Indicates whether or not the consumer should consider itself invalid when a partition is stolen.</param>
         /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         /// <param name="prefetchSizeInBytes">The cache size of the prefetch queue. When set, the link makes a best effort to ensure prefetched messages fit into the specified size.</param>
@@ -449,6 +451,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                                                          EventPosition eventPosition,
                                                          EventHubsRetryPolicy retryPolicy,
                                                          bool trackLastEnqueuedEventProperties,
+                                                         bool invalidateConsumerWhenPartitionStolen,
                                                          long? ownerLevel,
                                                          uint? prefetchCount,
                                                          long? prefetchSizeInBytes)
@@ -462,6 +465,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 partitionId,
                 eventPosition,
                 trackLastEnqueuedEventProperties,
+                invalidateConsumerWhenPartitionStolen,
                 ownerLevel,
                 prefetchCount,
                 prefetchSizeInBytes,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -168,6 +168,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 {
                     link.Session?.SafeClose();
                     link.SafeClose();
+                    EventHubsEventSource.Log.FaultTolerantAmqpObjectClose(nameof(SendingAmqpLink), "", EventHubName, "", PartitionId, link.TerminalException?.Message);
                 });
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
@@ -77,5 +77,22 @@ namespace Azure.Messaging.EventHubs.Amqp
                     return instance;
             }
         }
+
+        /// <summary>
+        ///   Determines whether an exception signifies that a partition was stolen from an Event Hub
+        ///   consumer.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        ///
+        /// <returns><c>true</c> if <paramref name="instance" /> represents a partition being stolen from a consumer; otherwise, <c>false</c>.</returns>
+        ///
+        public static bool IsConsumerPartitionStolenException(this Exception instance) =>
+            instance switch
+            {
+                EventHubsException ex when ex.Reason == EventHubsException.FailureReason.ConsumerDisconnected => true,
+                AmqpException ex when string.Equals(ex.Error.Condition.Value, AmqpErrorCode.Stolen.Value, StringComparison.InvariantCultureIgnoreCase) => true,
+                _ => false
+            };
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -44,6 +44,9 @@ namespace Azure.Messaging.EventHubs.Consumer
         /// <summary>The name of the default consumer group in the Event Hubs service.</summary>
         public const string DefaultConsumerGroupName = "$Default";
 
+        /// <summary>Indicates whether or not the consumer should consider itself invalid when a partition is stolen by another consumer, as determined by the Event Hubs service.</summary>
+        private const bool InvalidateConsumerWhenPartitionIsStolen = false;
+
         /// <summary>The maximum wait time for receiving an event batch for the background publishing operation used for subscriptions.</summary>
         private readonly TimeSpan BackgroundPublishingWaitTime = TimeSpan.FromMilliseconds(250);
 
@@ -455,7 +458,7 @@ namespace Azure.Messaging.EventHubs.Consumer
 
                 try
                 {
-                    transportConsumer = Connection.CreateTransportConsumer(ConsumerGroup, partitionId, startingPosition, RetryPolicy, readOptions.TrackLastEnqueuedEventProperties, readOptions.OwnerLevel, (uint)readOptions.PrefetchCount);
+                    transportConsumer = Connection.CreateTransportConsumer(ConsumerGroup, partitionId, startingPosition, RetryPolicy, readOptions.TrackLastEnqueuedEventProperties, InvalidateConsumerWhenPartitionIsStolen, readOptions.OwnerLevel, (uint)readOptions.PrefetchCount);
                     partitionContext = new PartitionContext(partitionId, transportConsumer);
                     emptyPartitionEvent = new PartitionEvent(partitionContext, null);
                 }
@@ -917,7 +920,7 @@ namespace Azure.Messaging.EventHubs.Consumer
 
             try
             {
-                transportConsumer = Connection.CreateTransportConsumer(ConsumerGroup, partitionId, startingPosition, RetryPolicy, trackLastEnqueuedEventProperties, ownerLevel, prefetchCount);
+                transportConsumer = Connection.CreateTransportConsumer(ConsumerGroup, partitionId, startingPosition, RetryPolicy, trackLastEnqueuedEventProperties, InvalidateConsumerWhenPartitionIsStolen, ownerLevel, prefetchCount);
 
                 if (!ActiveConsumers.TryAdd(publisherId, transportConsumer))
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
@@ -101,6 +101,7 @@ namespace Azure.Messaging.EventHubs.Core
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="invalidateConsumerWhenPartitionStolen">Indicates whether or not the consumer should consider itself invalid when a partition is stolen.</param>
         /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         /// <param name="prefetchSizeInBytes">The cache size of the prefetch queue. When set, the link makes a best effort to ensure prefetched messages fit into the specified size.</param>
@@ -112,6 +113,7 @@ namespace Azure.Messaging.EventHubs.Core
                                                          EventPosition eventPosition,
                                                          EventHubsRetryPolicy retryPolicy,
                                                          bool trackLastEnqueuedEventProperties,
+                                                         bool invalidateConsumerWhenPartitionStolen,
                                                          long? ownerLevel,
                                                          uint? prefetchCount,
                                                          long? prefetchSizeInBytes);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -1094,6 +1094,308 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
+        ///   Indicates that an AMQP object was closed by the <c>FaultTolerantAmqpObject&lt;T&gt;</c> instance that manages it.
+        /// </summary>
+        ///
+        /// <param name="objectTypeName">The name of the AMQP object type being managed; normally this will be a type of AMQP link.</param>
+        /// <param name="identifier">The identifier of the client associated with the AMQP object.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the AMQP object is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the AMQP object is associated with.</param>
+        /// <param name="partitionId">The identifier of the partition that the AMQP object is associated with.</param>
+        /// <param name="errorMessage">The message for any terminal exception that may have occurred.</param>
+        ///
+        [Event(55, Level = EventLevel.Verbose, Message = "An AMQP object of type '{0}' was closed by the fault tolerant manager for client: '{1}', Event Hub: {2}, Consumer Group: {3}, and partition: {4}.  Terminal error message: '{5}'")]
+        public virtual void FaultTolerantAmqpObjectClose(string objectTypeName,
+                                                         string identifier,
+                                                         string eventHubName,
+                                                         string consumerGroup,
+                                                         string partitionId,
+                                                         string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(55, objectTypeName ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that creating an AMQP connection has started.
+        /// </summary>
+        ///
+        /// <param name="endpoint">The service endpoint that the connection is being opened for.</param>
+        /// <param name="transportType">The type of transport being used for the connection</param>
+        ///
+        [Event(56, Level = EventLevel.Verbose, Message = "Beginning creation of an AMQP connection for endpoint: '{0}' using the transport: '{1}`.")]
+        public virtual void AmqpConnectionCreateStart(string endpoint,
+                                                      string transportType)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(56, endpoint ?? string.Empty, transportType ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that creating an AMQP connection has completed.
+        /// </summary>
+        ///
+        /// <param name="endpoint">The service endpoint that the connection is being opened for.</param>
+        /// <param name="transportType">The type of transport being used for the connection</param>
+        ///
+        [Event(57, Level = EventLevel.Verbose, Message = "Completed creation of an AMQP connection for '{0}' using the transport '{1}`.")]
+        public virtual void AmqpConnectionCreateComplete(string endpoint,
+                                                         string transportType)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(57, endpoint ?? string.Empty, transportType ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an exception was encountered while creating an AMQP connection.
+        /// </summary>
+        ///
+        /// <param name="endpoint">The service endpoint that the connection is being opened for.</param>
+        /// <param name="transportType">The type of transport being used for the connection</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(58, Level = EventLevel.Verbose, Message = "An exception occurred while creating an AMQP connection for '{0}' using the transport '{1}`. Error Message: '{2}'")]
+        public virtual void AmqpConnectionCreateStartError(string endpoint,
+                                                           string transportType,
+                                                           string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(58, endpoint ?? string.Empty, transportType ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that creating an AMQP management link has started.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The type of transport being used for the connection</param>
+        ///
+        [Event(59, Level = EventLevel.Verbose, Message = "Beginning creation of an AMQP management link for Event Hub: '{0}'.")]
+        public virtual void AmqpManagementLinkCreateStart(string eventHubName)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(59, eventHubName ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that creating an AMQP management link has completed.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The type of transport being used for the connection</param>
+        ///
+        [Event(60, Level = EventLevel.Verbose, Message = "Completed creation of an AMQP management link for Event Hub: '{0}'.")]
+        public virtual void AmqpManagementLinkCreateComplete(string eventHubName)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(60, eventHubName ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an exception was encountered while creating an AMQP management link.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The type of transport being used for the connection</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(61, Level = EventLevel.Verbose, Message = "An exception occurred while creating an AMQP management link for Event Hub: '{0}'. Error Message: '{1}'")]
+        public virtual void AmqpManagementLinkCreateError(string eventHubName,
+                                                          string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(61, eventHubName ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that creating an AMQP consumer link has started.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The type of transport being used for the connection</param>
+        /// <param name="consumerGroup">The name of the consumer group that is associated with the link.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition associated with the link.</param>
+        /// <param name="ownerLevel">The owner level that is associated with the link.</param>
+        /// <param name="eventPosition">The position in the event stream that the link is being opened for.</param>
+        ///
+        [Event(62, Level = EventLevel.Verbose, Message = "Beginning creation of an AMQP consumer link for Event Hub: '{0}', Consumer Group: '{1}', Partition: '{2}'. (Owner Level: '{3}', Event Position: '{4}')")]
+        public virtual void AmqpConsumerLinkCreateStart(string eventHubName,
+                                                        string consumerGroup,
+                                                        string partitionId,
+                                                        string ownerLevel,
+                                                        string eventPosition)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(62, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty, ownerLevel ?? string.Empty, eventPosition ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that creating an AMQP consumer link has completed.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The type of transport being used for the connection</param>
+        /// <param name="consumerGroup">The name of the consumer group that is associated with the link.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition associated with the link.</param>
+        /// <param name="ownerLevel">The owner level that is associated with the link.</param>
+        /// <param name="eventPosition">The position in the event stream that the link is being opened for.</param>
+        ///
+        [Event(63, Level = EventLevel.Verbose, Message = "Completed creation of an AMQP consumer link for Event Hub: '{0}', Consumer Group: '{1}', Partition: '{2}'. (Owner Level: '{3}', Event Position: '{4}')")]
+        public virtual void AmqpConsumerLinkCreateComplete(string eventHubName,
+                                                           string consumerGroup,
+                                                           string partitionId,
+                                                           string ownerLevel,
+                                                           string eventPosition)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(63, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty, ownerLevel ?? string.Empty, eventPosition ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an exception was encountered while creating an AMQP consumer link.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The type of transport being used for the connection</param>
+        /// <param name="consumerGroup">The name of the consumer group that is associated with the link.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition associated with the link.</param>
+        /// <param name="ownerLevel">The owner level that is associated with the link.</param>
+        /// <param name="eventPosition">The position in the event stream that the link is being opened for.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(64, Level = EventLevel.Verbose, Message = "An exception occurred while creating an AMQP consumer link for Event Hub: '{0}', Consumer Group: '{1}', Partition: '{2}'. (Owner Level: '{3}', Event Position: '{4}') Error Message: '{5}'")]
+        public virtual void AmqpConsumerLinkCreateError(string eventHubName,
+                                                        string consumerGroup,
+                                                        string partitionId,
+                                                        string ownerLevel,
+                                                        string eventPosition,
+                                                        string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(64, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty, ownerLevel ?? string.Empty, eventPosition ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that creating an AMQP producer link has started.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The type of transport being used for the connection</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition associated with the link.</param>
+        /// <param name="featureSet">The set of active features that the link is being opened for.</param>
+        ///
+        [Event(65, Level = EventLevel.Verbose, Message = "Beginning creation of an AMQP producer link for Event Hub: '{0}', Partition: '{1}'. (Active Features: '{2}')")]
+        public virtual void AmqpProducerLinkCreateStart(string eventHubName,
+                                                        string partitionId,
+                                                        string featureSet)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(65, eventHubName ?? string.Empty, partitionId ?? string.Empty, featureSet ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that creating an AMQP producer link has completed.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The type of transport being used for the connection</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition associated with the link.</param>
+        /// <param name="featureSet">The set of active features that the link is being opened for.</param>
+        ///
+        [Event(66, Level = EventLevel.Verbose, Message = "Completed creation of an AMQP producer link for Event Hub: '{0}', Partition: '{1}'. (Active Features: '{2}')")]
+        public virtual void AmqpProducerLinkCreateComplete(string eventHubName,
+                                                           string partitionId,
+                                                           string featureSet)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(66, eventHubName ?? string.Empty, partitionId ?? string.Empty, featureSet ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an exception was encountered while creating an AMQP producer link.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The type of transport being used for the connection</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition associated with the link.</param>
+        /// <param name="featureSet">The set of active features that the link is being opened for.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(67, Level = EventLevel.Verbose, Message = "An exception occurred while creating an AMQP producer link for Event Hub: '{0}', Partition: '{1}'. (Active Features: '{2}') Error Message: '{3}'")]
+        public virtual void AmqpProducerLinkCreateError(string eventHubName,
+                                                        string partitionId,
+                                                        string featureSet,
+                                                        string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(67, eventHubName ?? string.Empty, partitionId ?? string.Empty, featureSet ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that a captured exception is being surfaced during creation an AMQP consumer link.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The type of transport being used for the connection</param>
+        /// <param name="consumerGroup">The name of the consumer group that is associated with the link.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition associated with the link.</param>
+        /// <param name="ownerLevel">The owner level that is associated with the link.</param>
+        /// <param name="eventPosition">The position in the event stream that the link is being opened for.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(68, Level = EventLevel.Verbose, Message = "An exception captured by fault tolerant close is being surfaced during consumer link creation for Event Hub: '{0}', Consumer Group: '{1}', Partition: '{2}'. (Owner Level: '{3}', Event Position: '{4}') Error Message: '{5}'")]
+        public virtual void AmqpConsumerLinkCreateCapturedErrorThrow(string eventHubName,
+                                                                     string consumerGroup,
+                                                                     string partitionId,
+                                                                     string ownerLevel,
+                                                                     string eventPosition,
+                                                                     string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(68, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty, ownerLevel ?? string.Empty, eventPosition ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an exception during closing of the exception is being captured to surface during the
+        ///   next creation attempt.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The type of transport being used for the connection</param>
+        /// <param name="consumerGroup">The name of the consumer group that is associated with the link.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition associated with the link.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(69, Level = EventLevel.Verbose, Message = "An exception during fault tolerant close is being captured to surface when the consumer link is next created for Event Hub: '{0}', Consumer Group: '{1}', Partition: '{2}'. Error Message: '{3}'")]
+        public virtual void AmqpConsumerLinkFaultCapture(string eventHubName,
+                                                         string consumerGroup,
+                                                         string partitionId,
+                                                         string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(69, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
         ///   Indicates that an exception was encountered in an unexpected code path, not directly associated with
         ///   an Event Hubs operation.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -430,6 +431,7 @@ namespace Azure.Messaging.EventHubs
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="invalidateConsumerWhenPartitionStolen">Indicates whether or not the consumer should consider itself invalid when a partition is stolen.</param>
         /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         /// <param name="prefetchSizeInBytes">The cache size of the prefetch queue. When set, the link makes a best effort to ensure prefetched messages fit into the specified size.</param>
@@ -441,6 +443,7 @@ namespace Azure.Messaging.EventHubs
                                                                    EventPosition eventPosition,
                                                                    EventHubsRetryPolicy retryPolicy,
                                                                    bool trackLastEnqueuedEventProperties = true,
+                                                                   bool invalidateConsumerWhenPartitionStolen = false,
                                                                    long? ownerLevel = default,
                                                                    uint? prefetchCount = default,
                                                                    long? prefetchSizeInBytes = default)
@@ -449,7 +452,7 @@ namespace Azure.Messaging.EventHubs
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
 
-            return InnerClient.CreateConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, ownerLevel, prefetchCount, prefetchSizeInBytes);
+            return InnerClient.CreateConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, invalidateConsumerWhenPartitionStolen, ownerLevel, prefetchCount, prefetchSizeInBytes);
         }
 
         /// <summary>
@@ -472,6 +475,7 @@ namespace Azure.Messaging.EventHubs
         ///   creation of clones or otherwise protecting the parameters is assumed to be the purview of the caller.
         /// </remarks>
         ///
+        [SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "`TransportType` is a reasonable name.  It's the property on the options argument which is invalid.")]
         internal virtual TransportClient CreateTransportClient(string fullyQualifiedNamespace,
                                                                string eventHubName,
                                                                EventHubTokenCredential credential,
@@ -484,9 +488,7 @@ namespace Azure.Messaging.EventHubs
                     return new AmqpClient(fullyQualifiedNamespace, eventHubName, credential, options);
 
                 default:
-#pragma warning disable CA2208 // Instantiate argument exceptions correctly.  "TransportType" is a reasonable name.  It's the property on the options argument which is invalid.
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidTransportType, options.TransportType.ToString()), nameof(options.TransportType));
-#pragma warning restore CA2208 // Instantiate argument exceptions correctly
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -38,6 +38,9 @@ namespace Azure.Messaging.EventHubs.Primitives
     ///
     public class PartitionReceiver : IAsyncDisposable
     {
+        /// <summary>Indicates whether or not the consumer should consider itself invalid when a partition is stolen by another consumer, as determined by the Event Hubs service.</summary>
+        private const bool InvalidateConsumerWhenPartitionIsStolen = false;
+
         /// <summary>Indicates whether or not this instance has been closed.</summary>
         private volatile bool _closed;
 
@@ -554,7 +557,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                                                    EventPosition eventPosition,
                                                                    EventHubsRetryPolicy retryPolicy,
                                                                    PartitionReceiverOptions options) =>
-            Connection.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, (uint?)options.PrefetchCount, options.PrefetchSizeInBytes);
+            Connection.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, options.TrackLastEnqueuedEventProperties, InvalidateConsumerWhenPartitionIsStolen, options.OwnerLevel, (uint?)options.PrefetchCount, options.PrefetchSizeInBytes);
 
         /// <summary>
         ///   Receives a batch of <see cref="EventData" /> from the Event Hub partition this client is associated with.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
@@ -732,7 +732,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var client = new AmqpClient("my.eventhub.com", "somePath", credential.Object, new EventHubConnectionOptions());
             await client.CloseAsync(cancellationSource.Token);
 
-            Assert.That(() => client.CreateConsumer("group", "0", EventPosition.Earliest, Mock.Of<EventHubsRetryPolicy>(), false, null, null, null), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+            Assert.That(() => client.CreateConsumer("group", "0", EventPosition.Earliest, Mock.Of<EventHubsRetryPolicy>(), false, false, null, null, null), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -36,6 +37,20 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   The set of test cases for general case exceptions.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> GeneralExceptionTestCases()
+        {
+           yield return new object[] { new Exception() };
+           yield return new object[] { new DivideByZeroException() };
+           yield return new object[] { new OutOfMemoryException() };
+           yield return new object[] { new EventHubsException("test", "fake", EventHubsException.FailureReason.ClientClosed) };
+           yield return new object[] { new EventHubsException(true, "test", "fake", EventHubsException.FailureReason.ServiceBusy) };
+           yield return new object[] { new EventHubsException(false, "test", "fake", EventHubsException.FailureReason.GeneralError) };
+        }
+
+        /// <summary>
         ///   Verifies functionality of the constructor.
         /// </summary>
         ///
@@ -44,7 +59,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheEventHubName(string eventHub)
         {
-            Assert.That(() => new AmqpConsumer(eventHub, "$DEFAULT", "0", EventPosition.Earliest, true, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpConsumer(eventHub, "$DEFAULT", "0", EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -56,7 +71,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheConsumerGroup(string group)
         {
-            Assert.That(() => new AmqpConsumer("myHub", group, "0", EventPosition.Earliest, true, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpConsumer("myHub", group, "0", EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresThePartition(string partition)
         {
-            Assert.That(() => new AmqpConsumer("aHub", "$DEFAULT", partition, EventPosition.Earliest, true, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpConsumer("aHub", "$DEFAULT", partition, EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -78,7 +93,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheConnectionScope()
         {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), true, null, null, null, null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), true, false, null, null, null, null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -88,7 +103,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheMessageConverter()
         {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), true, null, null, null, Mock.Of<AmqpConnectionScope>(), null, Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), null, Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -98,7 +113,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheRetryPolicy()
         {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.Latest, true, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), null), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.Latest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), null), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -109,7 +124,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CloseMarksTheConsumerAsClosed()
         {
-            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, true, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
+            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(consumer.IsClosed, Is.False, "The consumer should not be closed on creation");
 
             await consumer.CloseAsync(CancellationToken.None);
@@ -124,7 +139,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CloseRespectsTheCancellationToken()
         {
-            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, true, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
+            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             using var cancellationSource = new CancellationTokenSource();
 
             cancellationSource.Cancel();
@@ -155,7 +170,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using var cancellationSource = new CancellationTokenSource();
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, true, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(count, null, cancellationSource.Token), Throws.InstanceOf<ArgumentException>());
         }
 
@@ -180,7 +195,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, true, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
@@ -199,6 +214,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partition = "3";
             var eventPosition = EventPosition.FromOffset(123);
             var trackLastEnqueued = false;
+            var invalidateOnSteal = true;
             var ownerLevel = 123L;
             var tokenValue = "123ABC";
             var retryPolicy = new BasicRetryPolicy(retryOptions);
@@ -226,7 +242,7 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
 
             mockScope
@@ -257,6 +273,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partition = "3";
             var eventPosition = EventPosition.FromOffset(123);
             var trackLastEnqueued = false;
+            var invalidateOnSteal = true;
             var ownerLevel = 123L;
             var tokenValue = "123ABC";
             var retryPolicy = new BasicRetryPolicy(retryOptions);
@@ -284,7 +301,7 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
 
             mockScope
@@ -316,6 +333,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partition = "3";
             var eventPosition = EventPosition.FromOffset(123);
             var trackLastEnqueued = false;
+            var invalidateOnSteal = true;
             var ownerLevel = 123L;
             var tokenValue = "123ABC";
             var retryPolicy = new BasicRetryPolicy(retryOptions);
@@ -343,7 +361,7 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
 
             mockScope
@@ -373,6 +391,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partition = "3";
             var eventPosition = EventPosition.FromOffset(123);
             var trackLastEnqueued = false;
+            var invalidateOnSteal = true;
             var ownerLevel = 123L;
             var tokenValue = "123ABC";
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
@@ -400,7 +419,7 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<CancellationToken>()))
                .Throws(embeddedException);
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<OperationCanceledException>());
 
             mockScope
@@ -430,6 +449,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partition = "3";
             var eventPosition = EventPosition.FromOffset(123);
             var trackLastEnqueued = false;
+            var invalidateOnSteal = true;
             var ownerLevel = 123L;
             var tokenValue = "123ABC";
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
@@ -457,7 +477,7 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<CancellationToken>()))
                .Throws(embeddedException);
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<OperationCanceledException>());
 
             mockScope
@@ -495,7 +515,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using var cancellationSource = new CancellationTokenSource();
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, false, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             await consumer.CloseAsync(cancellationSource.Token);
 
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
@@ -519,12 +539,294 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
             var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, null, null, null, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, false, null, null, null, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
 
             scope.Dispose();
 
             Assert.That(async () => await consumer.ReceiveAsync(100, null, CancellationToken.None),
                 Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.CloseConsumerLink "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloseConsumerLinkDetectsAStolenPartition()
+        {
+            var eventHub = "fake-hub";
+            var terminalException = new AmqpException(new Error { Condition = AmqpErrorCode.Stolen });
+            var link = new ReceivingAmqpLink(new AmqpLinkSettings());
+            var mockConsumer = new MockAmqpConsumer(eventHub, true, terminalException);
+
+            try
+            {
+                mockConsumer.InvokeCloseConsumerLink(link);
+                Assert.That(GetActivePartitionStolenException(mockConsumer), Is.SameAs(terminalException));
+            }
+            finally
+            {
+                link?.SafeClose();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.CloseConsumerLink "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(GeneralExceptionTestCases))]
+        public void CloseConsumerLinkIgnoresGeneralExceptions(Exception terminalException)
+        {
+            var eventHub = "fake-hub";
+            var link = new ReceivingAmqpLink(new AmqpLinkSettings());
+            var mockConsumer = new MockAmqpConsumer(eventHub, true, terminalException);
+
+            try
+            {
+                mockConsumer.InvokeCloseConsumerLink(link);
+                Assert.That(GetActivePartitionStolenException(mockConsumer), Is.Null);
+            }
+            finally
+            {
+                link?.SafeClose();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.OpenConsumerLink "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OpenConsumerLinkSurfacesAStolenPartition()
+        {
+            var eventHub = "fake-hub";
+            var terminalException = new EventHubsException(eventHub, "Expected", EventHubsException.FailureReason.ConsumerDisconnected);
+            var capturedException = default(Exception);
+            var mockConsumer = new MockAmqpConsumer(eventHub, true, terminalException);
+
+            SetActivePartitionStolenException(mockConsumer, terminalException);
+
+            try
+            {
+                await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                capturedException = ex;
+            }
+
+            Assert.That(capturedException, Is.Not.Null, "An exception should have been surfaced.");
+            Assert.That(capturedException.GetType(), Is.EqualTo(terminalException.GetType()), "The captured exception was not of the expected type.");
+            Assert.That(capturedException, Is.SameAs(terminalException), "The mocked terminal exception should have been surfaced.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.OpenConsumerLink "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiveAsyncSurfacesStolenPartitionWhenInvalidated()
+        {
+            var eventHub = "fake-hub";
+            var terminalException = new AmqpException(AmqpErrorCode.Stolen, "This is a terminal exception message.");
+            var expectedException = terminalException.TranslateServiceException(eventHub);
+            var capturedException = default(Exception);
+            var mockConsumer = new MockAmqpConsumer(eventHub, true, terminalException);
+
+            SetActivePartitionStolenException(mockConsumer, terminalException);
+
+            try
+            {
+                await mockConsumer.ReceiveAsync(10, TimeSpan.FromSeconds(1), CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                capturedException = ex;
+            }
+
+            Assert.That(capturedException, Is.Not.Null, "An exception should have been surfaced.");
+            Assert.That(capturedException.GetType(), Is.EqualTo(expectedException.GetType()), "The captured exception was not of the expected type.");
+            Assert.That(capturedException.Message, Is.EqualTo(expectedException.Message), "The mocked terminal exception should have been surfaced.");
+
+            // Because the terminal exception was injected, it should not attempt to open the actual link.
+
+            mockConsumer.MockConnectionScope
+               .Verify(scope => scope.OpenConsumerLinkAsync(
+                   It.IsAny<string>(),
+                   It.IsAny<string>(),
+                   It.IsAny<EventPosition>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<uint>(),
+                   It.IsAny<long?>(),
+                   It.IsAny<long?>(),
+                   It.IsAny<bool>(),
+                   It.IsAny<CancellationToken>()),
+               Times.Never);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.OpenConsumerLink "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void OpenConsumerLinkClearsTheStolenExceptionWhenInvalidateIsNotSet()
+        {
+            var eventHub = "fake-hub";
+            var terminalException = new AmqpException(new Error { Condition = AmqpErrorCode.Stolen });
+            var mockConsumer = new MockAmqpConsumer(eventHub, false, terminalException);
+
+            SetActivePartitionStolenException(mockConsumer, terminalException);
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the first call.");
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.Nothing, "The second call should not throw.");
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.Nothing, "The third call should not throw.");
+
+            var capturedException = GetActivePartitionStolenException(mockConsumer);
+            Assert.That(capturedException, Is.Null, "The active exception should have been cleared after it was surfaced.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.OpenConsumerLink "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void OpenConsumerLinkPreservesTheStolenExceptionWhenInvalidateIsSet()
+        {
+            var eventHub = "fake-hub";
+            var terminalException = new EventHubsException(eventHub, "Expected", EventHubsException.FailureReason.ConsumerDisconnected);
+            var mockConsumer = new MockAmqpConsumer(eventHub, true, terminalException);
+
+            SetActivePartitionStolenException(mockConsumer, terminalException);
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the first call.");
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the second call.");
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the third call.");
+
+            var capturedException = GetActivePartitionStolenException(mockConsumer);
+            Assert.That(capturedException, Is.SameAs(terminalException), "The active exception should have been preserved after the calls were completed.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.OpenConsumerLink "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiveAsyncDetectsAndCapturesAStolenPartition()
+        {
+            var eventHub = "fake-hub";
+            var terminalException = new AmqpException(AmqpErrorCode.Stolen, "This is a terminal exception message.");
+            var expectedException = terminalException.TranslateServiceException(eventHub);
+            var capturedException = default(Exception);
+            var mockConsumer = new MockAmqpConsumer(eventHub, true, terminalException);
+
+            mockConsumer.MockConnectionScope
+               .Setup(scope => scope.OpenConsumerLinkAsync(
+                   It.IsAny<string>(),
+                   It.IsAny<string>(),
+                   It.IsAny<EventPosition>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<uint>(),
+                   It.IsAny<long?>(),
+                   It.IsAny<long?>(),
+                   It.IsAny<bool>(),
+                   It.IsAny<CancellationToken>()))
+               .Throws(terminalException);
+
+            try
+            {
+                await mockConsumer.ReceiveAsync(10, TimeSpan.FromSeconds(1), CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                capturedException = ex;
+            }
+
+            Assert.That(capturedException, Is.Not.Null, "An exception should have been surfaced.");
+            Assert.That(capturedException.GetType(), Is.EqualTo(expectedException.GetType()), "The captured exception was not of the expected type.");
+            Assert.That(capturedException.Message, Is.EqualTo(expectedException.Message), "The mocked terminal exception should have been surfaced.");
+
+            var preservedException = GetActivePartitionStolenException(mockConsumer);
+            Assert.That(preservedException, Is.SameAs(terminalException), "The preserved exception should match the terminal exception.");
+        }
+
+        /// <summary>
+        ///   Gets the active partition stolen exception for a consumer, using its
+        ///   private field.
+        /// </summary>
+        ///
+        /// <param name="consumer">The consumer to retrieve the exception from.</param>
+        ///
+        /// <returns>The active partition stolen exception of the <paramref name="consumer"/>, if present; otherwise, <c>null</c>.</returns>
+        ///
+        private Exception GetActivePartitionStolenException(AmqpConsumer consumer) =>
+            (Exception)
+                typeof(AmqpConsumer)
+                    .GetField("_activePartitionStolenException", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(consumer);
+
+        /// <summary>
+        ///   Sets the active partition stolen exception for a consumer, using its
+        ///   private field.
+        /// </summary>
+        ///
+        /// <param name="consumer">The consumer to retrieve the exception from.</param>
+        /// <param name="exception">The exception to set.</param>
+        ///
+        private void SetActivePartitionStolenException(AmqpConsumer consumer,
+                                                       Exception exception) =>
+            typeof(AmqpConsumer)
+                .GetField("_activePartitionStolenException", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(consumer, exception);
+
+        /// <summary>
+        ///   A class that an be used for testing members of the consumer
+        ///   that are not part of the public API surface.
+        /// </summary>
+        ///
+        private class MockAmqpConsumer : AmqpConsumer
+        {
+            public Mock<AmqpConnectionScope> MockConnectionScope;
+            public Exception TransformedTerminalException;
+
+            public MockAmqpConsumer(string eventHubName,
+                                    bool invalidateConsumerWhenPartitionIsStolen) : this(eventHubName, invalidateConsumerWhenPartitionIsStolen, new(), null)
+            {
+            }
+
+            public MockAmqpConsumer(string eventHubName,
+                                    bool invalidateConsumerWhenPartitionIsStolen,
+                                    Exception transformedTerminalException) : this(eventHubName, invalidateConsumerWhenPartitionIsStolen, new(), transformedTerminalException)
+            {
+            }
+
+            public MockAmqpConsumer(string eventHubName,
+                                    bool invalidateConsumerWhenPartitionIsStolen,
+                                    Mock<AmqpConnectionScope> mockConnectionScope,
+                                    Exception transformedTerminalException) : base(eventHubName, "fake", "0", EventPosition.Earliest, true, invalidateConsumerWhenPartitionIsStolen, null, null, null, mockConnectionScope.Object, new(), new BasicRetryPolicy(new()))
+            {
+                MockConnectionScope = mockConnectionScope;
+                TransformedTerminalException = transformedTerminalException;
+            }
+
+            public Task<ReceivingAmqpLink> InvokeCreateConsumerLinkAsync(string consumerGroup,
+                                                                         string partitionId,
+                                                                         EventPosition eventStartingPosition,
+                                                                         uint prefetchCount,
+                                                                         long? prefetchSizeInBytes,
+                                                                         long? ownerLevel,
+                                                                         bool trackLastEnqueuedEventProperties,
+                                                                         TimeSpan timeout,
+                                                                         CancellationToken cancellationToken) => CreateConsumerLinkAsync(consumerGroup, partitionId, eventStartingPosition, prefetchCount, prefetchSizeInBytes, ownerLevel, trackLastEnqueuedEventProperties, timeout, cancellationToken);
+
+            public void InvokeCloseConsumerLink(ReceivingAmqpLink link) => CloseConsumerLink(link);
+
+            protected override Exception GetTerminalException(ReceivingAmqpLink link) => TransformedTerminalException;
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
@@ -753,11 +753,12 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedConsumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
             var expectedRetryPolicy = new EventHubsRetryOptions { MaximumRetries = 67 }.ToRetryPolicy();
             var expectedTrackLastEnqueued = false;
+            var expectedInvalidateConsumerWhenPartitionIsStolen = true;
             var expectedPrefetch = 99U;
             var expectedOwnerLevel = 123L;
 
-            connection.CreateTransportConsumer(expectedConsumerGroup, expectedPartition, expectedPosition, expectedRetryPolicy, expectedTrackLastEnqueued, expectedOwnerLevel, expectedPrefetch);
-            (var actualConsumerGroup, var actualPartition, EventPosition actualPosition, var actualRetry, var actualTrackLastEnqueued, var actualOwnerLevel, var actualPrefetch) = transportClient.CreateConsumerCalledWith;
+            connection.CreateTransportConsumer(expectedConsumerGroup, expectedPartition, expectedPosition, expectedRetryPolicy, expectedTrackLastEnqueued, expectedInvalidateConsumerWhenPartitionIsStolen, expectedOwnerLevel, expectedPrefetch);
+            (var actualConsumerGroup, var actualPartition, EventPosition actualPosition, var actualRetry, var actualTrackLastEnqueued, var actualInvalidateConsumerWhenPartitionIsStolen, var actualOwnerLevel, var actualPrefetch) = transportClient.CreateConsumerCalledWith;
 
             Assert.That(actualPartition, Is.EqualTo(expectedPartition), "The partition should have been passed.");
             Assert.That(actualConsumerGroup, Is.EqualTo(expectedConsumerGroup), "The consumer groups should match.");
@@ -766,6 +767,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(actualOwnerLevel, Is.EqualTo(expectedOwnerLevel), "The owner levels should match.");
             Assert.That(actualPrefetch, Is.EqualTo(expectedPrefetch), "The prefetch counts should match.");
             Assert.That(actualTrackLastEnqueued, Is.EqualTo(expectedTrackLastEnqueued), "The flag for tracking the last enqueued event should match.");
+            Assert.That(actualInvalidateConsumerWhenPartitionIsStolen, Is.EqualTo(expectedInvalidateConsumerWhenPartitionIsStolen), "The flag for invalidating the consumer on a stolen partition should match.");
         }
 
         /// <summary>
@@ -1031,7 +1033,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private class ObservableTransportClientMock : TransportClient
         {
-            public (string ConsumerGroup, string Partition, EventPosition Position, EventHubsRetryPolicy RetryPolicy, bool TrackLastEnqueued, long? OwnerLevel, uint? Prefetch) CreateConsumerCalledWith;
+            public (string ConsumerGroup, string Partition, EventPosition Position, EventHubsRetryPolicy RetryPolicy, bool TrackLastEnqueued, bool InvalidateOnSteal, long? OwnerLevel, uint? Prefetch) CreateConsumerCalledWith;
             public (string PartitionId, TransportProducerFeatures Features, PartitionPublishingOptions PartitionOptions, EventHubsRetryPolicy RetryPolicy) CreateProducerCalledWith;
             public string GetPartitionPropertiesCalledForId;
             public bool WasGetPropertiesCalled;
@@ -1066,11 +1068,12 @@ namespace Azure.Messaging.EventHubs.Tests
                                                              EventPosition eventPosition,
                                                              EventHubsRetryPolicy retryPolicy,
                                                              bool trackLastEnqueuedEventProperties = true,
+                                                             bool invalidateConsumerWhenPartitionIsStolen = false,
                                                              long? ownerLevel = default,
                                                              uint? prefetchCount = default,
                                                              long? prefechSize = default)
             {
-                CreateConsumerCalledWith = (consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, ownerLevel, prefetchCount);
+                CreateConsumerCalledWith = (consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, invalidateConsumerWhenPartitionIsStolen, ownerLevel, prefetchCount);
                 return default;
             }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -1638,7 +1638,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     // The consumer should be able to read events from another partition after being superseded.  Start a new reader for the other partition,
                     // using the same lower level.  Wait for both readers to complete and then signal for cancellation.
 
-                    await Task.Delay(250);
+                    await Task.Delay(TimeSpan.FromSeconds(1), cancellationSource.Token);
                     var lowerReadState = await ReadEventsFromPartitionAsync(consumer, partitions[1], sourceEvents.Count, cancellationSource.Token, readOptions: lowerOptions);
 
                     await Task.WhenAny(higherMonitor.EndCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -632,7 +632,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Task.FromResult(new[] { "0", "1" }));
 
             mockConnection
-                .Setup(conn => conn.CreateTransportConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<long?>(), It.IsAny<uint?>(), It.IsAny<long?>()))
+                .Setup(conn => conn.CreateTransportConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<long?>(), It.IsAny<uint?>(), It.IsAny<long?>()))
                 .Returns(transportConsumer);
 
             await using var enumerator = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), options).GetAsyncEnumerator();
@@ -644,6 +644,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
+                    It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<long?>(),
                     (uint)options.PrefetchCount,
@@ -1367,7 +1368,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Task.FromResult(new[] { "0", "1" }));
 
             mockConnection
-                .Setup(conn => conn.CreateTransportConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<long?>(), It.IsAny<uint?>(), It.IsAny<long?>()))
+                .Setup(conn => conn.CreateTransportConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<long?>(), It.IsAny<uint?>(), It.IsAny<long?>()))
                 .Returns(transportConsumer);
 
             await using var enumerator = consumer.ReadEventsAsync(options).GetAsyncEnumerator();
@@ -1379,6 +1380,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
+                    It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<long?>(),
                     (uint)options.PrefetchCount,
@@ -2558,6 +2560,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                         string partitionId, EventPosition eventPosition,
                                                                         EventHubsRetryPolicy retryPolicy,
                                                                         bool trackLastEnqueuedEventProperties = true,
+                                                                        bool invalidateConsumerWhenPartitionIsStolen = false,
                                                                         long? ownerLevel = default,
                                                                         uint? prefetchCount = default,
                                                                         long? prefetchSizeInBytes = default) => TransportConsumerFactory();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -383,6 +383,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var partition = new EventProcessorPartition { PartitionId = "99" };
             var position = EventPosition.FromOffset(12);
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, PrefetchCount = 37, PrefetchSizeInBytes = 44, LoadBalancingUpdateInterval = TimeSpan.FromMinutes(1) };
+            var expectedOwnerLevel = 0;
+            var expectedInvalidationOnSteal = true;
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockConnection = new Mock<EventHubConnection>();
             var mockConsumer = new Mock<SettableTransportConsumer>();
@@ -402,7 +404,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Task.CompletedTask);
 
             mockConnection
-                .Setup(connection => connection.CreateTransportConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<uint?>(), It.IsAny<long?>()))
+                .Setup(connection => connection.CreateTransportConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<uint?>(), It.IsAny<long?>()))
                 .Returns(mockConsumer.Object);
 
             var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
@@ -417,7 +419,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     position,
                     It.IsAny<EventHubsRetryPolicy>(),
                     options.TrackLastEnqueuedEventProperties,
-                    0,
+                    expectedInvalidationOnSteal,
+                    expectedOwnerLevel,
                     (uint?)options.PrefetchCount,
                     options.PrefetchSizeInBytes),
                 Times.Once);
@@ -1196,6 +1199,146 @@ namespace Azure.Messaging.EventHubs.Tests
                     mockConnection,
                     It.IsAny<EventProcessorOptions>()),
                 Times.AtLeast(2));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskDoesNotReplaceTheConsumerWhenThePartitionIsStolen()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Callback(() => completionSource.TrySetResult(true))
+                .Throws(new EventHubsException("fake", "OMG WTF", EventHubsException.FailureReason.ConsumerDisconnected));
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            cancellationSource.Cancel();
+
+            mockProcessor
+                .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<EventPosition>(),
+                    mockConnection,
+                    It.IsAny<EventProcessorOptions>()),
+                Times.Once);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskDoesNotInvokeTheErrorHandlerWhenThePartitionIsStolen()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Callback(() => completionSource.TrySetResult(true))
+                .Throws(new EventHubsException("fake", "OMG WTF", EventHubsException.FailureReason.ConsumerDisconnected));
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            cancellationSource.Cancel();
+
+            mockProcessor
+                .Protected()
+                .Verify("OnProcessingErrorAsync", Times.Never(),
+                    ItExpr.IsAny<Exception>(),
+                    ItExpr.IsAny<EventProcessorPartition>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingReportsWhenThePartitionIsStolen()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Throws(new EventHubsException("fake", "OMG WTF", EventHubsException.FailureReason.ConsumerDisconnected));
+
+            mockLoadBalancer
+                .Setup(lb => lb.ReportPartitionStolen(It.IsAny<string>()))
+                .Callback(() => completionSource.TrySetResult(true));
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            cancellationSource.Cancel();
+
+            mockLoadBalancer
+                .Verify(lb => lb.ReportPartitionStolen(
+                    It.IsAny<string>()),
+                Times.Once);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
@@ -746,6 +746,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedPartitionId = "partitionId";
             var expectedPosition = EventPosition.FromOffset(55);
             var expectedRetryPolicy = Mock.Of<EventHubsRetryPolicy>();
+            var expectedInvalidateOnSteal = false;
             var expectedOptions = new PartitionReceiverOptions
             {
                 OwnerLevel = 99,
@@ -763,6 +764,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     expectedPosition,
                     expectedRetryPolicy,
                     expectedOptions.TrackLastEnqueuedEventProperties,
+                    expectedInvalidateOnSteal,
                     expectedOptions.OwnerLevel,
                     (uint?)expectedOptions.PrefetchCount,
                     expectedOptions.PrefetchSizeInBytes),
@@ -797,6 +799,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
                     It.IsAny<bool>(),
+                    It.IsAny<bool>(),
                     It.IsAny<long?>(),
                     It.IsAny<uint?>(),
                     It.IsAny<long?>()))
@@ -830,6 +833,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
+                    It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<long?>(),
                     It.IsAny<uint?>(),
@@ -1048,6 +1052,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
                     It.IsAny<bool>(),
+                    It.IsAny<bool>(),
                     It.IsAny<long?>(),
                     It.IsAny<uint?>(),
                     It.IsAny<long?>()))
@@ -1094,6 +1099,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
                     It.IsAny<bool>(),
+                    It.IsAny<bool>(),
                     It.IsAny<long?>(),
                     It.IsAny<uint?>(),
                     It.IsAny<long?>()))
@@ -1138,6 +1144,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
+                    It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<long?>(),
                     It.IsAny<uint?>(),
@@ -1206,6 +1213,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
                     It.IsAny<bool>(),
+                    It.IsAny<bool>(),
                     It.IsAny<long?>(),
                     It.IsAny<uint?>(),
                     It.IsAny<long?>()))
@@ -1250,6 +1258,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
+                    It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<long?>(),
                     It.IsAny<uint?>(),
@@ -1348,6 +1357,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
                     It.IsAny<bool>(),
+                    It.IsAny<bool>(),
                     It.IsAny<long?>(),
                     It.IsAny<uint?>(),
                     It.IsAny<long?>()))
@@ -1405,6 +1415,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
+                    It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<long?>(),
                     It.IsAny<uint?>(),


### PR DESCRIPTION
# Summary 

The AMQP transport library used by Event Hubs manages aspects of the transport in the background, notably the flow of data into the prefetch queue.  In doing
so it controls attempts to read data, and detecting connection/link failures to provide resiliency for callers.

Access to the AMQP link is managed through the `FaultTolerantAmqpObject<T>` which uses a `GetOrCreate` pattern to handle faults and provide a resilient experience for callers.  When a link was discarded due to a fault, it was not observable to clients and a new link would be created on the next `GetOrCreate` call.  In the majority of scenarios, this behavior is desirable.  However, in some scenarios - such as a partition being stolen by another event consumer asserting exclusive access, the failure must be surfaced to callers so that the correct remediation can be taken.

The focus of these changes is to ensure that errors causing link termination are surfaced via logging and that a stolen partition is treated as a special case and is always surfaced to callers.  Because this behavior was a direct impact to the load balancing aspects of the event processor, testing exposed some additional load balancing gaps that were also addressed.  Lost partitions will now be detected more reliably and the processor will proactively relinquish ownership and allow load balancing to make recovery decisions.

# References and Resources 

- [Event Hubs: Fix Unobserved Stolen Partitions (#21297)](https://github.com/Azure/azure-sdk-for-net/issues/21297)