### PR TITLE
Add ASP.NET Core section to demo DI

### DIFF
--- a/sdk/search/Azure.Search.Documents/README.md
+++ b/sdk/search/Azure.Search.Documents/README.md
@@ -104,7 +104,7 @@ public void ConfigureServices(IServiceCollection services)
 {
     services.AddAzureClients(builder =>
     {
-        builder.AddSearchClient(Configuration.GetSection("Search"));
+        builder.AddSearchClient(Configuration.GetSection("SearchClient"));
     });
   
     services.AddControllers();
@@ -114,15 +114,29 @@ To use the preceding code, add this to your configuration:
 
 ```json
 {
-    "Search": {
+    "SearchClient": {
       "endpoint": "https://<resource-name>.search.windows.net",
-      "credential": { "key": "resource key" },
       "indexname": "nycjobs"
     }
 }
 ```
+You'll also need to provide your resource key to authenticate the client, but you shouldn't be putting that information in the configuration. Instead, when in development, use [User-Secrets](https://docs.microsoft.com/aspnet/core/security/app-secrets?view=aspnetcore-5.0&tabs=windows#how-the-secret-manager-tool-works). Add the following to `secrets.json`:
 
-For more details, see [Dependency injection with the Azure SDK for .NET](https://docs.microsoft.com/dotnet/azure/sdk/dependency-injection).
+```json
+{
+    "SearchClient": {
+      "credential": { "key": "<you resource key>" }
+    }
+}
+```
+When running in production, it's preferable to use [environment variables](https://docs.microsoft.com/aspnet/core/security/app-secrets?view=aspnetcore-5.0&tabs=windows#environment-variables):
+
+```
+SEARCH__CREDENTIAL__KEY="..."
+```
+Or use other secure ways of storing secrets like [Azure Key Vault](https://docs.microsoft.com/en-us/aspnet/core/security/key-vault-configuration?view=aspnetcore-5.0).
+
+For more details about Dependency Injection in ASP.NET Core apps, see [Dependency injection with the Azure SDK for .NET](https://docs.microsoft.com/dotnet/azure/sdk/dependency-injection).
 
 ## Key concepts
 

--- a/sdk/search/Azure.Search.Documents/README.md
+++ b/sdk/search/Azure.Search.Documents/README.md
@@ -134,7 +134,7 @@ When running in production, it's preferable to use [environment variables](https
 ```
 SEARCH__CREDENTIAL__KEY="..."
 ```
-Or use other secure ways of storing secrets like [Azure Key Vault](https://docs.microsoft.com/en-us/aspnet/core/security/key-vault-configuration?view=aspnetcore-5.0).
+Or use other secure ways of storing secrets like [Azure Key Vault](https://docs.microsoft.com/aspnet/core/security/key-vault-configuration?view=aspnetcore-5.0).
 
 For more details about Dependency Injection in ASP.NET Core apps, see [Dependency injection with the Azure SDK for .NET](https://docs.microsoft.com/dotnet/azure/sdk/dependency-injection).
 

--- a/sdk/search/Azure.Search.Documents/README.md
+++ b/sdk/search/Azure.Search.Documents/README.md
@@ -96,6 +96,33 @@ string key = Environment.GetEnvironmentVariable("SEARCH_API_KEY");
 AzureKeyCredential credential = new AzureKeyCredential(key);
 SearchClient client = new SearchClient(endpoint, indexName, credential);
 ```
+### ASP.NET Core
+To inject `SearchClient` as a dependency in an ASP.NET Core app, first install the package `Microsoft.Extensions.Azure`. Then register the client in the `Startup.ConfigureServices` method:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddAzureClients(builder =>
+    {
+        builder.AddSearchClient(Configuration.GetSection("Search"));
+    });
+  
+    services.AddControllers();
+}
+```
+To use the preceding code, add this to your configuration:
+
+```json
+{
+    "Search": {
+      "endpoint": "https://<resource-name>.search.windows.net",
+      "credential": { "key": "resource key" },
+      "indexname": "nycjobs"
+    }
+}
+```
+
+For more details, see [Dependency injection with the Azure SDK for .NET](https://docs.microsoft.com/dotnet/azure/sdk/dependency-injection).
 
 ## Key concepts
 


### PR DESCRIPTION
Context: 

Since Dependency Injection is a key workflow for .NET developers and we've seen requests from customers ([twitter](https://twitter.com/WestDiscGolf/status/1387084607493914627), [stackoverflow](https://stackoverflow.com/questions/52206269/azure-search-net-sdk-searchindexclient-dependency-injection)) requesting for DI related content for the new SDKs, we're adding a section about DI for ASP.NET Core in the readme. This has been discussed various folks (David Fowler, David Pine, Scott Addie etc.), and they think it'll be helpful to users. 

cc @maggiepint 