### PR TITLE
Fixed pipeline break in WPS extensions

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="System.Memory.Data" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ExcludeFromProjectReferenceToConversion Include="Azure.Messaging.WebPubSub" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
The extension project depends on NuGet package, but the pipeline thinks it depends on sources which have changed. 