### PR TITLE
[Translator] Use IsEnvironmentReadyAsync to make sure credentials are propagated

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 
@@ -31,7 +32,8 @@ namespace Azure.AI.Translation.Document.Tests
 
         protected override async ValueTask<bool> IsEnvironmentReadyAsync()
         {
-            var client = new DocumentTranslationClient(new System.Uri(Endpoint), Credential);
+            string endpoint = Environment.GetEnvironmentVariable(EndpointEnvironmentVariableName);
+            var client = new DocumentTranslationClient(new Uri(endpoint), Credential);
             try
             {
                 await client.GetDocumentFormatsAsync();

--- a/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
@@ -31,7 +31,7 @@ namespace Azure.AI.Translation.Document.Tests
 
         protected override async ValueTask<bool> IsEnvironmentReadyAsync()
         {
-            var client = new DocumentTranslationClient(new System.Uri(Endpoint), new AzureKeyCredential(ApiKey));
+            var client = new DocumentTranslationClient(new System.Uri(Endpoint), Credential);
             try
             {
                 await client.GetDocumentFormatsAsync();

--- a/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.Translation.Document.Tests
@@ -27,5 +28,19 @@ namespace Azure.AI.Translation.Document.Tests
         public string Endpoint => GetRecordedVariable(EndpointEnvironmentVariableName);
         public string StorageConnectionString => GetRecordedVariable(StorageConnectionStringEnvironmentVariableName, options => options.HasSecretConnectionStringParameter("AccountKey", SanitizedValue.Base64));
         public string StorageAccountName => GetRecordedVariable(StorageAccountNameEnvironmentVariableName);
+
+        protected override async ValueTask<bool> IsEnvironmentReadyAsync()
+        {
+            var client = new DocumentTranslationClient(new System.Uri(Endpoint), new AzureKeyCredential(ApiKey));
+            try
+            {
+                await client.GetDocumentFormatsAsync();
+            }
+            catch (RequestFailedException e) when (e.Status == 401)
+            {
+                return false;
+            }
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Removing flaky tests because credentials are not ready