### PR TITLE
[Messaging Clients] Retry Calculation Fix

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/RetryPolicies/BasicRetryPolicyTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/RetryPolicies/BasicRetryPolicyTests.cs
@@ -357,5 +357,29 @@ namespace Azure.Messaging.EventHubs.Tests
                 previousDelay = delay.Value;
             }
         }
+
+        /// <summary>
+        ///  Verifies functionality of the <see cref="BasicRetryPolicy.CalculateRetryDelay" />
+        ///  method.
+        /// </summary>
+        ///
+        [Test]
+        public void CalculateRetryDelayDoesNotOverlowTimespanMaximum()
+        {
+            // The fixed policy can't exceed the maximum due to limitations on
+            // the configured Delay and MaximumRetries; the exponential policy
+            // will overflow a TimeSpan on the 38th retry with maximum values if
+            // the calculation is uncapped.
+
+            var policy = new BasicRetryPolicy(new EventHubsRetryOptions
+            {
+                MaximumRetries = 100,
+                Delay = TimeSpan.FromMinutes(5),
+                MaximumDelay = TimeSpan.MaxValue,
+                Mode = EventHubsRetryMode.Exponential
+            });
+
+            Assert.That(policy.CalculateRetryDelay(new EventHubsException(true, "fake", EventHubsException.FailureReason.ServiceTimeout), 88), Is.EqualTo(TimeSpan.MaxValue));
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -28,6 +28,8 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - The `EventHubConsumerClient` and `PartitionReceiver` will now properly surface an exception when another another consumer stealing ownership of a partition when the service forcibly terminates the active link in the background.  Previously, the client did not observe the error directly and did not make callers attempted to recover the faulted link which reasserted ownership and caused the partition to "bounce" between owners until a load balancing cycle completed.
 
+- The retry policy used by clients will no longer overflow the `TimeSpan` maximum when using an `Exponential` strategy with a large number of retries and long delay set.
+
 ## 5.4.1 (2021-05-11)
 
 ### Changes

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 7.2.0-beta.4 (Unreleased)
 
+### Key Bug Fixes
+
+- The retry policy used by clients will no longer overflow the `TimeSpan` maximum when using an `Exponential` strategy with a large number of retries and long delay set.
 
 ## 7.2.0-beta.3 (2021-05-12)
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/BasicRetryPolicyTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/BasicRetryPolicyTests.cs
@@ -333,5 +333,29 @@ namespace Azure.Messaging.ServiceBus.Tests
                 previousDelay = delay.Value;
             }
         }
+
+        /// <summary>
+        ///  Verifies functionality of the <see cref="BasicRetryPolicy.CalculateRetryDelay" />
+        ///  method.
+        /// </summary>
+        ///
+        [Test]
+        public void CalculateRetryDelayDoesNotOverlowTimespanMaximum()
+        {
+            // The fixed policy can't exceed the maximum due to limitations on
+            // the configured Delay and MaximumRetries; the exponential policy
+            // will overflow a TimeSpan on the 38th retry with maximum values if
+            // the calculation is uncapped.
+
+            var policy = new BasicRetryPolicy(new ServiceBusRetryOptions
+            {
+                MaxRetries = 100,
+                Delay = TimeSpan.FromMinutes(5),
+                MaxDelay = TimeSpan.MaxValue,
+                Mode = ServiceBusRetryMode.Exponential
+            });
+
+            Assert.That(policy.CalculateRetryDelay(new ServiceBusException(true, "transient", "fake", ServiceBusFailureReason.ServiceTimeout), 88), Is.EqualTo(TimeSpan.MaxValue));
+        }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to clamp the calculation for the natural delay (before it is clamped to the `MaxDelay`) to prevent overflowing the `TimeSpan` type.

# References and Related

- [[QUERY] Trouble configuring the retry mechanism using exponential retry mode (#21581)](https://github.com/Azure/azure-sdk-for-net/issues/21581)