### PR TITLE
Sort callback parameters per API review

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/README.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/README.md
@@ -125,7 +125,7 @@ public void ConfigureServices(IServiceCollection services)
     services.AddAzureClients(builder =>
     {
         // Register a client using MyApplicationOptions to get constructor parameters
-        builder.AddClient<SecretClient, SecretClientOptions>((provider, credential, options) =>
+        builder.AddClient<SecretClient, SecretClientOptions>((options, credential, provider) =>
         {
             var appOptions = provider.GetService<IOptions<MyApplicationOptions>>();
             return new SecretClient(appOptions.Value.KeyVaultEndpoint, credential, options);

--- a/sdk/extensions/Microsoft.Extensions.Azure/api/Microsoft.Extensions.Azure.netstandard2.0.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/api/Microsoft.Extensions.Azure.netstandard2.0.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Extensions.Azure
     public sealed partial class AzureClientFactoryBuilder : Azure.Core.Extensions.IAzureClientFactoryBuilder, Azure.Core.Extensions.IAzureClientFactoryBuilderWithConfiguration<Microsoft.Extensions.Configuration.IConfiguration>, Azure.Core.Extensions.IAzureClientFactoryBuilderWithCredential
     {
         internal AzureClientFactoryBuilder() { }
-        public Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(System.Func<Azure.Core.TokenCredential, TOptions, TClient> factory) where TOptions : class { throw null; }
-        public Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(System.Func<System.IServiceProvider, Azure.Core.TokenCredential, TOptions, TClient> factory) where TOptions : class { throw null; }
-        public Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(System.Func<System.IServiceProvider, TOptions, TClient> factory) where TOptions : class { throw null; }
+        public Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(System.Func<TOptions, Azure.Core.TokenCredential, System.IServiceProvider, TClient> factory) where TOptions : class { throw null; }
+        public Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(System.Func<TOptions, Azure.Core.TokenCredential, TClient> factory) where TOptions : class { throw null; }
+        public Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(System.Func<TOptions, System.IServiceProvider, TClient> factory) where TOptions : class { throw null; }
         public Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(System.Func<TOptions, TClient> factory) where TOptions : class { throw null; }
         Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> Azure.Core.Extensions.IAzureClientFactoryBuilder.RegisterClientFactory<TClient, TOptions>(System.Func<TOptions, TClient> clientFactory) { throw null; }
         Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> Azure.Core.Extensions.IAzureClientFactoryBuilderWithConfiguration<Microsoft.Extensions.Configuration.IConfiguration>.RegisterClientFactory<TClient, TOptions>(Microsoft.Extensions.Configuration.IConfiguration configuration) { throw null; }

--- a/sdk/extensions/Microsoft.Extensions.Azure/samples/StartupWithOptions.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/samples/StartupWithOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Azure.Samples
             services.AddAzureClients(builder =>
             {
                 // Register a client using MyApplicationOptions to get constructor parameters
-                builder.AddClient<SecretClient, SecretClientOptions>((provider, credential, options) =>
+                builder.AddClient<SecretClient, SecretClientOptions>((options, credential, provider) =>
                 {
                     var appOptions = provider.GetService<IOptions<MyApplicationOptions>>();
                     return new SecretClient(appOptions.Value.KeyVaultEndpoint, credential, options);

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/AzureClientFactoryBuilder.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/AzureClientFactoryBuilder.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Extensions.Azure
 
         IAzureClientBuilder<TClient, TOptions> IAzureClientFactoryBuilderWithCredential.RegisterClientFactory<TClient, TOptions>(Func<TOptions, TokenCredential, TClient> clientFactory, bool requiresCredential)
         {
-            return RegisterClientFactory<TClient, TOptions>((_, options, credential) => clientFactory(options, credential), requiresCredential);
+            return RegisterClientFactory<TClient, TOptions>((options, credential, _) => clientFactory(options, credential), requiresCredential);
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.Azure
         /// <returns>The <see cref="IAzureClientBuilder{TClient, TOptions}"/> to allow client configuration.</returns>
         public IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(Func<TOptions, TClient> factory) where TOptions : class
         {
-            return RegisterClientFactory<TClient, TOptions>((_, options, _) => factory(options), false);
+            return RegisterClientFactory<TClient, TOptions>((options, _, _) => factory(options), false);
         }
 
         /// <summary>
@@ -132,9 +132,9 @@ namespace Microsoft.Extensions.Azure
         /// <typeparam name="TClient">The type of the client.</typeparam>
         /// <typeparam name="TOptions">The type of the client options.</typeparam>
         /// <returns>The <see cref="IAzureClientBuilder{TClient, TOptions}"/> to allow client configuration.</returns>
-        public IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(Func<TokenCredential, TOptions, TClient> factory) where TOptions : class
+        public IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(Func<TOptions, TokenCredential, TClient> factory) where TOptions : class
         {
-            return RegisterClientFactory<TClient, TOptions>((_, options, credential) => factory(credential, options), true);
+            return RegisterClientFactory<TClient, TOptions>((options, credential, _) => factory(options, credential), true);
         }
 
         /// <summary>
@@ -144,9 +144,9 @@ namespace Microsoft.Extensions.Azure
         /// <typeparam name="TClient">The type of the client.</typeparam>
         /// <typeparam name="TOptions">The type of the client options.</typeparam>
         /// <returns>The <see cref="IAzureClientBuilder{TClient, TOptions}"/> to allow client configuration.</returns>
-        public IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(Func<IServiceProvider, TOptions, TClient> factory) where TOptions : class
+        public IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(Func<TOptions, IServiceProvider, TClient> factory) where TOptions : class
         {
-            return RegisterClientFactory<TClient, TOptions>((provider, options, _) => factory(provider, options), true);
+            return RegisterClientFactory<TClient, TOptions>((options, _, provider) => factory(options, provider), true);
         }
 
         /// <summary>
@@ -156,14 +156,14 @@ namespace Microsoft.Extensions.Azure
         /// <typeparam name="TClient">The type of the client.</typeparam>
         /// <typeparam name="TOptions">The type of the client options.</typeparam>
         /// <returns>The <see cref="IAzureClientBuilder{TClient, TOptions}"/> to allow client configuration.</returns>
-        public IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(Func<IServiceProvider, TokenCredential, TOptions, TClient> factory) where TOptions : class
+        public IAzureClientBuilder<TClient, TOptions> AddClient<TClient, TOptions>(Func<TOptions, TokenCredential, IServiceProvider, TClient> factory) where TOptions : class
         {
-            return RegisterClientFactory<TClient, TOptions>((provider, options, credential) => factory(provider, credential, options), true);
+            return RegisterClientFactory<TClient, TOptions>((options, credential, provider) => factory(options, credential, provider), true);
         }
 
-        private IAzureClientBuilder<TClient, TOptions> RegisterClientFactory<TClient, TOptions>(Func<IServiceProvider, TOptions, TokenCredential, TClient> clientFactory, bool requiresCredential) where TOptions : class
+        private IAzureClientBuilder<TClient, TOptions> RegisterClientFactory<TClient, TOptions>(Func<TOptions, TokenCredential, IServiceProvider, TClient> clientFactory, bool requiresCredential) where TOptions : class
         {
-            var clientRegistration = new ClientRegistration<TClient>(DefaultClientName, (provider, options, credential) => clientFactory(provider, (TOptions) options, credential));
+            var clientRegistration = new ClientRegistration<TClient>(DefaultClientName, (provider, options, credential) => clientFactory((TOptions) options, credential, provider));
             clientRegistration.RequiresTokenCredential = requiresCredential;
 
             _serviceCollection.AddSingleton(clientRegistration);

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/AzureClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/AzureClientFactoryTests.cs
@@ -376,7 +376,7 @@ namespace Azure.Core.Extensions.Tests
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddAzureClients(builder =>
-                builder.AddClient<TestClientWithCredentials, TestClientOptions>((credential, options) => new TestClientWithCredentials(new Uri("http://localhost/"), credential, options))
+                builder.AddClient<TestClientWithCredentials, TestClientOptions>((options, credential) => new TestClientWithCredentials(new Uri("http://localhost/"), credential, options))
             );
             ServiceProvider provider = serviceCollection.BuildServiceProvider();
             TestClientWithCredentials client = provider.GetService<TestClientWithCredentials>();
@@ -392,7 +392,7 @@ namespace Azure.Core.Extensions.Tests
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton("conn str");
             serviceCollection.AddAzureClients(builder =>
-                builder.AddClient<TestClient, TestClientOptions>((p, options) => new TestClient(p.GetService<string>(),  options))
+                builder.AddClient<TestClient, TestClientOptions>((options, p) => new TestClient(p.GetService<string>(),  options))
             );
             ServiceProvider provider = serviceCollection.BuildServiceProvider();
             TestClient client = provider.GetService<TestClient>();
@@ -407,7 +407,7 @@ namespace Azure.Core.Extensions.Tests
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton(new Uri("http://localhost/"));
             serviceCollection.AddAzureClients(builder =>
-                builder.AddClient<TestClientWithCredentials, TestClientOptions>((p, credential, options) => new TestClientWithCredentials(p.GetService<Uri>(), credential, options))
+                builder.AddClient<TestClientWithCredentials, TestClientOptions>((options, credential, p) => new TestClientWithCredentials(p.GetService<Uri>(), credential, options))
             );
             ServiceProvider provider = serviceCollection.BuildServiceProvider();
             TestClientWithCredentials client = provider.GetService<TestClientWithCredentials>();


### PR DESCRIPTION
The signatures a now nice and orderly

```
AddClient<TClient, TOptions>(System.Func<TOptions, Azure.Core.TokenCredential, System.IServiceProvider, TClient> factory) where TOptions : class { throw null; }
AddClient<TClient, TOptions>(System.Func<TOptions, Azure.Core.TokenCredential, TClient> factory) where TOptions : class { throw null; }
AddClient<TClient, TOptions>(System.Func<TOptions, System.IServiceProvider, TClient> factory) where TOptions : class { throw null; }
AddClient<TClient, TOptions>(System.Func<TOptions, TClient> factory) where TOptions : class { throw null; }
```
