### PR TITLE
[Translation] Enable tests and more

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationLiveTestBase.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationLiveTestBase.cs
@@ -15,7 +15,7 @@ namespace Azure.AI.Translation.Document.Tests
 {
     public abstract class DocumentTranslationLiveTestBase : RecordedTestBase<DocumentTranslationTestEnvironment>
     {
-        protected TimeSpan PollingInterval => TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0 : 30);
+        protected TimeSpan PollingInterval => TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0 : 5);
 
         public DocumentTranslationLiveTestBase(bool isAsync, RecordedTestMode? mode = null)
             : base(isAsync, mode)

--- a/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
@@ -32,11 +32,11 @@ namespace Azure.AI.Translation.Document.Tests
 
         protected override async ValueTask<bool> IsEnvironmentReadyAsync()
         {
-            string endpoint = Environment.GetEnvironmentVariable(EndpointEnvironmentVariableName);
+            string endpoint = GetVariable(EndpointEnvironmentVariableName);
             var client = new DocumentTranslationClient(new Uri(endpoint), Credential);
             try
             {
-                await client.GetDocumentFormatsAsync();
+                await client.GetAllTranslationStatusesAsync().ToEnumerableAsync();
             }
             catch (RequestFailedException e) when (e.Status == 401)
             {

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTarget.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTarget.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source698049479?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source50458932?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-eb10404cd7faca4bbff43c1cb5b01a17-164cac8981089746-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-68def2b1c8151249a498360e6d5a62fa-0d8fc374b4d6c540-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "251d52a14369df430fc579df7ccffe74",
-        "x-ms-date": "Mon, 29 Mar 2021 22:05:29 GMT",
+        "x-ms-client-request-id": "d94d800cd488f642ac78fa94247cd16a",
+        "x-ms-date": "Fri, 04 Jun 2021 16:59:34 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:05:28 GMT",
-        "ETag": "\u00220x8D8F2FEC38F50C4\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 22:05:28 GMT",
+        "Date": "Fri, 04 Jun 2021 16:59:35 GMT",
+        "ETag": "\u00220x8D9277A2231D6A5\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 16:59:36 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "251d52a14369df430fc579df7ccffe74",
-        "x-ms-request-id": "07f4ed91-501e-0035-2be7-248446000000",
+        "x-ms-client-request-id": "d94d800cd488f642ac78fa94247cd16a",
+        "x-ms-request-id": "5b4b16e9-d01e-0049-1562-59aab9000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source698049479/Document1.txt",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source50458932/Document1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "27",
         "If-None-Match": "*",
-        "traceparent": "00-4be022584c123f4eb230f2bd4288aec3-e8b7b1765ed25746-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-00ee3c24a9889f48bf26254f88dea656-5db560ec46c1b94b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "ea41cd2ed3cabcea600064179df2d013",
-        "x-ms-date": "Mon, 29 Mar 2021 22:05:29 GMT",
+        "x-ms-client-request-id": "f4f52c8408e4a6f0709f07794052ed63",
+        "x-ms-date": "Fri, 04 Jun 2021 16:59:36 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,29 +47,29 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
-        "Date": "Mon, 29 Mar 2021 22:05:28 GMT",
-        "ETag": "\u00220x8D8F2FEC3DBF27C\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 22:05:29 GMT",
+        "Date": "Fri, 04 Jun 2021 16:59:35 GMT",
+        "ETag": "\u00220x8D9277A225CF7F2\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 16:59:36 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "ea41cd2ed3cabcea600064179df2d013",
+        "x-ms-client-request-id": "f4f52c8408e4a6f0709f07794052ed63",
         "x-ms-content-crc64": "V7knc5S52gk=",
-        "x-ms-request-id": "07f4edf9-501e-0035-06e7-248446000000",
+        "x-ms-request-id": "5b4b1789-d01e-0049-2862-59aab9000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d829add4f1de5744a033d6184cc3b1ad-e13be3aae1dc184b-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "fceeecd3913cdc5e25d62bdb6421cc62",
+        "traceparent": "00-3cc36b250923f24fbf32e4b05c713c28-16c69821a30d8343-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "37209b2b3f10c3f8a160dc445b5cea5f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -89,65 +89,65 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "aab09a36-deb3-4aac-b6b6-7ae2aa7eb57a",
+        "apim-request-id": "c82190c7-d05e-4505-bef3-88193cb80a00",
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:05:29 GMT",
-        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/f4bee4d9-1607-4d25-b930-d0cb95c363a6",
+        "Date": "Fri, 04 Jun 2021 16:59:37 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/610ab646-4f3b-45aa-8783-a0a716a3dead",
         "Set-Cookie": [
-          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "aab09a36-deb3-4aac-b6b6-7ae2aa7eb57a"
+        "X-RequestId": "c82190c7-d05e-4505-bef3-88193cb80a00"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/f4bee4d9-1607-4d25-b930-d0cb95c363a6",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/610ab646-4f3b-45aa-8783-a0a716a3dead",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "c18e721e6127cefd6760c568df2c421c",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "62bfd8b3e75f034f90a769e9cdc9b559",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "115739aa-158e-49f5-9f64-2d4e77045476",
+        "apim-request-id": "8079331d-bd81-4c2f-a985-a773f2967522",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 29 Mar 2021 22:05:30 GMT",
-        "ETag": "\u0022249CE59B2C5F40050766B1F37F6A5A8B127F3EA66A951DC9D1762AA3E970BAD1\u0022",
+        "Date": "Fri, 04 Jun 2021 16:59:37 GMT",
+        "ETag": "\u002217E14F1DFB9D3CA3DAFD72D6DDAD1AFD994F762E9D5DFD9729B441D61D3B27B3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "115739aa-158e-49f5-9f64-2d4e77045476"
+        "X-RequestId": "8079331d-bd81-4c2f-a985-a773f2967522"
       },
       "ResponseBody": {
-        "id": "f4bee4d9-1607-4d25-b930-d0cb95c363a6",
-        "createdDateTimeUtc": "2021-03-29T22:05:29.9357334Z",
-        "lastActionDateTimeUtc": "2021-03-29T22:05:30.1071124Z",
+        "id": "610ab646-4f3b-45aa-8783-a0a716a3dead",
+        "createdDateTimeUtc": "2021-06-04T16:59:37.7296451Z",
+        "lastActionDateTimeUtc": "2021-06-04T16:59:37.8498777Z",
         "status": "ValidationFailed",
         "error": {
           "code": "InvalidRequest",
-          "message": "Cannot access source document location with the current permissions.",
+          "message": "Cannot access target document location with the current permissions.",
           "target": "Operation",
           "innerError": {
-            "code": "InvalidDocumentAccessLevel",
-            "message": "Cannot access source document location with the current permissions."
+            "code": "InvalidTargetDocumentAccessLevel",
+            "message": "Cannot access target document location with the current permissions."
           }
         },
         "summary": {
@@ -166,6 +166,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
-    "RandomSeed": "50827542"
+    "RandomSeed": "1953610546"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTargetAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTargetAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source18224896?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source38512333?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-f3a6f6ef0c104a438b2439d00250a773-d6f090e267e17c44-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-bf811c71e5ea734999d2ef3d2b66a45e-fbc092707966d64b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "3f10d19745857fc61c122af6c3d72724",
-        "x-ms-date": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "x-ms-client-request-id": "e787d903733439ae6e3445cdb576528f",
+        "x-ms-date": "Fri, 04 Jun 2021 17:00:29 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:03:32 GMT",
-        "ETag": "\u00220x8D8F2FE7E222549\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "Date": "Fri, 04 Jun 2021 17:00:28 GMT",
+        "ETag": "\u00220x8D9277A41A75198\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 17:00:29 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "3f10d19745857fc61c122af6c3d72724",
-        "x-ms-request-id": "edb702e0-f01e-002c-49e7-2404fd000000",
+        "x-ms-client-request-id": "e787d903733439ae6e3445cdb576528f",
+        "x-ms-request-id": "5b4bca36-d01e-0049-4263-59aab9000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source18224896/Document1.txt",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source38512333/Document1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "27",
         "If-None-Match": "*",
-        "traceparent": "00-024be1d22e24a6408e44f64cf72ac5d4-c881574e9730eb42-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6b4d14f36bc7ff46a992c9c910f7aa43-077d6b19f27f224b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "28c5fa18444d725ba99cbba42b4d8792",
-        "x-ms-date": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "x-ms-client-request-id": "38612a20facbdfd93dc8697702af40d1",
+        "x-ms-date": "Fri, 04 Jun 2021 17:00:29 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,29 +47,29 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
-        "Date": "Mon, 29 Mar 2021 22:03:32 GMT",
-        "ETag": "\u00220x8D8F2FE7E585DC6\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "Date": "Fri, 04 Jun 2021 17:00:28 GMT",
+        "ETag": "\u00220x8D9277A41C7CF8D\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 17:00:29 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "28c5fa18444d725ba99cbba42b4d8792",
+        "x-ms-client-request-id": "38612a20facbdfd93dc8697702af40d1",
         "x-ms-content-crc64": "V7knc5S52gk=",
-        "x-ms-request-id": "edb70314-f01e-002c-77e7-2404fd000000",
+        "x-ms-request-id": "5b4bcac9-d01e-0049-1f63-59aab9000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c28db55da4b91445bad5e446cab15fc4-c3da274c414ccb4b-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "9e0739f09d606a72731fd80ea4475968",
+        "traceparent": "00-7810415c07ed0a489c5e4deb63381aa1-774352619709d04a-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fdd40549e901dba48dee3c5a25439947",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -89,65 +89,65 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1ab77998-6570-4d29-adc9-2f751df5ea41",
+        "apim-request-id": "a6fc2c27-1cc0-4b54-855a-e7894ecec9b1",
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:03:32 GMT",
-        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/9bee1b87-044a-4945-a9df-2e875e2e3fe1",
+        "Date": "Fri, 04 Jun 2021 17:00:28 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/04d30643-556c-4c89-9577-7dc55ba57c0e",
         "Set-Cookie": [
-          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "1ab77998-6570-4d29-adc9-2f751df5ea41"
+        "X-RequestId": "a6fc2c27-1cc0-4b54-855a-e7894ecec9b1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/9bee1b87-044a-4945-a9df-2e875e2e3fe1",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/04d30643-556c-4c89-9577-7dc55ba57c0e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "7e9d14f44a0e52b2769d96e8892254ce",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c6e3b880d82a0901ffa8a96c093736bf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "18e380b0-258b-4331-af5f-9e5b8c740fec",
+        "apim-request-id": "a67c35e7-93f7-4536-be9f-443294219847",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 29 Mar 2021 22:03:33 GMT",
-        "ETag": "\u002263A575F29138241B6067A5A0552DCE7593A83CDB926B6B5C2252BA4E15C72314\u0022",
+        "Date": "Fri, 04 Jun 2021 17:00:28 GMT",
+        "ETag": "\u00229B0E9039A9BBAB46655C921E7CD7A7765586E9D991E8AB2039C17DABAD5B9D86\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "18e380b0-258b-4331-af5f-9e5b8c740fec"
+        "X-RequestId": "a67c35e7-93f7-4536-be9f-443294219847"
       },
       "ResponseBody": {
-        "id": "9bee1b87-044a-4945-a9df-2e875e2e3fe1",
-        "createdDateTimeUtc": "2021-03-29T22:03:33.3975576Z",
-        "lastActionDateTimeUtc": "2021-03-29T22:03:33.5123233Z",
+        "id": "04d30643-556c-4c89-9577-7dc55ba57c0e",
+        "createdDateTimeUtc": "2021-06-04T17:00:29.5096587Z",
+        "lastActionDateTimeUtc": "2021-06-04T17:00:29.5772423Z",
         "status": "ValidationFailed",
         "error": {
           "code": "InvalidRequest",
-          "message": "Cannot access source document location with the current permissions.",
+          "message": "Cannot access target document location with the current permissions.",
           "target": "Operation",
           "innerError": {
-            "code": "InvalidDocumentAccessLevel",
-            "message": "Cannot access source document location with the current permissions."
+            "code": "InvalidTargetDocumentAccessLevel",
+            "message": "Cannot access target document location with the current permissions."
           }
         },
         "summary": {
@@ -166,6 +166,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
-    "RandomSeed": "248593475"
+    "RandomSeed": "1037268022"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/SingleSourceMultipleTargetsTest.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/SingleSourceMultipleTargetsTest.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://nourdocuments.blob.core.windows.net/source1147604042?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source2128357373?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-91387ebfbf89bc488ab2d4dab299d796-44e6def3c36a8948-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-33a4e1804ec86e4eb7d008653c9b7288-86f30e0679fcd449-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "bf04900932f2039abc6133015407b409",
-        "x-ms-date": "Thu, 25 Mar 2021 15:30:38 GMT",
+        "x-ms-client-request-id": "c1157aae9c49ce65a4eb9b908a76fdce",
+        "x-ms-date": "Fri, 04 Jun 2021 18:08:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 25 Mar 2021 15:30:13 GMT",
-        "ETag": "\u00220x8D8EFA2E26BF46D\u0022",
-        "Last-Modified": "Thu, 25 Mar 2021 15:30:13 GMT",
+        "Date": "Fri, 04 Jun 2021 18:08:43 GMT",
+        "ETag": "\u00220x8D92783CAAE4D7E\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:08:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "bf04900932f2039abc6133015407b409",
-        "x-ms-request-id": "bc944364-d01e-0053-2a8b-2173a7000000",
+        "x-ms-client-request-id": "c1157aae9c49ce65a4eb9b908a76fdce",
+        "x-ms-request-id": "65b8e8c7-201e-0072-2d6c-59ef1d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://nourdocuments.blob.core.windows.net/source1147604042/Document1.txt",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source2128357373/Document1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "27",
         "If-None-Match": "*",
-        "traceparent": "00-6afa5e801a47624bb526d0ea597b0da9-244507f94f69da47-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f83d1c3202b35f4b85b1e9681171f9a7-401f85dca220bd4e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "001aee5f41bf4c7e46265e7c8d583be6",
-        "x-ms-date": "Thu, 25 Mar 2021 15:30:40 GMT",
+        "x-ms-client-request-id": "e0989eaab8081fdab1a8864f452f10af",
+        "x-ms-date": "Fri, 04 Jun 2021 18:08:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
-        "Date": "Thu, 25 Mar 2021 15:30:13 GMT",
-        "ETag": "\u00220x8D8EFA2E2C8DE75\u0022",
-        "Last-Modified": "Thu, 25 Mar 2021 15:30:14 GMT",
+        "Date": "Fri, 04 Jun 2021 18:08:43 GMT",
+        "ETag": "\u00220x8D92783CAC6A482\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:08:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "001aee5f41bf4c7e46265e7c8d583be6",
+        "x-ms-client-request-id": "e0989eaab8081fdab1a8864f452f10af",
         "x-ms-content-crc64": "V7knc5S52gk=",
-        "x-ms-request-id": "bc9443ea-d01e-0053-218b-2173a7000000",
+        "x-ms-request-id": "65b8e91f-201e-0072-786c-59ef1d000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://nourdocuments.blob.core.windows.net/target694729396?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1093049613?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0114d950219191458ce7a9d6c0567285-5c582ba7d1890648-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-36725dd7cdfa8e498eec53d91c5b2f76-f1cfc7ab8302d346-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "34a42c5aaf85fd2e568ac79d39c827c6",
-        "x-ms-date": "Thu, 25 Mar 2021 15:30:40 GMT",
+        "x-ms-client-request-id": "d322f61beb27c42d94a83f021bfadaf9",
+        "x-ms-date": "Fri, 04 Jun 2021 18:08:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,26 +76,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 25 Mar 2021 15:30:14 GMT",
-        "ETag": "\u00220x8D8EFA2E2EF45D3\u0022",
-        "Last-Modified": "Thu, 25 Mar 2021 15:30:14 GMT",
+        "Date": "Fri, 04 Jun 2021 18:08:44 GMT",
+        "ETag": "\u00220x8D92783CACE103A\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:08:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "34a42c5aaf85fd2e568ac79d39c827c6",
-        "x-ms-request-id": "bc944485-d01e-0053-2d8b-2173a7000000",
+        "x-ms-client-request-id": "d322f61beb27c42d94a83f021bfadaf9",
+        "x-ms-request-id": "65b8e965-201e-0072-316c-59ef1d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://nourdocuments.blob.core.windows.net/target265836862?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target2049567471?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8250915c282ea84fbfbfecbef1f42d7e-83560932d32eca47-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8026dc864f6fc84492b1550753b111e2-4c8ccd4c4e75d348-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "6d533940c78ab81279cbd31d7664264d",
-        "x-ms-date": "Thu, 25 Mar 2021 15:30:41 GMT",
+        "x-ms-client-request-id": "857c98cdf5f5f59f10a016158974dbeb",
+        "x-ms-date": "Fri, 04 Jun 2021 18:08:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -103,26 +103,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 25 Mar 2021 15:30:14 GMT",
-        "ETag": "\u00220x8D8EFA2E311EF46\u0022",
-        "Last-Modified": "Thu, 25 Mar 2021 15:30:14 GMT",
+        "Date": "Fri, 04 Jun 2021 18:08:44 GMT",
+        "ETag": "\u00220x8D92783CAD4C82C\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:08:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "6d533940c78ab81279cbd31d7664264d",
-        "x-ms-request-id": "bc9444ea-d01e-0053-068b-2173a7000000",
+        "x-ms-client-request-id": "857c98cdf5f5f59f10a016158974dbeb",
+        "x-ms-request-id": "65b8e990-201e-0072-556c-59ef1d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://nourdocuments.blob.core.windows.net/target1883796556?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1082533506?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-75ceabee6f58e644acd0e84efb99e7cf-69393d98ba4c684b-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fa93ba93ebe8e14ca4ea688b883ba1f7-d83b1c36e955af4b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "d410dbfa3eda03ec68b6b6ae0c5e36b5",
-        "x-ms-date": "Thu, 25 Mar 2021 15:30:41 GMT",
+        "x-ms-client-request-id": "fbdb7f6eb2821c6a740f9b1c96aeab56",
+        "x-ms-date": "Fri, 04 Jun 2021 18:08:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -130,27 +130,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 25 Mar 2021 15:30:14 GMT",
-        "ETag": "\u00220x8D8EFA2E33471AD\u0022",
-        "Last-Modified": "Thu, 25 Mar 2021 15:30:14 GMT",
+        "Date": "Fri, 04 Jun 2021 18:08:44 GMT",
+        "ETag": "\u00220x8D92783CADABCAD\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:08:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d410dbfa3eda03ec68b6b6ae0c5e36b5",
-        "x-ms-request-id": "bc94455a-d01e-0053-698b-2173a7000000",
+        "x-ms-client-request-id": "fbdb7f6eb2821c6a740f9b1c96aeab56",
+        "x-ms-request-id": "65b8e9a9-201e-0072-696c-59ef1d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translator.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "187",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-543fb587d05b094aafcc483474f9aa23-ec0d0e54c09b474c-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210325.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "9201184fcf4691647c0be35adfe026a0",
+        "traceparent": "00-72bd361537bf1346a63bef6624f141da-c22b913ccd457749-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "3277625525878201dd174b17ae0a3463",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -178,58 +178,255 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "6b1c8e2d-7932-438b-b1e7-bdc2b44e0cff",
+        "apim-request-id": "04b361bc-21ed-4f81-835d-5efc5d96d1b2",
         "Content-Length": "0",
-        "Date": "Thu, 25 Mar 2021 15:30:14 GMT",
-        "Operation-Location": "https://document-translator.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/4d555cfa-e30e-47df-b22e-2b4cc2c5876d",
+        "Date": "Fri, 04 Jun 2021 18:08:44 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
         "Set-Cookie": [
-          "ARRAffinity=36da0e643e19b219e9cc242244bbb17606f2f9cdc98871c377756b22cded58cb;Path=/;HttpOnly;Secure;Domain=doctrans.northeu.microsofttranslator.com",
-          "ARRAffinitySameSite=36da0e643e19b219e9cc242244bbb17606f2f9cdc98871c377756b22cded58cb;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.northeu.microsofttranslator.com"
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6b1c8e2d-7932-438b-b1e7-bdc2b44e0cff"
+        "X-RequestId": "04b361bc-21ed-4f81-835d-5efc5d96d1b2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translator.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/4d555cfa-e30e-47df-b22e-2b4cc2c5876d",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210325.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "4bcdec5069b6fa66676a22105b0a6c6d",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5b8c9817f41de64a126981e603d979f2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e7673a88-8fcc-4e95-b2d7-eb6a960189fa",
+        "apim-request-id": "87f5e25d-e929-4b47-bbd6-90987f8717a4",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 25 Mar 2021 15:30:15 GMT",
-        "ETag": "\u00221393E8AF244B2A20CFD9314FD8DD2D9967630FAB3757BD1CDF5281309787F7CD\u0022",
+        "Date": "Fri, 04 Jun 2021 18:08:44 GMT",
+        "ETag": "\u002276644934162322BF0E787D3316AF075EE2995C19E319F389B90966166DAB8E3B\u0022",
+        "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=52534756bc24481c0848ee2def3c54a057fd0e51707d9dcf782aa603bbaa9f24;Path=/;HttpOnly;Secure;Domain=doctrans.northeu.microsofttranslator.com",
-          "ARRAffinitySameSite=52534756bc24481c0848ee2def3c54a057fd0e51707d9dcf782aa603bbaa9f24;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.northeu.microsofttranslator.com"
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e7673a88-8fcc-4e95-b2d7-eb6a960189fa"
+        "X-RequestId": "87f5e25d-e929-4b47-bbd6-90987f8717a4"
       },
       "ResponseBody": {
-        "id": "4d555cfa-e30e-47df-b22e-2b4cc2c5876d",
-        "createdDateTimeUtc": "2021-03-25T15:30:15.8992289",
-        "lastActionDateTimeUtc": "2021-03-25T15:30:15.8992292",
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:45.3966461Z",
         "status": "NotStarted",
         "summary": {
-          "total": 0,
+          "total": 3,
           "failed": 0,
           "success": 0,
           "inProgress": 0,
+          "notYetStarted": 3,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1233bf6bb86448fa7e581d6b67536e69",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e61151b5-cb5e-4663-b61a-5a61ff83fc45",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:08:46 GMT",
+        "ETag": "\u002276644934162322BF0E787D3316AF075EE2995C19E319F389B90966166DAB8E3B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e61151b5-cb5e-4663-b61a-5a61ff83fc45"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:45.3966461Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 3,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fd0538db502160381791201ea31b7e04",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c89055fc-ef93-4fef-8a1c-a1ac7bc931d9",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:08:47 GMT",
+        "ETag": "\u002276644934162322BF0E787D3316AF075EE2995C19E319F389B90966166DAB8E3B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c89055fc-ef93-4fef-8a1c-a1ac7bc931d9"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:45.3966461Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 3,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "eeac589d22d65eff9d43dcc5d6df7fbf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "29d8c15e-8bbc-4c82-ba10-effcdd627d91",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:08:48 GMT",
+        "ETag": "\u002276644934162322BF0E787D3316AF075EE2995C19E319F389B90966166DAB8E3B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "29d8c15e-8bbc-4c82-ba10-effcdd627d91"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:45.3966461Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 3,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "cb0a18fb7cd31ad086d2fbd397dca463",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "71e79d1f-c4ef-4439-8426-db4c690fedda",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:08:49 GMT",
+        "ETag": "\u0022481700558B692EC7ECCE418193C28337AA37C531617EC4C0FCE38390BAC61C13\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "71e79d1f-c4ef-4439-8426-db4c690fedda"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:50.0448849Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
           "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
@@ -237,36 +434,473 @@
       }
     },
     {
-      "RequestUri": "https://document-translator.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/4d555cfa-e30e-47df-b22e-2b4cc2c5876d",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210325.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "4b26689cba252b06777e58ce5b912488",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0ecd19d97fa6b99238a65fde73738937",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ae543f5b-bb53-4d94-a7f0-4754d37910ac",
+        "apim-request-id": "49419554-41be-4391-a507-ae1055cc051f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Length": "289",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 25 Mar 2021 15:30:46 GMT",
-        "ETag": "\u002290D7CE39959E6C44A429543E9EDA1C83EB175421A09A007BF694534D40F4700A\u0022",
+        "Date": "Fri, 04 Jun 2021 18:08:50 GMT",
+        "ETag": "\u0022481700558B692EC7ECCE418193C28337AA37C531617EC4C0FCE38390BAC61C13\u0022",
+        "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=36da0e643e19b219e9cc242244bbb17606f2f9cdc98871c377756b22cded58cb;Path=/;HttpOnly;Secure;Domain=doctrans.northeu.microsofttranslator.com",
-          "ARRAffinitySameSite=36da0e643e19b219e9cc242244bbb17606f2f9cdc98871c377756b22cded58cb;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.northeu.microsofttranslator.com"
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "49419554-41be-4391-a507-ae1055cc051f"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:50.0448849Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8b236111b310213088916704262bc6c1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "595d9a67-98e8-452e-ba20-024ae6782e46",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:08:51 GMT",
+        "ETag": "\u0022481700558B692EC7ECCE418193C28337AA37C531617EC4C0FCE38390BAC61C13\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ae543f5b-bb53-4d94-a7f0-4754d37910ac"
+        "X-RequestId": "595d9a67-98e8-452e-ba20-024ae6782e46"
       },
       "ResponseBody": {
-        "id": "4d555cfa-e30e-47df-b22e-2b4cc2c5876d",
-        "createdDateTimeUtc": "2021-03-25T15:30:15.8992289",
-        "lastActionDateTimeUtc": "2021-03-25T15:30:37.4763847",
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:50.0448849Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bdeb799e70127b188651922d1cf2a613",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f7180460-69d6-41cd-b706-cad154fe9309",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:08:53 GMT",
+        "ETag": "\u0022481700558B692EC7ECCE418193C28337AA37C531617EC4C0FCE38390BAC61C13\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "f7180460-69d6-41cd-b706-cad154fe9309"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:50.0448849Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "36c1c34819b92652e8ab8615178e920d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a11a3855-7a73-4aaf-ae2e-e2bfe6f56dfa",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:08:54 GMT",
+        "ETag": "\u0022481700558B692EC7ECCE418193C28337AA37C531617EC4C0FCE38390BAC61C13\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "a11a3855-7a73-4aaf-ae2e-e2bfe6f56dfa"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:50.0448849Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fa3f9edfcc87a02549a704bf20030595",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9649608a-fadf-41e2-a307-8eea3a8b9023",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:08:56 GMT",
+        "ETag": "\u0022481700558B692EC7ECCE418193C28337AA37C531617EC4C0FCE38390BAC61C13\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "9649608a-fadf-41e2-a307-8eea3a8b9023"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:50.0448849Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "63bb53eb906a840726c4d566ea0363f8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c3dab9dc-6308-4c6d-821c-ca568af7a05f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:08:57 GMT",
+        "ETag": "\u0022B3DAE017F0FCAF8749D407BF144C197A9D7B42C1188485C9F114D7695321CC3E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c3dab9dc-6308-4c6d-821c-ca568af7a05f"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:50.0448849Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 2,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 54
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7e4d85beabb27c8c9e20ec11149306e4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2246848e-2098-440f-9260-da4bafbaa16a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:08:58 GMT",
+        "ETag": "\u0022B3DAE017F0FCAF8749D407BF144C197A9D7B42C1188485C9F114D7695321CC3E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2246848e-2098-440f-9260-da4bafbaa16a"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:50.0448849Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 2,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 54
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c429f0a62fd24fa296bbd4c2f6beb646",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9a4851f9-6eac-407b-82c3-6178b9b0a342",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:08:59 GMT",
+        "ETag": "\u0022B3DAE017F0FCAF8749D407BF144C197A9D7B42C1188485C9F114D7695321CC3E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "9a4851f9-6eac-407b-82c3-6178b9b0a342"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:50.0448849Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 2,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 54
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9a000c4487b53fe3c73ec449a3f66f92",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c2117f8b-1931-4525-a65d-0a04264edd59",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Length": "290",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:00 GMT",
+        "ETag": "\u0022B3DAE017F0FCAF8749D407BF144C197A9D7B42C1188485C9F114D7695321CC3E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c2117f8b-1931-4525-a65d-0a04264edd59"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:50.0448849Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 2,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 54
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fabff0be9fd98f25e3fee7f7d7c985df",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7ace76f3-4ddc-4629-8649-a3b258e7c3b7",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:01 GMT",
+        "ETag": "\u002210C462766C8576C005CB1D5CDB9D299E2043489966955B3F205EC5627C108D24\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "7ace76f3-4ddc-4629-8649-a3b258e7c3b7"
+      },
+      "ResponseBody": {
+        "id": "d2a78eb8-1455-4fa3-859f-8cbceb34aa39",
+        "createdDateTimeUtc": "2021-06-04T18:08:45.2261775Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:08:50.0448849Z",
         "status": "Succeeded",
         "summary": {
           "total": 3,
@@ -280,65 +914,70 @@
       }
     },
     {
-      "RequestUri": "https://document-translator.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/4d555cfa-e30e-47df-b22e-2b4cc2c5876d/documents",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d2a78eb8-1455-4fa3-859f-8cbceb34aa39/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210325.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "1f5d1590eb90e6ffb2062bdcac533672",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "08cda66a6c921f2f0de9fc946a59aba0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fa541e4d-0531-4828-b427-e5f14ed7f07d",
+        "apim-request-id": "5abf3508-721a-42de-8c8a-cc96723d5f72",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 25 Mar 2021 15:30:46 GMT",
-        "ETag": "\u0022280009B726B70FBA3E27F292139CE2EF0E38B8F21CD3FC89EFD65FE4DFB76B45\u0022",
+        "Date": "Fri, 04 Jun 2021 18:09:01 GMT",
+        "ETag": "\u00224D9702F02889912277EBCFAAA466AB2506270007AC49A877C52DCE700CF977DC\u0022",
+        "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=52534756bc24481c0848ee2def3c54a057fd0e51707d9dcf782aa603bbaa9f24;Path=/;HttpOnly;Secure;Domain=doctrans.northeu.microsofttranslator.com",
-          "ARRAffinitySameSite=52534756bc24481c0848ee2def3c54a057fd0e51707d9dcf782aa603bbaa9f24;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.northeu.microsofttranslator.com"
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "fa541e4d-0531-4828-b427-e5f14ed7f07d"
+        "X-RequestId": "5abf3508-721a-42de-8c8a-cc96723d5f72"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://nourdocuments.blob.core.windows.net/target694729396/Document1.txt",
-            "sourcePath": "https://nourdocuments.blob.core.windows.net/source1147604042/Document1.txt",
-            "createdDateTimeUtc": "2021-03-25T15:30:27.8139427",
-            "lastActionDateTimeUtc": "2021-03-25T15:30:37.4604184",
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target1093049613/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source2128357373/Document1.txt",
+            "createdDateTimeUtc": "2021-06-04T18:08:49.7124578Z",
+            "lastActionDateTimeUtc": "2021-06-04T18:08:56.4776316Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000005dc-0000-0000-0000-000000000000",
+            "id": "0008211c-0000-0000-0000-000000000000",
             "characterCharged": 27
           },
           {
-            "path": "https://nourdocuments.blob.core.windows.net/target265836862/Document1.txt",
-            "sourcePath": "https://nourdocuments.blob.core.windows.net/source1147604042/Document1.txt",
-            "createdDateTimeUtc": "2021-03-25T15:30:26.782106",
-            "lastActionDateTimeUtc": "2021-03-25T15:30:37.3666992",
-            "status": "Succeeded",
-            "to": "es",
-            "progress": 1,
-            "id": "000005dd-0000-0000-0000-000000000000",
-            "characterCharged": 27
-          },
-          {
-            "path": "https://nourdocuments.blob.core.windows.net/target1883796556/Document1.txt",
-            "sourcePath": "https://nourdocuments.blob.core.windows.net/source1147604042/Document1.txt",
-            "createdDateTimeUtc": "2021-03-25T15:30:25.7685752",
-            "lastActionDateTimeUtc": "2021-03-25T15:30:37.4211738",
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target1082533506/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source2128357373/Document1.txt",
+            "createdDateTimeUtc": "2021-06-04T18:08:49.6727071Z",
+            "lastActionDateTimeUtc": "2021-06-04T18:09:01.6292229Z",
             "status": "Succeeded",
             "to": "ar",
             "progress": 1,
-            "id": "000005de-0000-0000-0000-000000000000",
+            "id": "0008211e-0000-0000-0000-000000000000",
+            "characterCharged": 27
+          },
+          {
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target2049567471/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source2128357373/Document1.txt",
+            "createdDateTimeUtc": "2021-06-04T18:08:49.672707Z",
+            "lastActionDateTimeUtc": "2021-06-04T18:08:56.4869575Z",
+            "status": "Succeeded",
+            "to": "es",
+            "progress": 1,
+            "id": "0008211d-0000-0000-0000-000000000000",
             "characterCharged": 27
           }
         ]
@@ -347,8 +986,8 @@
   ],
   "Variables": {
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=nourdocuments;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translator.cognitiveservices.azure.com/",
-    "RandomSeed": "1187973938"
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "624419513"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/SingleSourceMultipleTargetsTestAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/SingleSourceMultipleTargetsTestAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://nourdocuments.blob.core.windows.net/source179339698?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1415707658?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c8acdeef7e976b41a5ce504f9b9e8cec-694e470269725b44-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b56fcd87753d32499f5c57a0bea26e74-ffcfe3991907db45-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "da6eb3f4a694cc7513d27b03f1086916",
-        "x-ms-date": "Thu, 25 Mar 2021 15:31:27 GMT",
+        "x-ms-client-request-id": "7b20b0e20b79a71f139e4fcc8648539b",
+        "x-ms-date": "Fri, 04 Jun 2021 18:09:02 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 25 Mar 2021 15:31:00 GMT",
-        "ETag": "\u00220x8D8EFA2FEB56016\u0022",
-        "Last-Modified": "Thu, 25 Mar 2021 15:31:00 GMT",
+        "Date": "Fri, 04 Jun 2021 18:09:01 GMT",
+        "ETag": "\u00220x8D92783D5454263\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:09:02 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "da6eb3f4a694cc7513d27b03f1086916",
-        "x-ms-request-id": "bc948b7e-d01e-0053-3d8b-2173a7000000",
+        "x-ms-client-request-id": "7b20b0e20b79a71f139e4fcc8648539b",
+        "x-ms-request-id": "65b922a1-201e-0072-596c-59ef1d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://nourdocuments.blob.core.windows.net/source179339698/Document1.txt",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1415707658/Document1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "27",
         "If-None-Match": "*",
-        "traceparent": "00-64e74015f78c3a4d91ea1fbbe57a3734-9cb6136567860040-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-41361a66e753614898e9c9f60cd5509f-0c8e4f444046ee43-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "904508ffab5552eb384b140996e83e9c",
-        "x-ms-date": "Thu, 25 Mar 2021 15:31:27 GMT",
+        "x-ms-client-request-id": "2269226b34171a753d56f8335ab3e02b",
+        "x-ms-date": "Fri, 04 Jun 2021 18:09:02 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
-        "Date": "Thu, 25 Mar 2021 15:31:01 GMT",
-        "ETag": "\u00220x8D8EFA2FF0A213A\u0022",
-        "Last-Modified": "Thu, 25 Mar 2021 15:31:01 GMT",
+        "Date": "Fri, 04 Jun 2021 18:09:01 GMT",
+        "ETag": "\u00220x8D92783D551194F\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:09:02 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "904508ffab5552eb384b140996e83e9c",
+        "x-ms-client-request-id": "2269226b34171a753d56f8335ab3e02b",
         "x-ms-content-crc64": "V7knc5S52gk=",
-        "x-ms-request-id": "bc948bf5-d01e-0053-238b-2173a7000000",
+        "x-ms-request-id": "65b922ce-201e-0072-7f6c-59ef1d000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://nourdocuments.blob.core.windows.net/target1031722108?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target553744585?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6e330a2c5fb5694b9fa84b8e803178c9-1776d38a665a6c4d-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1a75323d72375a43b75534925aea70d8-83acc1a36714dd4e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "0fa8fadfd91c1623fd244604ff8a129d",
-        "x-ms-date": "Thu, 25 Mar 2021 15:31:28 GMT",
+        "x-ms-client-request-id": "46ce757a31ecef839085a2e7ac4d0242",
+        "x-ms-date": "Fri, 04 Jun 2021 18:09:02 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,26 +76,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 25 Mar 2021 15:31:01 GMT",
-        "ETag": "\u00220x8D8EFA2FF2FD62A\u0022",
-        "Last-Modified": "Thu, 25 Mar 2021 15:31:01 GMT",
+        "Date": "Fri, 04 Jun 2021 18:09:01 GMT",
+        "ETag": "\u00220x8D92783D554D58E\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:09:02 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "0fa8fadfd91c1623fd244604ff8a129d",
-        "x-ms-request-id": "bc948c91-d01e-0053-268b-2173a7000000",
+        "x-ms-client-request-id": "46ce757a31ecef839085a2e7ac4d0242",
+        "x-ms-request-id": "65b922fc-201e-0072-266c-59ef1d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://nourdocuments.blob.core.windows.net/target1193092975?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1251704802?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-31b5cd547fb9304791939b402d063096-f6d5299131925b4c-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-92b223979e31644e9e3fb6d5911828d5-34de2127d08cc341-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "dff472b6495c1bc7a249926c362b94df",
-        "x-ms-date": "Thu, 25 Mar 2021 15:31:28 GMT",
+        "x-ms-client-request-id": "6772237cadf3063b3e2213ec4c60be23",
+        "x-ms-date": "Fri, 04 Jun 2021 18:09:02 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -103,26 +103,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 25 Mar 2021 15:31:01 GMT",
-        "ETag": "\u00220x8D8EFA2FF52A6A4\u0022",
-        "Last-Modified": "Thu, 25 Mar 2021 15:31:02 GMT",
+        "Date": "Fri, 04 Jun 2021 18:09:01 GMT",
+        "ETag": "\u00220x8D92783D55D629E\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:09:02 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "dff472b6495c1bc7a249926c362b94df",
-        "x-ms-request-id": "bc948ce6-d01e-0053-718b-2173a7000000",
+        "x-ms-client-request-id": "6772237cadf3063b3e2213ec4c60be23",
+        "x-ms-request-id": "65b9232d-201e-0072-4b6c-59ef1d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://nourdocuments.blob.core.windows.net/target1677185926?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target709880579?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-1613d5914cb8014b86bd98130ef4983e-1b396497b70ae148-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a6fdcf296f3d3c40b13a4ebfb0037139-3db6aedc51788040-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "07c00d122fe379215886a54e39c0016b",
-        "x-ms-date": "Thu, 25 Mar 2021 15:31:28 GMT",
+        "x-ms-client-request-id": "5584d30cf07e32e686afd2329009f5f1",
+        "x-ms-date": "Fri, 04 Jun 2021 18:09:02 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -130,27 +130,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 25 Mar 2021 15:31:01 GMT",
-        "ETag": "\u00220x8D8EFA2FF7528F8\u0022",
-        "Last-Modified": "Thu, 25 Mar 2021 15:31:02 GMT",
+        "Date": "Fri, 04 Jun 2021 18:09:01 GMT",
+        "ETag": "\u00220x8D92783D56616C2\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:09:02 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "07c00d122fe379215886a54e39c0016b",
-        "x-ms-request-id": "bc948d30-d01e-0053-358b-2173a7000000",
+        "x-ms-client-request-id": "5584d30cf07e32e686afd2329009f5f1",
+        "x-ms-request-id": "65b92380-201e-0072-116c-59ef1d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translator.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "187",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bdc1daff1e44004291ad8e95e49ad9c1-eb58a37590f7c144-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210325.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "a8cb3126829de1b1f37a8f91aac6f9b2",
+        "traceparent": "00-a0382a16d126f5468a7b0f995e3a6de4-cf561ec9ba9f7743-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b8bc3678866192c83fae0e6f034425e4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -178,52 +178,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "2ca77a4b-1a21-478e-9a47-8f76da1c8126",
+        "apim-request-id": "ab9b3f1c-89ed-47ee-989d-ba8158d49cd6",
         "Content-Length": "0",
-        "Date": "Thu, 25 Mar 2021 15:31:01 GMT",
-        "Operation-Location": "https://document-translator.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/48e155cb-f56e-4a61-b917-91e20d8e9400",
+        "Date": "Fri, 04 Jun 2021 18:09:02 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
         "Set-Cookie": [
-          "ARRAffinity=36da0e643e19b219e9cc242244bbb17606f2f9cdc98871c377756b22cded58cb;Path=/;HttpOnly;Secure;Domain=doctrans.northeu.microsofttranslator.com",
-          "ARRAffinitySameSite=36da0e643e19b219e9cc242244bbb17606f2f9cdc98871c377756b22cded58cb;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.northeu.microsofttranslator.com"
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2ca77a4b-1a21-478e-9a47-8f76da1c8126"
+        "X-RequestId": "ab9b3f1c-89ed-47ee-989d-ba8158d49cd6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translator.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/48e155cb-f56e-4a61-b917-91e20d8e9400",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210325.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "0478782468dc43d2d26504c221cc6888",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2f40a9c38dbd33fd8c346dfd69d3ad19",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5717d039-ce4c-437b-9053-ea21ae9668f6",
+        "apim-request-id": "d412a98f-50a9-4587-acc6-bd91e38f28de",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 25 Mar 2021 15:31:02 GMT",
-        "ETag": "\u00227D34DF340C128472C11DFBDF3AC41148A4929DCD4677825780690238A937976E\u0022",
+        "Date": "Fri, 04 Jun 2021 18:09:02 GMT",
+        "ETag": "\u002297AE6B0AC858F35E4CF306F17BEBEB1144CE20D2E57243915AE37534AF76CE1B\u0022",
+        "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=52534756bc24481c0848ee2def3c54a057fd0e51707d9dcf782aa603bbaa9f24;Path=/;HttpOnly;Secure;Domain=doctrans.northeu.microsofttranslator.com",
-          "ARRAffinitySameSite=52534756bc24481c0848ee2def3c54a057fd0e51707d9dcf782aa603bbaa9f24;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.northeu.microsofttranslator.com"
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "5717d039-ce4c-437b-9053-ea21ae9668f6"
+        "X-RequestId": "d412a98f-50a9-4587-acc6-bd91e38f28de"
       },
       "ResponseBody": {
-        "id": "48e155cb-f56e-4a61-b917-91e20d8e9400",
-        "createdDateTimeUtc": "2021-03-25T15:31:02.5500153",
-        "lastActionDateTimeUtc": "2021-03-25T15:31:02.5500158",
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:02.4684613Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -237,36 +242,617 @@
       }
     },
     {
-      "RequestUri": "https://document-translator.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/48e155cb-f56e-4a61-b917-91e20d8e9400",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210325.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "f910009037c88fe95cdf13699f8fcf91",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "29d4fa1d6a0185a10af215d0e1762e41",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "54732718-8a69-4aed-a37d-8e229b3822af",
+        "apim-request-id": "37c7e1e7-ac4e-4d44-872b-b8451b3790ae",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 25 Mar 2021 15:31:32 GMT",
-        "ETag": "\u0022CAA96AFAF3529C73AF0CB74CCF6E534135531D1B7B7CF5DAA030002216A0FE33\u0022",
+        "Date": "Fri, 04 Jun 2021 18:09:03 GMT",
+        "ETag": "\u0022E1FB8BD61973C5F383A1630C9F5D6B1EE09FB8DD658E75607075F906862814EA\u0022",
+        "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=36da0e643e19b219e9cc242244bbb17606f2f9cdc98871c377756b22cded58cb;Path=/;HttpOnly;Secure;Domain=doctrans.northeu.microsofttranslator.com",
-          "ARRAffinitySameSite=36da0e643e19b219e9cc242244bbb17606f2f9cdc98871c377756b22cded58cb;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.northeu.microsofttranslator.com"
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "54732718-8a69-4aed-a37d-8e229b3822af"
+        "X-RequestId": "37c7e1e7-ac4e-4d44-872b-b8451b3790ae"
       },
       "ResponseBody": {
-        "id": "48e155cb-f56e-4a61-b917-91e20d8e9400",
-        "createdDateTimeUtc": "2021-03-25T15:31:02.5500153",
-        "lastActionDateTimeUtc": "2021-03-25T15:31:22.5815137",
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:02.6943967Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 3,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e76fee89c6c8ea3439892c2d19ca296b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8724e8bc-3e9e-4e09-ae8d-226192ee3ec3",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:04 GMT",
+        "ETag": "\u002280D0B9A347E98B8BD0DEECDBE25390F2DBBD6982F8694F48D162E2D850FDCF3D\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "8724e8bc-3e9e-4e09-ae8d-226192ee3ec3"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.610829Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0852f500fb7058e208ba24ca772c5116",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "db9d64e3-506d-4d33-9675-9b169c1439f0",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:05 GMT",
+        "ETag": "\u00227545248B1BAC19FA7BC8949E548732069BA44485B70181082BC8DB94B1FC39FB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "db9d64e3-506d-4d33-9675-9b169c1439f0"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.8461685Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7a742b06c6645751c6e9f0783e746b40",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b743aef5-7654-4e95-ac51-63a51c9784e1",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:06 GMT",
+        "ETag": "\u00227545248B1BAC19FA7BC8949E548732069BA44485B70181082BC8DB94B1FC39FB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "b743aef5-7654-4e95-ac51-63a51c9784e1"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.8461685Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ecd0a9c925238ed10b16df0da169730c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "83a688e9-451d-49d5-84e0-f0986f788063",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:08 GMT",
+        "ETag": "\u00227545248B1BAC19FA7BC8949E548732069BA44485B70181082BC8DB94B1FC39FB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "83a688e9-451d-49d5-84e0-f0986f788063"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.8461685Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ee261637ae563906a3fa41870b6a1a93",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7f2e455f-c39b-4a85-b38e-1fa436331958",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:09 GMT",
+        "ETag": "\u00227545248B1BAC19FA7BC8949E548732069BA44485B70181082BC8DB94B1FC39FB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "7f2e455f-c39b-4a85-b38e-1fa436331958"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.8461685Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "cd01e44f655ce0f259e56e4ee743b65d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a25bd18b-5ee5-4c33-b3a7-6211ba061341",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:10 GMT",
+        "ETag": "\u00227545248B1BAC19FA7BC8949E548732069BA44485B70181082BC8DB94B1FC39FB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "a25bd18b-5ee5-4c33-b3a7-6211ba061341"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.8461685Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2840e3757d4d1aeaa2964829e34a82a1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3ca9efbf-b9f3-420c-aedf-da46e58b948d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:11 GMT",
+        "ETag": "\u0022C874894EE23D2B3E5D7869BEFDDCA1786DF76AD7684472489D10157EEFB1F338\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "3ca9efbf-b9f3-420c-aedf-da46e58b948d"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.8461685Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 2,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 54
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bdbe4bfba567d2af234594703fb8525f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7a985da3-d95f-45a3-aaf9-9575f341400c",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:12 GMT",
+        "ETag": "\u0022C874894EE23D2B3E5D7869BEFDDCA1786DF76AD7684472489D10157EEFB1F338\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "7a985da3-d95f-45a3-aaf9-9575f341400c"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.8461685Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 2,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 54
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2711e443f22ad145f9e72ac61cc8fc0f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2399e65f-d175-464f-aa33-d1f407e20c71",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:13 GMT",
+        "ETag": "\u0022C874894EE23D2B3E5D7869BEFDDCA1786DF76AD7684472489D10157EEFB1F338\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2399e65f-d175-464f-aa33-d1f407e20c71"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.8461685Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 2,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 54
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9b53cd62f985d0f6336d0407e979daea",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "288a7a05-4afb-4491-924b-5d88f4619388",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:14 GMT",
+        "ETag": "\u0022C874894EE23D2B3E5D7869BEFDDCA1786DF76AD7684472489D10157EEFB1F338\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "288a7a05-4afb-4491-924b-5d88f4619388"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.8461685Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 2,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 54
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ffe5e8445b39097705edc3807ae9b65a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "15303745-7bd2-4e95-bfc8-c69fb8270b7f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:15 GMT",
+        "ETag": "\u0022C874894EE23D2B3E5D7869BEFDDCA1786DF76AD7684472489D10157EEFB1F338\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "15303745-7bd2-4e95-bfc8-c69fb8270b7f"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.8461685Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 2,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 54
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "720d8448b6654adaed40f3bced3ee880",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "22341add-75a0-4524-a24e-9858b9dcaed5",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 04 Jun 2021 18:09:16 GMT",
+        "ETag": "\u0022BB58868101D128C2DD1877A6B7175F4B351FC1CC71D9E81EAF9335B089E8F037\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "22341add-75a0-4524-a24e-9858b9dcaed5"
+      },
+      "ResponseBody": {
+        "id": "87f71af7-7f44-46e1-abec-e4b09f372da0",
+        "createdDateTimeUtc": "2021-06-04T18:09:02.4684609Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:09:04.8461685Z",
         "status": "Succeeded",
         "summary": {
           "total": 3,
@@ -280,65 +866,70 @@
       }
     },
     {
-      "RequestUri": "https://document-translator.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/48e155cb-f56e-4a61-b917-91e20d8e9400/documents",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/87f71af7-7f44-46e1-abec-e4b09f372da0/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210325.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "c02af38dfc48be8f5f88d5377eefbf27",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "3382400cfde307d6564a96983676554a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6bdc214f-b99e-40c6-8307-b284a4fbf8c0",
+        "apim-request-id": "b09d097e-d20e-4c14-9123-a38eee9f63f6",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 25 Mar 2021 15:31:33 GMT",
-        "ETag": "\u0022F7F58B41CC4C85F32F4F15B1C9B51BFADE8FAB764DF9F87585472A558C968892\u0022",
+        "Date": "Fri, 04 Jun 2021 18:09:16 GMT",
+        "ETag": "\u0022AA8859EE32208B05F86C28648B2ECBD4B368FD092A22FEF01229B8F7A2BCC5B6\u0022",
+        "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=52534756bc24481c0848ee2def3c54a057fd0e51707d9dcf782aa603bbaa9f24;Path=/;HttpOnly;Secure;Domain=doctrans.northeu.microsofttranslator.com",
-          "ARRAffinitySameSite=52534756bc24481c0848ee2def3c54a057fd0e51707d9dcf782aa603bbaa9f24;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.northeu.microsofttranslator.com"
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6bdc214f-b99e-40c6-8307-b284a4fbf8c0"
+        "X-RequestId": "b09d097e-d20e-4c14-9123-a38eee9f63f6"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://nourdocuments.blob.core.windows.net/target1193092975/Document1.txt",
-            "sourcePath": "https://nourdocuments.blob.core.windows.net/source179339698/Document1.txt",
-            "createdDateTimeUtc": "2021-03-25T15:31:12.0931251",
-            "lastActionDateTimeUtc": "2021-03-25T15:31:22.5654933",
-            "status": "Succeeded",
-            "to": "es",
-            "progress": 1,
-            "id": "000005e0-0000-0000-0000-000000000000",
-            "characterCharged": 27
-          },
-          {
-            "path": "https://nourdocuments.blob.core.windows.net/target1031722108/Document1.txt",
-            "sourcePath": "https://nourdocuments.blob.core.windows.net/source179339698/Document1.txt",
-            "createdDateTimeUtc": "2021-03-25T15:31:12.034427",
-            "lastActionDateTimeUtc": "2021-03-25T15:31:22.5212018",
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target553744585/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source1415707658/Document1.txt",
+            "createdDateTimeUtc": "2021-06-04T18:09:04.6177375Z",
+            "lastActionDateTimeUtc": "2021-06-04T18:09:16.4406495Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000005df-0000-0000-0000-000000000000",
+            "id": "0008211f-0000-0000-0000-000000000000",
             "characterCharged": 27
           },
           {
-            "path": "https://nourdocuments.blob.core.windows.net/target1677185926/Document1.txt",
-            "sourcePath": "https://nourdocuments.blob.core.windows.net/source179339698/Document1.txt",
-            "createdDateTimeUtc": "2021-03-25T15:31:10.9605992",
-            "lastActionDateTimeUtc": "2021-03-25T15:31:22.514896",
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target709880579/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source1415707658/Document1.txt",
+            "createdDateTimeUtc": "2021-06-04T18:09:04.6108283Z",
+            "lastActionDateTimeUtc": "2021-06-04T18:09:11.4490775Z",
             "status": "Succeeded",
             "to": "ar",
             "progress": 1,
-            "id": "000005e1-0000-0000-0000-000000000000",
+            "id": "00082121-0000-0000-0000-000000000000",
+            "characterCharged": 27
+          },
+          {
+            "path": "https://mariaridoctrans29prim.blob.core.windows.net/target1251704802/Document1.txt",
+            "sourcePath": "https://mariaridoctrans29prim.blob.core.windows.net/source1415707658/Document1.txt",
+            "createdDateTimeUtc": "2021-06-04T18:09:04.6108282Z",
+            "lastActionDateTimeUtc": "2021-06-04T18:09:11.4130791Z",
+            "status": "Succeeded",
+            "to": "es",
+            "progress": 1,
+            "id": "00082120-0000-0000-0000-000000000000",
             "characterCharged": 27
           }
         ]
@@ -347,8 +938,8 @@
   ],
   "Variables": {
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=nourdocuments;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translator.cognitiveservices.azure.com/",
-    "RandomSeed": "2140383205"
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
+    "RandomSeed": "454019433"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTarget.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTarget.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1975097330?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1290901225?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8fdaac7f320bec4cabb24c00bfe95ce1-ea9b7014b4144740-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-119f720bccb2284bad74a2d2ec877a7b-7ecbe59895b83f47-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "39813578d6bc9900ae5eeaa526bb6c41",
-        "x-ms-date": "Mon, 29 Mar 2021 20:02:37 GMT",
+        "x-ms-client-request-id": "99aec2509dc53ed7e02bb20d04101b52",
+        "x-ms-date": "Fri, 04 Jun 2021 18:05:36 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,27 +17,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 20:02:37 GMT",
-        "ETag": "\u00220x8D8F2ED9A29DBE7\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 20:02:38 GMT",
+        "Date": "Fri, 04 Jun 2021 18:05:36 GMT",
+        "ETag": "\u00220x8D927835B15D550\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:05:37 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "39813578d6bc9900ae5eeaa526bb6c41",
-        "x-ms-request-id": "963bd64b-701e-009b-74d6-242957000000",
+        "x-ms-client-request-id": "99aec2509dc53ed7e02bb20d04101b52",
+        "x-ms-request-id": "238a27d0-f01e-002c-2b6c-5904fd000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e2acc8f745078845977852b480d8ccbc-c62fa90c51bc7b45-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "8e55a27be348b38b411bf91a17ebe28b",
+        "traceparent": "00-87b3d6eb1d172640a526c4a1358f5f7d-c79d6c14742fb14e-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "550a1223f8821f942903c0a7a397e850",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -57,57 +57,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "35c0b636-033c-41ae-971e-b91ab83f22f7",
+        "apim-request-id": "b4a54501-7bb7-4112-9b64-9b74ee197043",
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 20:02:38 GMT",
-        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/5fae77cb-59cd-4021-bae7-5fcc4fb6cd2c",
+        "Date": "Fri, 04 Jun 2021 18:05:37 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df3442fe-df58-4bfc-9c8b-c4f7bea84fcb",
         "Set-Cookie": [
-          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "35c0b636-033c-41ae-971e-b91ab83f22f7"
+        "X-RequestId": "b4a54501-7bb7-4112-9b64-9b74ee197043"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/5fae77cb-59cd-4021-bae7-5fcc4fb6cd2c",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df3442fe-df58-4bfc-9c8b-c4f7bea84fcb",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "495abe4052c5dbe59a303ed4e45da222",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f89b9ad88feaa415cd4f869d68ab6d8d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "53971b6a-d8d4-411e-ae00-8ca19014c2ed",
+        "apim-request-id": "8bd0fcd4-e4ec-4e50-919a-9c1167041778",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 29 Mar 2021 20:02:38 GMT",
-        "ETag": "\u00221896FC34685EE237390A421959D24389AF788E84405256DFBB9BA149CAFC8E40\u0022",
+        "Date": "Fri, 04 Jun 2021 18:05:37 GMT",
+        "ETag": "\u0022EFA5C84DA83EB52E6046EEB361FF393E9B30540294EA9ECF3A5ADB1238512011\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "53971b6a-d8d4-411e-ae00-8ca19014c2ed"
+        "X-RequestId": "8bd0fcd4-e4ec-4e50-919a-9c1167041778"
       },
       "ResponseBody": {
-        "id": "5fae77cb-59cd-4021-bae7-5fcc4fb6cd2c",
-        "createdDateTimeUtc": "2021-03-29T20:02:38.6637111",
-        "lastActionDateTimeUtc": "2021-03-29T20:02:38.8240231",
+        "id": "df3442fe-df58-4bfc-9c8b-c4f7bea84fcb",
+        "createdDateTimeUtc": "2021-06-04T18:05:37.8748708Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:05:37.9444476Z",
         "status": "ValidationFailed",
         "error": {
           "code": "InvalidRequest",
@@ -134,6 +134,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
-    "RandomSeed": "1304523582"
+    "RandomSeed": "204108283"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTargetAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTargetAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1191210950?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target251245700?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-a2cb45d0a5e7b84aa8aae7da508d72b3-e18eac37575b8d4a-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-706cd945daee0d48afaa31ae0d1aeade-ebf28081a9edd04f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "f5d48f90a78e5b44a791fc59ae8a9b77",
-        "x-ms-date": "Mon, 29 Mar 2021 22:04:07 GMT",
+        "x-ms-client-request-id": "5313e61598cf0252cc10aeb8a795cf09",
+        "x-ms-date": "Fri, 04 Jun 2021 18:05:39 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,27 +17,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:04:07 GMT",
-        "ETag": "\u00220x8D8F2FE92F16DAC\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 22:04:07 GMT",
+        "Date": "Fri, 04 Jun 2021 18:05:38 GMT",
+        "ETag": "\u00220x8D927835C180B3F\u0022",
+        "Last-Modified": "Fri, 04 Jun 2021 18:05:38 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "f5d48f90a78e5b44a791fc59ae8a9b77",
-        "x-ms-request-id": "edb75c2f-f01e-002c-04e7-2404fd000000",
+        "x-ms-client-request-id": "5313e61598cf0252cc10aeb8a795cf09",
+        "x-ms-request-id": "238a2d5f-f01e-002c-4e6c-5904fd000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9ef8394e8a59e24894651e885d4231bd-7af6e745a8352f4b-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "278b37e4c1330177a6d9cc86e292a3c2",
+        "traceparent": "00-fad5c4714c372f418e453e7ee18bdcf7-49e1fa4924031e49-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "670c4668886c2c191cfa1711f4b4fb9c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -57,57 +57,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "386b9e79-779e-4fc1-8289-d4d320ba37f9",
+        "apim-request-id": "13a39daa-1c10-4c00-8610-d4b2b8ed837e",
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:04:07 GMT",
-        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/e23a6b30-7872-4e7d-9375-b925b7f56a93",
+        "Date": "Fri, 04 Jun 2021 18:05:38 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3c0003c6-afac-40d1-9ddd-96fc7c4558e6",
         "Set-Cookie": [
-          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=20358cd7aa5d6b0695f01ef171fc9a95880154357830e1c6bb513b73834a2e5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "386b9e79-779e-4fc1-8289-d4d320ba37f9"
+        "X-RequestId": "13a39daa-1c10-4c00-8610-d4b2b8ed837e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/e23a6b30-7872-4e7d-9375-b925b7f56a93",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3c0003c6-afac-40d1-9ddd-96fc7c4558e6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "c89cd07360e4d120015f5965b1179f2e",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4390130f0f95de5daf1257b42ecc6547",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e7151610-a5c3-400c-bbdd-43a796e6eba8",
+        "apim-request-id": "42c3e823-474f-48c9-bece-a33f3b39a802",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 29 Mar 2021 22:04:08 GMT",
-        "ETag": "\u00220BF9587DDA3BEF711909560197A9B84EC427FBA2A5A1558629A6302C182D2953\u0022",
+        "Date": "Fri, 04 Jun 2021 18:05:38 GMT",
+        "ETag": "\u002280731383A137E40F657EE13BC864F1920868E42F45BF43B08A910D687C2486A8\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=0ff46fa6d58b00f2d44b7073721903c0eace480139d8ecfc38f61130af5e1587;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e7151610-a5c3-400c-bbdd-43a796e6eba8"
+        "X-RequestId": "42c3e823-474f-48c9-bece-a33f3b39a802"
       },
       "ResponseBody": {
-        "id": "e23a6b30-7872-4e7d-9375-b925b7f56a93",
-        "createdDateTimeUtc": "2021-03-29T22:04:07.7752119Z",
-        "lastActionDateTimeUtc": "2021-03-29T22:04:08.0995268Z",
+        "id": "3c0003c6-afac-40d1-9ddd-96fc7c4558e6",
+        "createdDateTimeUtc": "2021-06-04T18:05:39.2214942Z",
+        "lastActionDateTimeUtc": "2021-06-04T18:05:39.2697976Z",
         "status": "ValidationFailed",
         "error": {
           "code": "InvalidRequest",
@@ -134,6 +134,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
-    "RandomSeed": "422929117"
+    "RandomSeed": "340012801"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/TranslationOperationLiveTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/TranslationOperationLiveTests.cs
@@ -51,7 +51,6 @@ namespace Azure.AI.Translation.Document.Tests
         }
 
         [RecordedTest]
-        [Ignore("Flaky test. Enable once service provides fix/information")]
         public async Task SingleSourceMultipleTargetsTest()
         {
             Uri source = await CreateSourceContainerAsync(oneTestDocuments);
@@ -251,7 +250,6 @@ namespace Azure.AI.Translation.Document.Tests
         }
 
         [RecordedTest]
-        [Ignore("Flaky test. Enable once service provides fix/information")]
         public async Task WrongSourceRightTarget()
         {
             Uri source = new("https://idont.ex.ist");
@@ -272,7 +270,6 @@ namespace Azure.AI.Translation.Document.Tests
         }
 
         [RecordedTest]
-        [Ignore("Flaky test. Enable once service provides fix/information")]
         public async Task RightSourceWrongTarget()
         {
             Uri source = await CreateSourceContainerAsync(oneTestDocuments);
@@ -285,7 +282,7 @@ namespace Azure.AI.Translation.Document.Tests
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.UpdateStatusAsync());
 
-            Assert.AreEqual("InvalidDocumentAccessLevel", ex.ErrorCode);
+            Assert.AreEqual("InvalidTargetDocumentAccessLevel", ex.ErrorCode);
 
             Assert.IsTrue(operation.HasCompleted);
             Assert.IsFalse(operation.HasValue);


### PR DESCRIPTION
- Enable flaky tests that the service has worked on (had to update recordings as now we target v1.0)
- Makes polling interval for live scenarios to 5 seconds as our documents are small
- Uses `GetAllTranslationStatuses` as a different endpoint that involves user data to see if with that we can get consistent green builds