### PR TITLE
[MetricsAdvisor] Removed getters from collections

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Breaking Changes
 - `NotificationHook.ExternalLink` and `WebNotificationHook.Endpoint` are now of type `Uri`.
+- Removed getter from `GetIncidentsForDetectionConfigurationOptions.DimensionsToFilter`. Elements can be added directly to it without user instantiation.
 - Renamed all `SkipCount` listing options to `Skip`. Affected classes include `GetAlertsOptions`, `GetDataFeedsOptions`, `GetHooksOptions`, and others.
 - Renamed all `TopCount` listing options to `MaxPageSize`. Affected classes include `GetAlertsOptions`, `GetDataFeedsOptions`, `GetHooksOptions`, and others.
 - Removed data feed sources `ElasticsearchDataFeedSource` and `HttpRequestDataFeedSource` as they are not supported by the service anymore. A different type of data feed source must be used for data ingestion instead.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -109,7 +109,7 @@ namespace Azure.AI.MetricsAdvisor
     public partial class GetIncidentsForDetectionConfigurationOptions
     {
         public GetIncidentsForDetectionConfigurationOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
-        public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DimensionKey> DimensionsToFilter { get { throw null; } set { } }
+        public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DimensionKey> DimensionsToFilter { get { throw null; } }
         public System.DateTimeOffset EndTime { get { throw null; } }
         public int? MaxPageSize { get { throw null; } set { } }
         public System.DateTimeOffset StartTime { get { throw null; } }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetIncidentsForDetectionConfigurationOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetIncidentsForDetectionConfigurationOptions.cs
@@ -16,8 +16,6 @@ namespace Azure.AI.MetricsAdvisor
     /// </summary>
     public class GetIncidentsForDetectionConfigurationOptions
     {
-        private IList<DimensionKey> _dimensionsToFilter;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="GetIncidentsForDetectionConfigurationOptions"/> class.
         /// </summary>
@@ -44,17 +42,7 @@ namespace Azure.AI.MetricsAdvisor
         /// Filters the result by series. Only incidents detected in the time series groups specified will
         /// be returned.
         /// </summary>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public IList<DimensionKey> DimensionsToFilter
-        {
-            get => _dimensionsToFilter;
-            set
-            {
-                Argument.AssertNotNull(value, nameof(DimensionsToFilter));
-                _dimensionsToFilter = value;
-            }
-        }
-#pragma warning restore CA2227 // Collection properties should be readonly
+        public IList<DimensionKey> DimensionsToFilter { get; }
 
         /// <summary>
         /// If set, specifies the maximum limit of items returned in each page of results. Note:

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample08_QueryIncidentsAndRootCauses.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample08_QueryIncidentsAndRootCauses.cs
@@ -36,11 +36,10 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
             var endTime = DateTimeOffset.UtcNow;
-            var options = new GetIncidentsForDetectionConfigurationOptions(startTime, endTime)
-            {
-                DimensionsToFilter = new List<DimensionKey>() { groupKey1, groupKey2 },
-                MaxPageSize = 3
-            };
+            var options = new GetIncidentsForDetectionConfigurationOptions(startTime, endTime) { MaxPageSize = 3 };
+
+            options.DimensionsToFilter.Add(groupKey1);
+            options.DimensionsToFilter.Add(groupKey2);
 
             int incidentCount = 0;
 


### PR DESCRIPTION
Fixes https://github.com/azure/azure-sdk-for-net/issues/20622.

We had already removed the getters from collections in MA, but ended up forgetting this one.