### PR TITLE
[Service Bus] Retry Options Docs

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryOptions.cs
@@ -36,6 +36,9 @@ namespace Azure.Messaging.ServiceBus
         ///   to have failed.
         /// </summary>
         ///
+        ///
+        /// <value>The default retry limit is 3.</value>
+        ///
         public int MaxRetries
         {
             get => _maxRetries;
@@ -52,6 +55,9 @@ namespace Azure.Messaging.ServiceBus
         ///   on which to base calculations for a backoff-based approach.
         /// </summary>
         ///
+        ///
+        /// <value>The default delay is 0.8 seconds.</value>
+        ///
         public TimeSpan Delay
         {
             get => _delay;
@@ -66,6 +72,9 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         ///   The maximum permissible delay between retry attempts.
         /// </summary>
+        ///
+        ///
+        /// <value>The default maximum delay is 60 seconds.</value>
         ///
         public TimeSpan MaxDelay
         {
@@ -82,6 +91,9 @@ namespace Azure.Messaging.ServiceBus
         ///   The maximum duration to wait for completion of a single attempt, whether the initial
         ///   attempt or a retry.
         /// </summary>
+        ///
+        ///
+        /// <value>The default timeout is 60 seconds.</value>
         ///
         public TimeSpan TryTimeout
         {


### PR DESCRIPTION
# Summary

The focus of these changes is to document the default value used for each property of the `ServiceBusRetryOptions`.