### PR TITLE
[Storage] Buffer reads of blobs encrypted on client side.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed bug where specifying "*" as IfMatch condition could lead to inconsistend read in BlobClient.DownloadTo.
 - Fixed bug where specifying conditions in BlobBaseClient.OpenRead could override allowModifications flag in BlobOpenReadOptions leading to inconsistent read.
 - Fixed bug where BlobProperties.IsLatestVersion from BlobBaseClient.GetProperties did not set the value (defaulted to false).
+- Fixed bug where reading blob with Client Side Encryption enabled results in high CPU.
 
 ## 12.8.4 (2021-05-20)
 - Fixed bug where Client Side Encryption during large transactions (greater than max int value) would throw an exception.

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -240,7 +240,11 @@ namespace Azure.Storage.Cryptography
                         aesProvider.Padding = PaddingMode.None;
                     }
 
-                    return new CryptoStream(contentStream, aesProvider.CreateDecryptor(), CryptoStreamMode.Read);
+                    // Buffer network stream. CryptoStream issues tiny (~16 byte) reads which can lead to resources churn.
+                    // By default buffer is 4KB.
+                    var bufferedContentStream = new BufferedStream(contentStream);
+
+                    return new CryptoStream(bufferedContentStream, aesProvider.CreateDecryptor(), CryptoStreamMode.Read);
                 }
             }
 


### PR DESCRIPTION
This addresses https://github.com/Azure/azure-sdk-for-net/issues/21594

Sample program is here: https://github.com/Azure/azure-sdk-for-net/issues/21594#issuecomment-856062675

Before:
![image](https://user-images.githubusercontent.com/61715331/121054827-95990f00-c771-11eb-8ed5-e7f082c8fbda.png)

After:
![image](https://user-images.githubusercontent.com/61715331/121054882-a184d100-c771-11eb-99da-053d39a84808.png)
