### PR TITLE
[ACR] Improve instructions for authenticating a client

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
@@ -13,6 +13,8 @@ Use the client library for Azure Container Registry to:
 
 ## Getting started
 
+To develop .NET application code that can connect to an Azure Container Registry instance, you will need the `Azure.Containers.ContainerRegistry` library.
+
 ### Install the package
 
 Install the Azure Container Registry client library for .NET with [NuGet][nuget]:
@@ -23,49 +25,29 @@ dotnet add package Azure.Containers.ContainerRegistry --prerelease
 
 ### Prerequisites
 
-You need an [Azure subscription][azure_sub] and a [Container Registry account][container_registry_docs] to use this package.
+You will need an [Azure subscription][azure_sub] and a [Container Registry service instance][container_registry_docs] for your application to connect to.
 
 To create a new Container Registry, you can use the [Azure Portal][container_registry_create_portal],
 [Azure PowerShell][container_registry_create_ps], or the [Azure CLI][container_registry_create_cli].
-Here's an example using the Azure CLI:
+Here'a an example of creating a new registry using the Azure CLI:
 
 ```Powershell
-az acr create --name MyContainerRegistry --resource-group MyResourceGroup --location westus --sku Basic
+az acr create --name myregistry --resource-group myresourcegroup --location westus --sku Basic
 ```
 
 ### Authenticate the client
 
-The [Azure Identity library][identity] provides easy Azure Active Directory support for authentication.  You can [authenticate with the Azure CLI](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity#authenticating-via-the-azure-cli) when developing and debugging locally.  Please see the [Azure Identity README][identity] for more approaches to authenticating with `DefaultAzureCredential`.
+For your application to connect to your registry, you'll need to create a `ContainerRegistryClient` that can authenticate with the registry service.  The [Azure Identity library][identity] provides easy Azure Active Directory support for authentication.  
+
+When you're developing and debugging your application locally, you can use your own user account to authenticate with your registry.  One approach to accomplish this is to [authenticate with the Azure CLI](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity#authenticating-via-the-azure-cli) and run your application from this environment.  If your application is using a client that has been constructed to authenticate with `DefaultAzureCredential`, it will correctly authenticate with the registry at the specified endpoint.  
 
 ```C#
-// Create a ContainerRegistryClient that will authenticate through Azure Active Directory
-Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
+// Create a ContainerRegistryClient that will authenticate to your registry through Azure Active Directory
+Uri endpoint = new Uri("https://myregistry.azurecr.io");
 ContainerRegistryClient client = new ContainerRegistryClient(endpoint, new DefaultAzureCredential());
 ```
 
-Note that this samples assume you have a `REGISTRY_ENDPOINT` environment variable set.  This would be set to a string containing the `https://` prefix and the name of the login server, for example "https://myregistry.azurecr.io".
-
-#### National Clouds
-
-To authenticate with a registry in a [National Cloud](https://docs.microsoft.com/azure/active-directory/develop/authentication-national-cloud), you will need to make the following additions to your client configuration:
-
-- Set the `AuthorityHost` in the credential options or via the `AZURE_AUTHORITY_HOST` environment variable
-- Set the `AuthenticationScope` in `ContainerRegistryClientOptions`
-
-```C#
-// Create a ContainerRegistryClient that will authenticate through AAD in the China national cloud
-Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
-ContainerRegistryClient client = new ContainerRegistryClient(endpoint,
-    new DefaultAzureCredential(
-        new DefaultAzureCredentialOptions()
-        {
-            AuthorityHost = AzureAuthorityHosts.AzureChina
-        }),
-    new ContainerRegistryClientOptions()
-    {
-        AuthenticationScope = "https://management.chinacloudapi.cn/.default"
-    });
-```
+Please see the [Azure Identity README][identity] for more approaches to authenticating with `DefaultAzureCredential`, both locally and in deployment environments.  To connect to registries in non-public Azure Clouds, see the samples below.
 
 For more information on using AAD with Azure Container Registry, please see the service's [Authentication Overview](https://docs.microsoft.com/azure/container-registry/container-registry-authentication).
 
@@ -92,6 +74,9 @@ We guarantee that all client instance methods are thread-safe and independent of
 
 ## Examples
 
+The following snippets show brief samples of common operations a user might use the ACR SDK library for.  
+Please note that each sample assumes there is a `REGISTRY_ENDPOINT` environment variable set to a string containing the `https://` prefix and the name of the login server, for example "https://myregistry.azurecr.io".
+
 ### Sync examples
 
 - [List repositories](#list-repositories)
@@ -105,6 +90,10 @@ We guarantee that all client instance methods are thread-safe and independent of
 - [List tags with anonymous access asynchronously](#list-tags-with-anonymous-access)
 - [Set artifact properties asynchronously](#set-artifact-properties)
 - [Delete images asynchronously](#delete-images)
+
+### Advanced authentication
+ 
+- [Create a client that can authenticate with a registry in a national cloud](#authenticate-in-a-national-cloud)
 
 ### List repositories
 
@@ -290,6 +279,28 @@ await foreach (string repositoryName in repositoryNames)
         await repository.GetArtifact(imageManifest.Digest).DeleteAsync();
     }
 }
+```
+
+### Authenticate in a National Cloud
+
+To authenticate with a registry in a [National Cloud](https://docs.microsoft.com/azure/active-directory/develop/authentication-national-cloud), you will need to make the following additions to your client configuration:
+
+- Set the `AuthorityHost` in the credential options or via the `AZURE_AUTHORITY_HOST` environment variable
+- Set the `AuthenticationScope` in `ContainerRegistryClientOptions`
+
+```C#
+// Create a ContainerRegistryClient that will authenticate through AAD in the China national cloud
+Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
+ContainerRegistryClient client = new ContainerRegistryClient(endpoint,
+    new DefaultAzureCredential(
+        new DefaultAzureCredentialOptions()
+        {
+            AuthorityHost = AzureAuthorityHosts.AzureChina
+        }),
+    new ContainerRegistryClientOptions()
+    {
+        AuthenticationScope = "https://management.chinacloudapi.cn/.default"
+    });
 ```
 
 ## Troubleshooting

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
@@ -37,7 +37,7 @@ az acr create --name myregistry --resource-group myresourcegroup --location west
 
 ### Authenticate the client
 
-For your application to connect to your registry, you'll need to create a `ContainerRegistryClient` that can authenticate with it.  The [Azure Identity library][identity] provides easy Azure Active Directory support for authenticating Azure SDK clients with their corresponding Azure services.  
+For your application to connect to your registry, you'll need to create a `ContainerRegistryClient` that can authenticate with it.  The [Azure Identity library][identity] makes it easy to add Azure Active Directory support for authenticating Azure SDK clients with their corresponding Azure services.  
 
 When you're developing and debugging your application locally, you can use your own user to authenticate with your registry.  One way to accomplish this is to [authenticate your user with the Azure CLI](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity#authenticating-via-the-azure-cli) and run your application from this environment.  If your application is using a client that has been constructed to authenticate with `DefaultAzureCredential`, it will correctly authenticate with the registry at the specified endpoint.  
 
@@ -74,7 +74,7 @@ We guarantee that all client instance methods are thread-safe and independent of
 
 ## Examples
 
-The following snippets show brief samples of common operations a user might use the ACR SDK library for.  
+The following snippets show brief samples of common developer scenarios using the ACR SDK library. 
 Please note that each sample assumes there is a `REGISTRY_ENDPOINT` environment variable set to a string containing the `https://` prefix and the name of the login server, for example "https://myregistry.azurecr.io".
 
 ### Sync examples

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
@@ -37,9 +37,9 @@ az acr create --name myregistry --resource-group myresourcegroup --location west
 
 ### Authenticate the client
 
-For your application to connect to your registry, you'll need to create a `ContainerRegistryClient` that can authenticate with the registry service.  The [Azure Identity library][identity] provides easy Azure Active Directory support for authentication.  
+For your application to connect to your registry, you'll need to create a `ContainerRegistryClient` that can authenticate with it.  The [Azure Identity library][identity] provides easy Azure Active Directory support for authenticating Azure SDK clients with their corresponding Azure services.  
 
-When you're developing and debugging your application locally, you can use your own user account to authenticate with your registry.  One approach to accomplish this is to [authenticate with the Azure CLI](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity#authenticating-via-the-azure-cli) and run your application from this environment.  If your application is using a client that has been constructed to authenticate with `DefaultAzureCredential`, it will correctly authenticate with the registry at the specified endpoint.  
+When you're developing and debugging your application locally, you can use your own user to authenticate with your registry.  One way to accomplish this is to [authenticate your user with the Azure CLI](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity#authenticating-via-the-azure-cli) and run your application from this environment.  If your application is using a client that has been constructed to authenticate with `DefaultAzureCredential`, it will correctly authenticate with the registry at the specified endpoint.  
 
 ```C#
 // Create a ContainerRegistryClient that will authenticate to your registry through Azure Active Directory


### PR DESCRIPTION
Per [discussion](https://github.com/Azure/azure-sdk-for-net/pull/21493#discussion_r645773812) with @schaabs, we'd like to move away from documenting environment variables for AAD set-up and instead point users toward simpler options in the developer environment.  This update to the ACR readme makes a new proposal for the suggested changes.