### PR TITLE
Batch receive fixes

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         private readonly Lazy<SessionMessageProcessor> _sessionMessageProcessor;
         private readonly Lazy<ServiceBusScaleMonitor> _scaleMonitor;
 
-        private bool _disposed;
-        private bool _started;
+        private volatile bool _disposed;
+        private volatile bool _started;
         // Serialize execution of StopAsync to avoid calling Unregister* concurrently
         private readonly SemaphoreSlim _stopAsyncSemaphore = new SemaphoreSlim(1, 1);
         private CancellationTokenRegistration _batchReceiveRegistration;

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -7,46 +7,39 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
-using Azure.Core.Pipeline;
 using Azure.Messaging.ServiceBus;
-using Microsoft.Azure.WebJobs.Extensions.Clients.Shared;
 using Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config;
-using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Scale;
-using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 {
     internal sealed class ServiceBusListener : IListener, IScaleMonitorProvider
     {
-        private readonly MessagingProvider _messagingProvider;
         private readonly ITriggeredFunctionExecutor _triggerExecutor;
-        private readonly string _functionId;
-        private readonly ServiceBusEntityType _entityType;
         private readonly string _entityPath;
         private readonly bool _isSessionsEnabled;
         private readonly bool _autoCompleteMessagesOptionEvaluatedValue;
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly ServiceBusOptions _serviceBusOptions;
-        private readonly ILoggerFactory _loggerFactory;
         private readonly bool _singleDispatch;
         private readonly ILogger<ServiceBusListener> _logger;
 
         private readonly Lazy<MessageProcessor> _messageProcessor;
-        private Lazy<ServiceBusReceiver> _batchReceiver;
-        private Lazy<ServiceBusClient> _client;
-        private Lazy<SessionMessageProcessor> _sessionMessageProcessor;
-        private Lazy<ServiceBusScaleMonitor> _scaleMonitor;
+        private readonly Lazy<ServiceBusReceiver> _batchReceiver;
+        private readonly Lazy<ServiceBusClient> _client;
+        private readonly Lazy<SessionMessageProcessor> _sessionMessageProcessor;
+        private readonly Lazy<ServiceBusScaleMonitor> _scaleMonitor;
 
         private bool _disposed;
         private bool _started;
         // Serialize execution of StopAsync to avoid calling Unregister* concurrently
         private readonly SemaphoreSlim _stopAsyncSemaphore = new SemaphoreSlim(1, 1);
+        private readonly TaskCompletionSource<IReadOnlyList<ServiceBusReceivedMessage>> _batchReceiveCompletionSource;
+        private CancellationTokenRegistration _batchReceiveRegistration;
+        private Task _batchLoop;
 
         public ServiceBusListener(
             string functionId,
@@ -62,47 +55,49 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             bool singleDispatch,
             ServiceBusClientFactory clientFactory)
         {
-            _functionId = functionId;
-            _entityType = entityType;
             _entityPath = entityPath;
             _isSessionsEnabled = isSessionsEnabled;
             _autoCompleteMessagesOptionEvaluatedValue = autoCompleteMessagesOptionEvaluatedValue;
             _triggerExecutor = triggerExecutor;
             _cancellationTokenSource = new CancellationTokenSource();
-            _messagingProvider = messagingProvider;
-            _loggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger<ServiceBusListener>();
-
+            _batchReceiveCompletionSource = new TaskCompletionSource<IReadOnlyList<ServiceBusReceivedMessage>>(TaskCreationOptions
+                .RunContinuationsAsynchronously);
+            _batchReceiveRegistration = _cancellationTokenSource.Token.Register(static state =>
+            {
+                var tcs = (TaskCompletionSource<IReadOnlyList<ServiceBusReceivedMessage>>)state;
+                tcs.TrySetCanceled();
+            }, _batchReceiveCompletionSource, useSynchronizationContext: false);
             _client = new Lazy<ServiceBusClient>(
                 () =>
                     clientFactory.CreateClientFromSetting(connection));
 
             _batchReceiver = new Lazy<ServiceBusReceiver>(
-                () => _messagingProvider.CreateBatchMessageReceiver(
+                () => messagingProvider.CreateBatchMessageReceiver(
                     _client.Value,
                     _entityPath,
                     options.ToReceiverOptions()));
 
             _messageProcessor = new Lazy<MessageProcessor>(
-                () => _messagingProvider.CreateMessageProcessor(
+                () => messagingProvider.CreateMessageProcessor(
                     _client.Value,
                     _entityPath,
                     options.ToProcessorOptions(_autoCompleteMessagesOptionEvaluatedValue)));
 
             _sessionMessageProcessor = new Lazy<SessionMessageProcessor>(
-                () => _messagingProvider.CreateSessionMessageProcessor(
+                () => messagingProvider.CreateSessionMessageProcessor(
                     _client.Value,
                     _entityPath,
                     options.ToSessionProcessorOptions(_autoCompleteMessagesOptionEvaluatedValue)));
 
             _scaleMonitor = new Lazy<ServiceBusScaleMonitor>(
                 () => new ServiceBusScaleMonitor(
-                    _functionId,
-                    _entityType,
+                    functionId,
+                    entityType,
                     _entityPath,
                     connection,
                     _batchReceiver,
-                    _loggerFactory,
+                    loggerFactory,
                     clientFactory));
 
             _singleDispatch = singleDispatch;
@@ -133,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             }
             else
             {
-                StartMessageBatchReceiver(_cancellationTokenSource.Token);
+                _batchLoop = RunBatchReceiveLoopAsync(_cancellationTokenSource.Token);
             }
             _started = true;
         }
@@ -150,23 +145,34 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                         throw new InvalidOperationException("The listener has not yet been started or has already been stopped.");
                     }
 
-                    // StopProcessingAsync method stop new messages from being processed while allowing in-flight messages to complete.
-                    // As the amount of time functions are allowed to complete processing varies by SKU, we specify max timespan
-                    // as the amount of time Service Bus SDK should wait for in-flight messages to complete procesing after
-                    // unregistering the message handler so that functions have as long as the host continues to run time to complete.
+                    _cancellationTokenSource.Cancel();
+
+                    // CloseAsync method stop new messages from being processed while allowing in-flight messages to be processed.
                     if (_singleDispatch)
                     {
                         if (_isSessionsEnabled)
                         {
-                            await _sessionMessageProcessor.Value.Processor.StopProcessingAsync(cancellationToken).ConfigureAwait(false);
+                            await _sessionMessageProcessor.Value.Processor.CloseAsync(cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {
-                            await _messageProcessor.Value.Processor.StopProcessingAsync(cancellationToken).ConfigureAwait(false);
+                            await _messageProcessor.Value.Processor.CloseAsync(cancellationToken).ConfigureAwait(false);
                         }
                     }
-                    // Batch processing will be stopped via the _cancellationTokenSource on its next iteration
-                    _cancellationTokenSource.Cancel();
+                    else
+                    {
+                        try
+                        {
+                            await _batchLoop.ConfigureAwait(false);
+                        }
+                        catch (TaskCanceledException)
+                        {
+                            // expected when stopping
+                        }
+
+                        await _batchReceiver.Value.CloseAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
                     _started = false;
                 }
                 finally
@@ -185,33 +191,43 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         [SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "_cancellationTokenSource")]
         public void Dispose()
         {
-            if (!_disposed)
+            if (_disposed)
             {
-                // Running callers might still be using the cancellation token.
-                // Mark it canceled but don't dispose of the source while the callers are running.
-                // Otherwise, callers would receive ObjectDisposedException when calling token.Register.
-                // For now, rely on finalization to clean up _cancellationTokenSource's wait handle (if allocated).
-                _cancellationTokenSource.Cancel();
-
-                if (_batchReceiver != null && _batchReceiver.IsValueCreated)
-                {
-                    _batchReceiver.Value.CloseAsync().Wait();
-                    _batchReceiver = null;
-                }
-
-                if (_client != null && _client.IsValueCreated)
-                {
-#pragma warning disable AZC0107 // DO NOT call public asynchronous method in synchronous scope.
-                    _client.Value.DisposeAsync().EnsureCompleted();
-#pragma warning restore AZC0107 // DO NOT call public asynchronous method in synchronous scope.
-                    _client = null;
-                }
-
-                _stopAsyncSemaphore.Dispose();
-                _cancellationTokenSource.Dispose();
-
-                _disposed = true;
+                return;
             }
+
+            // Running callers might still be using the cancellation token.
+            // Mark it canceled but don't dispose of the source while the callers are running.
+            // Otherwise, callers would receive ObjectDisposedException when calling token.Register.
+            // For now, rely on finalization to clean up _cancellationTokenSource's wait handle (if allocated).
+            _cancellationTokenSource.Cancel();
+
+            if (_batchReceiver.IsValueCreated)
+            {
+#pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult().
+                _batchReceiver.Value.CloseAsync(CancellationToken.None).GetAwaiter().GetResult();
+#pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult().
+            }
+
+            if (_messageProcessor.IsValueCreated)
+            {
+#pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult().
+                _messageProcessor.Value.Processor.CloseAsync(CancellationToken.None).GetAwaiter().GetResult();
+#pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult().
+            }
+
+            if (_client.IsValueCreated)
+            {
+#pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult().
+                _client.Value.DisposeAsync().AsTask().GetAwaiter().GetResult();
+#pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult().
+            }
+
+            _stopAsyncSemaphore.Dispose();
+            _cancellationTokenSource.Dispose();
+            _batchReceiveRegistration.Dispose();
+
+            _disposed = true;
         }
 
         internal async Task ProcessMessageAsync(ProcessMessageEventArgs args)
@@ -252,7 +268,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             }
         }
 
-        internal void StartMessageBatchReceiver(CancellationToken cancellationToken)
+        private async Task RunBatchReceiveLoopAsync(CancellationToken cancellationToken)
         {
             ServiceBusClient sessionClient = null;
             ServiceBusReceiver receiver = null;
@@ -265,122 +281,142 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                 receiver = _batchReceiver.Value;
             }
 
-            Task.Run(async () =>
+            while (true)
             {
-                while (true)
+                try
                 {
-                    try
+                    if (cancellationToken.IsCancellationRequested)
                     {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            _logger.LogInformation("Message processing has been stopped or cancelled");
-                            return;
-                        }
+                        _logger.LogInformation("Message processing has been stopped or cancelled");
+                        return;
+                    }
 
-                        if (_isSessionsEnabled && (receiver == null || receiver.IsClosed))
+                    if (_isSessionsEnabled && (receiver == null || receiver.IsClosed))
+                    {
+                        try
                         {
-                            try
-                            {
-                                receiver = await sessionClient.AcceptNextSessionAsync(
-                                    _entityPath,
-                                    new ServiceBusSessionReceiverOptions
-                                    {
-                                        PrefetchCount = _serviceBusOptions.PrefetchCount
-                                    },
-                                    cancellationToken).ConfigureAwait(false);
-                            }
-                            catch (ServiceBusException ex)
+                            receiver = await sessionClient.AcceptNextSessionAsync(
+                                _entityPath,
+                                new ServiceBusSessionReceiverOptions
+                                {
+                                    PrefetchCount = _serviceBusOptions.PrefetchCount
+                                },
+                                cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (ServiceBusException ex)
                             when (ex.Reason == ServiceBusFailureReason.ServiceTimeout)
-                            {
-                                // it's expected if the entity is empty, try next time
-                                continue;
-                            }
-                        }
-
-                        IReadOnlyList<ServiceBusReceivedMessage> messages =
-                            await receiver.ReceiveMessagesAsync(
-                                _serviceBusOptions.MaxBatchSize,
-                                cancellationToken: cancellationToken)
-                                .ConfigureAwait(false);
-
-                        if (messages.Count > 0)
                         {
-                            ServiceBusReceivedMessage[] messagesArray = messages.ToArray();
-                            ServiceBusTriggerInput input = ServiceBusTriggerInput.CreateBatch(messagesArray);
-                            if (_isSessionsEnabled)
-                            {
-                                input.MessageActions = new ServiceBusSessionMessageActions((ServiceBusSessionReceiver)receiver);
-                            }
-                            else
-                            {
-                                input.MessageActions = new ServiceBusMessageActions(receiver);
-                            }
-                            FunctionResult result = await _triggerExecutor.TryExecuteAsync(input.GetTriggerFunctionData(), cancellationToken).ConfigureAwait(false);
+                            // it's expected if the entity is empty, try next time
+                            continue;
+                        }
+                    }
 
-                            if (cancellationToken.IsCancellationRequested)
-                            {
-                                return;
-                            }
+                    _ = ReceiveBatchAsync(receiver, cancellationToken);
+                    IReadOnlyList<ServiceBusReceivedMessage> messages = await _batchReceiveCompletionSource.Task.ConfigureAwait(false);
 
-                            // Complete batch of messages only if the execution was successful
-                            if (_autoCompleteMessagesOptionEvaluatedValue && _started)
-                            {
-                                if (result.Succeeded)
-                                {
-                                    List<Task> completeTasks = new List<Task>();
-                                    foreach (ServiceBusReceivedMessage message in messagesArray)
-                                    {
-                                        completeTasks.Add(receiver.CompleteMessageAsync(message, cancellationToken));
-                                    }
-                                    await Task.WhenAll(completeTasks).ConfigureAwait(false);
-                                }
-                                else
-                                {
-                                    List<Task> abandonTasks = new List<Task>();
-                                    foreach (ServiceBusReceivedMessage message in messagesArray)
-                                    {
-                                        abandonTasks.Add(receiver.AbandonMessageAsync(message, cancellationToken: cancellationToken));
-                                    }
-                                    await Task.WhenAll(abandonTasks).ConfigureAwait(false);
-                                }
-                            }
+                    if (messages.Count > 0)
+                    {
+                        ServiceBusReceivedMessage[] messagesArray = messages.ToArray();
+                        ServiceBusTriggerInput input = ServiceBusTriggerInput.CreateBatch(messagesArray);
+                        if (_isSessionsEnabled)
+                        {
+                            input.MessageActions = new ServiceBusSessionMessageActions((ServiceBusSessionReceiver)receiver);
                         }
                         else
                         {
-                            // Close the session and release the session lock after draining all messages for the accepted session.
-                            if (_isSessionsEnabled)
+                            input.MessageActions = new ServiceBusMessageActions(receiver);
+                        }
+                        FunctionResult result = await _triggerExecutor.TryExecuteAsync(input.GetTriggerFunctionData(), cancellationToken).ConfigureAwait(false);
+
+                        // Complete batch of messages only if the execution was successful
+                        if (_autoCompleteMessagesOptionEvaluatedValue)
+                        {
+                            if (result.Succeeded)
                             {
-                                // Use CancellationToken.None to attempt to close the receiver even when shutting down
-                                await receiver.CloseAsync(CancellationToken.None).ConfigureAwait(false);
+                                List<Task> completeTasks = new List<Task>();
+                                foreach (ServiceBusReceivedMessage message in messagesArray)
+                                {
+                                    // skip messages that were settled in the user's function
+                                    if (input.MessageActions.SettledMessages.Contains(message))
+                                    {
+                                        continue;
+                                    }
+
+                                    // Pass CancellationToken.None to allow autocompletion to finish even when shutting down
+                                    completeTasks.Add(receiver.CompleteMessageAsync(message, CancellationToken.None));
+                                }
+
+                                await Task.WhenAll(completeTasks).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                List<Task> abandonTasks = new List<Task>();
+                                foreach (ServiceBusReceivedMessage message in messagesArray)
+                                {
+                                    // skip messages that were settled in the user's function
+                                    if (input.MessageActions.SettledMessages.Contains(message))
+                                    {
+                                        continue;
+                                    }
+
+                                    // Pass CancellationToken.None to allow abandon to finish even when shutting down
+                                    abandonTasks.Add(receiver.AbandonMessageAsync(message, cancellationToken: CancellationToken.None));
+                                }
+
+                                await Task.WhenAll(abandonTasks).ConfigureAwait(false);
                             }
                         }
                     }
-                    catch (ObjectDisposedException)
+                    else
                     {
-                        // Ignore as we are stopping the host
-                    }
-                    catch (Exception ex)
-                    {
-                        // Log another exception
-                        _logger.LogError(ex, $"An unhandled exception occurred in the message batch receive loop");
-
-                        if (_isSessionsEnabled && receiver != null)
+                        // Close the session and release the session lock after draining all messages for the accepted session.
+                        if (_isSessionsEnabled)
                         {
-                            // Attempt to close the session and release session lock to accept a new session on the next loop iteration
-                            try
-                            {
-                                // Use CancellationToken.None to attempt to close the receiver even when shutting down
-                                await receiver.CloseAsync(CancellationToken.None).ConfigureAwait(false);
-                            }
-                            catch
-                            {
-                                // Best effort
-                                receiver = null;
-                            }
+                            // Use CancellationToken.None to attempt to close the receiver even when shutting down
+                            await receiver.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                         }
                     }
                 }
-            }, cancellationToken);
+                catch (ObjectDisposedException)
+                {
+                    // Ignore as we are stopping the host
+                }
+                catch (TaskCanceledException)
+                    when(cancellationToken.IsCancellationRequested)
+                {
+                    // Ignore as we are stopping the host
+                    _logger.LogInformation("Message processing has been stopped or cancelled");
+                }
+                catch (Exception ex)
+                {
+                    // Log another exception
+                    _logger.LogError(ex, $"An unhandled exception occurred in the message batch receive loop");
+
+                    if (_isSessionsEnabled && receiver != null)
+                    {
+                        // Attempt to close the session and release session lock to accept a new session on the next loop iteration
+                        try
+                        {
+                            // Use CancellationToken.None to attempt to close the receiver even when shutting down
+                            await receiver.CloseAsync(CancellationToken.None).ConfigureAwait(false);
+                        }
+                        catch
+                        {
+                            // Best effort
+                            receiver = null;
+                        }
+                    }
+                }
+            }
+        }
+
+        private async Task ReceiveBatchAsync(ServiceBusReceiver receiver, CancellationToken cancellationToken)
+        {
+            IReadOnlyList<ServiceBusReceivedMessage> messages = await receiver.ReceiveMessagesAsync(
+                    _serviceBusOptions.MaxBatchSize,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            _batchReceiveCompletionSource.TrySetResult(messages);
         }
 
         private void ThrowIfDisposed()

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -155,15 +155,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                     }
                     else
                     {
-                        try
-                        {
-                            await _batchLoop.ConfigureAwait(false);
-                        }
-                        catch (TaskCanceledException)
-                        {
-                            // expected when stopping
-                        }
-
+                        await _batchLoop.ConfigureAwait(false);
                         await _batchReceiver.Value.CloseAsync(cancellationToken).ConfigureAwait(false);
                     }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -14,7 +14,8 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Sources" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" />
+      <!--Revert after Service Bus release-->
+      <!--<PackageReference Include="Azure.Messaging.ServiceBus" />-->
   </ItemGroup>
 
   <ItemGroup>
@@ -27,5 +28,10 @@
     <Compile Include="..\..\Azure.Messaging.ServiceBus\src\Resources.Designer.cs" LinkBase="Shared" />
     <Compile Include="..\..\..\extensions\Microsoft.Azure.WebJobs.Extensions.Clients\src\Shared\WebJobsConfigurationExtensions.cs" LinkBase="Shared" />
 
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--Revert after Service Bus release-->
+    <ProjectReference Include="..\..\Azure.Messaging.ServiceBus\src\Azure.Messaging.ServiceBus.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/ServiceBusMessageActions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/ServiceBusMessageActions.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         private readonly ProcessMessageEventArgs _eventArgs;
         private readonly ProcessSessionMessageEventArgs _sessionEventArgs;
 
+        internal HashSet<ServiceBusReceivedMessage> SettledMessages { get; } = new();
+
         internal ServiceBusMessageActions(ProcessSessionMessageEventArgs sessionEventArgs)
         {
             _sessionEventArgs = sessionEventArgs;
@@ -50,6 +52,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             {
                 await _sessionEventArgs.AbandonMessageAsync(message, propertiesToModify, cancellationToken).ConfigureAwait(false);
             }
+
+            SettledMessages.Add(message);
         }
 
         ///<inheritdoc cref="ServiceBusReceiver.CompleteMessageAsync(ServiceBusReceivedMessage, CancellationToken)"/>
@@ -69,6 +73,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             {
                 await _sessionEventArgs.CompleteMessageAsync(message, cancellationToken).ConfigureAwait(false);
             }
+
+            SettledMessages.Add(message);
         }
 
         ///<inheritdoc cref="ServiceBusReceiver.DeadLetterMessageAsync(ServiceBusReceivedMessage, string, string, CancellationToken)"/>
@@ -105,6 +111,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                     cancellationToken)
                 .ConfigureAwait(false);
             }
+
+            SettledMessages.Add(message);
         }
 
         ///<inheritdoc cref="ServiceBusReceiver.DeadLetterMessageAsync(ServiceBusReceivedMessage, IDictionary{string, object}, CancellationToken)"/>
@@ -137,6 +145,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                     cancellationToken)
                 .ConfigureAwait(false);
             }
+
+            SettledMessages.Add(message);
         }
 
         ///<inheritdoc cref="ServiceBusReceiver.DeferMessageAsync(ServiceBusReceivedMessage, IDictionary{string, object}, CancellationToken)"/>
@@ -169,6 +179,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                     cancellationToken)
                 .ConfigureAwait(false);
             }
+
+            SettledMessages.Add(message);
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
         {
             if (attribute.IsAutoCompleteMessagesOptionSet)
             {
-                _logger.LogInformation($"The 'AutoCompleteMessages' option has been overrriden to '{attribute.AutoCompleteMessages}' value for '{functionName}' function.");
+                _logger.LogInformation($"The 'AutoCompleteMessages' option has been overriden to '{attribute.AutoCompleteMessages}' value for '{functionName}' function.");
 
                 return attribute.AutoCompleteMessages;
             }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 builder.ConfigureWebJobs(b =>
                     b.AddServiceBus(sbOptions =>
                     {
-                        // Will be disabled for drain mode validation as messages are completed by functoin code to validate draining allows completion
+                        // Will be disabled for drain mode validation as messages are completed by function code to validate draining allows completion
                         sbOptions.AutoCompleteMessages = autoComplete;
                         sbOptions.MaxAutoLockRenewalDuration = TimeSpan.FromMinutes(MaxAutoRenewDurationMin);
                         sbOptions.MaxConcurrentSessions = 1;
@@ -464,7 +464,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         {
             public static void SBQueue1Trigger(
                 [ServiceBusTrigger(FirstQueueNameKey, IsSessionsEnabled = true)]
-                ServiceBusReceivedMessage message, int deliveryCount,
+                ServiceBusReceivedMessage message,
+                int deliveryCount,
                 ServiceBusSessionMessageActions messageSession,
                 ILogger log,
                 string lockToken)
@@ -477,7 +478,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             public static void SBSub1Trigger(
                 [ServiceBusTrigger(TopicNameKey, FirstSubscriptionNameKey, IsSessionsEnabled = true)]
-                ServiceBusReceivedMessage message, int deliveryCount,
+                ServiceBusReceivedMessage message,
+                int deliveryCount,
                 ServiceBusSessionMessageActions messageSession,
                 ILogger log,
                 string lockToken)
@@ -773,7 +775,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
     internal class ServiceBusSessionsTestHelper
 #pragma warning restore SA1402 // File may only contain a single type
     {
-        public static void ProcessMessage(ServiceBusReceivedMessage message, ILogger log, EventWaitHandle waitHandle1,
+        public static void ProcessMessage(
+            ServiceBusReceivedMessage message,
+            ILogger log,
+            EventWaitHandle waitHandle1,
             EventWaitHandle waitHandle2)
         {
             string messageString = message.Body.ToString();
@@ -792,17 +797,13 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         public static string GetLogsAsString(List<LogMessage> messages)
         {
-            if (messages.Count() != 5 && messages.Count() != 10)
-            {
-            }
-
-            string reuslt = string.Empty;
+            string result = string.Empty;
             foreach (LogMessage message in messages)
             {
-                reuslt += message.FormattedMessage + System.Environment.NewLine;
+                result += message.FormattedMessage + System.Environment.NewLine;
             }
 
-            return reuslt;
+            return result;
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
@@ -245,7 +245,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         public async Task StopAsync(CancellationToken cancellationToken)
         {
             var logs = _host.GetTestLoggerProvider().GetAllLogMessages();
-            var errors = logs.Where(p => p.Level == LogLevel.Error);
+            var errors = logs.Where(
+                p => p.Level == LogLevel.Error &&
+                // Ignore this error that the SDK logs when cancelling batch receive
+                !p.FormattedMessage.Contains("ReceiveBatchAsync Exception: System.Threading.Tasks.TaskCanceledException"));
             Assert.IsEmpty(errors, string.Join(",", errors.Select(e => e.FormattedMessage)));
 
             var client = new ServiceBusAdministrationClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
@@ -249,6 +249,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.IsEmpty(errors, string.Join(",", errors.Select(e => e.FormattedMessage)));
 
             var client = new ServiceBusAdministrationClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
+
+            // wait for a few seconds to allow updated counts to propagate
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
             QueueRuntimeProperties properties = await client.GetQueueRuntimePropertiesAsync(WebJobsServiceBusTestBase._firstQueueScope.QueueName, CancellationToken.None);
             Assert.AreEqual(0, properties.TotalMessageCount);
         }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/21382
- Adds more determinism to stopping a host that uses batch receive by allowing processing/autocompletion to finish. Uses the same strategy introduced in SB SDK to allow batch receive to cancel early to avoid waiting for a long time when shutting down.
- Prevents error when autoCompleteMessages = true and user completes message in batch function (already worked like this for single dispatch functions)