### PR TITLE
[Storage] Perf test client ctors.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Infrastructure/BlobTest.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Infrastructure/BlobTest.cs
@@ -9,15 +9,14 @@ namespace Azure.Storage.Blobs.Perf
 {
     public abstract class BlobTest<TOptions> : ContainerTest<TOptions> where TOptions : SizeOptions
     {
+        protected static string BlobName { get; } = $"Azure.Storage.Blobs.Perf.BlobTest-{Guid.NewGuid()}";
         protected BlobClient BlobClient { get; private set; }
         protected BlockBlobClient BlockBlobClient { get; private set; }
 
         public BlobTest(TOptions options) : base(options)
         {
-            var blobName = $"Azure.Storage.Blobs.Perf.BlobTest-{Guid.NewGuid()}";
-
-            BlobClient = BlobContainerClient.GetBlobClient(blobName);
-            BlockBlobClient = BlobContainerClient.GetBlockBlobClient(blobName);
+            BlobClient = BlobContainerClient.GetBlobClient(BlobName);
+            BlockBlobClient = BlobContainerClient.GetBlockBlobClient(BlobName);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/CreateClients.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/CreateClients.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Storage.Blobs.Specialized;
+using Azure.Test.Perf;
+
+namespace Azure.Storage.Blobs.Perf.Scenarios
+{
+    /// <summary>
+    /// This tests various client ctors and hierarchy traversal.
+    /// </summary>
+    public class CreateClients : BlobTest<SizeOptions>
+    {
+        private static readonly string s_connectionString = $"DefaultEndpointsProtocol=https;AccountName=foo;AccountKey={Convert.ToBase64String(Guid.NewGuid().ToByteArray())};EndpointSuffix=core.windows.net";
+        private static readonly AzureSasCredential s_azureSasCredential = new AzureSasCredential("foo");
+        private static readonly TokenCredential s_tokenCredential = new ClientSecretCredential("foo", "bar", "baz");
+
+        public CreateClients(SizeOptions options) : base(options)
+        {
+        }
+
+#pragma warning disable CA1806 // Do not ignore method results
+        public override void Run(CancellationToken cancellationToken)
+        {
+            // traverse hierarchy down
+            BlobServiceClient.GetBlobContainerClient(ContainerName);
+            BlobContainerClient.GetBlobClient(BlobName);
+            BlobContainerClient.GetBlobBaseClient(BlobName);
+            BlobContainerClient.GetBlockBlobClient(BlobName);
+            BlobContainerClient.GetPageBlobClient(BlobName);
+            BlobContainerClient.GetAppendBlobClient(BlobName);
+
+            // traverse hierarchy up
+            BlobClient.GetParentBlobContainerClient();
+            BlobContainerClient.GetParentBlobServiceClient();
+
+            // BlobServiceClient ctors
+            new BlobServiceClient(s_connectionString);
+            new BlobServiceClient(BlobServiceClient.Uri);
+            new BlobServiceClient(BlobServiceClient.Uri, s_azureSasCredential);
+            new BlobServiceClient(BlobServiceClient.Uri, s_tokenCredential);
+            new BlobServiceClient(BlobServiceClient.Uri, StorageSharedKeyCredential);
+
+            // BlobContainerClient ctors
+            new BlobContainerClient(s_connectionString, ContainerName);
+            new BlobContainerClient(BlobContainerClient.Uri);
+            new BlobContainerClient(BlobContainerClient.Uri, s_azureSasCredential);
+            new BlobContainerClient(BlobContainerClient.Uri, s_tokenCredential);
+            new BlobContainerClient(BlobContainerClient.Uri, StorageSharedKeyCredential);
+
+            // BlobClient ctors
+            new BlobClient(s_connectionString, ContainerName, BlobName);
+            new BlobClient(BlobContainerClient.Uri);
+            new BlobClient(BlobContainerClient.Uri, s_azureSasCredential);
+            new BlobClient(BlobContainerClient.Uri, s_tokenCredential);
+            new BlobClient(BlobContainerClient.Uri, StorageSharedKeyCredential);
+
+            // BlobBaseClient ctors
+            new BlobBaseClient(s_connectionString, ContainerName, BlobName);
+            new BlobBaseClient(BlobContainerClient.Uri);
+            new BlobBaseClient(BlobContainerClient.Uri, s_azureSasCredential);
+            new BlobBaseClient(BlobContainerClient.Uri, s_tokenCredential);
+            new BlobBaseClient(BlobContainerClient.Uri, StorageSharedKeyCredential);
+
+            // AppendBlobClient ctors
+            new AppendBlobClient(s_connectionString, ContainerName, BlobName);
+            new AppendBlobClient(BlobContainerClient.Uri);
+            new AppendBlobClient(BlobContainerClient.Uri, s_azureSasCredential);
+            new AppendBlobClient(BlobContainerClient.Uri, s_tokenCredential);
+            new AppendBlobClient(BlobContainerClient.Uri, StorageSharedKeyCredential);
+
+            // BlockBlobClient ctors
+            new BlockBlobClient(s_connectionString, ContainerName, BlobName);
+            new BlockBlobClient(BlobContainerClient.Uri);
+            new BlockBlobClient(BlobContainerClient.Uri, s_azureSasCredential);
+            new BlockBlobClient(BlobContainerClient.Uri, s_tokenCredential);
+            new BlockBlobClient(BlobContainerClient.Uri, StorageSharedKeyCredential);
+
+            // PageBlobClient ctors
+            new PageBlobClient(s_connectionString, ContainerName, BlobName);
+            new PageBlobClient(BlobContainerClient.Uri);
+            new PageBlobClient(BlobContainerClient.Uri, s_azureSasCredential);
+            new PageBlobClient(BlobContainerClient.Uri, s_tokenCredential);
+            new PageBlobClient(BlobContainerClient.Uri, StorageSharedKeyCredential);
+        }
+#pragma warning restore CA1806 // Do not ignore method results
+
+        public override Task RunAsync(CancellationToken cancellationToken)
+        {
+            Run(cancellationToken);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/CreateClients.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/CreateClients.cs
@@ -40,9 +40,13 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
             new DataLakeDirectoryClient(s_directoryUri, s_tokenCredential);
             new DataLakeDirectoryClient(s_directoryUri, s_testEnvironment.DataLakeCredential);
 
-            new DataLakeDirectoryClient(s_fileUri);
-            new DataLakeDirectoryClient(s_fileUri, s_tokenCredential);
-            new DataLakeDirectoryClient(s_fileUri, s_testEnvironment.DataLakeCredential);
+            new DataLakeFileClient(s_fileUri);
+            new DataLakeFileClient(s_fileUri, s_tokenCredential);
+            new DataLakeFileClient(s_fileUri, s_testEnvironment.DataLakeCredential);
+
+            new DataLakePathClient(s_fileUri);
+            new DataLakePathClient(s_fileUri, s_tokenCredential);
+            new DataLakePathClient(s_fileUri, s_testEnvironment.DataLakeCredential);
 
             serviceClient.GetFileSystemClient("foo");
             fileSystemClient.GetDirectoryClient("foo");

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/CreateClients.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/CreateClients.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Test.Perf;
+
+namespace Azure.Storage.Files.DataLake.Perf.Scenarios
+{
+    /// <summary>
+    /// This tests various client ctors and hierarchy traversal.
+    /// </summary>
+    public class CreateClients : PerfTest<PerfOptions>
+    {
+        private static readonly TokenCredential s_tokenCredential = new ClientSecretCredential("foo", "bar", "baz");
+        private static readonly PerfTestEnvironment s_testEnvironment = PerfTestEnvironment.Instance;
+        private static readonly Uri s_fileSystemUri = new DataLakeUriBuilder(s_testEnvironment.DataLakeServiceUri) { FileSystemName = "foo" }.ToUri();
+        private static readonly Uri s_directoryUri = new DataLakeUriBuilder(s_testEnvironment.DataLakeServiceUri) { FileSystemName = "foo", DirectoryOrFilePath = "bar" }.ToUri();
+        private static readonly Uri s_fileUri = new DataLakeUriBuilder(s_testEnvironment.DataLakeServiceUri) { FileSystemName = "foo", DirectoryOrFilePath = "bar/baz" }.ToUri();
+
+        public CreateClients(PerfOptions options) : base(options)
+        {
+        }
+
+#pragma warning disable CA1806 // Do not ignore method results
+        public override void Run(CancellationToken cancellationToken)
+        {
+            var serviceClient = new DataLakeServiceClient(s_testEnvironment.DataLakeServiceUri);
+            new DataLakeServiceClient(s_testEnvironment.DataLakeServiceUri, s_tokenCredential);
+            new DataLakeServiceClient(s_testEnvironment.DataLakeServiceUri, s_testEnvironment.DataLakeCredential);
+
+            var fileSystemClient = new DataLakeFileSystemClient(s_fileSystemUri);
+            new DataLakeFileSystemClient(s_fileSystemUri, s_tokenCredential);
+            new DataLakeFileSystemClient(s_fileSystemUri, s_testEnvironment.DataLakeCredential);
+
+            var directoryClient = new DataLakeDirectoryClient(s_directoryUri);
+            new DataLakeDirectoryClient(s_directoryUri, s_tokenCredential);
+            new DataLakeDirectoryClient(s_directoryUri, s_testEnvironment.DataLakeCredential);
+
+            new DataLakeDirectoryClient(s_fileUri);
+            new DataLakeDirectoryClient(s_fileUri, s_tokenCredential);
+            new DataLakeDirectoryClient(s_fileUri, s_testEnvironment.DataLakeCredential);
+
+            serviceClient.GetFileSystemClient("foo");
+            fileSystemClient.GetDirectoryClient("foo");
+            fileSystemClient.GetFileClient("foo");
+            directoryClient.GetFileClient("foo");
+        }
+#pragma warning restore CA1806 // Do not ignore method results
+
+        public override Task RunAsync(CancellationToken cancellationToken)
+        {
+            Run(cancellationToken);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Scenarios/CreateClients.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Scenarios/CreateClients.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Test.Perf;
+
+namespace Azure.Storage.Files.Shares.Perf.Scenarios
+{
+    /// <summary>
+    /// This tests various client ctors and hierarchy traversal.
+    /// </summary>
+    public class CreateClients : PerfTest<PerfOptions>
+    {
+        private static readonly string s_connectionString = $"DefaultEndpointsProtocol=https;AccountName=foo;AccountKey={Convert.ToBase64String(Guid.NewGuid().ToByteArray())};EndpointSuffix=core.windows.net";
+        private static readonly Uri s_serviceUri = new Uri("https://foo.files.core.windows.net");
+        private static readonly Uri s_shareUri = new Uri("https://foo.files.core.windows.net/foo");
+        private static readonly Uri s_directoryUri = new Uri("https://foo.files.core.windows.net/foo/bar");
+        private static readonly Uri s_fileUri = new Uri("https://foo.files.core.windows.net/foo/bar/baz");
+        private static readonly AzureSasCredential s_azureSasCredential = new AzureSasCredential("foo");
+        private static readonly StorageSharedKeyCredential s_storageSharedKey = new StorageSharedKeyCredential("foo", Convert.ToBase64String(Guid.NewGuid().ToByteArray()));
+
+        public CreateClients(PerfOptions options) : base(options)
+        {
+        }
+
+#pragma warning disable CA1806 // Do not ignore method results
+        public override void Run(CancellationToken cancellationToken)
+        {
+            var serviceClient = new ShareServiceClient(s_connectionString);
+            new ShareServiceClient(s_serviceUri);
+            new ShareServiceClient(s_serviceUri, s_azureSasCredential);
+            new ShareServiceClient(s_serviceUri, s_storageSharedKey);
+
+            var shareClient = new ShareClient(s_connectionString, "foo");
+            new ShareClient(s_shareUri);
+            new ShareClient(s_shareUri, s_azureSasCredential);
+            new ShareClient(s_shareUri, s_storageSharedKey);
+
+            var directoryClient = new ShareDirectoryClient(s_connectionString, "foo", "bar");
+            new ShareDirectoryClient(s_directoryUri);
+            new ShareDirectoryClient(s_directoryUri, s_azureSasCredential);
+            new ShareDirectoryClient(s_directoryUri, s_storageSharedKey);
+
+            new ShareFileClient(s_connectionString, "foo", "bar/baz");
+            new ShareFileClient(s_fileUri);
+            new ShareFileClient(s_fileUri, s_azureSasCredential);
+            new ShareFileClient(s_fileUri, s_storageSharedKey);
+
+            serviceClient.GetShareClient("foo");
+            shareClient.GetDirectoryClient("bar");
+            directoryClient.GetFileClient("baz");
+        }
+#pragma warning restore CA1806 // Do not ignore method results
+
+        public override Task RunAsync(CancellationToken cancellationToken)
+        {
+            Run(cancellationToken);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
To address https://github.com/Azure/azure-sdk-for-net/issues/21622

Calls to various ctors and hierarchy are piled up in single test because:
- we don't add new but rather expand options
- they change infrequently
- this is to catch regressions, regressing single ctor should give enough signal to trigger investigation.