### PR TITLE
[MetricsAdvisor] Regenerate code from latest swagger

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Renamed all `SkipCount` listing options to `Skip`. Affected classes include `GetAlertsOptions`, `GetDataFeedsOptions`, `GetHooksOptions`, and others.
 - Renamed all `TopCount` listing options to `MaxPageSize`. Affected classes include `GetAlertsOptions`, `GetDataFeedsOptions`, `GetHooksOptions`, and others.
 - Removed data feed sources `ElasticsearchDataFeedSource` and `HttpRequestDataFeedSource` as they are not supported by the service anymore. A different type of data feed source must be used for data ingestion instead.
+- Removed granularity type `DataFeedGranularityType.PerSecond` as it's not supported by the service anymore.
 
 ## 1.0.0-beta.3 (2021-02-09)
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -19,19 +19,6 @@ namespace Azure.AI.MetricsAdvisor
         public static bool operator !=(Azure.AI.MetricsAdvisor.AlertQueryTimeMode left, Azure.AI.MetricsAdvisor.AlertQueryTimeMode right) { throw null; }
         public override string ToString() { throw null; }
     }
-    public static partial class AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2ModelFactory
-    {
-        public static Azure.AI.MetricsAdvisor.Models.AnomalyAlert AnomalyAlert(string id = null, System.DateTimeOffset timestamp = default(System.DateTimeOffset), System.DateTimeOffset createdTime = default(System.DateTimeOffset), System.DateTimeOffset modifiedTime = default(System.DateTimeOffset)) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration AnomalyAlertConfiguration(string id = null, string name = null, string description = null, Azure.AI.MetricsAdvisor.Models.MetricAnomalyAlertConfigurationsOperator? crossMetricsOperator = default(Azure.AI.MetricsAdvisor.Models.MetricAnomalyAlertConfigurationsOperator?), System.Collections.Generic.IList<string> splitAlertByDimensions = null, System.Collections.Generic.IList<string> idsOfHooksToAlert = null, System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.MetricAnomalyAlertConfiguration> metricAlertConfigurations = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration AnomalyDetectionConfiguration(string id = null, string name = null, string description = null, string metricId = null, Azure.AI.MetricsAdvisor.Models.MetricWholeSeriesDetectionCondition wholeSeriesDetectionConditions = null, System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.MetricSeriesGroupDetectionCondition> seriesGroupDetectionConditions = null, System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.MetricSingleSeriesDetectionCondition> seriesDetectionConditions = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.DataFeedIngestionProgress DataFeedIngestionProgress(System.DateTimeOffset? latestSuccessTimestamp = default(System.DateTimeOffset?), System.DateTimeOffset? latestActiveTimestamp = default(System.DateTimeOffset?)) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.DataFeedIngestionStatus DataFeedIngestionStatus(System.DateTimeOffset timestamp = default(System.DateTimeOffset), Azure.AI.MetricsAdvisor.Models.IngestionStatusType status = default(Azure.AI.MetricsAdvisor.Models.IngestionStatusType), string message = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.DataFeedMetric DataFeedMetric(string metricId = null, string metricName = null, string metricDisplayName = null, string metricDescription = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.EnrichmentStatus EnrichmentStatus(System.DateTimeOffset timestamp = default(System.DateTimeOffset), string status = null, string message = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.IncidentRootCause IncidentRootCause(Azure.AI.MetricsAdvisor.Models.DimensionKey dimensionKey = null, System.Collections.Generic.IReadOnlyList<string> paths = null, double score = 0, string description = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.MetricSeriesData MetricSeriesData(Azure.AI.MetricsAdvisor.Models.MetricSeriesDefinition definition = null, System.Collections.Generic.IReadOnlyList<System.DateTimeOffset> timestamps = null, System.Collections.Generic.IReadOnlyList<double> values = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.MetricSeriesDefinition MetricSeriesDefinition(string metricId = null, System.Collections.Generic.IReadOnlyDictionary<string, string> dimension = null) { throw null; }
-    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct FeedbackQueryTimeMode : System.IEquatable<Azure.AI.MetricsAdvisor.FeedbackQueryTimeMode>
     {
@@ -212,6 +199,19 @@ namespace Azure.AI.MetricsAdvisor
         public MetricsAdvisorKeyCredential(string subscriptionKey, string apiKey) { }
         public void UpdateApiKey(string apiKey) { }
         public void UpdateSubscriptionKey(string subscriptionKey) { }
+    }
+    public static partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory
+    {
+        public static Azure.AI.MetricsAdvisor.Models.AnomalyAlert AnomalyAlert(string id = null, System.DateTimeOffset timestamp = default(System.DateTimeOffset), System.DateTimeOffset createdTime = default(System.DateTimeOffset), System.DateTimeOffset modifiedTime = default(System.DateTimeOffset)) { throw null; }
+        public static Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration AnomalyAlertConfiguration(string id = null, string name = null, string description = null, Azure.AI.MetricsAdvisor.Models.MetricAnomalyAlertConfigurationsOperator? crossMetricsOperator = default(Azure.AI.MetricsAdvisor.Models.MetricAnomalyAlertConfigurationsOperator?), System.Collections.Generic.IList<string> splitAlertByDimensions = null, System.Collections.Generic.IList<string> idsOfHooksToAlert = null, System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.MetricAnomalyAlertConfiguration> metricAlertConfigurations = null) { throw null; }
+        public static Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration AnomalyDetectionConfiguration(string id = null, string name = null, string description = null, string metricId = null, Azure.AI.MetricsAdvisor.Models.MetricWholeSeriesDetectionCondition wholeSeriesDetectionConditions = null, System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.MetricSeriesGroupDetectionCondition> seriesGroupDetectionConditions = null, System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.MetricSingleSeriesDetectionCondition> seriesDetectionConditions = null) { throw null; }
+        public static Azure.AI.MetricsAdvisor.Models.DataFeedIngestionProgress DataFeedIngestionProgress(System.DateTimeOffset? latestSuccessTimestamp = default(System.DateTimeOffset?), System.DateTimeOffset? latestActiveTimestamp = default(System.DateTimeOffset?)) { throw null; }
+        public static Azure.AI.MetricsAdvisor.Models.DataFeedIngestionStatus DataFeedIngestionStatus(System.DateTimeOffset timestamp = default(System.DateTimeOffset), Azure.AI.MetricsAdvisor.Models.IngestionStatusType status = default(Azure.AI.MetricsAdvisor.Models.IngestionStatusType), string message = null) { throw null; }
+        public static Azure.AI.MetricsAdvisor.Models.DataFeedMetric DataFeedMetric(string metricId = null, string metricName = null, string metricDisplayName = null, string metricDescription = null) { throw null; }
+        public static Azure.AI.MetricsAdvisor.Models.EnrichmentStatus EnrichmentStatus(System.DateTimeOffset timestamp = default(System.DateTimeOffset), string status = null, string message = null) { throw null; }
+        public static Azure.AI.MetricsAdvisor.Models.IncidentRootCause IncidentRootCause(Azure.AI.MetricsAdvisor.Models.DimensionKey dimensionKey = null, System.Collections.Generic.IReadOnlyList<string> paths = null, double score = 0, string description = null) { throw null; }
+        public static Azure.AI.MetricsAdvisor.Models.MetricSeriesData MetricSeriesData(Azure.AI.MetricsAdvisor.Models.MetricSeriesDefinition definition = null, System.Collections.Generic.IReadOnlyList<System.DateTimeOffset> timestamps = null, System.Collections.Generic.IReadOnlyList<double> values = null) { throw null; }
+        public static Azure.AI.MetricsAdvisor.Models.MetricSeriesDefinition MetricSeriesDefinition(string metricId = null, System.Collections.Generic.IReadOnlyDictionary<string, string> dimension = null) { throw null; }
     }
 }
 namespace Azure.AI.MetricsAdvisor.Administration
@@ -624,7 +624,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public static Azure.AI.MetricsAdvisor.Models.DataFeedGranularityType Hourly { get { throw null; } }
         public static Azure.AI.MetricsAdvisor.Models.DataFeedGranularityType Monthly { get { throw null; } }
         public static Azure.AI.MetricsAdvisor.Models.DataFeedGranularityType PerMinute { get { throw null; } }
-        public static Azure.AI.MetricsAdvisor.Models.DataFeedGranularityType PerSecond { get { throw null; } }
         public static Azure.AI.MetricsAdvisor.Models.DataFeedGranularityType Weekly { get { throw null; } }
         public static Azure.AI.MetricsAdvisor.Models.DataFeedGranularityType Yearly { get { throw null; } }
         public bool Equals(Azure.AI.MetricsAdvisor.Models.DataFeedGranularityType other) { throw null; }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -200,19 +200,6 @@ namespace Azure.AI.MetricsAdvisor
         public void UpdateApiKey(string apiKey) { }
         public void UpdateSubscriptionKey(string subscriptionKey) { }
     }
-    public static partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory
-    {
-        public static Azure.AI.MetricsAdvisor.Models.AnomalyAlert AnomalyAlert(string id = null, System.DateTimeOffset timestamp = default(System.DateTimeOffset), System.DateTimeOffset createdTime = default(System.DateTimeOffset), System.DateTimeOffset modifiedTime = default(System.DateTimeOffset)) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration AnomalyAlertConfiguration(string id = null, string name = null, string description = null, Azure.AI.MetricsAdvisor.Models.MetricAnomalyAlertConfigurationsOperator? crossMetricsOperator = default(Azure.AI.MetricsAdvisor.Models.MetricAnomalyAlertConfigurationsOperator?), System.Collections.Generic.IList<string> splitAlertByDimensions = null, System.Collections.Generic.IList<string> idsOfHooksToAlert = null, System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.MetricAnomalyAlertConfiguration> metricAlertConfigurations = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration AnomalyDetectionConfiguration(string id = null, string name = null, string description = null, string metricId = null, Azure.AI.MetricsAdvisor.Models.MetricWholeSeriesDetectionCondition wholeSeriesDetectionConditions = null, System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.MetricSeriesGroupDetectionCondition> seriesGroupDetectionConditions = null, System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.MetricSingleSeriesDetectionCondition> seriesDetectionConditions = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.DataFeedIngestionProgress DataFeedIngestionProgress(System.DateTimeOffset? latestSuccessTimestamp = default(System.DateTimeOffset?), System.DateTimeOffset? latestActiveTimestamp = default(System.DateTimeOffset?)) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.DataFeedIngestionStatus DataFeedIngestionStatus(System.DateTimeOffset timestamp = default(System.DateTimeOffset), Azure.AI.MetricsAdvisor.Models.IngestionStatusType status = default(Azure.AI.MetricsAdvisor.Models.IngestionStatusType), string message = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.DataFeedMetric DataFeedMetric(string metricId = null, string metricName = null, string metricDisplayName = null, string metricDescription = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.EnrichmentStatus EnrichmentStatus(System.DateTimeOffset timestamp = default(System.DateTimeOffset), string status = null, string message = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.IncidentRootCause IncidentRootCause(Azure.AI.MetricsAdvisor.Models.DimensionKey dimensionKey = null, System.Collections.Generic.IReadOnlyList<string> paths = null, double score = 0, string description = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.MetricSeriesData MetricSeriesData(Azure.AI.MetricsAdvisor.Models.MetricSeriesDefinition definition = null, System.Collections.Generic.IReadOnlyList<System.DateTimeOffset> timestamps = null, System.Collections.Generic.IReadOnlyList<double> values = null) { throw null; }
-        public static Azure.AI.MetricsAdvisor.Models.MetricSeriesDefinition MetricSeriesDefinition(string metricId = null, System.Collections.Generic.IReadOnlyDictionary<string, string> dimension = null) { throw null; }
-    }
 }
 namespace Azure.AI.MetricsAdvisor.Administration
 {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders.cs
@@ -10,10 +10,10 @@ using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor
 {
-    internal partial class AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders
+    internal partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders
     {
         private readonly Response _response;
-        public AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders(Response response)
+        public MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders(Response response)
         {
             _response = response;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders.cs
@@ -10,10 +10,10 @@ using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor
 {
-    internal partial class AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders
+    internal partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders
     {
         private readonly Response _response;
-        public AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders(Response response)
+        public MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders(Response response)
         {
             _response = response;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders.cs
@@ -10,10 +10,10 @@ using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor
 {
-    internal partial class AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders
+    internal partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders
     {
         private readonly Response _response;
-        public AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders(Response response)
+        public MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders(Response response)
         {
             _response = response;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders.cs
@@ -10,10 +10,10 @@ using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor
 {
-    internal partial class AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders
+    internal partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders
     {
         private readonly Response _response;
-        public AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders(Response response)
+        public MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders(Response response)
         {
             _response = response;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders.cs
@@ -10,10 +10,10 @@ using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor
 {
-    internal partial class AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders
+    internal partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders
     {
         private readonly Response _response;
-        public AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders(Response response)
+        public MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders(Response response)
         {
             _response = response;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders.cs
@@ -10,10 +10,10 @@ using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor
 {
-    internal partial class AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders
+    internal partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders
     {
         private readonly Response _response;
-        public AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders(Response response)
+        public MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders(Response response)
         {
             _response = response;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory.cs
@@ -12,7 +12,7 @@ using Azure.AI.MetricsAdvisor.Models;
 namespace Azure.AI.MetricsAdvisor
 {
     /// <summary> Model factory for read-only models. </summary>
-    public static partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory
+    internal static partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory
     {
         /// <summary> Initializes new instance of AnomalyAlertConfiguration class. </summary>
         /// <param name="id"> anomaly alerting configuration unique id. </param>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory.cs
@@ -12,7 +12,7 @@ using Azure.AI.MetricsAdvisor.Models;
 namespace Azure.AI.MetricsAdvisor
 {
     /// <summary> Model factory for read-only models. </summary>
-    public static partial class AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2ModelFactory
+    public static partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory
     {
         /// <summary> Initializes new instance of AnomalyAlertConfiguration class. </summary>
         /// <param name="id"> anomaly alerting configuration unique id. </param>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient.cs
@@ -16,18 +16,18 @@ using Azure.Core.Pipeline;
 
 namespace Azure.AI.MetricsAdvisor
 {
-    internal partial class AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2RestClient
+    internal partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient
     {
         private string endpoint;
         private ClientDiagnostics _clientDiagnostics;
         private HttpPipeline _pipeline;
 
-        /// <summary> Initializes a new instance of AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2RestClient. </summary>
+        /// <summary> Initializes a new instance of MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient. </summary>
         /// <param name="clientDiagnostics"> The handler for diagnostic messaging in the client. </param>
         /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
         /// <param name="endpoint"> Supported Cognitive Services endpoints (protocol and hostname, for example: https://&lt;resource-name&gt;.cognitiveservices.azure.com). </param>
         /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/> is null. </exception>
-        public AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2RestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint)
+        public MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint)
         {
             if (endpoint == null)
             {
@@ -294,7 +294,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> anomaly alerting configuration. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public async Task<ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders>> CreateAnomalyAlertingConfigurationAsync(AnomalyAlertConfiguration body, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders>> CreateAnomalyAlertingConfigurationAsync(AnomalyAlertConfiguration body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -303,7 +303,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateAnomalyAlertingConfigurationRequest(body);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:
@@ -317,7 +317,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> anomaly alerting configuration. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders> CreateAnomalyAlertingConfiguration(AnomalyAlertConfiguration body, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders> CreateAnomalyAlertingConfiguration(AnomalyAlertConfiguration body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -326,7 +326,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateAnomalyAlertingConfigurationRequest(body);
             _pipeline.Send(message, cancellationToken);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:
@@ -797,7 +797,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> anomaly detection configuration. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public async Task<ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders>> CreateAnomalyDetectionConfigurationAsync(AnomalyDetectionConfiguration body, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders>> CreateAnomalyDetectionConfigurationAsync(AnomalyDetectionConfiguration body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -806,7 +806,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateAnomalyDetectionConfigurationRequest(body);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:
@@ -820,7 +820,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> anomaly detection configuration. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders> CreateAnomalyDetectionConfiguration(AnomalyDetectionConfiguration body, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders> CreateAnomalyDetectionConfiguration(AnomalyDetectionConfiguration body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -829,7 +829,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateAnomalyDetectionConfigurationRequest(body);
             _pipeline.Send(message, cancellationToken);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:
@@ -1409,7 +1409,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> Create data source credential request. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public async Task<ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders>> CreateCredentialAsync(DataSourceCredentialEntity body, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders>> CreateCredentialAsync(DataSourceCredentialEntity body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -1418,7 +1418,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateCredentialRequest(body);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:
@@ -1432,7 +1432,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> Create data source credential request. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders> CreateCredential(DataSourceCredentialEntity body, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders> CreateCredential(DataSourceCredentialEntity body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -1441,7 +1441,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateCredentialRequest(body);
             _pipeline.Send(message, cancellationToken);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:
@@ -1814,7 +1814,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> parameters to create a data feed. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public async Task<ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders>> CreateDataFeedAsync(DataFeedDetail body, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders>> CreateDataFeedAsync(DataFeedDetail body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -1823,7 +1823,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateDataFeedRequest(body);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:
@@ -1837,7 +1837,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> parameters to create a data feed. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> CreateDataFeed(DataFeedDetail body, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> CreateDataFeed(DataFeedDetail body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -1846,7 +1846,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateDataFeedRequest(body);
             _pipeline.Send(message, cancellationToken);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:
@@ -2198,7 +2198,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> metric feedback. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public async Task<ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders>> CreateMetricFeedbackAsync(MetricFeedback body, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders>> CreateMetricFeedbackAsync(MetricFeedback body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -2207,7 +2207,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateMetricFeedbackRequest(body);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:
@@ -2221,7 +2221,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> metric feedback. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders> CreateMetricFeedback(MetricFeedback body, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders> CreateMetricFeedback(MetricFeedback body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -2230,7 +2230,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateMetricFeedbackRequest(body);
             _pipeline.Send(message, cancellationToken);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:
@@ -2334,7 +2334,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> Create hook request. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public async Task<ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders>> CreateHookAsync(NotificationHook body, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders>> CreateHookAsync(NotificationHook body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -2343,7 +2343,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateHookRequest(body);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:
@@ -2357,7 +2357,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="body"> Create hook request. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
-        public ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders> CreateHook(NotificationHook body, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders> CreateHook(NotificationHook body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -2366,7 +2366,7 @@ namespace Azure.AI.MetricsAdvisor
 
             using var message = CreateCreateHookRequest(body);
             _pipeline.Send(message, cancellationToken);
-            var headers = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders(message.Response);
+            var headers = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders(message.Response);
             switch (message.Response.Status)
             {
                 case 201:

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureSQLConnectionStringParam.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureSQLConnectionStringParam.Serialization.cs
@@ -15,14 +15,17 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("connectionString");
-            writer.WriteStringValue(ConnectionString);
+            if (Optional.IsDefined(ConnectionString))
+            {
+                writer.WritePropertyName("connectionString");
+                writer.WriteStringValue(ConnectionString);
+            }
             writer.WriteEndObject();
         }
 
         internal static AzureSQLConnectionStringParam DeserializeAzureSQLConnectionStringParam(JsonElement element)
         {
-            string connectionString = default;
+            Optional<string> connectionString = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("connectionString"))
@@ -31,7 +34,7 @@ namespace Azure.AI.MetricsAdvisor.Models
                     continue;
                 }
             }
-            return new AzureSQLConnectionStringParam(connectionString);
+            return new AzureSQLConnectionStringParam(connectionString.Value);
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureSQLConnectionStringParam.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureSQLConnectionStringParam.cs
@@ -5,23 +5,20 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The AzureSQLConnectionStringParam. </summary>
     internal partial class AzureSQLConnectionStringParam
     {
         /// <summary> Initializes a new instance of AzureSQLConnectionStringParam. </summary>
-        /// <param name="connectionString"> The connection string to access the Azure SQL. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="connectionString"/> is null. </exception>
-        public AzureSQLConnectionStringParam(string connectionString)
+        public AzureSQLConnectionStringParam()
         {
-            if (connectionString == null)
-            {
-                throw new ArgumentNullException(nameof(connectionString));
-            }
+        }
 
+        /// <summary> Initializes a new instance of AzureSQLConnectionStringParam. </summary>
+        /// <param name="connectionString"> The connection string to access the Azure SQL. </param>
+        internal AzureSQLConnectionStringParam(string connectionString)
+        {
             ConnectionString = connectionString;
         }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataFeedGranularityType.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataFeedGranularityType.cs
@@ -28,7 +28,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         private const string DailyValue = "Daily";
         private const string HourlyValue = "Hourly";
         private const string PerMinuteValue = "Minutely";
-        private const string PerSecondValue = "Secondly";
         private const string CustomValue = "Custom";
         /// <summary> Determines if two <see cref="DataFeedGranularityType"/> values are the same. </summary>
         public static bool operator ==(DataFeedGranularityType left, DataFeedGranularityType right) => left.Equals(right);

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataLakeGen2SharedKeyParam.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataLakeGen2SharedKeyParam.Serialization.cs
@@ -15,14 +15,17 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("accountKey");
-            writer.WriteStringValue(AccountKey);
+            if (Optional.IsDefined(AccountKey))
+            {
+                writer.WritePropertyName("accountKey");
+                writer.WriteStringValue(AccountKey);
+            }
             writer.WriteEndObject();
         }
 
         internal static DataLakeGen2SharedKeyParam DeserializeDataLakeGen2SharedKeyParam(JsonElement element)
         {
-            string accountKey = default;
+            Optional<string> accountKey = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("accountKey"))
@@ -31,7 +34,7 @@ namespace Azure.AI.MetricsAdvisor.Models
                     continue;
                 }
             }
-            return new DataLakeGen2SharedKeyParam(accountKey);
+            return new DataLakeGen2SharedKeyParam(accountKey.Value);
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataLakeGen2SharedKeyParam.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataLakeGen2SharedKeyParam.cs
@@ -5,23 +5,20 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The DataLakeGen2SharedKeyParam. </summary>
     internal partial class DataLakeGen2SharedKeyParam
     {
         /// <summary> Initializes a new instance of DataLakeGen2SharedKeyParam. </summary>
-        /// <param name="accountKey"> The account key to access the Azure Data Lake Storage Gen2. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="accountKey"/> is null. </exception>
-        public DataLakeGen2SharedKeyParam(string accountKey)
+        public DataLakeGen2SharedKeyParam()
         {
-            if (accountKey == null)
-            {
-                throw new ArgumentNullException(nameof(accountKey));
-            }
+        }
 
+        /// <summary> Initializes a new instance of DataLakeGen2SharedKeyParam. </summary>
+        /// <param name="accountKey"> The account key to access the Azure Data Lake Storage Gen2. </param>
+        internal DataLakeGen2SharedKeyParam(string accountKey)
+        {
             AccountKey = accountKey;
         }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailHookInfoPatch.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailHookInfoPatch.Serialization.cs
@@ -37,6 +37,16 @@ namespace Azure.AI.MetricsAdvisor.Models
                 writer.WritePropertyName("externalLink");
                 writer.WriteStringValue(ExternalLink);
             }
+            if (Optional.IsCollectionDefined(Admins))
+            {
+                writer.WritePropertyName("admins");
+                writer.WriteStartArray();
+                foreach (var item in Admins)
+                {
+                    writer.WriteStringValue(item);
+                }
+                writer.WriteEndArray();
+            }
             writer.WriteEndObject();
         }
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.Serialization.cs
@@ -32,6 +32,16 @@ namespace Azure.AI.MetricsAdvisor.Models
                 writer.WritePropertyName("externalLink");
                 writer.WriteStringValue(InternalExternalLink);
             }
+            if (Optional.IsCollectionDefined(Administrators))
+            {
+                writer.WritePropertyName("admins");
+                writer.WriteStartArray();
+                foreach (var item in Administrators)
+                {
+                    writer.WriteStringValue(item);
+                }
+                writer.WriteEndArray();
+            }
             writer.WriteEndObject();
         }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.Serialization.cs
@@ -53,7 +53,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             string hookName = default;
             Optional<string> description = default;
             Optional<string> externalLink = default;
-            Optional<IList<string>> admins = default;
+            Optional<IReadOnlyList<string>> admins = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("hookParameter"))

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.Serialization.cs
@@ -53,7 +53,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             string hookName = default;
             Optional<string> description = default;
             Optional<string> externalLink = default;
-            Optional<IReadOnlyList<string>> admins = default;
+            Optional<IList<string>> admins = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("hookParameter"))

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.cs
@@ -13,5 +13,19 @@ namespace Azure.AI.MetricsAdvisor.Models
     /// <summary> The EmailHookInfo. </summary>
     public partial class EmailNotificationHook : NotificationHook
     {
+
+        /// <summary> Initializes a new instance of EmailNotificationHook. </summary>
+        /// <param name="hookType"> hook type. </param>
+        /// <param name="id"> Hook unique id. </param>
+        /// <param name="name"> hook unique name. </param>
+        /// <param name="description"> hook description. </param>
+        /// <param name="internalExternalLink"> hook external link. </param>
+        /// <param name="administrators"> hook administrators. </param>
+        /// <param name="hookParameter"> . </param>
+        internal EmailNotificationHook(HookType hookType, string id, string name, string description, string internalExternalLink, IReadOnlyList<string> administrators, EmailHookParameter hookParameter) : base(hookType, id, name, description, internalExternalLink, administrators)
+        {
+            HookParameter = hookParameter;
+            HookType = hookType;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.cs
@@ -13,19 +13,5 @@ namespace Azure.AI.MetricsAdvisor.Models
     /// <summary> The EmailHookInfo. </summary>
     public partial class EmailNotificationHook : NotificationHook
     {
-
-        /// <summary> Initializes a new instance of EmailNotificationHook. </summary>
-        /// <param name="hookType"> hook type. </param>
-        /// <param name="id"> Hook unique id. </param>
-        /// <param name="name"> hook unique name. </param>
-        /// <param name="description"> hook description. </param>
-        /// <param name="internalExternalLink"> hook external link. </param>
-        /// <param name="administrators"> hook administrators. </param>
-        /// <param name="hookParameter"> . </param>
-        internal EmailNotificationHook(HookType hookType, string id, string name, string description, string internalExternalLink, IReadOnlyList<string> administrators, EmailHookParameter hookParameter) : base(hookType, id, name, description, internalExternalLink, administrators)
-        {
-            HookParameter = hookParameter;
-            HookType = hookType;
-        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/HookInfoPatch.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/HookInfoPatch.Serialization.cs
@@ -32,6 +32,16 @@ namespace Azure.AI.MetricsAdvisor.Models
                 writer.WritePropertyName("externalLink");
                 writer.WriteStringValue(ExternalLink);
             }
+            if (Optional.IsCollectionDefined(Admins))
+            {
+                writer.WritePropertyName("admins");
+                writer.WriteStartArray();
+                foreach (var item in Admins)
+                {
+                    writer.WriteStringValue(item);
+                }
+                writer.WriteEndArray();
+            }
             writer.WriteEndObject();
         }
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.Serialization.cs
@@ -30,6 +30,16 @@ namespace Azure.AI.MetricsAdvisor.Models
                 writer.WritePropertyName("externalLink");
                 writer.WriteStringValue(InternalExternalLink);
             }
+            if (Optional.IsCollectionDefined(Administrators))
+            {
+                writer.WritePropertyName("admins");
+                writer.WriteStartArray();
+                foreach (var item in Administrators)
+                {
+                    writer.WriteStringValue(item);
+                }
+                writer.WriteEndArray();
+            }
             writer.WriteEndObject();
         }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.Serialization.cs
@@ -58,7 +58,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             string hookName = default;
             Optional<string> description = default;
             Optional<string> externalLink = default;
-            Optional<IReadOnlyList<string>> admins = default;
+            Optional<IList<string>> admins = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("hookType"))

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.Serialization.cs
@@ -58,7 +58,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             string hookName = default;
             Optional<string> description = default;
             Optional<string> externalLink = default;
-            Optional<IList<string>> admins = default;
+            Optional<IReadOnlyList<string>> admins = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("hookType"))

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalInKVParam.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalInKVParam.Serialization.cs
@@ -19,8 +19,11 @@ namespace Azure.AI.MetricsAdvisor.Models
             writer.WriteStringValue(KeyVaultEndpoint);
             writer.WritePropertyName("keyVaultClientId");
             writer.WriteStringValue(KeyVaultClientId);
-            writer.WritePropertyName("keyVaultClientSecret");
-            writer.WriteStringValue(KeyVaultClientSecret);
+            if (Optional.IsDefined(KeyVaultClientSecret))
+            {
+                writer.WritePropertyName("keyVaultClientSecret");
+                writer.WriteStringValue(KeyVaultClientSecret);
+            }
             writer.WritePropertyName("servicePrincipalIdNameInKV");
             writer.WriteStringValue(ServicePrincipalIdNameInKV);
             writer.WritePropertyName("servicePrincipalSecretNameInKV");
@@ -34,7 +37,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         {
             string keyVaultEndpoint = default;
             string keyVaultClientId = default;
-            string keyVaultClientSecret = default;
+            Optional<string> keyVaultClientSecret = default;
             string servicePrincipalIdNameInKV = default;
             string servicePrincipalSecretNameInKV = default;
             string tenantId = default;
@@ -71,7 +74,7 @@ namespace Azure.AI.MetricsAdvisor.Models
                     continue;
                 }
             }
-            return new ServicePrincipalInKVParam(keyVaultEndpoint, keyVaultClientId, keyVaultClientSecret, servicePrincipalIdNameInKV, servicePrincipalSecretNameInKV, tenantId);
+            return new ServicePrincipalInKVParam(keyVaultEndpoint, keyVaultClientId, keyVaultClientSecret.Value, servicePrincipalIdNameInKV, servicePrincipalSecretNameInKV, tenantId);
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalInKVParam.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalInKVParam.cs
@@ -15,12 +15,11 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary> Initializes a new instance of ServicePrincipalInKVParam. </summary>
         /// <param name="keyVaultEndpoint"> The Key Vault endpoint that storing the service principal. </param>
         /// <param name="keyVaultClientId"> The Client Id to access the Key Vault. </param>
-        /// <param name="keyVaultClientSecret"> The Client Secret to access the Key Vault. </param>
         /// <param name="servicePrincipalIdNameInKV"> The secret name of the service principal&apos;s client Id in the Key Vault. </param>
         /// <param name="servicePrincipalSecretNameInKV"> The secret name of the service principal&apos;s client secret in the Key Vault. </param>
         /// <param name="tenantId"> The tenant id of your service principal. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="keyVaultEndpoint"/>, <paramref name="keyVaultClientId"/>, <paramref name="keyVaultClientSecret"/>, <paramref name="servicePrincipalIdNameInKV"/>, <paramref name="servicePrincipalSecretNameInKV"/>, or <paramref name="tenantId"/> is null. </exception>
-        public ServicePrincipalInKVParam(string keyVaultEndpoint, string keyVaultClientId, string keyVaultClientSecret, string servicePrincipalIdNameInKV, string servicePrincipalSecretNameInKV, string tenantId)
+        /// <exception cref="ArgumentNullException"> <paramref name="keyVaultEndpoint"/>, <paramref name="keyVaultClientId"/>, <paramref name="servicePrincipalIdNameInKV"/>, <paramref name="servicePrincipalSecretNameInKV"/>, or <paramref name="tenantId"/> is null. </exception>
+        public ServicePrincipalInKVParam(string keyVaultEndpoint, string keyVaultClientId, string servicePrincipalIdNameInKV, string servicePrincipalSecretNameInKV, string tenantId)
         {
             if (keyVaultEndpoint == null)
             {
@@ -29,10 +28,6 @@ namespace Azure.AI.MetricsAdvisor.Models
             if (keyVaultClientId == null)
             {
                 throw new ArgumentNullException(nameof(keyVaultClientId));
-            }
-            if (keyVaultClientSecret == null)
-            {
-                throw new ArgumentNullException(nameof(keyVaultClientSecret));
             }
             if (servicePrincipalIdNameInKV == null)
             {
@@ -47,6 +42,22 @@ namespace Azure.AI.MetricsAdvisor.Models
                 throw new ArgumentNullException(nameof(tenantId));
             }
 
+            KeyVaultEndpoint = keyVaultEndpoint;
+            KeyVaultClientId = keyVaultClientId;
+            ServicePrincipalIdNameInKV = servicePrincipalIdNameInKV;
+            ServicePrincipalSecretNameInKV = servicePrincipalSecretNameInKV;
+            TenantId = tenantId;
+        }
+
+        /// <summary> Initializes a new instance of ServicePrincipalInKVParam. </summary>
+        /// <param name="keyVaultEndpoint"> The Key Vault endpoint that storing the service principal. </param>
+        /// <param name="keyVaultClientId"> The Client Id to access the Key Vault. </param>
+        /// <param name="keyVaultClientSecret"> The Client Secret to access the Key Vault. </param>
+        /// <param name="servicePrincipalIdNameInKV"> The secret name of the service principal&apos;s client Id in the Key Vault. </param>
+        /// <param name="servicePrincipalSecretNameInKV"> The secret name of the service principal&apos;s client secret in the Key Vault. </param>
+        /// <param name="tenantId"> The tenant id of your service principal. </param>
+        internal ServicePrincipalInKVParam(string keyVaultEndpoint, string keyVaultClientId, string keyVaultClientSecret, string servicePrincipalIdNameInKV, string servicePrincipalSecretNameInKV, string tenantId)
+        {
             KeyVaultEndpoint = keyVaultEndpoint;
             KeyVaultClientId = keyVaultClientId;
             KeyVaultClientSecret = keyVaultClientSecret;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebNotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebNotificationHook.Serialization.cs
@@ -32,6 +32,16 @@ namespace Azure.AI.MetricsAdvisor.Models
                 writer.WritePropertyName("externalLink");
                 writer.WriteStringValue(InternalExternalLink);
             }
+            if (Optional.IsCollectionDefined(Administrators))
+            {
+                writer.WritePropertyName("admins");
+                writer.WriteStartArray();
+                foreach (var item in Administrators)
+                {
+                    writer.WriteStringValue(item);
+                }
+                writer.WriteEndArray();
+            }
             writer.WriteEndObject();
         }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebNotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebNotificationHook.Serialization.cs
@@ -53,7 +53,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             string hookName = default;
             Optional<string> description = default;
             Optional<string> externalLink = default;
-            Optional<IList<string>> admins = default;
+            Optional<IReadOnlyList<string>> admins = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("hookParameter"))

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebNotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebNotificationHook.Serialization.cs
@@ -53,7 +53,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             string hookName = default;
             Optional<string> description = default;
             Optional<string> externalLink = default;
-            Optional<IReadOnlyList<string>> admins = default;
+            Optional<IList<string>> admins = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("hookParameter"))

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebhookHookInfoPatch.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebhookHookInfoPatch.Serialization.cs
@@ -37,6 +37,16 @@ namespace Azure.AI.MetricsAdvisor.Models
                 writer.WritePropertyName("externalLink");
                 writer.WriteStringValue(ExternalLink);
             }
+            if (Optional.IsCollectionDefined(Admins))
+            {
+                writer.WritePropertyName("admins");
+                writer.WriteStartArray();
+                foreach (var item in Admins)
+                {
+                    writer.WriteStringValue(item);
+                }
+                writer.WriteEndArray();
+            }
             writer.WriteEndObject();
         }
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebhookHookParameter.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebhookHookParameter.Serialization.cs
@@ -16,11 +16,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            if (Optional.IsDefined(Endpoint))
-            {
-                writer.WritePropertyName("endpoint");
-                writer.WriteStringValue(Endpoint);
-            }
+            writer.WritePropertyName("endpoint");
+            writer.WriteStringValue(Endpoint);
             if (Optional.IsDefined(Username))
             {
                 writer.WritePropertyName("username");
@@ -57,7 +54,7 @@ namespace Azure.AI.MetricsAdvisor.Models
 
         internal static WebhookHookParameter DeserializeWebhookHookParameter(JsonElement element)
         {
-            Optional<string> endpoint = default;
+            string endpoint = default;
             Optional<string> username = default;
             Optional<string> password = default;
             Optional<IDictionary<string, string>> headers = default;
@@ -106,7 +103,7 @@ namespace Azure.AI.MetricsAdvisor.Models
                     continue;
                 }
             }
-            return new WebhookHookParameter(endpoint.Value, username.Value, password.Value, Optional.ToDictionary(headers), certificateKey.Value, certificatePassword.Value);
+            return new WebhookHookParameter(endpoint, username.Value, password.Value, Optional.ToDictionary(headers), certificateKey.Value, certificatePassword.Value);
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebhookHookParameter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebhookHookParameter.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using Azure.Core;
 
@@ -14,8 +15,16 @@ namespace Azure.AI.MetricsAdvisor.Models
     internal partial class WebhookHookParameter
     {
         /// <summary> Initializes a new instance of WebhookHookParameter. </summary>
-        public WebhookHookParameter()
+        /// <param name="endpoint"> API address, will be called when alert is triggered, only support POST method via SSL. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/> is null. </exception>
+        public WebhookHookParameter(string endpoint)
         {
+            if (endpoint == null)
+            {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
+
+            Endpoint = endpoint;
             Headers = new ChangeTrackingDictionary<string, string>();
         }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebhookHookParameterPatch.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebhookHookParameterPatch.Serialization.cs
@@ -15,8 +15,11 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("endpoint");
-            writer.WriteStringValue(Endpoint);
+            if (Optional.IsDefined(Endpoint))
+            {
+                writer.WritePropertyName("endpoint");
+                writer.WriteStringValue(Endpoint);
+            }
             if (Optional.IsDefined(Username))
             {
                 writer.WritePropertyName("username");

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebhookHookParameterPatch.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebhookHookParameterPatch.cs
@@ -5,7 +5,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using Azure.Core;
 
@@ -15,21 +14,13 @@ namespace Azure.AI.MetricsAdvisor.Models
     internal partial class WebhookHookParameterPatch
     {
         /// <summary> Initializes a new instance of WebhookHookParameterPatch. </summary>
-        /// <param name="endpoint"> API address, will be called when alert is triggered, only support POST method via SSL. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/> is null. </exception>
-        public WebhookHookParameterPatch(string endpoint)
+        public WebhookHookParameterPatch()
         {
-            if (endpoint == null)
-            {
-                throw new ArgumentNullException(nameof(endpoint));
-            }
-
-            Endpoint = endpoint;
             Headers = new ChangeTrackingDictionary<string, string>();
         }
 
         /// <summary> API address, will be called when alert is triggered, only support POST method via SSL. </summary>
-        public string Endpoint { get; }
+        public string Endpoint { get; set; }
         /// <summary> (Deprecated) The username, if using basic authentication. </summary>
         public string Username { get; set; }
         /// <summary> (Deprecated) The password, if using basic authentication. </summary>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
     {
         private readonly ClientDiagnostics _clientDiagnostics;
 
-        private readonly AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2RestClient _serviceRestClient;
+        private readonly MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient _serviceRestClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MetricsAdvisorAdministrationClient"/> class.
@@ -50,7 +50,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             _clientDiagnostics = new ClientDiagnostics(options);
             HttpPipeline pipeline = HttpPipelineBuilder.Build(options, new MetricsAdvisorKeyCredentialPolicy(credential));
 
-            _serviceRestClient = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2RestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri);
+            _serviceRestClient = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri);
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             _clientDiagnostics = new ClientDiagnostics(options);
             HttpPipeline pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, Constants.DefaultCognitiveScope));
 
-            _serviceRestClient = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2RestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri);
+            _serviceRestClient = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri);
         }
 
         /// <summary>
@@ -286,7 +286,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             try
             {
                 DataFeedDetail dataFeedDetail = dataFeed.GetDataFeedDetail();
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> response = await _serviceRestClient.CreateDataFeedAsync(dataFeedDetail, cancellationToken).ConfigureAwait(false);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> response = await _serviceRestClient.CreateDataFeedAsync(dataFeedDetail, cancellationToken).ConfigureAwait(false);
 
                 string dataFeedId = ClientCommon.GetDataFeedId(response.Headers.Location);
 
@@ -328,7 +328,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             try
             {
                 DataFeedDetail dataFeedDetail = dataFeed.GetDataFeedDetail();
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> response = _serviceRestClient.CreateDataFeed(dataFeedDetail, cancellationToken);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> response = _serviceRestClient.CreateDataFeed(dataFeedDetail, cancellationToken);
 
                 string dataFeedId = ClientCommon.GetDataFeedId(response.Headers.Location);
 
@@ -742,7 +742,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
 
             try
             {
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders> response = await _serviceRestClient.CreateAnomalyDetectionConfigurationAsync(detectionConfiguration, cancellationToken).ConfigureAwait(false);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders> response = await _serviceRestClient.CreateAnomalyDetectionConfigurationAsync(detectionConfiguration, cancellationToken).ConfigureAwait(false);
                 string detectionConfigurationId = ClientCommon.GetAnomalyDetectionConfigurationId(response.Headers.Location);
 
                 try
@@ -783,7 +783,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
 
             try
             {
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders> response = _serviceRestClient.CreateAnomalyDetectionConfiguration(detectionConfiguration, cancellationToken);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyDetectionConfigurationHeaders> response = _serviceRestClient.CreateAnomalyDetectionConfiguration(detectionConfiguration, cancellationToken);
                 string detectionConfigurationId = ClientCommon.GetAnomalyDetectionConfigurationId(response.Headers.Location);
 
                 try
@@ -1137,7 +1137,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
 
             try
             {
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders> response = await _serviceRestClient.CreateAnomalyAlertingConfigurationAsync(alertConfiguration, cancellationToken).ConfigureAwait(false);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders> response = await _serviceRestClient.CreateAnomalyAlertingConfigurationAsync(alertConfiguration, cancellationToken).ConfigureAwait(false);
                 string alertConfigurationId = ClientCommon.GetAnomalyAlertConfigurationId(response.Headers.Location);
 
                 try
@@ -1179,7 +1179,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
 
             try
             {
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders> response = _serviceRestClient.CreateAnomalyAlertingConfiguration(alertConfiguration, cancellationToken);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateAnomalyAlertingConfigurationHeaders> response = _serviceRestClient.CreateAnomalyAlertingConfiguration(alertConfiguration, cancellationToken);
                 string alertConfigurationId = ClientCommon.GetAnomalyAlertConfigurationId(response.Headers.Location);
 
                 try
@@ -1525,7 +1525,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
 
             try
             {
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders> response = await _serviceRestClient.CreateHookAsync(hook, cancellationToken).ConfigureAwait(false);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders> response = await _serviceRestClient.CreateHookAsync(hook, cancellationToken).ConfigureAwait(false);
                 string hookId = ClientCommon.GetHookId(response.Headers.Location);
 
                 try
@@ -1566,7 +1566,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
 
             try
             {
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders> response = _serviceRestClient.CreateHook(hook, cancellationToken);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateHookHeaders> response = _serviceRestClient.CreateHook(hook, cancellationToken);
                 string hookId = ClientCommon.GetHookId(response.Headers.Location);
 
                 try
@@ -1908,7 +1908,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
 
             try
             {
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders> response = await _serviceRestClient.CreateCredentialAsync(credentialEntity, cancellationToken).ConfigureAwait(false);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders> response = await _serviceRestClient.CreateCredentialAsync(credentialEntity, cancellationToken).ConfigureAwait(false);
                 string credentialId = ClientCommon.GetCredentialId(response.Headers.Location);
 
                 try
@@ -1950,7 +1950,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
 
             try
             {
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders> response = _serviceRestClient.CreateCredential(credentialEntity, cancellationToken);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateCredentialHeaders> response = _serviceRestClient.CreateCredential(credentialEntity, cancellationToken);
                 string credentialId = ClientCommon.GetCredentialId(response.Headers.Location);
 
                 try

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorClient.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.MetricsAdvisor
     {
         private readonly ClientDiagnostics _clientDiagnostics;
 
-        private readonly AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2RestClient _serviceRestClient;
+        private readonly MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient _serviceRestClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MetricsAdvisorClient"/> class.
@@ -52,7 +52,7 @@ namespace Azure.AI.MetricsAdvisor
             _clientDiagnostics = new ClientDiagnostics(options);
             HttpPipeline pipeline = HttpPipelineBuilder.Build(options, new MetricsAdvisorKeyCredentialPolicy(credential));
 
-            _serviceRestClient = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2RestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri);
+            _serviceRestClient = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace Azure.AI.MetricsAdvisor
             _clientDiagnostics = new ClientDiagnostics(options);
             HttpPipeline pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, Constants.DefaultCognitiveScope));
 
-            _serviceRestClient = new AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2RestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri);
+            _serviceRestClient = new MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri);
         }
 
         /// <summary>
@@ -683,7 +683,7 @@ namespace Azure.AI.MetricsAdvisor
 
             try
             {
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders> response = await _serviceRestClient.CreateMetricFeedbackAsync(feedback, cancellationToken).ConfigureAwait(false);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders> response = await _serviceRestClient.CreateMetricFeedbackAsync(feedback, cancellationToken).ConfigureAwait(false);
                 string feedbackId = ClientCommon.GetFeedbackId(response.Headers.Location);
 
                 try
@@ -723,7 +723,7 @@ namespace Azure.AI.MetricsAdvisor
 
             try
             {
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders> response = _serviceRestClient.CreateMetricFeedback(feedback, cancellationToken);
+                ResponseWithHeaders<MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2CreateMetricFeedbackHeaders> response = _serviceRestClient.CreateMetricFeedback(feedback, cancellationToken);
                 string feedbackId = ClientCommon.GetFeedbackId(response.Headers.Location);
 
                 try

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/CodeGenInternal/HookInfoPatch.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/CodeGenInternal/HookInfoPatch.cs
@@ -9,6 +9,6 @@ namespace Azure.AI.MetricsAdvisor.Models
     internal partial class HookInfoPatch
     {
         /// <summary> hook administrators. </summary>
-        public IReadOnlyList<string> Admins { get; internal set; }
+        public IList<string> Admins { get; internal set; }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/CodeGenInternal/HookInfoPatch.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/CodeGenInternal/HookInfoPatch.cs
@@ -9,6 +9,6 @@ namespace Azure.AI.MetricsAdvisor.Models
     internal partial class HookInfoPatch
     {
         /// <summary> hook administrators. </summary>
-        public IList<string> Admins { get; internal set; }
+        public IReadOnlyList<string> Admins { get; internal set; }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/CodeGenInternal/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/CodeGenInternal/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.MetricsAdvisor
+{
+    internal static partial class MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2ModelFactory
+    {
+    }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedGranularityType.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedGranularityType.cs
@@ -43,12 +43,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public static DataFeedGranularityType PerMinute { get; } = new DataFeedGranularityType(PerMinuteValue);
 
         /// <summary>
-        /// Ingestion happens once a second.
-        /// </summary>
-        [CodeGenMember("Secondly")]
-        public static DataFeedGranularityType PerSecond { get; } = new DataFeedGranularityType(PerSecondValue);
-
-        /// <summary>
         /// Ingestion happens in a customized interval. Period can be set with
         /// <see cref="DataFeedGranularity.CustomGranularityValue"/>.
         /// </summary>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/EmailNotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/EmailNotificationHook.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             EmailsToAlert = new ChangeTrackingList<string>();
         }
 
-        internal EmailNotificationHook(HookType hookType, string id, string name, string description, string externalLink, IList<string> administrators, EmailHookParameter hookParameter)
+        internal EmailNotificationHook(HookType hookType, string id, string name, string description, string externalLink, IReadOnlyList<string> administrators, EmailHookParameter hookParameter)
             : base(hookType, id, name, description, externalLink, administrators)
         {
             HookType = hookType;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/EmailNotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/EmailNotificationHook.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             EmailsToAlert = new ChangeTrackingList<string>();
         }
 
-        internal EmailNotificationHook(HookType hookType, string id, string name, string description, string externalLink, IReadOnlyList<string> administrators, EmailHookParameter hookParameter)
+        internal EmailNotificationHook(HookType hookType, string id, string name, string description, string externalLink, IList<string> administrators, EmailHookParameter hookParameter)
             : base(hookType, id, name, description, externalLink, administrators)
         {
             HookType = hookType;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/NotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/NotificationHook.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             Administrators = new ChangeTrackingList<string>();
         }
 
-        internal NotificationHook(HookType hookType, string id, string name, string description, string internalExternalLink, IList<string> administrators)
+        internal NotificationHook(HookType hookType, string id, string name, string description, string internalExternalLink, IReadOnlyList<string> administrators)
         {
             HookType = hookType;
             Id = id;
@@ -45,7 +45,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// The list of user e-mails with administrative rights to manage this hook.
         /// </summary>
         [CodeGenMember("Admins")]
-        public IList<string> Administrators { get; }
+        public IReadOnlyList<string> Administrators { get; }
 
         /// <summary> The hook type. </summary>
         internal HookType HookType { get; set; }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/NotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/NotificationHook.cs
@@ -18,7 +18,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         {
         }
 
-        internal NotificationHook(HookType hookType, string id, string name, string description, string internalExternalLink, IReadOnlyList<string> administrators)
+        internal NotificationHook(HookType hookType, string id, string name, string description, string internalExternalLink, IList<string> administrators)
         {
             HookType = hookType;
             Id = id;
@@ -44,7 +44,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// The list of user e-mails with administrative rights to manage this hook.
         /// </summary>
         [CodeGenMember("Admins")]
-        public IReadOnlyList<string> Administrators { get; }
+        public IList<string> Administrators { get; }
 
         /// <summary> The hook type. </summary>
         internal HookType HookType { get; set; }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/NotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/NotificationHook.cs
@@ -16,6 +16,7 @@ namespace Azure.AI.MetricsAdvisor.Models
     {
         internal NotificationHook()
         {
+            Administrators = new ChangeTrackingList<string>();
         }
 
         internal NotificationHook(HookType hookType, string id, string name, string description, string internalExternalLink, IList<string> administrators)

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/WebNotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/WebNotificationHook.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             Headers = new ChangeTrackingDictionary<string, string>();
         }
 
-        internal WebNotificationHook(HookType hookType, string id, string name, string description, string externalLink, IReadOnlyList<string> administrators, WebhookHookParameter hookParameter)
+        internal WebNotificationHook(HookType hookType, string id, string name, string description, string externalLink, IList<string> administrators, WebhookHookParameter hookParameter)
             : base(hookType, id, name, description, externalLink, administrators)
         {
             HookType = hookType;
@@ -69,9 +69,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// Used by CodeGen during serialization.
         /// </summary>
-        internal WebhookHookParameter HookParameter => new WebhookHookParameter()
+        internal WebhookHookParameter HookParameter => new WebhookHookParameter(Endpoint.AbsoluteUri)
         {
-            Endpoint = Endpoint.AbsoluteUri,
             Username = Username,
             Password = Password,
             CertificateKey = CertificateKey,

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/WebNotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/WebNotificationHook.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             Headers = new ChangeTrackingDictionary<string, string>();
         }
 
-        internal WebNotificationHook(HookType hookType, string id, string name, string description, string externalLink, IList<string> administrators, WebhookHookParameter hookParameter)
+        internal WebNotificationHook(HookType hookType, string id, string name, string description, string externalLink, IReadOnlyList<string> administrators, WebhookHookParameter hookParameter)
             : base(hookType, id, name, description, externalLink, administrators)
         {
             HookType = hookType;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/autorest.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/autorest.md
@@ -7,7 +7,7 @@ Run `dotnet msbuild /t:GenerateCode` to generate code.
 
 ``` yaml
 input-file:
-    - https://github.com/Azure/azure-rest-api-specs/blob/2a25feb3b173dfe858977b2fafeeeb9ae83b2f3a/specification/cognitiveservices/data-plane/MetricsAdvisor/preview/v1.0/MetricsAdvisor.json
+    - https://github.com/Azure/azure-rest-api-specs/blob/08f5e391f2153a99580b458cc71ef88e45dd0531/specification/cognitiveservices/data-plane/MetricsAdvisor/preview/v1.0/MetricsAdvisor.json
 ```
 
 ### Make generated models internal by default

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/autorest.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/autorest.md
@@ -837,13 +837,3 @@ directive:
         }
       }
 ```
-
-## Make secrets not required in Credential-related definitions
-
-``` yaml
-directive:
-  from: swagger-document
-  where: $.definitions.ServicePrincipalParam
-  transform: >
-    $["required"] = ["clientId", "tenantId"]
-```


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-net/issues/21177.

A bunch of internal renames and internal code changes since some properties are not marked as required anymore. We also removed the enum value `DataFeedGranularityType.PerSecond` because the service does not support it anymore.

We could also remove one of our swagger transforms.