### PR TITLE
Ignore ClampDelay test

### DIFF
--- a/sdk/search/Azure.Search.Documents/tests/Batching/ManualRetryDelayTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Batching/ManualRetryDelayTests.cs
@@ -55,6 +55,7 @@ namespace Azure.Search.Documents.Tests
         }
 
         [Test]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/19002")]
         public async Task ClampDelay()
         {
             Stopwatch watch = new Stopwatch();


### PR DESCRIPTION
It's being rather flaky https://github.com/Azure/azure-sdk-for-net/issues/19002