### PR TITLE
Adding ACS Recording Download SDK

### DIFF
--- a/sdk/communication/Azure.Communication.CallingServer/api/Azure.Communication.CallingServer.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/api/Azure.Communication.CallingServer.netstandard2.0.cs
@@ -164,6 +164,23 @@ namespace Azure.Communication.CallingServer
         public bool? IsMuted { get { throw null; } set { } }
         public string ParticipantId { get { throw null; } set { } }
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct ContentTransferOptions : System.IEquatable<Azure.Communication.CallingServer.ContentTransferOptions>
+    {
+        public long InitialTransferSize { get { throw null; } set { } }
+        public int MaximumConcurrency { get { throw null; } set { } }
+        public long MaximumTransferSize { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public bool Equals(Azure.Communication.CallingServer.ContentTransferOptions obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public static bool operator ==(Azure.Communication.CallingServer.ContentTransferOptions left, Azure.Communication.CallingServer.ContentTransferOptions right) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public static bool operator !=(Azure.Communication.CallingServer.ContentTransferOptions left, Azure.Communication.CallingServer.ContentTransferOptions right) { throw null; }
+    }
     public partial class ConversationClient
     {
         protected ConversationClient() { }
@@ -173,6 +190,12 @@ namespace Azure.Communication.CallingServer
         public ConversationClient(System.Uri endpoint, Azure.Core.TokenCredential tokenCredential, Azure.Communication.CallingServer.CallClientOptions options = null) { }
         public virtual Azure.Response AddParticipant(string conversationId, Azure.Communication.CommunicationIdentifier participant, System.Uri callbackUri, string alternateCallerId = null, string operationContext = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> AddParticipantAsync(string conversationId, Azure.Communication.CommunicationIdentifier participant, System.Uri callbackUri, string alternateCallerId = null, string operationContext = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<System.IO.Stream> DownloadStreaming(System.Uri sourceEndpoint, Azure.HttpRange range = default(Azure.HttpRange), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<System.IO.Stream>> DownloadStreamingAsync(System.Uri sourceEndpoint, Azure.HttpRange range = default(Azure.HttpRange), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response DownloadTo(System.Uri sourceEndpoint, System.IO.Stream destinationStream, Azure.Communication.CallingServer.ContentTransferOptions transferOptions = default(Azure.Communication.CallingServer.ContentTransferOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response DownloadTo(System.Uri sourceEndpoint, string destinationPath, Azure.Communication.CallingServer.ContentTransferOptions transferOptions = default(Azure.Communication.CallingServer.ContentTransferOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> DownloadToAsync(System.Uri sourceEndpoint, System.IO.Stream destinationStream, Azure.Communication.CallingServer.ContentTransferOptions transferOptions = default(Azure.Communication.CallingServer.ContentTransferOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> DownloadToAsync(System.Uri sourceEndpoint, string destinationPath, Azure.Communication.CallingServer.ContentTransferOptions transferOptions = default(Azure.Communication.CallingServer.ContentTransferOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Communication.CallingServer.GetCallRecordingStateResponse> GetRecordingState(string conversationId, string recordingId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallingServer.GetCallRecordingStateResponse>> GetRecordingStateAsync(string conversationId, string recordingId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Communication.CallingServer.JoinCallResponse> JoinCall(string conversationId, Azure.Communication.CommunicationIdentifier source, Azure.Communication.CallingServer.JoinCallOptions callOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Azure.Communication.CallingServer.csproj
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Azure.Communication.CallingServer.csproj
@@ -27,6 +27,7 @@
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="$(AzureCoreSharedSources)RetriableStream.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureCoreSharedSources)OperationHelpers.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
   </ItemGroup>

--- a/sdk/communication/Azure.Communication.CallingServer/src/Constants.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Constants.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Communication.CallingServer
+{
+    internal static class Constants
+    {
+        public const int KB = 1024;
+        public const int MB = KB * 1024;
+
+        /// <summary>
+        /// ContentDownloader values.
+        /// </summary>
+        internal static class ContentDownloader
+        {
+            public const int RetriableStreamRetries = 4;
+
+            internal static class Partition
+            {
+                public const int DefaultConcurrentTransfersCount = 5;
+                public const int MaxDownloadBytes = 256 * MB;
+                public const int DefaultBufferSize = 4 * MB;
+                public const int DefaultInitalDownloadRangeSize = 256 * MB;
+            }
+        }
+
+        /// <summary>
+        /// Header Name constant values.
+        /// </summary>
+        internal static class HeaderNames
+        {
+            public const string XMsPrefix = "x-ms-";
+            public const string ContentLength = "Content-Length";
+            public const string ContentType = "Content-Type";
+            public const string Range = "Range";
+            public const string ContentRange = "Content-Range";
+            public const string XMsHost = XMsPrefix + "host";
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/Constants.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Constants.cs
@@ -19,7 +19,6 @@ namespace Azure.Communication.CallingServer
             {
                 public const int DefaultConcurrentTransfersCount = 5;
                 public const int MaxDownloadBytes = 256 * MB;
-                public const int DefaultBufferSize = 4 * MB;
                 public const int DefaultInitalDownloadRangeSize = 256 * MB;
             }
         }

--- a/sdk/communication/Azure.Communication.CallingServer/src/ContentDownloader.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/ContentDownloader.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Communication.CallingServer.Models;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.Communication.CallingServer
+{
+    internal class ContentDownloader
+    {
+        private readonly ConversationClient _client;
+
+        internal ContentDownloader(ConversationClient client)
+        {
+            _client = client;
+        }
+
+        internal async Task<Response<Stream>> DownloadStreamingInternal(Uri endpoint, HttpRange range, bool async, CancellationToken cancellationToken)
+        {
+            using DiagnosticScope scope = _client._clientDiagnostics.CreateScope($"{nameof(ConversationClient)}.{nameof(ConversationClient.DownloadStreaming)}");
+            scope.Start();
+
+            try
+            {
+                Argument.AssertNotNull(endpoint, nameof(endpoint));
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+
+            Response<Stream> response = await StartDownloadAsync(endpoint, range, async: async, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            Stream stream = RetriableStream.Create(
+                response.Value,
+                startOffset => StartDownloadAsync(endpoint, range, startOffset, async, cancellationToken).EnsureCompleted().Value,
+                async startOffset => (await StartDownloadAsync(endpoint, range, startOffset, async, cancellationToken).ConfigureAwait(false)).Value,
+                _client._pipeline.ResponseClassifier,
+                Constants.ContentDownloader.RetriableStreamRetries
+                );
+
+            return Response.FromValue(stream, response.GetRawResponse());
+        }
+
+        internal async Task<Response> StagedDownloadAsync(Stream destination, Uri endpoint,
+            ContentTransferOptions transferOptions = default, bool async = true, CancellationToken cancellationToken = default)
+        {
+            PartitionedDownloader downloader = new(_client, transferOptions);
+            if (async)
+            {
+                return await downloader.DownloadToAsync(destination, endpoint, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                return downloader.DownloadTo(destination, endpoint, cancellationToken);
+            }
+        }
+
+        private async Task<Response<Stream>> StartDownloadAsync(Uri endpoint, HttpRange range = default, long startOffset = 0,
+            bool async = true, CancellationToken cancellationToken = default)
+        {
+            HttpRange? pageRange = null;
+
+            if (range != default || startOffset != 0)
+            {
+                pageRange = new HttpRange(
+                    range.Offset + startOffset,
+                    range.Length.HasValue ?
+                        range.Length.Value - startOffset :
+                        null);
+            }
+
+            HttpMessage message = GetHttpMessage(endpoint, pageRange);
+            if (async)
+            {
+                await _client._pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                switch (message.Response.Status)
+                {
+                    case 200:
+                    case 206:
+                        {
+                            Stream value = message.ExtractResponseContent();
+                            return Response.FromValue(value, message.Response);
+                        }
+                    default:
+                        throw await _client._clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        ;
+                }
+            }
+            else
+            {
+                _client._pipeline.Send(message, cancellationToken);
+
+                switch (message.Response.Status)
+                {
+                    case 200:
+                    case 206:
+                        {
+                            Stream value = message.ExtractResponseContent();
+                            return Response.FromValue(value, message.Response);
+                        }
+                    default:
+                        throw _client._clientDiagnostics.CreateRequestFailedException(message.Response);
+                }
+            }
+        }
+
+        private HttpMessage GetHttpMessage(Uri endpoint, HttpRange? rangeHeader = null)
+        {
+            HttpMessage message = _client._pipeline.CreateMessage();
+            Request request = message.Request;
+            request.Method = RequestMethod.Get;
+            var uri = new RequestUriBuilder();
+            uri.Reset(endpoint);
+
+            request.Uri = uri;
+
+            if (rangeHeader != null)
+            {
+                request.Headers.Add(Constants.HeaderNames.Range, rangeHeader.ToString());
+            }
+
+            // Even if using an external location, we must use the acs resource's information to sign our request.
+            string path = uri.Path;
+            if (path.StartsWith("/", StringComparison.InvariantCulture))
+            {
+                path = path.Substring(1);
+            }
+
+            request.Headers.Add(Constants.HeaderNames.XMsHost, new Uri(_client._resourceEndpoint).Authority);
+            message.SetProperty("uriToSignRequestWith", new Uri(_client._resourceEndpoint + path));
+
+            message.BufferResponse = false;
+            return message;
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/ContentDownloader.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/ContentDownloader.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Communication.CallingServer.Models;
 using Azure.Core;
 using Azure.Core.Pipeline;
 
@@ -20,50 +19,47 @@ namespace Azure.Communication.CallingServer
             _client = client;
         }
 
-        internal async Task<Response<Stream>> DownloadStreamingInternal(Uri endpoint, HttpRange range, bool async, CancellationToken cancellationToken)
+        internal async Task<Response<Stream>> DownloadStreamingInternal(Uri sourceEndpoint, HttpRange range, bool async, CancellationToken cancellationToken)
         {
-            using DiagnosticScope scope = _client._clientDiagnostics.CreateScope($"{nameof(ConversationClient)}.{nameof(ConversationClient.DownloadStreaming)}");
-            scope.Start();
+            Argument.AssertNotNull(sourceEndpoint, nameof(sourceEndpoint));
 
-            try
+            Response<Stream> response;
+            if (async)
             {
-                Argument.AssertNotNull(endpoint, nameof(endpoint));
+                response = await StartDownloadAsync(sourceEndpoint, range, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            else
             {
-                scope.Failed(ex);
-                throw;
+                response = StartDownload(sourceEndpoint, range, cancellationToken: cancellationToken);
             }
-
-            Response<Stream> response = await StartDownloadAsync(endpoint, range, async: async, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             Stream stream = RetriableStream.Create(
                 response.Value,
-                startOffset => StartDownloadAsync(endpoint, range, startOffset, async, cancellationToken).EnsureCompleted().Value,
-                async startOffset => (await StartDownloadAsync(endpoint, range, startOffset, async, cancellationToken).ConfigureAwait(false)).Value,
+                startOffset => StartDownload(sourceEndpoint, range, startOffset, cancellationToken).Value,
+                async startOffset => (await StartDownloadAsync(sourceEndpoint, range, startOffset, cancellationToken).ConfigureAwait(false)).Value,
                 _client._pipeline.ResponseClassifier,
                 Constants.ContentDownloader.RetriableStreamRetries
-                );
+            );
 
             return Response.FromValue(stream, response.GetRawResponse());
         }
 
-        internal async Task<Response> StagedDownloadAsync(Stream destination, Uri endpoint,
+        internal async Task<Response> StagedDownloadAsync(Uri sourceEndpoint, Stream destinationStream,
             ContentTransferOptions transferOptions = default, bool async = true, CancellationToken cancellationToken = default)
         {
             PartitionedDownloader downloader = new(_client, transferOptions);
             if (async)
             {
-                return await downloader.DownloadToAsync(destination, endpoint, cancellationToken).ConfigureAwait(false);
+                return await downloader.DownloadToAsync(destinationStream, sourceEndpoint, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                return downloader.DownloadTo(destination, endpoint, cancellationToken);
+                return downloader.DownloadTo(destinationStream, sourceEndpoint, cancellationToken);
             }
         }
 
-        private async Task<Response<Stream>> StartDownloadAsync(Uri endpoint, HttpRange range = default, long startOffset = 0,
-            bool async = true, CancellationToken cancellationToken = default)
+        private async Task<Response<Stream>> StartDownloadAsync(Uri sourceEndpoint, HttpRange range = default, long startOffset = 0,
+            CancellationToken cancellationToken = default)
         {
             HttpRange? pageRange = null;
 
@@ -76,48 +72,58 @@ namespace Azure.Communication.CallingServer
                         null);
             }
 
-            HttpMessage message = GetHttpMessage(endpoint, pageRange);
-            if (async)
-            {
-                await _client._pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
-                switch (message.Response.Status)
-                {
-                    case 200:
-                    case 206:
-                        {
-                            Stream value = message.ExtractResponseContent();
-                            return Response.FromValue(value, message.Response);
-                        }
-                    default:
-                        throw await _client._clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
-                        ;
-                }
-            }
-            else
-            {
-                _client._pipeline.Send(message, cancellationToken);
+            HttpMessage message = GetHttpMessage(sourceEndpoint, pageRange);
 
-                switch (message.Response.Status)
-                {
-                    case 200:
-                    case 206:
-                        {
-                            Stream value = message.ExtractResponseContent();
-                            return Response.FromValue(value, message.Response);
-                        }
-                    default:
-                        throw _client._clientDiagnostics.CreateRequestFailedException(message.Response);
-                }
+            await _client._pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+            switch (message.Response.Status)
+            {
+                case 200:
+                case 206:
+                    {
+                        Stream value = message.ExtractResponseContent();
+                        return Response.FromValue(value, message.Response);
+                    }
+                default:
+                    throw await _client._clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
         }
 
-        private HttpMessage GetHttpMessage(Uri endpoint, HttpRange? rangeHeader = null)
+        private Response<Stream> StartDownload(Uri sourceEndpoint, HttpRange range = default, long startOffset = 0, CancellationToken cancellationToken = default)
+        {
+            HttpRange? pageRange = null;
+
+            if (range != default || startOffset != 0)
+            {
+                pageRange = new HttpRange(
+                    range.Offset + startOffset,
+                    range.Length.HasValue ?
+                        range.Length.Value - startOffset :
+                        null);
+            }
+
+            HttpMessage message = GetHttpMessage(sourceEndpoint, pageRange);
+            _client._pipeline.Send(message, cancellationToken);
+
+            switch (message.Response.Status)
+            {
+                case 200:
+                case 206:
+                    {
+                        Stream value = message.ExtractResponseContent();
+                        return Response.FromValue(value, message.Response);
+                    }
+                default:
+                    throw _client._clientDiagnostics.CreateRequestFailedException(message.Response);
+            }
+        }
+
+        private HttpMessage GetHttpMessage(Uri sourceEndpoint, HttpRange? rangeHeader = null)
         {
             HttpMessage message = _client._pipeline.CreateMessage();
             Request request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RequestUriBuilder();
-            uri.Reset(endpoint);
+            uri.Reset(sourceEndpoint);
 
             request.Uri = uri;
 

--- a/sdk/communication/Azure.Communication.CallingServer/src/ConversationClient.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/ConversationClient.cs
@@ -10,7 +10,6 @@ using Azure.Communication.Pipeline;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
-using Azure.Communication.CallingServer.Models;
 
 namespace Azure.Communication.CallingServer
 {
@@ -656,7 +655,7 @@ namespace Azure.Communication.CallingServer
         /// operation downloads the recording's content.
         ///
         /// </summary>
-        /// <param name="endpoint">
+        /// <param name="sourceEndpoint">
         /// Recording's content's url location.
         /// </param>
         /// <param name="range">
@@ -676,11 +675,11 @@ namespace Azure.Communication.CallingServer
         /// a failure occurs.
         /// </remarks>
         public virtual async Task<Response<Stream>> DownloadStreamingAsync(
-            Uri endpoint,
+            Uri sourceEndpoint,
             HttpRange range = default,
             CancellationToken cancellationToken = default) =>
             await _contentDownloader.DownloadStreamingInternal(
-                endpoint,
+                sourceEndpoint,
                 range,
                 async: true,
                 cancellationToken)
@@ -691,7 +690,7 @@ namespace Azure.Communication.CallingServer
         /// operation downloads the recording's content.
         ///
         /// </summary>
-        /// <param name="endpoint">
+        /// <param name="sourceEndpoint">
         /// Recording's content's url location.
         /// </param>
         /// <param name="range">
@@ -711,26 +710,26 @@ namespace Azure.Communication.CallingServer
         /// a failure occurs.
         /// </remarks>
         public virtual Response<Stream> DownloadStreaming(
-        Uri endpoint,
-        HttpRange range = default,
-        CancellationToken cancellationToken = default) =>
-        _contentDownloader.DownloadStreamingInternal(
-            endpoint,
-            range,
-            async: false,
-            cancellationToken)
-        .EnsureCompleted();
+            Uri sourceEndpoint,
+            HttpRange range = default,
+            CancellationToken cancellationToken = default) =>
+            _contentDownloader.DownloadStreamingInternal(
+                sourceEndpoint,
+                range,
+                async: false,
+                cancellationToken)
+            .EnsureCompleted();
 
         /// <summary>
-        /// The <see cref="DownloadTo(Stream, Uri, ContentTransferOptions, CancellationToken)"/>
+        /// The <see cref="DownloadTo(Uri, Stream, ContentTransferOptions, CancellationToken)"/>
         /// operation downloads the specified content using parallel requests,
-        /// and writes the content to <paramref name="destination"/>.
+        /// and writes the content to <paramref name="destinationStream"/>.
         /// </summary>
-        /// <param name="destination">
-        /// A <see cref="Stream"/> to write the downloaded content to.
-        /// </param>
-        /// <param name="endpoint">
+        /// <param name="sourceEndpoint">
         /// A <see cref="Uri"/> with the Recording's content's url location.
+        /// </param>
+        /// <param name="destinationStream">
+        /// A <see cref="Stream"/> to write the downloaded content to.
         /// </param>
         /// <param name="transferOptions">
         /// Optional <see cref="ContentTransferOptions"/> to configure
@@ -747,20 +746,20 @@ namespace Azure.Communication.CallingServer
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual Response DownloadTo(Stream destination, Uri endpoint,
+        public virtual Response DownloadTo(Uri sourceEndpoint, Stream destinationStream,
             ContentTransferOptions transferOptions = default, CancellationToken cancellationToken = default) =>
-            _contentDownloader.StagedDownloadAsync(destination, endpoint, transferOptions, async: false, cancellationToken: cancellationToken).EnsureCompleted();
+            _contentDownloader.StagedDownloadAsync(sourceEndpoint, destinationStream, transferOptions, async: false, cancellationToken: cancellationToken).EnsureCompleted();
 
         /// <summary>
-        /// The <see cref="DownloadToAsync(Stream, Uri, ContentTransferOptions, CancellationToken)"/>
+        /// The <see cref="DownloadToAsync(Uri, Stream, ContentTransferOptions, CancellationToken)"/>
         /// operation downloads the specified content using parallel requests,
-        /// and writes the content to <paramref name="destination"/>.
+        /// and writes the content to <paramref name="destinationStream"/>.
         /// </summary>
-        /// <param name="destination">
-        /// A <see cref="Stream"/> to write the downloaded content to.
-        /// </param>
-        /// <param name="endpoint">
+        /// <param name="sourceEndpoint">
         /// A <see cref="Uri"/> with the Recording's content's url location.
+        /// </param>
+        /// <param name="destinationStream">
+        /// A <see cref="Stream"/> to write the downloaded content to.
         /// </param>
         /// <param name="transferOptions">
         /// Optional <see cref="ContentTransferOptions"/> to configure
@@ -777,20 +776,20 @@ namespace Azure.Communication.CallingServer
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response> DownloadToAsync(Stream destination, Uri endpoint, ContentTransferOptions transferOptions = default, CancellationToken cancellationToken = default) =>
-            await _contentDownloader.StagedDownloadAsync(destination, endpoint, transferOptions, async: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+        public virtual async Task<Response> DownloadToAsync(Uri sourceEndpoint, Stream destinationStream, ContentTransferOptions transferOptions = default, CancellationToken cancellationToken = default) =>
+            await _contentDownloader.StagedDownloadAsync(sourceEndpoint, destinationStream, transferOptions, async: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="DownloadTo(string, Uri, ContentTransferOptions, CancellationToken)"/>
+        /// The <see cref="DownloadTo(Uri, string, ContentTransferOptions, CancellationToken)"/>
         /// operation downloads the specified content using parallel requests,
-        /// and writes the content to <paramref name="path"/>.
+        /// and writes the content to <paramref name="destinationPath"/>.
         /// </summary>
-        /// <param name="path">
+        /// <param name="sourceEndpoint">
+        /// A <see cref="Uri"/> with the Recording's content's url location.
+        /// </param>
+        /// <param name="destinationPath">
         /// A file path to write the downloaded content to.
         /// </param>
-        /// <param name="endpoint">
-        /// A <see cref="Uri"/> with the Recording's content's url location.
-        /// </param>
         /// <param name="transferOptions">
         /// Optional <see cref="ContentTransferOptions"/> to configure
         /// parallel transfer behavior.
@@ -806,24 +805,24 @@ namespace Azure.Communication.CallingServer
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual Response DownloadTo(string path, Uri endpoint,
+        public virtual Response DownloadTo(Uri sourceEndpoint, string destinationPath,
             ContentTransferOptions transferOptions = default, CancellationToken cancellationToken = default)
         {
-            using Stream destination = File.Create(path);
-            return _contentDownloader.StagedDownloadAsync(destination, endpoint, transferOptions,
+            using Stream destination = File.Create(destinationPath);
+            return _contentDownloader.StagedDownloadAsync(sourceEndpoint, destination, transferOptions,
                 async: false, cancellationToken: cancellationToken).EnsureCompleted();
         }
 
         /// <summary>
-        /// The <see cref="DownloadToAsync(string, Uri, ContentTransferOptions, CancellationToken)"/>
+        /// The <see cref="DownloadToAsync(Uri, string, ContentTransferOptions, CancellationToken)"/>
         /// operation downloads the specified content using parallel requests,
-        /// and writes the content to <paramref name="path"/>.
+        /// and writes the content to <paramref name="destinationPath"/>.
         /// </summary>
-        /// <param name="path">
-        /// A file path to write the downloaded content to.
-        /// </param>
-        /// <param name="endpoint">
+        /// <param name="sourceEndpoint">
         /// A <see cref="Uri"/> with the Recording's content's url location.
+        /// </param>
+        /// <param name="destinationPath">
+        /// A file path to write the downloaded content to.
         /// </param>
         /// <param name="transferOptions">
         /// Optional <see cref="ContentTransferOptions"/> to configure
@@ -840,11 +839,11 @@ namespace Azure.Communication.CallingServer
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response> DownloadToAsync(string path, Uri endpoint,
+        public virtual async Task<Response> DownloadToAsync(Uri sourceEndpoint, string destinationPath,
             ContentTransferOptions transferOptions = default, CancellationToken cancellationToken = default)
         {
-            using Stream destination = File.Create(path);
-            return await _contentDownloader.StagedDownloadAsync(destination, endpoint, transferOptions,
+            using Stream destination = File.Create(destinationPath);
+            return await _contentDownloader.StagedDownloadAsync(sourceEndpoint, destination, transferOptions,
                 async: true, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/ContentTransferOptions.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/ContentTransferOptions.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+
+namespace Azure.Communication.CallingServer.Models
+{
+    /// <summary>
+    /// <see cref="ContentTransferOptions"/> is used to provide options for parallel transfers.
+    /// </summary>
+    public struct ContentTransferOptions : IEquatable<ContentTransferOptions>
+    {
+        /// <summary>
+        /// The maximum length of an transfer in bytes.
+        /// </summary>
+        public long? MaximumTransferSize { get; set; }
+
+        /// <summary>
+        /// The maximum number of workers that may be used in a parallel transfer.
+        /// </summary>
+        public int? MaximumConcurrency { get; set; }
+
+        /// <summary>
+        /// The size of the first range request in bytes. Blobs smaller than this limit will
+        /// be downloaded in a single request. Blobs larger than this limit will continue being
+        /// downloaded in chunks of size <see cref="MaximumTransferSize"/>.
+        /// </summary>
+        public long? InitialTransferSize { get; set; }
+
+        /// <summary>
+        /// Check if two ContentTransferOptions instances are equal.
+        /// </summary>
+        /// <param name="obj">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+            => obj is ContentTransferOptions other
+            && Equals(other);
+
+        /// <summary>
+        /// Get a hash code for the ParallelTransferOptions.
+        /// </summary>
+        /// <returns>Hash code for the ParallelTransferOptions.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+            => MaximumTransferSize.GetHashCode()
+            ^ MaximumConcurrency.GetHashCode()
+            ^ InitialTransferSize.GetHashCode();
+
+        /// <summary>
+        /// Check if two ParallelTransferOptions instances are equal.
+        /// </summary>
+        /// <param name="left">The first instance to compare.</param>
+        /// <param name="right">The second instance to compare.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator ==(ContentTransferOptions left, ContentTransferOptions right) => left.Equals(right);
+
+        /// <summary>
+        /// Check if two ParallelTransferOptions instances are equal.
+        /// </summary>
+        /// <param name="left">The first instance to compare.</param>
+        /// <param name="right">The second instance to compare.</param>
+        /// <returns>True if they're not equal, false otherwise.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator !=(ContentTransferOptions left, ContentTransferOptions right) => !(left == right);
+
+        /// <summary>
+        /// Check if two ParallelTransferOptions instances are equal.
+        /// </summary>
+        /// <param name="obj">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Equals(ContentTransferOptions obj)
+            => MaximumTransferSize == obj.MaximumTransferSize
+            && MaximumConcurrency == obj.MaximumConcurrency
+            && InitialTransferSize == obj.InitialTransferSize;
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/ContentTransferOptions.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/ContentTransferOptions.cs
@@ -4,29 +4,45 @@
 using System;
 using System.ComponentModel;
 
-namespace Azure.Communication.CallingServer.Models
+namespace Azure.Communication.CallingServer
 {
     /// <summary>
     /// <see cref="ContentTransferOptions"/> is used to provide options for parallel transfers.
     /// </summary>
     public struct ContentTransferOptions : IEquatable<ContentTransferOptions>
     {
+        private long? _maximumTransferSize;
+        private int? _maximumConcurrency;
+        private long? _initialTransferSize;
+
         /// <summary>
-        /// The maximum length of an transfer in bytes.
+        /// The maximum length of a transfer in bytes.
         /// </summary>
-        public long? MaximumTransferSize { get; set; }
+        public long MaximumTransferSize
+        {
+            get { return _maximumTransferSize ?? Constants.ContentDownloader.Partition.MaxDownloadBytes; }
+            set { _maximumTransferSize = value; }
+        }
 
         /// <summary>
         /// The maximum number of workers that may be used in a parallel transfer.
         /// </summary>
-        public int? MaximumConcurrency { get; set; }
+        public int MaximumConcurrency
+        {
+            get { return _maximumConcurrency ?? Constants.ContentDownloader.Partition.DefaultConcurrentTransfersCount; }
+            set { _maximumConcurrency = value; }
+        }
 
         /// <summary>
         /// The size of the first range request in bytes. Blobs smaller than this limit will
         /// be downloaded in a single request. Blobs larger than this limit will continue being
         /// downloaded in chunks of size <see cref="MaximumTransferSize"/>.
         /// </summary>
-        public long? InitialTransferSize { get; set; }
+        public long InitialTransferSize
+        {
+            get { return _initialTransferSize ?? Constants.ContentDownloader.Partition.DefaultInitalDownloadRangeSize; }
+            set { _initialTransferSize = value; }
+        }
 
         /// <summary>
         /// Check if two ContentTransferOptions instances are equal.

--- a/sdk/communication/Azure.Communication.CallingServer/src/PartitionedDownloader.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/PartitionedDownloader.cs
@@ -1,0 +1,323 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Communication.CallingServer.Models;
+using Azure.Core.Pipeline;
+
+namespace Azure.Communication.CallingServer
+{
+    internal class PartitionedDownloader
+    {
+        /// <summary>
+        /// The client used to download the blob.
+        /// </summary>
+        private readonly ConversationClient _client;
+
+        /// <summary>
+        /// The maximum number of simultaneous workers.
+        /// </summary>
+        private readonly int _maxWorkerCount;
+
+        /// <summary>
+        /// The size of the first range requested (which can be larger than the
+        /// other ranges).
+        /// </summary>
+        private readonly long _initialRangeSize;
+
+        /// <summary>
+        /// The size of subsequent ranges.
+        /// </summary>
+        private readonly long _rangeSize;
+
+        internal PartitionedDownloader(
+            ConversationClient client,
+            ContentTransferOptions transferOptions = default)
+        {
+            _client = client;
+
+            // Set _maxWorkerCount
+            if (transferOptions.MaximumConcurrency.HasValue
+                && transferOptions.MaximumConcurrency > 0)
+            {
+                _maxWorkerCount = transferOptions.MaximumConcurrency.Value;
+            }
+            else
+            {
+                _maxWorkerCount = Constants.ContentDownloader.Partition.DefaultConcurrentTransfersCount;
+            }
+
+            // Set _rangeSize
+            if (transferOptions.MaximumTransferSize.HasValue
+                && transferOptions.MaximumTransferSize.Value > 0)
+            {
+                _rangeSize = Math.Min(transferOptions.MaximumTransferSize.Value, Constants.ContentDownloader.Partition.MaxDownloadBytes);
+            }
+            else
+            {
+                _rangeSize = Constants.ContentDownloader.Partition.DefaultBufferSize;
+            }
+
+            // Set _initialRangeSize
+            if (transferOptions.InitialTransferSize.HasValue
+                && transferOptions.InitialTransferSize.Value > 0)
+            {
+                _initialRangeSize = transferOptions.InitialTransferSize.Value;
+            }
+            else
+            {
+                _initialRangeSize = Constants.ContentDownloader.Partition.DefaultInitalDownloadRangeSize;
+            }
+        }
+
+        internal async Task<Response> DownloadToAsync(
+            Stream destination,
+            Uri endpoint,
+            CancellationToken cancellationToken)
+        {
+            // Wrap the download range calls in a Download span for distributed
+            // tracing
+            DiagnosticScope scope = _client._clientDiagnostics.CreateScope($"{nameof(ConversationClient)}.{nameof(ConversationClient.DownloadTo)}");
+            try
+            {
+                scope.Start();
+
+                // Just start downloading using an initial range.  If it's a
+                // small blob, we'll get the whole thing in one shot.  If it's
+                // a large blob, we'll get its full size in Content-Range and
+                // can keep downloading it in segments.
+                var initialRange = new HttpRange(0, _initialRangeSize);
+                Task<Response<Stream>> initialResponseTask =
+                    _client.DownloadStreamingAsync(
+                        endpoint,
+                        initialRange,
+                        cancellationToken);
+
+                Response<Stream> initialResponse;
+                try
+                {
+                    initialResponse = await initialResponseTask.ConfigureAwait(false);
+                }
+                catch (RequestFailedException ex) when (ex.ErrorCode == "Invalid Range")
+                {
+                    initialResponse = await _client.DownloadStreamingAsync(
+                        endpoint,
+                        range: default,
+                        cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                // If the first segment was the entire blob, we'll copy that to
+                // the output stream and finish now
+                long initialLength = ParseResponseContentLength(initialResponse);
+                long totalLength = ParseRangeTotalLength(initialResponse);
+                if (initialLength == totalLength)
+                {
+                    await CopyToAsync(
+                        initialResponse,
+                        destination,
+                        cancellationToken)
+                        .ConfigureAwait(false);
+                    return initialResponse.GetRawResponse();
+                }
+
+                // Create a queue of tasks that will each download one segment
+                // of the blob.  The queue maintains the order of the segments
+                // so we can keep appending to the end of the destination
+                // stream when each segment finishes.
+                var runningTasks = new Queue<Task<Response<Stream>>>();
+                runningTasks.Enqueue(initialResponseTask);
+
+                // Fill the queue with tasks to download each of the remaining
+                // ranges in the blob
+                foreach (HttpRange httpRange in GetRanges(initialLength, totalLength))
+                {
+                    // Add the next Task (which will start the download but
+                    // return before it's completed downloading)
+                    runningTasks.Enqueue(_client.DownloadStreamingAsync(
+                        endpoint,
+                        httpRange,
+                        cancellationToken));
+
+                    // If we have fewer tasks than alotted workers, then just
+                    // continue adding tasks until we have _maxWorkerCount
+                    // running in parallel
+                    if (runningTasks.Count < _maxWorkerCount)
+                    {
+                        continue;
+                    }
+
+                    // Once all the workers are busy, wait for the first
+                    // segment to finish downloading before we create more work
+                    await ConsumeQueuedTask().ConfigureAwait(false);
+                }
+
+                // Wait for all of the remaining segments to download
+                while (runningTasks.Count > 0)
+                {
+                    await ConsumeQueuedTask().ConfigureAwait(false);
+                }
+
+                return initialResponse.GetRawResponse();
+
+                // Wait for the first segment in the queue of tasks to complete
+                // downloading and copy it to the destination stream
+                async Task ConsumeQueuedTask()
+                {
+                    // Don't need to worry about 304s here because the ETag
+                    // condition will turn into a 412 and throw a proper
+                    // RequestFailedException
+                    using Stream result =
+                        await runningTasks.Dequeue().ConfigureAwait(false);
+
+                    // Even though the BlobDownloadInfo is returned immediately,
+                    // CopyToAsync causes ConsumeQueuedTask to wait until the
+                    // download is complete
+                    await CopyToAsync(
+                        result,
+                        destination,
+                        cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+            finally
+            {
+                scope.Dispose();
+            }
+        }
+
+        private static long ParseResponseContentLength(Response<Stream> initialResponse)
+        {
+            initialResponse.GetRawResponse().Headers.TryGetValue("Content-Length", out string initialContentLength);
+            long initialLength = long.Parse(initialContentLength ?? "0", CultureInfo.InvariantCulture.NumberFormat);
+            return initialLength;
+        }
+
+        internal Response DownloadTo(
+            Stream destination,
+            Uri endpoint,
+            CancellationToken cancellationToken)
+        {
+            // Wrap the download range calls in a Download span for distributed
+            // tracing
+            DiagnosticScope scope = _client._clientDiagnostics.CreateScope($"{nameof(ConversationClient)}.{nameof(ConversationClient.DownloadTo)}");
+            try
+            {
+                scope.Start();
+
+                // Just start downloading using an initial range.  If it's a
+                // small blob, we'll get the whole thing in one shot.  If it's
+                // a large blob, we'll get its full size in Content-Range and
+                // can keep downloading it in segments.
+                var initialRange = new HttpRange(0, _initialRangeSize);
+                Response<Stream> initialResponse;
+
+                try
+                {
+                    initialResponse = _client.DownloadStreaming(
+                        endpoint,
+                        initialRange,
+                        cancellationToken);
+                }
+                catch (RequestFailedException ex) when (ex.ErrorCode == "Invalid Range")
+                {
+                    initialResponse = _client.DownloadStreaming(
+                        endpoint,
+                        range: default,
+                        cancellationToken);
+                }
+
+                // Copy the first segment to the destination stream
+                CopyTo(initialResponse, destination, cancellationToken);
+
+                // If the first segment was the entire blob, we're finished now
+                long initialLength = ParseResponseContentLength(initialResponse);
+                long totalLength = ParseRangeTotalLength(initialResponse);
+                if (initialLength == totalLength)
+                {
+                    return initialResponse.GetRawResponse();
+                }
+
+                // Download each of the remaining ranges in the blob
+                foreach (HttpRange httpRange in GetRanges(initialLength, totalLength))
+                {
+                    // Don't need to worry about 304s here because the ETag
+                    // condition will turn into a 412 and throw a proper
+                    // RequestFailedException
+                    Response<Stream> result = _client.DownloadStreaming(
+                        endpoint,
+                        httpRange,
+                        cancellationToken);
+                    CopyTo(result.Value, destination, cancellationToken);
+                }
+
+                return initialResponse.GetRawResponse();
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+            finally
+            {
+                scope.Dispose();
+            }
+        }
+
+        private static long ParseRangeTotalLength(Response<Stream> response)
+        {
+            response.GetRawResponse().Headers.TryGetValue("Content-Range", out string range);
+
+            if (range == null)
+            {
+                return 0;
+            }
+            int lengthSeparator = range.IndexOf("/", StringComparison.InvariantCultureIgnoreCase);
+            if (lengthSeparator == -1)
+            {
+                throw new ArgumentException("Could not obtain the total length from HTTP range " + range);
+            }
+            return long.Parse(range.Substring(lengthSeparator + 1), CultureInfo.InvariantCulture);
+        }
+
+        private static async Task CopyToAsync(
+            Stream result,
+            Stream destination,
+            CancellationToken cancellationToken)
+        {
+            await result.CopyToAsync(
+                destination,
+                100000,
+                cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        private static void CopyTo(
+            Stream result,
+            Stream destination,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            result.CopyTo(destination, 1000000);
+            result.Dispose();
+        }
+
+        private IEnumerable<HttpRange> GetRanges(long initialLength, long totalLength)
+        {
+            for (long offset = initialLength; offset < totalLength; offset += _rangeSize)
+            {
+                yield return new HttpRange(offset, Math.Min(totalLength - offset, _rangeSize));
+            }
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/PartitionedDownloader.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/PartitionedDownloader.cs
@@ -7,8 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Communication.CallingServer.Models;
-using Azure.Core.Pipeline;
 
 namespace Azure.Communication.CallingServer
 {
@@ -40,39 +38,9 @@ namespace Azure.Communication.CallingServer
             ContentTransferOptions transferOptions = default)
         {
             _client = client;
-
-            // Set _maxWorkerCount
-            if (transferOptions.MaximumConcurrency.HasValue
-                && transferOptions.MaximumConcurrency > 0)
-            {
-                _maxWorkerCount = transferOptions.MaximumConcurrency.Value;
-            }
-            else
-            {
-                _maxWorkerCount = Constants.ContentDownloader.Partition.DefaultConcurrentTransfersCount;
-            }
-
-            // Set _rangeSize
-            if (transferOptions.MaximumTransferSize.HasValue
-                && transferOptions.MaximumTransferSize.Value > 0)
-            {
-                _rangeSize = Math.Min(transferOptions.MaximumTransferSize.Value, Constants.ContentDownloader.Partition.MaxDownloadBytes);
-            }
-            else
-            {
-                _rangeSize = Constants.ContentDownloader.Partition.DefaultBufferSize;
-            }
-
-            // Set _initialRangeSize
-            if (transferOptions.InitialTransferSize.HasValue
-                && transferOptions.InitialTransferSize.Value > 0)
-            {
-                _initialRangeSize = transferOptions.InitialTransferSize.Value;
-            }
-            else
-            {
-                _initialRangeSize = Constants.ContentDownloader.Partition.DefaultInitalDownloadRangeSize;
-            }
+            _maxWorkerCount = transferOptions.MaximumConcurrency;
+            _rangeSize = Math.Min(transferOptions.MaximumTransferSize, Constants.ContentDownloader.Partition.MaxDownloadBytes);
+            _initialRangeSize = transferOptions.InitialTransferSize;
         }
 
         internal async Task<Response> DownloadToAsync(
@@ -80,119 +48,72 @@ namespace Azure.Communication.CallingServer
             Uri endpoint,
             CancellationToken cancellationToken)
         {
-            // Wrap the download range calls in a Download span for distributed
-            // tracing
-            DiagnosticScope scope = _client._clientDiagnostics.CreateScope($"{nameof(ConversationClient)}.{nameof(ConversationClient.DownloadTo)}");
+            var initialRange = new HttpRange(0, _initialRangeSize);
+            Task<Response<Stream>> initialResponseTask =
+                _client.DownloadStreamingAsync(
+                    endpoint,
+                    initialRange,
+                    cancellationToken);
+
+            Response<Stream> initialResponse;
             try
             {
-                scope.Start();
+                initialResponse = await initialResponseTask.ConfigureAwait(false);
+            }
+            catch (RequestFailedException ex) when (ex.ErrorCode == "Invalid Range")
+            {
+                initialResponseTask = _client.DownloadStreamingAsync(
+                    endpoint,
+                    range: default,
+                    cancellationToken);
+                initialResponse = await initialResponseTask.ConfigureAwait(false);
+            }
 
-                // Just start downloading using an initial range.  If it's a
-                // small blob, we'll get the whole thing in one shot.  If it's
-                // a large blob, we'll get its full size in Content-Range and
-                // can keep downloading it in segments.
-                var initialRange = new HttpRange(0, _initialRangeSize);
-                Task<Response<Stream>> initialResponseTask =
-                    _client.DownloadStreamingAsync(
-                        endpoint,
-                        initialRange,
-                        cancellationToken);
-
-                Response<Stream> initialResponse;
-                try
-                {
-                    initialResponse = await initialResponseTask.ConfigureAwait(false);
-                }
-                catch (RequestFailedException ex) when (ex.ErrorCode == "Invalid Range")
-                {
-                    initialResponse = await _client.DownloadStreamingAsync(
-                        endpoint,
-                        range: default,
-                        cancellationToken)
-                        .ConfigureAwait(false);
-                }
-
-                // If the first segment was the entire blob, we'll copy that to
-                // the output stream and finish now
-                long initialLength = ParseResponseContentLength(initialResponse);
-                long totalLength = ParseRangeTotalLength(initialResponse);
-                if (initialLength == totalLength)
-                {
-                    await CopyToAsync(
-                        initialResponse,
-                        destination,
-                        cancellationToken)
-                        .ConfigureAwait(false);
-                    return initialResponse.GetRawResponse();
-                }
-
-                // Create a queue of tasks that will each download one segment
-                // of the blob.  The queue maintains the order of the segments
-                // so we can keep appending to the end of the destination
-                // stream when each segment finishes.
-                var runningTasks = new Queue<Task<Response<Stream>>>();
-                runningTasks.Enqueue(initialResponseTask);
-
-                // Fill the queue with tasks to download each of the remaining
-                // ranges in the blob
-                foreach (HttpRange httpRange in GetRanges(initialLength, totalLength))
-                {
-                    // Add the next Task (which will start the download but
-                    // return before it's completed downloading)
-                    runningTasks.Enqueue(_client.DownloadStreamingAsync(
-                        endpoint,
-                        httpRange,
-                        cancellationToken));
-
-                    // If we have fewer tasks than alotted workers, then just
-                    // continue adding tasks until we have _maxWorkerCount
-                    // running in parallel
-                    if (runningTasks.Count < _maxWorkerCount)
-                    {
-                        continue;
-                    }
-
-                    // Once all the workers are busy, wait for the first
-                    // segment to finish downloading before we create more work
-                    await ConsumeQueuedTask().ConfigureAwait(false);
-                }
-
-                // Wait for all of the remaining segments to download
-                while (runningTasks.Count > 0)
-                {
-                    await ConsumeQueuedTask().ConfigureAwait(false);
-                }
-
+            long initialLength = ParseResponseContentLength(initialResponse);
+            long totalLength = ParseRangeTotalLength(initialResponse);
+            if (initialLength == totalLength)
+            {
+                await CopyToAsync(
+                    initialResponse,
+                    destination,
+                    cancellationToken)
+                    .ConfigureAwait(false);
                 return initialResponse.GetRawResponse();
+            }
 
-                // Wait for the first segment in the queue of tasks to complete
-                // downloading and copy it to the destination stream
-                async Task ConsumeQueuedTask()
+            var runningTasks = new Queue<Task<Response<Stream>>>();
+            runningTasks.Enqueue(initialResponseTask);
+
+            foreach (HttpRange httpRange in GetRanges(initialLength, totalLength))
+            {
+                runningTasks.Enqueue(_client.DownloadStreamingAsync(
+                    endpoint,
+                    httpRange,
+                    cancellationToken));
+
+                if (runningTasks.Count >= _maxWorkerCount)
                 {
-                    // Don't need to worry about 304s here because the ETag
-                    // condition will turn into a 412 and throw a proper
-                    // RequestFailedException
-                    using Stream result =
-                        await runningTasks.Dequeue().ConfigureAwait(false);
-
-                    // Even though the BlobDownloadInfo is returned immediately,
-                    // CopyToAsync causes ConsumeQueuedTask to wait until the
-                    // download is complete
-                    await CopyToAsync(
-                        result,
-                        destination,
-                        cancellationToken)
-                        .ConfigureAwait(false);
+                    await ConsumeQueuedTask().ConfigureAwait(false);
                 }
             }
-            catch (Exception ex)
+
+            while (runningTasks.Count > 0)
             {
-                scope.Failed(ex);
-                throw;
+                await ConsumeQueuedTask().ConfigureAwait(false);
             }
-            finally
+
+            return initialResponse.GetRawResponse();
+
+            async Task ConsumeQueuedTask()
             {
-                scope.Dispose();
+                using Stream result =
+                    await runningTasks.Dequeue().ConfigureAwait(false);
+
+                await CopyToAsync(
+                    result,
+                    destination,
+                    cancellationToken)
+                    .ConfigureAwait(false);
             }
         }
 
@@ -208,70 +129,43 @@ namespace Azure.Communication.CallingServer
             Uri endpoint,
             CancellationToken cancellationToken)
         {
-            // Wrap the download range calls in a Download span for distributed
-            // tracing
-            DiagnosticScope scope = _client._clientDiagnostics.CreateScope($"{nameof(ConversationClient)}.{nameof(ConversationClient.DownloadTo)}");
+            var initialRange = new HttpRange(0, _initialRangeSize);
+            Response<Stream> initialResponse;
+
             try
             {
-                scope.Start();
+                initialResponse = _client.DownloadStreaming(
+                    endpoint,
+                    initialRange,
+                    cancellationToken);
+            }
+            catch (RequestFailedException ex) when (ex.ErrorCode == "Invalid Range")
+            {
+                initialResponse = _client.DownloadStreaming(
+                    endpoint,
+                    range: default,
+                    cancellationToken);
+            }
 
-                // Just start downloading using an initial range.  If it's a
-                // small blob, we'll get the whole thing in one shot.  If it's
-                // a large blob, we'll get its full size in Content-Range and
-                // can keep downloading it in segments.
-                var initialRange = new HttpRange(0, _initialRangeSize);
-                Response<Stream> initialResponse;
+            CopyTo(initialResponse, destination, cancellationToken);
 
-                try
-                {
-                    initialResponse = _client.DownloadStreaming(
-                        endpoint,
-                        initialRange,
-                        cancellationToken);
-                }
-                catch (RequestFailedException ex) when (ex.ErrorCode == "Invalid Range")
-                {
-                    initialResponse = _client.DownloadStreaming(
-                        endpoint,
-                        range: default,
-                        cancellationToken);
-                }
-
-                // Copy the first segment to the destination stream
-                CopyTo(initialResponse, destination, cancellationToken);
-
-                // If the first segment was the entire blob, we're finished now
-                long initialLength = ParseResponseContentLength(initialResponse);
-                long totalLength = ParseRangeTotalLength(initialResponse);
-                if (initialLength == totalLength)
-                {
-                    return initialResponse.GetRawResponse();
-                }
-
-                // Download each of the remaining ranges in the blob
-                foreach (HttpRange httpRange in GetRanges(initialLength, totalLength))
-                {
-                    // Don't need to worry about 304s here because the ETag
-                    // condition will turn into a 412 and throw a proper
-                    // RequestFailedException
-                    Response<Stream> result = _client.DownloadStreaming(
-                        endpoint,
-                        httpRange,
-                        cancellationToken);
-                    CopyTo(result.Value, destination, cancellationToken);
-                }
-
+            long initialLength = ParseResponseContentLength(initialResponse);
+            long totalLength = ParseRangeTotalLength(initialResponse);
+            if (initialLength == totalLength)
+            {
                 return initialResponse.GetRawResponse();
             }
-            catch (Exception ex)
+
+            foreach (HttpRange httpRange in GetRanges(initialLength, totalLength))
             {
-                scope.Failed(ex);
-                throw;
+                Response<Stream> result = _client.DownloadStreaming(
+                    endpoint,
+                    httpRange,
+                    cancellationToken);
+                CopyTo(result.Value, destination, cancellationToken);
             }
-            finally
-            {
-                scope.Dispose();
-            }
+
+            return initialResponse.GetRawResponse();
         }
 
         private static long ParseRangeTotalLength(Response<Stream> response)
@@ -280,12 +174,12 @@ namespace Azure.Communication.CallingServer
 
             if (range == null)
             {
-                return 0;
+                return ParseResponseContentLength(response);
             }
             int lengthSeparator = range.IndexOf("/", StringComparison.InvariantCultureIgnoreCase);
             if (lengthSeparator == -1)
             {
-                throw new ArgumentException("Could not obtain the total length from HTTP range " + range);
+                throw new SystemException("Could not obtain the total length from HTTP range " + range);
             }
             return long.Parse(range.Substring(lengthSeparator + 1), CultureInfo.InvariantCulture);
         }

--- a/sdk/communication/Azure.Communication.CallingServer/src/PartitionedDownloader.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/PartitionedDownloader.cs
@@ -60,7 +60,7 @@ namespace Azure.Communication.CallingServer
             {
                 initialResponse = await initialResponseTask.ConfigureAwait(false);
             }
-            catch (RequestFailedException ex) when (ex.ErrorCode == "Invalid Range")
+            catch (RequestFailedException ex) when (ex.Status == 416) //Invalid Range
             {
                 initialResponseTask = _client.DownloadStreamingAsync(
                     endpoint,
@@ -139,7 +139,7 @@ namespace Azure.Communication.CallingServer
                     initialRange,
                     cancellationToken);
             }
-            catch (RequestFailedException ex) when (ex.ErrorCode == "Invalid Range")
+            catch (RequestFailedException ex) when (ex.Status == 416) // Invalid Range
             {
                 initialResponse = _client.DownloadStreaming(
                     endpoint,
@@ -184,14 +184,14 @@ namespace Azure.Communication.CallingServer
             return long.Parse(range.Substring(lengthSeparator + 1), CultureInfo.InvariantCulture);
         }
 
-        private static async Task CopyToAsync(
+        private async Task CopyToAsync(
             Stream result,
             Stream destination,
             CancellationToken cancellationToken)
         {
             await result.CopyToAsync(
                 destination,
-                100000,
+                (int)_rangeSize,
                 cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -202,7 +202,7 @@ namespace Azure.Communication.CallingServer
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            result.CopyTo(destination, 1000000);
+            result.CopyTo(destination);
             result.Dispose();
         }
 

--- a/sdk/communication/Azure.Communication.CallingServer/tests/Azure.Communication.CallingServer.Tests.csproj
+++ b/sdk/communication/Azure.Communication.CallingServer/tests/Azure.Communication.CallingServer.Tests.csproj
@@ -17,6 +17,8 @@
   <!-- Shared source from Azure.Core -->
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="$(AzureCoreSharedSources)RetriableStream.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\samples\README.md" Link="samples\README.md" />

--- a/sdk/communication/Azure.Communication.CallingServer/tests/ConversationClients/ContentDownloadTests.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/tests/ConversationClients/ContentDownloadTests.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+using System.Linq;
+using Azure.Core.Pipeline;
+using Azure.Communication.CallingServer.Models;
+using Azure.Communication.CallingServer.Tests.ConversationClients;
+
+namespace Azure.Communication.CallingServer.Tests.ContentDownloadTests
+{
+    public class ContentDownloadTests : ConversationClientBaseTests
+    {
+        private const string DummyRecordingMetadata = "{" +
+                                                "\"chunkDocumentId\": \"dummyDocId\"," +
+                                                "\"resourceId\": \"dummyResourceId\"," +
+                                                "\"callId\": \"dummyCallId\"," +
+                                                "\"chunkIndex\": 0," +
+                                                "\"chunkStartTime\": \"dummyStartTime\"," +
+                                                "\"chunkDuration\": 1.5," +
+                                                "\"version\": \"1.0\"," +
+                                                "\"pauseResumeIntervals\": [{" +
+                                                "\"startTime\": \"pauseStartTime\"," +
+                                                "\"duration\": 0.5" +
+                                                "}]," +
+                                                "\"recordingInfo\": {}," +
+                                                "\"participants\": [" +
+                                                "{\"participantId\": \"participantId00\"}," +
+                                                "{\"participantId\": \"participantId01\"}" +
+                                                "]" +
+                                                "}";
+        private readonly byte[] _dummyRecordingStream = new byte[]
+        {
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 0
+        };
+
+        private readonly Uri _dummyMetadataLocation = new("https://localhost/documents/metadata/document_id/acsmetadata");
+        private readonly Uri _dummyRecordingLocation = new("https://localhost/documents/document_id/");
+
+        private readonly HttpHeader[] _rangeResponseHeaders = new HttpHeader[]
+            {
+                new HttpHeader("Content-Range", "bytes 0-4/5")
+            };
+
+        [Test]
+        public void DownloadMetadata_Test()
+        {
+            ConversationClient _convClient = CreateMockConversationClient(200, DummyRecordingMetadata);
+
+            Stream metadata = _convClient.DownloadStreaming(_dummyMetadataLocation);
+
+            VerifyExpectedMetadata(metadata);
+        }
+
+        [Test]
+        public async Task DownloadMetadataAsync_Test()
+        {
+            ConversationClient _convClient = CreateMockConversationClient(200, DummyRecordingMetadata);
+
+            Stream metadata = await _convClient.DownloadStreamingAsync(_dummyMetadataLocation);
+
+            VerifyExpectedMetadata(metadata);
+        }
+
+        [Test]
+        public void DownloadRecording_Test()
+        {
+            ConversationClient _convClient = CreateMockConversationClient(200, _dummyRecordingStream);
+
+            Response<Stream> recording = _convClient.DownloadStreaming(_dummyRecordingLocation);
+
+            VerifyExpectedRecording(recording, 10);
+        }
+
+        [Test]
+        public void DownloadRecordingByRanges_Test()
+        {
+            ConversationClient _convClient = CreateMockConversationClient(206, _dummyRecordingStream.Take(5).ToArray(), _rangeResponseHeaders);
+
+            Response<Stream> recording = _convClient.DownloadStreaming(_dummyRecordingLocation, new HttpRange(0, 4));
+
+            VerifyExpectedRecording(recording, 5);
+        }
+
+        [Test]
+        public async Task DownloadRecordingAsync_Test()
+        {
+            ConversationClient _convClient = CreateMockConversationClient(200, _dummyRecordingStream);
+
+            Response<Stream> recording = await _convClient.DownloadStreamingAsync(_dummyRecordingLocation);
+
+            VerifyExpectedRecording(recording, 10);
+        }
+
+        [Test]
+        public async Task DownloadRecordingByRangesAsync_Test()
+        {
+            ConversationClient _convClient = CreateMockConversationClient(206, _dummyRecordingStream.Take(5).ToArray(), _rangeResponseHeaders);
+
+            Response<Stream> recording = await _convClient.DownloadStreamingAsync(_dummyRecordingLocation, new HttpRange(0, 4));
+
+            VerifyExpectedRecording(recording, 5);
+        }
+
+        [Test]
+        public void DownloadRecordingToStream_Test()
+        {
+            HttpHeader[] rangeHeaderResponse = new HttpHeader[]
+            {
+                new HttpHeader("Content-Range", "bytes 0-9/10"),
+                new HttpHeader("Content-Length", "10"),
+            };
+
+            ContentTransferOptions options = new();
+            options.InitialTransferSize = 10;
+
+            ConversationClient _convClient = CreateMockConversationClient(206, _dummyRecordingStream, rangeHeaderResponse);
+
+            Stream destination = new MemoryStream();
+            _convClient.DownloadTo(destination, _dummyRecordingLocation, options);
+
+            Assert.AreEqual(10, destination.Length);
+        }
+
+        [Test]
+        public void DownloadNotExistentContent_Failure_Test()
+        {
+            ConversationClient _convClient = CreateMockConversationClient(404);
+            Assert.Throws<RequestFailedException>(() => _convClient.DownloadStreaming(_dummyMetadataLocation));
+        }
+
+        [Test]
+        public void DownloadNotExistentContentAsync_Failure_Test()
+        {
+            ConversationClient _convClient = CreateMockConversationClient(404);
+            Assert.ThrowsAsync<RequestFailedException>(async () => await _convClient.DownloadStreamingAsync(_dummyMetadataLocation));
+        }
+
+        private static void VerifyExpectedMetadata(Stream metadata)
+        {
+            Assert.IsNotNull(metadata);
+            JsonElement expected = JsonDocument.Parse(DummyRecordingMetadata).RootElement;
+            JsonElement actual = JsonDocument.Parse(metadata).RootElement;
+            Assert.AreEqual(expected.GetProperty("chunkDocumentId").GetString(), actual.GetProperty("chunkDocumentId").GetString());
+        }
+
+        private static void VerifyExpectedRecording(Response<Stream> recording, int recordingLength)
+        {
+            Assert.IsNotNull(recording.Value);
+            Assert.IsTrue(recording.Value.GetType().Name.Contains(typeof(RetriableStream).Name));
+            Assert.AreEqual(recordingLength, recording.Value.Length);
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/tests/ConversationClients/ContentDownloadTests.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/tests/ConversationClients/ContentDownloadTests.cs
@@ -6,11 +6,9 @@ using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System.Linq;
 using Azure.Core.Pipeline;
-using Azure.Communication.CallingServer.Models;
 using Azure.Communication.CallingServer.Tests.ConversationClients;
 
 namespace Azure.Communication.CallingServer.Tests.ContentDownloadTests
@@ -123,7 +121,7 @@ namespace Azure.Communication.CallingServer.Tests.ContentDownloadTests
             ConversationClient _convClient = CreateMockConversationClient(206, _dummyRecordingStream, rangeHeaderResponse);
 
             Stream destination = new MemoryStream();
-            _convClient.DownloadTo(destination, _dummyRecordingLocation, options);
+            _convClient.DownloadTo(_dummyRecordingLocation, destination, options);
 
             Assert.AreEqual(10, destination.Length);
         }

--- a/sdk/communication/Azure.Communication.CallingServer/tests/ConversationClients/ConversationClientBaseTests.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/tests/ConversationClients/ConversationClientBaseTests.cs
@@ -40,5 +40,20 @@ namespace Azure.Communication.CallingServer.Tests.ConversationClients
             var convClient = new ConversationClient(uri, communicationTokenCredential, callClientOptions);
             return convClient;
         }
+
+        public ConversationClient CreateMockConversationClient(MockResponse[] mockResponses)
+        {
+            var uri = new Uri("https://acs.dummyresource.com");
+            var communicationTokenCredential =
+                new AzureKeyCredential(dummyAccessKey);
+
+            var callClientOptions = new CallClientOptions
+            {
+                Transport = new MockTransport(mockResponses)
+            };
+
+            var convClient = new ConversationClient(uri, communicationTokenCredential, callClientOptions);
+            return convClient;
+        }
     }
 }

--- a/sdk/communication/Shared/src/HMACAuthenticationPolicy.cs
+++ b/sdk/communication/Shared/src/HMACAuthenticationPolicy.cs
@@ -63,7 +63,17 @@ namespace Azure.Communication.Pipeline
         private void AddHeaders(HttpMessage message, string contentHash)
         {
             var utcNowString = DateTimeOffset.UtcNow.ToString("r", CultureInfo.InvariantCulture);
-            var authorization = GetAuthorizationHeader(message.Request.Method, message.Request.Uri.ToUri(), contentHash, utcNowString);
+            string authorization;
+
+            message.TryGetProperty("uriToSignRequestWith", out var uriToSignWith);
+            if (uriToSignWith != null && uriToSignWith.GetType() == typeof(Uri))
+            {
+                authorization = GetAuthorizationHeader(message.Request.Method, (Uri)uriToSignWith, contentHash, utcNowString);
+            }
+            else
+            {
+                authorization = GetAuthorizationHeader(message.Request.Method, message.Request.Uri.ToUri(), contentHash, utcNowString);
+            }
 
             message.Request.Headers.SetValue("x-ms-content-sha256", contentHash);
             message.Request.Headers.SetValue(HttpHeader.Names.Date, utcNowString);


### PR DESCRIPTION
This change adds a new 'DownloadStreaming' and 'DownloadStreamingAsync' methods
which allow users to download their requested content related to ACS Recording.
This as well adds 'DownloadTo' and 'DownloadToAsync' methods to provide
a streaming or a file and copy the content to those.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.

closes Azure/azure-sdk-pr#704