### PR TITLE
Fix build error in Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
@@ -21,7 +21,6 @@
 
   <ItemGroup>
     <Compile Include="..\..\..\eventgrid\Microsoft.Azure.WebJobs.Extensions.EventGrid\src\TriggerBinding\HttpRequestProcessor.cs" Link="EventGrid\HttpRequestProcessor.cs" />
-    <Compile Include="..\..\..\eventgrid\Microsoft.Azure.WebJobs.Extensions.EventGrid\src\TriggerBinding\SubscriptionValidationEvent.cs" Link="EventGrid\SubscriptionValidationEvent.cs" />
     <Compile Include="..\..\..\eventgrid\Microsoft.Azure.WebJobs.Extensions.EventGrid\src\TriggerBinding\SubscriptionValidationResponse.cs" Link="EventGrid\SubscriptionValidationResponse.cs" />
   </ItemGroup>
  


### PR DESCRIPTION
sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/TriggerBinding/SubscriptionValidationEvent.cs has been [removed](https://github.com/Azure/azure-sdk-for-net/commit/012db171c60356aedae977e02c5c8951afd9f61b).
Removing the reference to the file from Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj.