### PR TITLE
Remove readonly from Shared in HttpClientTransport

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -685,7 +685,7 @@ namespace Azure.Core.Pipeline
     }
     public partial class HttpClientTransport : Azure.Core.Pipeline.HttpPipelineTransport
     {
-        public static readonly Azure.Core.Pipeline.HttpClientTransport Shared;
+        public static Azure.Core.Pipeline.HttpClientTransport Shared;
         public HttpClientTransport() { }
         public HttpClientTransport(System.Net.Http.HttpClient client) { }
         public HttpClientTransport(System.Net.Http.HttpMessageHandler messageHandler) { }

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -685,7 +685,7 @@ namespace Azure.Core.Pipeline
     }
     public partial class HttpClientTransport : Azure.Core.Pipeline.HttpPipelineTransport
     {
-        public static readonly Azure.Core.Pipeline.HttpClientTransport Shared;
+        public static Azure.Core.Pipeline.HttpClientTransport Shared;
         public HttpClientTransport() { }
         public HttpClientTransport(System.Net.Http.HttpClient client) { }
         public HttpClientTransport(System.Net.Http.HttpMessageHandler messageHandler) { }

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -685,7 +685,7 @@ namespace Azure.Core.Pipeline
     }
     public partial class HttpClientTransport : Azure.Core.Pipeline.HttpPipelineTransport
     {
-        public static readonly Azure.Core.Pipeline.HttpClientTransport Shared;
+        public static Azure.Core.Pipeline.HttpClientTransport Shared;
         public HttpClientTransport() { }
         public HttpClientTransport(System.Net.Http.HttpClient client) { }
         public HttpClientTransport(System.Net.Http.HttpMessageHandler messageHandler) { }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -685,7 +685,7 @@ namespace Azure.Core.Pipeline
     }
     public partial class HttpClientTransport : Azure.Core.Pipeline.HttpPipelineTransport
     {
-        public static readonly Azure.Core.Pipeline.HttpClientTransport Shared;
+        public static Azure.Core.Pipeline.HttpClientTransport Shared;
         public HttpClientTransport() { }
         public HttpClientTransport(System.Net.Http.HttpClient client) { }
         public HttpClientTransport(System.Net.Http.HttpMessageHandler messageHandler) { }

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -51,7 +51,11 @@ namespace Azure.Core.Pipeline
         /// <summary>
         /// A shared instance of <see cref="HttpClientTransport"/> with default parameters.
         /// </summary>
-        public static readonly HttpClientTransport Shared = new HttpClientTransport();
+        // This should be considered a readonly field, but needs to be not initonly for
+        // fault injection workarounds for .NET Core.
+#pragma warning disable CA2211 // Non-constant fields should not be visible
+        public static HttpClientTransport Shared = new HttpClientTransport();
+#pragma warning restore CA2211 // Non-constant fields should not be visible
 
         /// <inheritdoc />
         public sealed override Request CreateRequest()


### PR DESCRIPTION
**Why do we need this?**
Some fault injection scenarios require changing the default `HttpClientTransport `which is held in `HttpClientTransport.Shared`. We set this to a new value using reflection.
This works for the .NET Framework runtime, but in .NET Core and .NET 5.0 a `System.FieldAccessException` is thrown with the message `Cannot set initonly static field 'Shared' after type 'Azure.Core.Pipeline.HttpClientTransport' is initialized.`
To get this to work in .NET Core and .NET 5.0, the `readonly` modifer needs to be removed from the `Shared `field.

An alternative would be to declare Shared as:

```csharp
public static HttpClientTransport Shared { get; private set; } = new HttpClientTransport();
```

but this would potentially break existing clients.

_Note: This is a workaround pending a proper design for a replaceable default `HttpClientTransport`._