### PR TITLE
[MetricsAdvisor] Added setters to data feed sources

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -447,41 +447,47 @@ namespace Azure.AI.MetricsAdvisor.Models
     public partial class AzureApplicationInsightsDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
     {
         public AzureApplicationInsightsDataFeedSource(string applicationId, string apiKey, string azureCloud, string query) { }
-        public string ApplicationId { get { throw null; } }
-        public string AzureCloud { get { throw null; } }
-        public string Query { get { throw null; } }
+        public string ApplicationId { get { throw null; } set { } }
+        public string AzureCloud { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        public void UpdateApiKey(string apiKey) { }
     }
     public partial class AzureBlobDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
     {
         public AzureBlobDataFeedSource(string connectionString, string container, string blobTemplate) { }
-        public string BlobTemplate { get { throw null; } }
-        public string Container { get { throw null; } }
+        public string BlobTemplate { get { throw null; } set { } }
+        public string Container { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
     }
     public partial class AzureCosmosDbDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
     {
         public AzureCosmosDbDataFeedSource(string connectionString, string sqlQuery, string database, string collectionId) { }
-        public string CollectionId { get { throw null; } }
-        public string Database { get { throw null; } }
-        public string SqlQuery { get { throw null; } }
+        public string CollectionId { get { throw null; } set { } }
+        public string Database { get { throw null; } set { } }
+        public string SqlQuery { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
     }
     public partial class AzureDataExplorerDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
     {
         public AzureDataExplorerDataFeedSource(string connectionString, string query) { }
-        public string Query { get { throw null; } }
+        public string Query { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
     }
     public partial class AzureDataLakeStorageGen2DataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
     {
         public AzureDataLakeStorageGen2DataFeedSource(string accountName, string accountKey, string fileSystemName, string directoryTemplate, string fileTemplate) { }
-        public string AccountName { get { throw null; } }
-        public string DirectoryTemplate { get { throw null; } }
-        public string FileSystemName { get { throw null; } }
-        public string FileTemplate { get { throw null; } }
+        public string AccountName { get { throw null; } set { } }
+        public string DirectoryTemplate { get { throw null; } set { } }
+        public string FileSystemName { get { throw null; } set { } }
+        public string FileTemplate { get { throw null; } set { } }
+        public void UpdateAccountKey(string accountKey) { }
     }
     public partial class AzureTableDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
     {
         public AzureTableDataFeedSource(string connectionString, string table, string query) { }
-        public string Query { get { throw null; } }
-        public string Table { get { throw null; } }
+        public string Query { get { throw null; } set { } }
+        public string Table { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct BoundaryDirection : System.IEquatable<Azure.AI.MetricsAdvisor.Models.BoundaryDirection>
@@ -884,9 +890,11 @@ namespace Azure.AI.MetricsAdvisor.Models
     public partial class InfluxDbDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
     {
         public InfluxDbDataFeedSource(string connectionString, string database, string username, string password, string query) { }
-        public string Database { get { throw null; } }
-        public string Query { get { throw null; } }
-        public string Username { get { throw null; } }
+        public string Database { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        public string Username { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
+        public void UpdatePassword(string password) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct IngestionStatusType : System.IEquatable<Azure.AI.MetricsAdvisor.Models.IngestionStatusType>
@@ -1076,13 +1084,15 @@ namespace Azure.AI.MetricsAdvisor.Models
     public partial class MongoDbDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
     {
         public MongoDbDataFeedSource(string connectionString, string database, string command) { }
-        public string Command { get { throw null; } }
-        public string Database { get { throw null; } }
+        public string Command { get { throw null; } set { } }
+        public string Database { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
     }
     public partial class MySqlDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
     {
         public MySqlDataFeedSource(string connectionString, string query) { }
-        public string Query { get { throw null; } }
+        public string Query { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
     }
     public partial class NotificationHook
     {
@@ -1114,7 +1124,8 @@ namespace Azure.AI.MetricsAdvisor.Models
     public partial class PostgreSqlDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
     {
         public PostgreSqlDataFeedSource(string connectionString, string query) { }
-        public string Query { get { throw null; } }
+        public string Query { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
     }
     public partial class ServicePrincipalDatasourceCredential : Azure.AI.MetricsAdvisor.Models.DatasourceCredential
     {
@@ -1172,7 +1183,8 @@ namespace Azure.AI.MetricsAdvisor.Models
     public partial class SqlServerDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
     {
         public SqlServerDataFeedSource(string connectionString, string query) { }
-        public string Query { get { throw null; } }
+        public string Query { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
     }
     public partial class SuppressCondition
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureApplicationInsightsDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureApplicationInsightsDataFeedSource.cs
@@ -51,17 +51,17 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The Application ID.
         /// </summary>
-        public string ApplicationId { get; }
+        public string ApplicationId { get; set; }
 
         /// <summary>
         /// The Azure cloud environment.
         /// </summary>
-        public string AzureCloud { get; }
+        public string AzureCloud { get; set; }
 
         /// <summary>
         /// The query used to filter the data to be ingested.
         /// </summary>
-        public string Query { get; }
+        public string Query { get; set; }
 
         /// <summary>
         /// The API key.
@@ -70,6 +70,16 @@ namespace Azure.AI.MetricsAdvisor.Models
         {
             get => Volatile.Read(ref _apiKey);
             private set => Volatile.Write(ref _apiKey, value);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="apiKey"></param>
+        public void UpdateApiKey(string apiKey)
+        {
+            Argument.AssertNotNullOrEmpty(apiKey, nameof(apiKey));
+
+            ApiKey = apiKey;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureApplicationInsightsDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureApplicationInsightsDataFeedSource.cs
@@ -73,12 +73,14 @@ namespace Azure.AI.MetricsAdvisor.Models
         }
 
         /// <summary>
+        /// Updates the API key.
         /// </summary>
-        /// <param name="apiKey"></param>
+        /// <param name="apiKey">The new API key to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="apiKey"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="apiKey"/> is empty.</exception>
         public void UpdateApiKey(string apiKey)
         {
             Argument.AssertNotNullOrEmpty(apiKey, nameof(apiKey));
-
             ApiKey = apiKey;
         }
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureBlobDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureBlobDataFeedSource.cs
@@ -110,12 +110,14 @@ namespace Azure.AI.MetricsAdvisor.Models
         }
 
         /// <summary>
+        /// Updates the connection string.
         /// </summary>
-        /// <param name="connectionString"></param>
+        /// <param name="connectionString">The new connection string to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionString"/> is empty.</exception>
         public void UpdateConnectionString(string connectionString)
         {
             Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
-
             ConnectionString = connectionString;
         }
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureBlobDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureBlobDataFeedSource.cs
@@ -71,7 +71,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The name of the blob container.
         /// </summary>
-        public string Container { get; }
+        public string Container { get; set; }
 
         /// <summary>
         /// This is the template of the Blob file names. For example: /%Y/%m/X_%Y-%m-%d-%h-%M.json. The following parameters are supported:
@@ -98,7 +98,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// </item>
         /// </list>
         /// </summary>
-        public string BlobTemplate { get; }
+        public string BlobTemplate { get; set; }
 
         /// <summary>
         /// The connection string for authenticating to the Azure Storage Account.
@@ -107,6 +107,16 @@ namespace Azure.AI.MetricsAdvisor.Models
         {
             get => Volatile.Read(ref _connectionString);
             private set => Volatile.Write(ref _connectionString, value);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+
+            ConnectionString = connectionString;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureCosmosDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureCosmosDbDataFeedSource.cs
@@ -51,17 +51,27 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The SQL query to retrieve the data to be ingested.
         /// </summary>
-        public string SqlQuery { get; }
+        public string SqlQuery { get; set; }
 
         /// <summary>
         /// The name of the database.
         /// </summary>
-        public string Database { get; }
+        public string Database { get; set; }
 
         /// <summary>
         /// The collection ID.
         /// </summary>
-        public string CollectionId { get; }
+        public string CollectionId { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+
+            ConnectionString = connectionString;
+        }
 
         /// <summary>
         /// The connection string.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureCosmosDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureCosmosDbDataFeedSource.cs
@@ -64,22 +64,24 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string CollectionId { get; set; }
 
         /// <summary>
-        /// </summary>
-        /// <param name="connectionString"></param>
-        public void UpdateConnectionString(string connectionString)
-        {
-            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
-
-            ConnectionString = connectionString;
-        }
-
-        /// <summary>
         /// The connection string.
         /// </summary>
         internal string ConnectionString
         {
             get => Volatile.Read(ref _connectionString);
             private set => Volatile.Write(ref _connectionString, value);
+        }
+
+        /// <summary>
+        /// Updates the connection string.
+        /// </summary>
+        /// <param name="connectionString">The new connection string to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionString"/> is empty.</exception>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+            ConnectionString = connectionString;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataExplorerDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataExplorerDataFeedSource.cs
@@ -43,7 +43,17 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The query to retrieve the data to be ingested.
         /// </summary>
-        public string Query { get; }
+        public string Query { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+
+            ConnectionString = connectionString;
+        }
 
         /// <summary>
         /// The connection string.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataExplorerDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataExplorerDataFeedSource.cs
@@ -46,22 +46,24 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string Query { get; set; }
 
         /// <summary>
-        /// </summary>
-        /// <param name="connectionString"></param>
-        public void UpdateConnectionString(string connectionString)
-        {
-            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
-
-            ConnectionString = connectionString;
-        }
-
-        /// <summary>
         /// The connection string.
         /// </summary>
         internal string ConnectionString
         {
             get => Volatile.Read(ref _connectionString);
             private set => Volatile.Write(ref _connectionString, value);
+        }
+
+        /// <summary>
+        /// Updates the connection string.
+        /// </summary>
+        /// <param name="connectionString">The new connection string to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionString"/> is empty.</exception>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+            ConnectionString = connectionString;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataLakeStorageGen2DataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataLakeStorageGen2DataFeedSource.cs
@@ -79,17 +79,17 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The name of the Storage Account.
         /// </summary>
-        public string AccountName { get; }
+        public string AccountName { get; set; }
 
         /// <summary>
         /// The name of the file system.
         /// </summary>
-        public string FileSystemName { get; }
+        public string FileSystemName { get; set; }
 
         /// <summary>
         /// The directory template.
         /// </summary>
-        public string DirectoryTemplate { get; }
+        public string DirectoryTemplate { get; set; }
 
         /// <summary>
         /// This is the file template of the Blob file. For example: X_%Y-%m-%d-%h-%M.json. The following parameters are supported:
@@ -116,7 +116,17 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// </item>
         /// </list>
         /// </summary>
-        public string FileTemplate { get; }
+        public string FileTemplate { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="accountKey"></param>
+        public void UpdateAccountKey(string accountKey)
+        {
+            Argument.AssertNotNullOrEmpty(accountKey, nameof(accountKey));
+
+            AccountKey = accountKey;
+        }
 
         /// <summary>
         /// The Storage Account key.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataLakeStorageGen2DataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataLakeStorageGen2DataFeedSource.cs
@@ -119,22 +119,24 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string FileTemplate { get; set; }
 
         /// <summary>
-        /// </summary>
-        /// <param name="accountKey"></param>
-        public void UpdateAccountKey(string accountKey)
-        {
-            Argument.AssertNotNullOrEmpty(accountKey, nameof(accountKey));
-
-            AccountKey = accountKey;
-        }
-
-        /// <summary>
         /// The Storage Account key.
         /// </summary>
         internal string AccountKey
         {
             get => Volatile.Read(ref _accountKey);
             private set => Volatile.Write(ref _accountKey, value);
+        }
+
+        /// <summary>
+        /// Updates the account key.
+        /// </summary>
+        /// <param name="accountKey">The new account key to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="accountKey"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="accountKey"/> is empty.</exception>
+        public void UpdateAccountKey(string accountKey)
+        {
+            Argument.AssertNotNullOrEmpty(accountKey, nameof(accountKey));
+            AccountKey = accountKey;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureTableDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureTableDataFeedSource.cs
@@ -47,12 +47,22 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The name of the Table.
         /// </summary>
-        public string Table { get; }
+        public string Table { get; set; }
 
         /// <summary>
         /// The query to retrieve the data to be ingested.
         /// </summary>
-        public string Query { get; }
+        public string Query { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+
+            ConnectionString = connectionString;
+        }
 
         /// <summary>
         /// The connection string for authenticating to the Azure Storage Account.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureTableDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureTableDataFeedSource.cs
@@ -55,22 +55,24 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string Query { get; set; }
 
         /// <summary>
-        /// </summary>
-        /// <param name="connectionString"></param>
-        public void UpdateConnectionString(string connectionString)
-        {
-            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
-
-            ConnectionString = connectionString;
-        }
-
-        /// <summary>
         /// The connection string for authenticating to the Azure Storage Account.
         /// </summary>
         internal string ConnectionString
         {
             get => Volatile.Read(ref _connectionString);
             private set => Volatile.Write(ref _connectionString, value);
+        }
+
+        /// <summary>
+        /// Updates the connection string.
+        /// </summary>
+        /// <param name="connectionString">The new connection string to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionString"/> is empty.</exception>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+            ConnectionString = connectionString;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/InfluxDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/InfluxDbDataFeedSource.cs
@@ -57,17 +57,37 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The name of the database.
         /// </summary>
-        public string Database { get; }
+        public string Database { get; set; }
 
         /// <summary>
         /// The access username.
         /// </summary>
-        public string Username { get; }
+        public string Username { get; set; }
 
         /// <summary>
         /// The query to retrieve the data to be ingested.
         /// </summary>
-        public string Query { get; }
+        public string Query { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+
+            ConnectionString = connectionString;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="password"></param>
+        public void UpdatePassword(string password)
+        {
+            Argument.AssertNotNullOrEmpty(password, nameof(password));
+
+            Password = password;
+        }
 
         /// <summary>
         /// The connection string.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/InfluxDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/InfluxDbDataFeedSource.cs
@@ -70,26 +70,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string Query { get; set; }
 
         /// <summary>
-        /// </summary>
-        /// <param name="connectionString"></param>
-        public void UpdateConnectionString(string connectionString)
-        {
-            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
-
-            ConnectionString = connectionString;
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <param name="password"></param>
-        public void UpdatePassword(string password)
-        {
-            Argument.AssertNotNullOrEmpty(password, nameof(password));
-
-            Password = password;
-        }
-
-        /// <summary>
         /// The connection string.
         /// </summary>
         internal string ConnectionString
@@ -105,6 +85,30 @@ namespace Azure.AI.MetricsAdvisor.Models
         {
             get => Volatile.Read(ref _password);
             private set => Volatile.Write(ref _password, value);
+        }
+
+        /// <summary>
+        /// Updates the connection string.
+        /// </summary>
+        /// <param name="connectionString">The new connection string to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionString"/> is empty.</exception>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+            ConnectionString = connectionString;
+        }
+
+        /// <summary>
+        /// Updates the password.
+        /// </summary>
+        /// <param name="password">The new password to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="password"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="password"/> is empty.</exception>
+        public void UpdatePassword(string password)
+        {
+            Argument.AssertNotNullOrEmpty(password, nameof(password));
+            Password = password;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MongoDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MongoDbDataFeedSource.cs
@@ -46,12 +46,22 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The name of the database.
         /// </summary>
-        public string Database { get; }
+        public string Database { get; set; }
 
         /// <summary>
         /// The query to retrieve the data to be ingested.
         /// </summary>
-        public string Command { get; }
+        public string Command { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+
+            ConnectionString = connectionString;
+        }
 
         /// <summary>
         /// The connection string.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MongoDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MongoDbDataFeedSource.cs
@@ -54,22 +54,24 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string Command { get; set; }
 
         /// <summary>
-        /// </summary>
-        /// <param name="connectionString"></param>
-        public void UpdateConnectionString(string connectionString)
-        {
-            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
-
-            ConnectionString = connectionString;
-        }
-
-        /// <summary>
         /// The connection string.
         /// </summary>
         internal string ConnectionString
         {
             get => Volatile.Read(ref _connectionString);
             private set => Volatile.Write(ref _connectionString, value);
+        }
+
+        /// <summary>
+        /// Updates the connection string.
+        /// </summary>
+        /// <param name="connectionString">The new connection string to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionString"/> is empty.</exception>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+            ConnectionString = connectionString;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MySqlDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MySqlDataFeedSource.cs
@@ -43,7 +43,17 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The query to retrieve the data to be ingested.
         /// </summary>
-        public string Query { get; }
+        public string Query { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+
+            ConnectionString = connectionString;
+        }
 
         /// <summary>
         /// The connection string.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MySqlDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MySqlDataFeedSource.cs
@@ -46,22 +46,24 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string Query { get; set; }
 
         /// <summary>
-        /// </summary>
-        /// <param name="connectionString"></param>
-        public void UpdateConnectionString(string connectionString)
-        {
-            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
-
-            ConnectionString = connectionString;
-        }
-
-        /// <summary>
         /// The connection string.
         /// </summary>
         internal string ConnectionString
         {
             get => Volatile.Read(ref _connectionString);
             private set => Volatile.Write(ref _connectionString, value);
+        }
+
+        /// <summary>
+        /// Updates the connection string.
+        /// </summary>
+        /// <param name="connectionString">The new connection string to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionString"/> is empty.</exception>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+            ConnectionString = connectionString;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/PostgreSqlDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/PostgreSqlDataFeedSource.cs
@@ -43,7 +43,17 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The query to retrieve the data to be ingested.
         /// </summary>
-        public string Query { get; }
+        public string Query { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+
+            ConnectionString = connectionString;
+        }
 
         /// <summary>
         /// The connection string.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/PostgreSqlDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/PostgreSqlDataFeedSource.cs
@@ -46,22 +46,24 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string Query { get; set; }
 
         /// <summary>
-        /// </summary>
-        /// <param name="connectionString"></param>
-        public void UpdateConnectionString(string connectionString)
-        {
-            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
-
-            ConnectionString = connectionString;
-        }
-
-        /// <summary>
         /// The connection string.
         /// </summary>
         internal string ConnectionString
         {
             get => Volatile.Read(ref _connectionString);
             private set => Volatile.Write(ref _connectionString, value);
+        }
+
+        /// <summary>
+        /// Updates the connection string.
+        /// </summary>
+        /// <param name="connectionString">The new connection string to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionString"/> is empty.</exception>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+            ConnectionString = connectionString;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/SqlServerDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/SqlServerDataFeedSource.cs
@@ -43,7 +43,17 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The query to retrieve the data to be ingested.
         /// </summary>
-        public string Query { get; }
+        public string Query { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+
+            ConnectionString = connectionString;
+        }
 
         /// <summary>
         /// The connection string.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/SqlServerDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/SqlServerDataFeedSource.cs
@@ -46,22 +46,24 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string Query { get; set; }
 
         /// <summary>
-        /// </summary>
-        /// <param name="connectionString"></param>
-        public void UpdateConnectionString(string connectionString)
-        {
-            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
-
-            ConnectionString = connectionString;
-        }
-
-        /// <summary>
         /// The connection string.
         /// </summary>
         internal string ConnectionString
         {
             get => Volatile.Read(ref _connectionString);
             private set => Volatile.Write(ref _connectionString, value);
+        }
+
+        /// <summary>
+        /// Updates the connection string.
+        /// </summary>
+        /// <param name="connectionString">The new connection string to be used for authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionString"/> is empty.</exception>
+        public void UpdateConnectionString(string connectionString)
+        {
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+            ConnectionString = connectionString;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 {
     public class DataFeedSourcesTests : MockClientTestBase
     {
-        private static object[] DataSourceTestCases =
+        private static object[] CreateDataSourceTestCases =
         {
             new object[] { new AzureApplicationInsightsDataFeedSource("mock", "secret", "mock", "mock"), "apiKey" },
             new object[] { new AzureBlobDataFeedSource("secret", "mock", "mock"), "connectionString" },
@@ -33,6 +33,22 @@ namespace Azure.AI.MetricsAdvisor.Tests
             new object[] { new SqlServerDataFeedSource("secret", "mock"), "connectionString" }
         };
 
+        private static object[] UpdateDataSourceTestCases =
+        {
+            new object[] { new AzureApplicationInsightsDataFeedSource("mock", "mock", "mock", "mock"), "apiKey" },
+            new object[] { new AzureBlobDataFeedSource("mock", "mock", "mock"), "connectionString" },
+            new object[] { new AzureCosmosDbDataFeedSource("mock", "mock", "mock", "mock"), "connectionString" },
+            new object[] { new AzureDataExplorerDataFeedSource("mock", "mock"), "connectionString" },
+            new object[] { new AzureDataLakeStorageGen2DataFeedSource("mock", "mock", "mock", "mock", "mock"), "accountKey" },
+            new object[] { new AzureTableDataFeedSource("mock", "mock", "mock"), "connectionString" },
+            new object[] { new InfluxDbDataFeedSource("mock", "mock", "mock", "mock", "mock"), "connectionString" },
+            new object[] { new InfluxDbDataFeedSource("mock", "mock", "mock", "mock", "mock"), "password" },
+            new object[] { new MongoDbDataFeedSource("mock", "mock", "mock"), "connectionString" },
+            new object[] { new MySqlDataFeedSource("mock", "mock"), "connectionString" },
+            new object[] { new PostgreSqlDataFeedSource("mock", "mock"), "connectionString" },
+            new object[] { new SqlServerDataFeedSource("mock", "mock"), "connectionString" }
+        };
+
         public DataFeedSourcesTests(bool isAsync) : base(isAsync)
         {
         }
@@ -46,7 +62,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         ";
 
         [Test]
-        [TestCaseSource(nameof(DataSourceTestCases))]
+        [TestCaseSource(nameof(CreateDataSourceTestCases))]
         public async Task DataFeedSourceSendsSecretDuringCreation(DataFeedSource dataSource, string secretPropertyName)
         {
             MockResponse createResponse = new MockResponse(201);
@@ -78,7 +94,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         }
 
         [Test]
-        [TestCaseSource(nameof(DataSourceTestCases))]
+        [TestCaseSource(nameof(UpdateDataSourceTestCases))]
         public async Task DataFeedSourceSendsSecretDuringUpdate(DataFeedSource dataSource, string secretPropertyName)
         {
             MockResponse updateResponse = new MockResponse(200);

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
@@ -114,6 +114,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 case AzureApplicationInsightsDataFeedSource d:
                     d.UpdateApiKey("new_secret");
                     break;
+                case AzureBlobDataFeedSource d:
+                    d.UpdateConnectionString("new_secret");
+                    break;
                 case AzureCosmosDbDataFeedSource d:
                     d.UpdateConnectionString("new_secret");
                     break;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
@@ -19,18 +19,18 @@ namespace Azure.AI.MetricsAdvisor.Tests
     {
         private static object[] DataSourceTestCases =
         {
-            new object[] { new AzureApplicationInsightsDataFeedSource("mock", "secret", "mock", "mock"), "\"apiKey\":\"secret\"" },
-            new object[] { new AzureBlobDataFeedSource("secret", "mock", "mock"), "\"connectionString\":\"secret\"" },
-            new object[] { new AzureCosmosDbDataFeedSource("secret", "mock", "mock", "mock"), "\"connectionString\":\"secret\"" },
-            new object[] { new AzureDataExplorerDataFeedSource("secret", "mock"), "\"connectionString\":\"secret\"" },
-            new object[] { new AzureDataLakeStorageGen2DataFeedSource("mock", "secret", "mock", "mock", "mock"), "\"accountKey\":\"secret\"" },
-            new object[] { new AzureTableDataFeedSource("secret", "mock", "mock"), "\"connectionString\":\"secret\"" },
-            new object[] { new InfluxDbDataFeedSource("secret", "mock", "mock", "mock", "mock"), "\"connectionString\":\"secret\"" },
-            new object[] { new InfluxDbDataFeedSource("mock", "mock", "mock", "secret", "mock"), "\"password\":\"secret\"" },
-            new object[] { new MongoDbDataFeedSource("secret", "mock", "mock"), "\"connectionString\":\"secret\"" },
-            new object[] { new MySqlDataFeedSource("secret", "mock"), "\"connectionString\":\"secret\"" },
-            new object[] { new PostgreSqlDataFeedSource("secret", "mock"), "\"connectionString\":\"secret\"" },
-            new object[] { new SqlServerDataFeedSource("secret", "mock"), "\"connectionString\":\"secret\"" }
+            new object[] { new AzureApplicationInsightsDataFeedSource("mock", "secret", "mock", "mock"), "apiKey" },
+            new object[] { new AzureBlobDataFeedSource("secret", "mock", "mock"), "connectionString" },
+            new object[] { new AzureCosmosDbDataFeedSource("secret", "mock", "mock", "mock"), "connectionString" },
+            new object[] { new AzureDataExplorerDataFeedSource("secret", "mock"), "connectionString" },
+            new object[] { new AzureDataLakeStorageGen2DataFeedSource("mock", "secret", "mock", "mock", "mock"), "accountKey" },
+            new object[] { new AzureTableDataFeedSource("secret", "mock", "mock"), "connectionString" },
+            new object[] { new InfluxDbDataFeedSource("secret", "mock", "mock", "mock", "mock"), "connectionString" },
+            new object[] { new InfluxDbDataFeedSource("mock", "mock", "mock", "secret", "mock"), "password" },
+            new object[] { new MongoDbDataFeedSource("secret", "mock", "mock"), "connectionString" },
+            new object[] { new MySqlDataFeedSource("secret", "mock"), "connectionString" },
+            new object[] { new PostgreSqlDataFeedSource("secret", "mock"), "connectionString" },
+            new object[] { new SqlServerDataFeedSource("secret", "mock"), "connectionString" }
         };
 
         public DataFeedSourcesTests(bool isAsync) : base(isAsync)
@@ -47,7 +47,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
         [Test]
         [TestCaseSource(nameof(DataSourceTestCases))]
-        public async Task DataFeedSourceSendsSecretDuringCreation(DataFeedSource dataSource, string expectedSubstring)
+        public async Task DataFeedSourceSendsSecretDuringCreation(DataFeedSource dataSource, string secretPropertyName)
         {
             MockResponse createResponse = new MockResponse(201);
             createResponse.AddHeader(new HttpHeader("Location", $"https://fakeresource.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/{FakeGuid}"));
@@ -72,6 +72,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MockRequest request = mockTransport.Requests.First();
             string content = ReadContent(request);
+            string expectedSubstring = $"\"{secretPropertyName}\":\"secret\"";
 
             Assert.That(content, Contains.Substring(expectedSubstring));
         }


### PR DESCRIPTION
Fixes https://github.com/azure/azure-sdk-for-net/issues/18317.

As in other PRs, added setters to DataFeedSources for Update convenience. Secrets are being handled with the `Update<secret-name>` method pattern.