### PR TITLE
[Event Hubs] Additional Connection Options

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -16,6 +16,10 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - When the `EventProcessorClient` detects a partition being stolen outside of a load balancing cycle, it will immediately surrender ownership rather than waiting for a load balancing cycle to confirm the ownership change.  This will help reduce event duplication from overlapping ownership of processors.
 
+- The `ConnectionOptions` available when creating a processor now support registering a callback delegate for participating in the validation of SSL certificates when connections are established.  This delegate may override the built-in validation and allow or deny certificates based on application-specific logic.
+
+- The `ConnectionOptions` available when creating a processor now support setting a custom size for the send and receive buffers of the transport.
+
 #### Key Bug Fixes
 
 - The `EventProcessorClient` will now properly respect another another consumer stealing ownership of a partition when the service forcibly terminates the active link in the background.  Previously, the client did not observe the error directly and attempted to recover the faulted link which reasserted ownership and caused the partition to "bounce" between owners until a load balancing cycle completed.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/EventHubConnectionOptionsExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/EventHubConnectionOptionsExtensions.cs
@@ -23,7 +23,10 @@ namespace Azure.Messaging.EventHubs.Core
             {
                 TransportType = instance.TransportType,
                 Proxy = instance.Proxy,
-                CustomEndpointAddress = instance.CustomEndpointAddress
+                CustomEndpointAddress = instance.CustomEndpointAddress,
+                SendBufferSizeInBytes = instance.SendBufferSizeInBytes,
+                ReceiveBufferSizeInBytes = instance.ReceiveBufferSizeInBytes,
+                CertificateValidationCallback = instance.CertificateValidationCallback
             };
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/EventHubConnectionOptionsExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/EventHubConnectionOptionsExtensionsTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using Azure.Messaging.EventHubs.Core;
 using Moq;
 using NUnit.Framework;
@@ -25,11 +27,14 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CloneProducesACopy()
         {
-            var options = new EventHubConnectionOptions
+           var options = new EventHubConnectionOptions
             {
                 TransportType = EventHubsTransportType.AmqpWebSockets,
                 Proxy = Mock.Of<IWebProxy>(),
-                CustomEndpointAddress = new Uri("https://fake.servciebus.net")
+                CustomEndpointAddress = new Uri("https://fake.servciebus.net"),
+                SendBufferSizeInBytes = 65,
+                ReceiveBufferSizeInBytes = 66,
+                CertificateValidationCallback = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors errors) => false
             };
 
             EventHubConnectionOptions clone = options.Clone();
@@ -37,6 +42,9 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(clone.TransportType, Is.EqualTo(options.TransportType), "The connection type of the clone should match.");
             Assert.That(clone.Proxy, Is.EqualTo(options.Proxy), "The proxy of the clone should match.");
             Assert.That(clone.CustomEndpointAddress, Is.EqualTo(options.CustomEndpointAddress), "The custom endpoint address clone should match.");
+            Assert.That(clone.SendBufferSizeInBytes, Is.EqualTo(options.SendBufferSizeInBytes), "The send buffer size clone should match.");
+            Assert.That(clone.ReceiveBufferSizeInBytes, Is.EqualTo(options.ReceiveBufferSizeInBytes), "The receive buffer size clone should match.");
+            Assert.That(clone.CertificateValidationCallback, Is.SameAs(options.CertificateValidationCallback), "The validation callback clone should match.");
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -18,6 +18,10 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - The `EventProcessor<TPartition>` now exposes the `ListPartitionIdsAsync` method, allowing custom processors to control the set of partitions known to the processor.  This can be used to reduce complexity when a custom processor is directly assigned a set of partitions to process rather than using load balancing to control ownership.
 
+- The `ConnectionOptions` available when creating client types now support registering a callback delegate for participating in the validation of SSL certificates when connections are established.  This delegate may override the built-in validation and allow or deny certificates based on application-specific logic.
+
+- The `ConnectionOptions` available when creating client types now support setting a custom size for the send and receive buffers of the transport.
+
 - Additional verbose logging has been added to allow monitoring of lower-level AMQP operations such as creating links, terminal exceptions that fault a link without an active operation, and when the service force-closes links.
 
 #### Key Bug Fixes

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -51,8 +51,11 @@ namespace Azure.Messaging.EventHubs
     public partial class EventHubConnectionOptions
     {
         public EventHubConnectionOptions() { }
+        public System.Net.Security.RemoteCertificateValidationCallback CertificateValidationCallback { get { throw null; } set { } }
         public System.Uri CustomEndpointAddress { get { throw null; } set { } }
         public System.Net.IWebProxy Proxy { get { throw null; } set { } }
+        public int ReceiveBufferSizeInBytes { get { throw null; } set { } }
+        public int SendBufferSizeInBytes { get { throw null; } set { } }
         public Azure.Messaging.EventHubs.EventHubsTransportType TransportType { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -174,7 +174,18 @@ namespace Azure.Messaging.EventHubs.Amqp
                 EventHubName = eventHubName;
                 Credential = credential;
                 MessageConverter = messageConverter ?? new AmqpMessageConverter();
-                ConnectionScope = connectionScope ?? new AmqpConnectionScope(ServiceEndpoint, ConnectionEndpoint, eventHubName, credential, clientOptions.TransportType, clientOptions.Proxy);
+
+                ConnectionScope = connectionScope ?? new AmqpConnectionScope(
+                    ServiceEndpoint,
+                    ConnectionEndpoint,
+                    eventHubName,
+                    credential,
+                    clientOptions.TransportType,
+                    clientOptions.Proxy,
+                    null,
+                    clientOptions.SendBufferSizeInBytes,
+                    clientOptions.ReceiveBufferSizeInBytes,
+                    clientOptions.CertificateValidationCallback);
 
                 ManagementLink = new FaultTolerantAmqpObject<RequestResponseAmqpLink>(
                     timeout => ConnectionScope.OpenManagementLinkAsync(timeout, CancellationToken.None),

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnectionOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnectionOptions.cs
@@ -4,6 +4,8 @@
 using System;
 using System.ComponentModel;
 using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -24,12 +26,38 @@ namespace Azure.Messaging.EventHubs
         public EventHubsTransportType TransportType { get; set; } = EventHubsTransportType.AmqpTcp;
 
         /// <summary>
+        ///   The size of the buffer used for sending information via the active transport.
+        /// </summary>
+        ///
+        /// <value>The size of the buffer, in bytes.  The default size is 8,192 bytes.</value>
+        ///
+        /// <remarks>
+        ///   This value is used to configure the <see cref="Socket.SendBufferSize" /> used by
+        ///   the active transport.
+        /// </remarks>
+        ///
+        public int SendBufferSizeInBytes { get; set; } = 8192;
+
+        /// <summary>
+        ///   The size of the buffer used for receiving information via the active transport.
+        /// </summary>
+        ///
+        /// <value>The size of the buffer, in bytes.  The default size is 8,192 bytes.</value>
+        ///
+        /// <remarks>
+        ///   This value is used to configure the <see cref="Socket.ReceiveBufferSize" /> used by
+        ///   the active transport.
+        /// </remarks>
+        ///
+        public int ReceiveBufferSizeInBytes { get; set; } = 8192;
+
+        /// <summary>
         ///   The proxy to use for communication over web sockets.
         /// </summary>
         ///
         /// <remarks>
-        ///   A proxy cannot be used for communication over TCP; if web sockets are not in
-        ///   use, specifying a proxy is an invalid option.
+        ///   A proxy cannot be used for communication over TCP; if the <see cref="TransportType" /> is not set
+        ///   to <see cref="EventHubsTransportType.AmqpWebSockets" />, specifying a proxy is invalid.
         /// </remarks>
         ///
         public IWebProxy Proxy { get; set; }
@@ -46,6 +74,15 @@ namespace Azure.Messaging.EventHubs
         /// </value>
         ///
         public Uri CustomEndpointAddress { get; set; }
+
+        /// <summary>
+        ///   A <see cref="RemoteCertificateValidationCallback" /> delegate allowing custom logic to be considered for
+        ///   validation of the remote certificate responsible for encrypting communication.
+        /// </summary>
+        ///
+        /// <value>The callback will be invoked any time a connection is established, including any reconnect attempts.</value>
+        ///
+        public RemoteCertificateValidationCallback CertificateValidationCallback { get; set; }
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
@@ -95,6 +95,37 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ProducerWithCustomBufferSizesCanSend(EventHubsTransportType transportType)
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                var connectionString = EventHubsTestEnvironment.Instance.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                var producerOptions = new EventHubProducerClientOptions
+                {
+                    ConnectionOptions = new EventHubConnectionOptions
+                    {
+                       ReceiveBufferSizeInBytes = 4096,
+                       SendBufferSizeInBytes = 12288
+                    }
+                };
+
+                await using (var producer = new EventHubProducerClient(connectionString, producerOptions))
+                {
+                    EventData[] events = new[] { new EventData(Encoding.UTF8.GetBytes("AWord")) };
+                    Assert.That(async () => await producer.SendAsync(events), Throws.Nothing);
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubProducerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
         public async Task ProducerCanSendToASpecificPartition()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))


### PR DESCRIPTION
# Summary 

The focus of these changes is to expose an additional set of connection options for configuring the transport.  Included are options for:

- A custom send buffer size
- A custom receive buffer size
- A delegate to participate in SSL certificate validation

# References and Resources 

- [Expose additional transport configuration in ConnectionOptions (#21482)](https://github.com/Azure/azure-sdk-for-net/issues/21482)
