### PR TITLE
[MetricsAdvisor] Updated detection config tests to use newly created data feeds

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         [TestCase(false)]
         public async Task CreateAndGetDetectionConfigurationWithHardCondition(bool useTokenCredential)
         {
-            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient(useTokenCredential);
             await using DisposableDataFeed disposableDataFeed = await CreateDisposableDataFeedAsync(adminClient);
 
             string configName = Recording.GenerateAlphaNumericId("config");

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
@@ -15,7 +15,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
     public class AnomalyDetectionConfigurationLiveTests : MetricsAdvisorLiveTestBase
     {
         private const string MetricName = "metric";
-        private const string DimensionNameA = "DimensionA";
+        private const string DimensionNameA = "dimensionA";
         private const string DimensionNameB = "dimensionB";
 
         public AnomalyDetectionConfigurationLiveTests(bool isAsync) : base(isAsync)

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
@@ -15,8 +15,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
     public class AnomalyDetectionConfigurationLiveTests : MetricsAdvisorLiveTestBase
     {
         private const string MetricName = "metric";
+        private const string DimensionNameA = "DimensionA";
+        private const string DimensionNameB = "dimensionB";
 
-        public AnomalyDetectionConfigurationLiveTests(bool isAsync) : base(isAsync, RecordedTestMode.Record)
+        public AnomalyDetectionConfigurationLiveTests(bool isAsync) : base(isAsync)
         {
         }
 
@@ -147,14 +149,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            groupConditions0.SeriesGroupKey.AddDimensionColumn("city", "Delhi");
+            groupConditions0.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Delhi");
 
             var groupConditions1 = new MetricSeriesGroupDetectionCondition()
             {
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            groupConditions1.SeriesGroupKey.AddDimensionColumn("city", "Koltaka");
+            groupConditions1.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Koltaka");
 
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions0);
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions1);
@@ -193,12 +195,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdGroupConditions0, Is.Not.Null);
 
-            ValidateGroupKey(createdGroupConditions0.SeriesGroupKey);
-
-            Dictionary<string, string> dimensionColumns = createdGroupConditions0.SeriesGroupKey.AsDictionary();
-
-            Assert.That(dimensionColumns.Count, Is.EqualTo(1));
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Delhi"));
+            ValidateDimensionKey(createdGroupConditions0.SeriesGroupKey, "Delhi");
 
             Assert.That(createdGroupConditions0.CrossConditionsOperator, Is.Null);
             Assert.That(createdGroupConditions0.HardThresholdCondition, Is.Null);
@@ -212,12 +209,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdGroupConditions1, Is.Not.Null);
 
-            ValidateGroupKey(createdGroupConditions1.SeriesGroupKey);
-
-            dimensionColumns = createdGroupConditions1.SeriesGroupKey.AsDictionary();
-
-            Assert.That(dimensionColumns.Count, Is.EqualTo(1));
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Koltaka"));
+            ValidateDimensionKey(createdGroupConditions1.SeriesGroupKey, "Koltaka");
 
             Assert.That(createdGroupConditions1.CrossConditionsOperator, Is.Null);
             Assert.That(createdGroupConditions1.HardThresholdCondition, Is.Null);
@@ -260,16 +252,16 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            seriesConditions0.SeriesKey.AddDimensionColumn("city", "Delhi");
-            seriesConditions0.SeriesKey.AddDimensionColumn("category", "Handmade");
+            seriesConditions0.SeriesKey.AddDimensionColumn(DimensionNameA, "Delhi");
+            seriesConditions0.SeriesKey.AddDimensionColumn(DimensionNameB, "Handmade");
 
             var seriesConditions1 = new MetricSingleSeriesDetectionCondition()
             {
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            seriesConditions1.SeriesKey.AddDimensionColumn("city", "Koltaka");
-            seriesConditions1.SeriesKey.AddDimensionColumn("category", "Grocery & Gourmet Food");
+            seriesConditions1.SeriesKey.AddDimensionColumn(DimensionNameA, "Koltaka");
+            seriesConditions1.SeriesKey.AddDimensionColumn(DimensionNameB, "Grocery & Gourmet Food");
 
             configToCreate.SeriesDetectionConditions.Add(seriesConditions0);
             configToCreate.SeriesDetectionConditions.Add(seriesConditions1);
@@ -308,12 +300,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdSeriesConditions0, Is.Not.Null);
 
-            ValidateSeriesKey(createdSeriesConditions0.SeriesKey);
-
-            Dictionary<string, string> dimensionColumns = createdSeriesConditions0.SeriesKey.AsDictionary();
-
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Delhi"));
-            Assert.That(dimensionColumns["category"], Is.EqualTo("Handmade"));
+            ValidateDimensionKey(createdSeriesConditions0.SeriesKey, "Delhi", "Handmade");
 
             Assert.That(createdSeriesConditions0.CrossConditionsOperator, Is.Null);
             Assert.That(createdSeriesConditions0.HardThresholdCondition, Is.Null);
@@ -327,12 +314,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdSeriesConditions1, Is.Not.Null);
 
-            ValidateSeriesKey(createdSeriesConditions1.SeriesKey);
-
-            dimensionColumns = createdSeriesConditions1.SeriesKey.AsDictionary();
-
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Koltaka"));
-            Assert.That(dimensionColumns["category"], Is.EqualTo("Grocery & Gourmet Food"));
+            ValidateDimensionKey(createdSeriesConditions1.SeriesKey, "Koltaka", "Grocery & Gourmet Food");
 
             Assert.That(createdSeriesConditions1.CrossConditionsOperator, Is.Null);
             Assert.That(createdSeriesConditions1.HardThresholdCondition, Is.Null);
@@ -378,7 +360,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            groupConditions.SeriesGroupKey.AddDimensionColumn("city", "Koltaka");
+            groupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Koltaka");
 
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions);
 
@@ -389,8 +371,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            seriesConditions.SeriesKey.AddDimensionColumn("city", "Delhi");
-            seriesConditions.SeriesKey.AddDimensionColumn("category", "Handmade");
+            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameA, "Delhi");
+            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameB, "Handmade");
 
             configToCreate.SeriesDetectionConditions.Add(seriesConditions);
 
@@ -430,12 +412,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions, Is.Not.Null);
 
-            ValidateGroupKey(updatedGroupConditions.SeriesGroupKey);
-
-            Dictionary<string, string> dimensionColumns = updatedGroupConditions.SeriesGroupKey.AsDictionary();
-
-            Assert.That(dimensionColumns.Count, Is.EqualTo(1));
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Koltaka"));
+            ValidateDimensionKey(updatedGroupConditions.SeriesGroupKey, "Koltaka");
 
             Assert.That(updatedGroupConditions.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions.HardThresholdCondition, Is.Null);
@@ -449,12 +426,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedSeriesConditions = updatedConfig.SeriesDetectionConditions.Single();
 
-            ValidateSeriesKey(updatedSeriesConditions.SeriesKey);
-
-            dimensionColumns = updatedSeriesConditions.SeriesKey.AsDictionary();
-
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Delhi"));
-            Assert.That(dimensionColumns["category"], Is.EqualTo("Handmade"));
+            ValidateDimensionKey(updatedSeriesConditions.SeriesKey, "Delhi", "Handmade");
 
             Assert.That(updatedSeriesConditions, Is.Not.Null);
             Assert.That(updatedSeriesConditions.CrossConditionsOperator, Is.Null);
@@ -500,7 +472,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            groupConditions.SeriesGroupKey.AddDimensionColumn("city", "Koltaka");
+            groupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Koltaka");
 
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions);
 
@@ -511,8 +483,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            seriesConditions.SeriesKey.AddDimensionColumn("city", "Delhi");
-            seriesConditions.SeriesKey.AddDimensionColumn("category", "Handmade");
+            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameA, "Delhi");
+            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameB, "Handmade");
 
             configToCreate.SeriesDetectionConditions.Add(seriesConditions);
 
@@ -552,12 +524,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions, Is.Not.Null);
 
-            ValidateGroupKey(updatedGroupConditions.SeriesGroupKey);
-
-            Dictionary<string, string> dimensionColumns = updatedGroupConditions.SeriesGroupKey.AsDictionary();
-
-            Assert.That(dimensionColumns.Count, Is.EqualTo(1));
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Koltaka"));
+            ValidateDimensionKey(updatedGroupConditions.SeriesGroupKey, "Koltaka");
 
             Assert.That(updatedGroupConditions.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions.HardThresholdCondition, Is.Null);
@@ -571,12 +538,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedSeriesConditions = updatedConfig.SeriesDetectionConditions.Single();
 
-            ValidateSeriesKey(updatedSeriesConditions.SeriesKey);
-
-            dimensionColumns = updatedSeriesConditions.SeriesKey.AsDictionary();
-
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Delhi"));
-            Assert.That(dimensionColumns["category"], Is.EqualTo("Handmade"));
+            ValidateDimensionKey(updatedSeriesConditions.SeriesKey, "Delhi", "Handmade");
 
             Assert.That(updatedSeriesConditions, Is.Not.Null);
             Assert.That(updatedSeriesConditions.CrossConditionsOperator, Is.Null);
@@ -624,7 +586,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            groupConditions.SeriesGroupKey.AddDimensionColumn("city", "Koltaka");
+            groupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Koltaka");
 
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions);
 
@@ -635,8 +597,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            seriesConditions.SeriesKey.AddDimensionColumn("city", "Delhi");
-            seriesConditions.SeriesKey.AddDimensionColumn("category", "Handmade");
+            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameA, "Delhi");
+            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameB, "Handmade");
 
             configToCreate.SeriesDetectionConditions.Add(seriesConditions);
 
@@ -658,7 +620,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(95.0, AnomalyDetectorDirection.Both, new(25, 26.0))
             };
 
-            newGroupConditions.SeriesGroupKey.AddDimensionColumn("city", "Delhi");
+            newGroupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Delhi");
 
             configToUpdate.SeriesGroupDetectionConditions.Add(newGroupConditions);
 
@@ -696,12 +658,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions0, Is.Not.Null);
 
-            ValidateGroupKey(updatedGroupConditions0.SeriesGroupKey);
-
-            Dictionary<string, string> dimensionColumns = updatedGroupConditions0.SeriesGroupKey.AsDictionary();
-
-            Assert.That(dimensionColumns.Count, Is.EqualTo(1));
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Koltaka"));
+            ValidateDimensionKey(updatedGroupConditions0.SeriesGroupKey, "Koltaka");
 
             Assert.That(updatedGroupConditions0.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions0.HardThresholdCondition, Is.Null);
@@ -715,12 +672,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions1, Is.Not.Null);
 
-            ValidateGroupKey(updatedGroupConditions1.SeriesGroupKey);
-
-            dimensionColumns = updatedGroupConditions1.SeriesGroupKey.AsDictionary();
-
-            Assert.That(dimensionColumns.Count, Is.EqualTo(1));
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Delhi"));
+            ValidateDimensionKey(updatedGroupConditions1.SeriesGroupKey, "Delhi");
 
             Assert.That(updatedGroupConditions1.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions1.HardThresholdCondition, Is.Null);
@@ -767,7 +719,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            groupConditions.SeriesGroupKey.AddDimensionColumn("city", "Koltaka");
+            groupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Koltaka");
 
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions);
 
@@ -778,8 +730,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            seriesConditions.SeriesKey.AddDimensionColumn("city", "Delhi");
-            seriesConditions.SeriesKey.AddDimensionColumn("category", "Handmade");
+            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameA, "Delhi");
+            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameB, "Handmade");
 
             configToCreate.SeriesDetectionConditions.Add(seriesConditions);
 
@@ -803,7 +755,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(95.0, AnomalyDetectorDirection.Both, new(25, 26.0))
             };
 
-            newGroupConditions.SeriesGroupKey.AddDimensionColumn("city", "Delhi");
+            newGroupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Delhi");
 
             configToUpdate.SeriesGroupDetectionConditions.Add(groupConditions);
             configToUpdate.SeriesGroupDetectionConditions.Add(newGroupConditions);
@@ -842,12 +794,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions0, Is.Not.Null);
 
-            ValidateGroupKey(updatedGroupConditions0.SeriesGroupKey);
-
-            Dictionary<string, string> dimensionColumns = updatedGroupConditions0.SeriesGroupKey.AsDictionary();
-
-            Assert.That(dimensionColumns.Count, Is.EqualTo(1));
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Koltaka"));
+            ValidateDimensionKey(updatedGroupConditions0.SeriesGroupKey, "Koltaka");
 
             Assert.That(updatedGroupConditions0.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions0.HardThresholdCondition, Is.Null);
@@ -861,12 +808,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions1, Is.Not.Null);
 
-            ValidateGroupKey(updatedGroupConditions1.SeriesGroupKey);
-
-            dimensionColumns = updatedGroupConditions1.SeriesGroupKey.AsDictionary();
-
-            Assert.That(dimensionColumns.Count, Is.EqualTo(1));
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Delhi"));
+            ValidateDimensionKey(updatedGroupConditions1.SeriesGroupKey, "Delhi");
 
             Assert.That(updatedGroupConditions1.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions1.HardThresholdCondition, Is.Null);
@@ -962,6 +904,30 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     Assert.That(async () => await adminClient.GetDetectionConfigurationAsync(configId), Throws.InstanceOf<RequestFailedException>().With.Message.Contains(errorCause));
                 }
             }
+        }
+
+        private void ValidateDimensionKey(DimensionKey dimensionKey, string expectedDimensionA)
+        {
+            Assert.That(dimensionKey, Is.Not.Null);
+
+            Dictionary<string, string> dimensionColumns = dimensionKey.AsDictionary();
+
+            Assert.That(dimensionColumns.Count, Is.EqualTo(1));
+            Assert.That(dimensionColumns.ContainsKey(DimensionNameA));
+            Assert.That(dimensionColumns[DimensionNameA], Is.EqualTo(expectedDimensionA));
+        }
+
+        private void ValidateDimensionKey(DimensionKey dimensionKey, string expectedDimensionA, string expectedDimensionB)
+        {
+            Assert.That(dimensionKey, Is.Not.Null);
+
+            Dictionary<string, string> dimensionDictionary = dimensionKey.AsDictionary();
+
+            Assert.That(dimensionDictionary.Count, Is.EqualTo(2));
+            Assert.That(dimensionDictionary.ContainsKey(DimensionNameA));
+            Assert.That(dimensionDictionary.ContainsKey(DimensionNameB));
+            Assert.That(dimensionDictionary[DimensionNameA], Is.EqualTo(expectedDimensionA));
+            Assert.That(dimensionDictionary[DimensionNameB], Is.EqualTo(expectedDimensionB));
         }
 
         private void ValidateHardThresholdCondition(HardThresholdCondition condition, AnomalyDetectorDirection direction, double? upperBound, double? lowerBound, int minimumNumber, double minimumRatio)
@@ -1070,7 +1036,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
                 Schema = new DataFeedSchema()
                 {
-                    MetricColumns = { new DataFeedMetric(MetricName) }
+                    MetricColumns = { new DataFeedMetric(MetricName) },
+                    DimensionColumns = { new DataFeedDimension(DimensionNameA), new DataFeedDimension(DimensionNameB) }
                 },
                 IngestionSettings = new DataFeedIngestionSettings() { IngestionStartTime = SamplingStartTime }
             };

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorTestEnvironment.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorTestEnvironment.cs
@@ -8,14 +8,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 {
     public class MetricsAdvisorTestEnvironment : TestEnvironment
     {
-        public const string MetricsAdvisorApiKeyVariableName = "METRICSADVISOR_PRIMARY_API_KEY";
-        public const string MetricsAdvisoSubscriptionKeyVariableName = "METRICSADVISOR_SUBSCRIPTION_KEY";
-        public const string MetricsAdvisorAccountNameVariableName = "METRICSADVISOR_ACCOUNT_NAME";
-
-        public string MetricsAdvisorApiKey => GetRecordedVariable(MetricsAdvisorApiKeyVariableName, options => options.IsSecret());
-        public string MetricsAdvisorSubscriptionKey => GetRecordedVariable(MetricsAdvisoSubscriptionKeyVariableName, options => options.IsSecret());
-        public string MetricsAdvisorAccountName => GetRecordedVariable(MetricsAdvisorAccountNameVariableName);
-        public string MetricsAdvisorUri => $"https://{MetricsAdvisorAccountName}.cognitiveservices.azure.com";
+        public const string DefaultEndpointSuffix = "azure.com";
+        public string MetricsAdvisorApiKey => GetRecordedVariable("METRICSADVISOR_PRIMARY_API_KEY", options => options.IsSecret());
+        public string MetricsAdvisorSubscriptionKey => GetRecordedVariable("METRICSADVISOR_SUBSCRIPTION_KEY", options => options.IsSecret());
+        public string MetricsAdvisorAccountName => GetRecordedVariable("METRICSADVISOR_ACCOUNT_NAME");
+        public string MetricsAdvisorEndpointSuffix => GetRecordedOptionalVariable("METRICSADVISOR_ENDPOINT_SUFFIX") ?? DefaultEndpointSuffix;
+        public string MetricsAdvisorUri => $"https://{MetricsAdvisorAccountName}.cognitiveservices.{MetricsAdvisorEndpointSuffix}";
 
         // Data feed sources
         public string SqlServerConnectionString => GetRecordedVariable("METRICSADVISOR_SQL_SERVER_CONNECTION_STRING", options => options.IsSecret(SanitizedValue.Base64));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorTestEnvironment.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorTestEnvironment.cs
@@ -8,12 +8,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 {
     public class MetricsAdvisorTestEnvironment : TestEnvironment
     {
-        public const string DefaultEndpointSuffix = "azure.com";
-        public string MetricsAdvisorApiKey => GetRecordedVariable("METRICSADVISOR_PRIMARY_API_KEY", options => options.IsSecret());
-        public string MetricsAdvisorSubscriptionKey => GetRecordedVariable("METRICSADVISOR_SUBSCRIPTION_KEY", options => options.IsSecret());
-        public string MetricsAdvisorAccountName => GetRecordedVariable("METRICSADVISOR_ACCOUNT_NAME");
-        public string MetricsAdvisorEndpointSuffix => GetRecordedOptionalVariable("METRICSADVISOR_ENDPOINT_SUFFIX") ?? DefaultEndpointSuffix;
-        public string MetricsAdvisorUri => $"https://{MetricsAdvisorAccountName}.cognitiveservices.{MetricsAdvisorEndpointSuffix}";
+        public const string MetricsAdvisorApiKeyVariableName = "METRICSADVISOR_PRIMARY_API_KEY";
+        public const string MetricsAdvisoSubscriptionKeyVariableName = "METRICSADVISOR_SUBSCRIPTION_KEY";
+        public const string MetricsAdvisorAccountNameVariableName = "METRICSADVISOR_ACCOUNT_NAME";
+
+        public string MetricsAdvisorApiKey => GetRecordedVariable(MetricsAdvisorApiKeyVariableName, options => options.IsSecret());
+        public string MetricsAdvisorSubscriptionKey => GetRecordedVariable(MetricsAdvisoSubscriptionKeyVariableName, options => options.IsSecret());
+        public string MetricsAdvisorAccountName => GetRecordedVariable(MetricsAdvisorAccountNameVariableName);
+        public string MetricsAdvisorUri => $"https://{MetricsAdvisorAccountName}.cognitiveservices.azure.com";
 
         // Data feed sources
         public string SqlServerConnectionString => GetRecordedVariable("METRICSADVISOR_SQL_SERVER_CONNECTION_STRING", options => options.IsSecret(SanitizedValue.Base64));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample03_DetectionConfigurationCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample03_DetectionConfigurationCrudOperations.cs
@@ -13,6 +13,7 @@ namespace Azure.AI.MetricsAdvisor.Samples
     public partial class MetricsAdvisorSamples : MetricsAdvisorTestEnvironment
     {
         [Test]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/21663")]
         public async Task CreateAndDeleteDetectionConfigurationAsync()
         {
             string endpoint = MetricsAdvisorUri;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithChangeAndSmartConditions.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithChangeAndSmartConditions.json
@@ -1,6 +1,131 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-87342586053b3540a0b2a686532c9c4e-32455f3795ddc64c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0bc4789bccb322b0369bcece4c32c53e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedejov15li",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "01361089-ec1e-43b2-b8d9-9431c6d8ef2a",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:45:35 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a8454a2b-56e8-4982-a206-e56b9418c5c8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "962",
+        "x-request-id": "01361089-ec1e-43b2-b8d9-9431c6d8ef2a"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a8454a2b-56e8-4982-a206-e56b9418c5c8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-87342586053b3540a0b2a686532c9c4e-a1dfdb6ff63d6a49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "aa0b8f680c11a3c82c12bda79522c490",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f977dfa9-c091-4733-9cfe-2b0f78cefbf9",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:45:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "163",
+        "x-request-id": "f977dfa9-c091-4733-9cfe-2b0f78cefbf9"
+      },
+      "ResponseBody": {
+        "dataFeedId": "a8454a2b-56e8-4982-a206-e56b9418c5c8",
+        "dataFeedName": "dataFeedejov15li",
+        "metrics": [
+          {
+            "metricId": "0208abc3-fb99-407a-ad71-9151abbba2b4",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:45:36Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,18 +133,15 @@
         "Content-Length": "426",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8afd170b4e7de348a92052f70014a8b9-e63b603a81023c40-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-24af825c66016e4fb7ffbed6753ccbf0-873a352f2a1f004e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "0bc4789bccb322b0369bcece4c32c53e",
+        "x-ms-client-request-id": "c68246900494620768f0969e03b5aa8e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configejov15li",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "name": "configYCJOus8l",
+        "metricId": "0208abc3-fb99-407a-ad71-9151abbba2b4",
         "wholeMetricConfiguration": {
           "conditionOperator": "AND",
           "smartDetectionCondition": {
@@ -44,49 +166,100 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "bacc79d6-cb3d-4232-bc7e-86584d0e115d",
+        "apim-request-id": "8f2b9773-b919-43d0-b323-e5d1fc208105",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:16 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f976bc08-2d42-4b90-8b65-e73248a48625",
+        "Date": "Wed, 09 Jun 2021 19:45:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9863e04d-5522-4ded-8180-46a22c44afcf",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "106",
-        "X-Request-ID": "bacc79d6-cb3d-4232-bc7e-86584d0e115d"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "131",
+        "x-request-id": "8f2b9773-b919-43d0-b323-e5d1fc208105"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f976bc08-2d42-4b90-8b65-e73248a48625",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9863e04d-5522-4ded-8180-46a22c44afcf",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8afd170b4e7de348a92052f70014a8b9-837f843c8708fb44-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-24af825c66016e4fb7ffbed6753ccbf0-2ce59939b183f74c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "aa0b8f680c11a3c82c12bda79522c490",
+        "x-ms-client-request-id": "a1df21b0090f148dd63ef408e75fc9f3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "10d1f53f-69e9-45ad-895b-29560f7cbd22",
+        "apim-request-id": "60c54665-7cdb-4009-b494-2d1f0b4bbb44",
         "Content-Length": "600",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:16 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "95",
+        "x-request-id": "60c54665-7cdb-4009-b494-2d1f0b4bbb44"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "9863e04d-5522-4ded-8180-46a22c44afcf",
+        "name": "configYCJOus8l",
+        "description": "",
+        "metricId": "0208abc3-fb99-407a-ad71-9151abbba2b4",
+        "wholeMetricConfiguration": {
+          "conditionOperator": "AND",
+          "smartDetectionCondition": {
+            "sensitivity": 23.0,
+            "anomalyDetectorDirection": "Down",
+            "suppressCondition": {
+              "minNumber": 3,
+              "minRatio": 4.0
+            }
+          },
+          "changeThresholdCondition": {
+            "changePercentage": 90.0,
+            "shiftPoint": 5,
+            "anomalyDetectorDirection": "Both",
+            "withinRange": true,
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 2.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9863e04d-5522-4ded-8180-46a22c44afcf",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f0f19b704780dd4f8a14a25a2e86d222-00a94b2a82272d48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ca1983dc0189270e0a5a3ea48c268d24",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0cf9b7be-0e83-4bac-bc7c-f8bffff121f3",
+        "Content-Length": "600",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:45:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
         "x-envoy-upstream-service-time": "94",
-        "X-Request-ID": "10d1f53f-69e9-45ad-895b-29560f7cbd22"
+        "x-request-id": "0cf9b7be-0e83-4bac-bc7c-f8bffff121f3"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "f976bc08-2d42-4b90-8b65-e73248a48625",
-        "name": "configejov15li",
+        "anomalyDetectionConfigurationId": "9863e04d-5522-4ded-8180-46a22c44afcf",
+        "name": "configYCJOus8l",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "0208abc3-fb99-407a-ad71-9151abbba2b4",
         "wholeMetricConfiguration": {
           "conditionOperator": "AND",
           "smartDetectionCondition": {
@@ -113,94 +286,58 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f976bc08-2d42-4b90-8b65-e73248a48625",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-35ea14a0f0423b4982e7c4a4c6e5fef4-9a3eab11aef1a546-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "664b44da747588b2904682c694040762",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4c2f4400-032a-4b50-8f93-d29ab046f72e",
-        "Content-Length": "600",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:16 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "110",
-        "X-Request-ID": "4c2f4400-032a-4b50-8f93-d29ab046f72e"
-      },
-      "ResponseBody": {
-        "anomalyDetectionConfigurationId": "f976bc08-2d42-4b90-8b65-e73248a48625",
-        "name": "configejov15li",
-        "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-        "wholeMetricConfiguration": {
-          "conditionOperator": "AND",
-          "smartDetectionCondition": {
-            "sensitivity": 23.0,
-            "anomalyDetectorDirection": "Down",
-            "suppressCondition": {
-              "minNumber": 3,
-              "minRatio": 4.0
-            }
-          },
-          "changeThresholdCondition": {
-            "changePercentage": 90.0,
-            "shiftPoint": 5,
-            "anomalyDetectorDirection": "Both",
-            "withinRange": true,
-            "suppressCondition": {
-              "minNumber": 1,
-              "minRatio": 2.0
-            }
-          }
-        },
-        "dimensionGroupOverrideConfigurations": [],
-        "seriesOverrideConfigurations": []
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f976bc08-2d42-4b90-8b65-e73248a48625",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9863e04d-5522-4ded-8180-46a22c44afcf",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8fdde7732216c84cbe5c7cdb818a9307-5100c0e250300b4c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-0d0dc37eda6202448c6aadbc40bc4b42-27153a30c2a8bb42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9e96f068b5038eaab021dfa10f098d14",
+        "x-ms-client-request-id": "54b6bc9911958778b86ef05610fe7b09",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "237fe08f-29e4-486b-aafe-e5a658dbb9f8",
+        "apim-request-id": "3a74d4f0-09a7-49b3-810c-e27f92765928",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:16 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "116",
-        "X-Request-ID": "237fe08f-29e4-486b-aafe-e5a658dbb9f8"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "130",
+        "x-request-id": "3a74d4f0-09a7-49b3-810c-e27f92765928"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a8454a2b-56e8-4982-a206-e56b9418c5c8",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e0f1d0a902cbe0428b1571a85bd20287-e9b62baa008a3c45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7fc1a327df9bae0512b796b5cae887b0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "35352391-88eb-41b1-8c75-0f924f51d518",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:45:38 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "322",
+        "x-request-id": "35352391-88eb-41b1-8c75-0f924f51d518"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "382686735"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithChangeAndSmartConditions.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithChangeAndSmartConditions.json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-87342586053b3540a0b2a686532c9c4e-32455f3795ddc64c-00",
+        "traceparent": "00-2d25d453089c4846990b8617ef91108f-1b781c591ad8e044-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0bc4789bccb322b0369bcece4c32c53e",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "01361089-ec1e-43b2-b8d9-9431c6d8ef2a",
+        "apim-request-id": "26cfcb63-53da-4af1-b357-d00ccd69b25e",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:35 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a8454a2b-56e8-4982-a206-e56b9418c5c8",
+        "Date": "Wed, 09 Jun 2021 23:03:18 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/28f4fec8-995b-48aa-93d6-dbdfb55c2f22",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "962",
-        "x-request-id": "01361089-ec1e-43b2-b8d9-9431c6d8ef2a"
+        "x-envoy-upstream-service-time": "922",
+        "x-request-id": "26cfcb63-53da-4af1-b357-d00ccd69b25e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a8454a2b-56e8-4982-a206-e56b9418c5c8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/28f4fec8-995b-48aa-93d6-dbdfb55c2f22",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-87342586053b3540a0b2a686532c9c4e-a1dfdb6ff63d6a49-00",
+        "traceparent": "00-2d25d453089c4846990b8617ef91108f-a00eb62d7aeca645-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "aa0b8f680c11a3c82c12bda79522c490",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f977dfa9-c091-4733-9cfe-2b0f78cefbf9",
+        "apim-request-id": "99256c2a-21f3-4de3-9d89-b002f93f9770",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:36 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "163",
-        "x-request-id": "f977dfa9-c091-4733-9cfe-2b0f78cefbf9"
+        "x-envoy-upstream-service-time": "168",
+        "x-request-id": "99256c2a-21f3-4de3-9d89-b002f93f9770"
       },
       "ResponseBody": {
-        "dataFeedId": "a8454a2b-56e8-4982-a206-e56b9418c5c8",
+        "dataFeedId": "28f4fec8-995b-48aa-93d6-dbdfb55c2f22",
         "dataFeedName": "dataFeedejov15li",
         "metrics": [
           {
-            "metricId": "0208abc3-fb99-407a-ad71-9151abbba2b4",
+            "metricId": "3255a1f9-54f3-47b8-b39e-39ac4f1a7b66",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:45:36Z",
+        "createdTime": "2021-06-09T23:03:18Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "426",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-24af825c66016e4fb7ffbed6753ccbf0-873a352f2a1f004e-00",
+        "traceparent": "00-da37c3f8722a2447814eaa449cb07612-0a9cb3469d09604d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c68246900494620768f0969e03b5aa8e",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "configYCJOus8l",
-        "metricId": "0208abc3-fb99-407a-ad71-9151abbba2b4",
+        "metricId": "3255a1f9-54f3-47b8-b39e-39ac4f1a7b66",
         "wholeMetricConfiguration": {
           "conditionOperator": "AND",
           "smartDetectionCondition": {
@@ -166,24 +166,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8f2b9773-b919-43d0-b323-e5d1fc208105",
+        "apim-request-id": "4c2d8b35-fbb3-4e40-819f-568ff3710500",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9863e04d-5522-4ded-8180-46a22c44afcf",
+        "Date": "Wed, 09 Jun 2021 23:03:18 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/729dc09d-7d6b-419c-92bd-ea13d9b6f817",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "131",
-        "x-request-id": "8f2b9773-b919-43d0-b323-e5d1fc208105"
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "4c2d8b35-fbb3-4e40-819f-568ff3710500"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9863e04d-5522-4ded-8180-46a22c44afcf",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/729dc09d-7d6b-419c-92bd-ea13d9b6f817",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-24af825c66016e4fb7ffbed6753ccbf0-2ce59939b183f74c-00",
+        "traceparent": "00-da37c3f8722a2447814eaa449cb07612-fe6dcc92b9211c4f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a1df21b0090f148dd63ef408e75fc9f3",
@@ -192,20 +192,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "60c54665-7cdb-4009-b494-2d1f0b4bbb44",
+        "apim-request-id": "4bddc465-a435-4f1a-bbb7-e49454113f60",
         "Content-Length": "600",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:36 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "95",
-        "x-request-id": "60c54665-7cdb-4009-b494-2d1f0b4bbb44"
+        "x-envoy-upstream-service-time": "111",
+        "x-request-id": "4bddc465-a435-4f1a-bbb7-e49454113f60"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "9863e04d-5522-4ded-8180-46a22c44afcf",
+        "anomalyDetectionConfigurationId": "729dc09d-7d6b-419c-92bd-ea13d9b6f817",
         "name": "configYCJOus8l",
         "description": "",
-        "metricId": "0208abc3-fb99-407a-ad71-9151abbba2b4",
+        "metricId": "3255a1f9-54f3-47b8-b39e-39ac4f1a7b66",
         "wholeMetricConfiguration": {
           "conditionOperator": "AND",
           "smartDetectionCondition": {
@@ -232,12 +232,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9863e04d-5522-4ded-8180-46a22c44afcf",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/729dc09d-7d6b-419c-92bd-ea13d9b6f817",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f0f19b704780dd4f8a14a25a2e86d222-00a94b2a82272d48-00",
+        "traceparent": "00-a6b2a87925ab9e469bb04d1ece01a75c-53ebbdd9989bfa4b-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ca1983dc0189270e0a5a3ea48c268d24",
@@ -246,20 +246,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0cf9b7be-0e83-4bac-bc7c-f8bffff121f3",
+        "apim-request-id": "4b1a7398-55f5-4d6f-a3aa-d8383e5e8a99",
         "Content-Length": "600",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:36 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "94",
-        "x-request-id": "0cf9b7be-0e83-4bac-bc7c-f8bffff121f3"
+        "x-envoy-upstream-service-time": "101",
+        "x-request-id": "4b1a7398-55f5-4d6f-a3aa-d8383e5e8a99"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "9863e04d-5522-4ded-8180-46a22c44afcf",
+        "anomalyDetectionConfigurationId": "729dc09d-7d6b-419c-92bd-ea13d9b6f817",
         "name": "configYCJOus8l",
         "description": "",
-        "metricId": "0208abc3-fb99-407a-ad71-9151abbba2b4",
+        "metricId": "3255a1f9-54f3-47b8-b39e-39ac4f1a7b66",
         "wholeMetricConfiguration": {
           "conditionOperator": "AND",
           "smartDetectionCondition": {
@@ -286,12 +286,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9863e04d-5522-4ded-8180-46a22c44afcf",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/729dc09d-7d6b-419c-92bd-ea13d9b6f817",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0d0dc37eda6202448c6aadbc40bc4b42-27153a30c2a8bb42-00",
+        "traceparent": "00-6d85accd2959a944bb68fb7f98343ac4-3313f6794545de4b-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "54b6bc9911958778b86ef05610fe7b09",
@@ -300,23 +300,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3a74d4f0-09a7-49b3-810c-e27f92765928",
+        "apim-request-id": "7e85db57-4075-4440-8787-95f609d68033",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:36 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "130",
-        "x-request-id": "3a74d4f0-09a7-49b3-810c-e27f92765928"
+        "x-envoy-upstream-service-time": "109",
+        "x-request-id": "7e85db57-4075-4440-8787-95f609d68033"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a8454a2b-56e8-4982-a206-e56b9418c5c8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/28f4fec8-995b-48aa-93d6-dbdfb55c2f22",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e0f1d0a902cbe0428b1571a85bd20287-e9b62baa008a3c45-00",
+        "traceparent": "00-3530d9419ae6444282c31e1f9878e3b8-04ee32417386a543-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7fc1a327df9bae0512b796b5cae887b0",
@@ -325,19 +325,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "35352391-88eb-41b1-8c75-0f924f51d518",
+        "apim-request-id": "0f0aaa31-5f43-4687-b9c0-da665bd4d058",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:38 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "322",
-        "x-request-id": "35352391-88eb-41b1-8c75-0f924f51d518"
+        "x-envoy-upstream-service-time": "347",
+        "x-request-id": "0f0aaa31-5f43-4687-b9c0-da665bd4d058"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "382686735"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithChangeAndSmartConditionsAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithChangeAndSmartConditionsAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-61dcebbd249b064780e9432346a19ed3-4886abf5518f3c4c-00",
+        "traceparent": "00-c599455436d63f4694dc452a207a2588-43f7e2192340bd43-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2eb9b0784558b349a2be39346d2b6df2",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "26dcab0a-2da3-4062-9650-6cdad2da4f91",
+        "apim-request-id": "6031fda2-61a2-4c21-bdf5-65dce7718774",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:10 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/af7fd77a-1e47-4b3e-ba1b-5b9399ea08ea",
+        "Date": "Wed, 09 Jun 2021 23:03:44 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c9c84dd5-b832-46fe-ade7-68a30e91f18d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "656",
-        "x-request-id": "26dcab0a-2da3-4062-9650-6cdad2da4f91"
+        "x-envoy-upstream-service-time": "572",
+        "x-request-id": "6031fda2-61a2-4c21-bdf5-65dce7718774"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/af7fd77a-1e47-4b3e-ba1b-5b9399ea08ea",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c9c84dd5-b832-46fe-ade7-68a30e91f18d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-61dcebbd249b064780e9432346a19ed3-f891e1ba64d1c949-00",
+        "traceparent": "00-c599455436d63f4694dc452a207a2588-69153b68a1c0934a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c71c9468b47051de6e07414f9cb4028c",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "12a8dcc8-d3fd-4e9a-a960-0394e0961d1c",
+        "apim-request-id": "53a12d37-89de-4033-ad68-1c98177ac566",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:10 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "150",
-        "x-request-id": "12a8dcc8-d3fd-4e9a-a960-0394e0961d1c"
+        "x-envoy-upstream-service-time": "166",
+        "x-request-id": "53a12d37-89de-4033-ad68-1c98177ac566"
       },
       "ResponseBody": {
-        "dataFeedId": "af7fd77a-1e47-4b3e-ba1b-5b9399ea08ea",
+        "dataFeedId": "c9c84dd5-b832-46fe-ade7-68a30e91f18d",
         "dataFeedName": "dataFeedl1Toi7c6",
         "metrics": [
           {
-            "metricId": "636e05e6-8df8-4c9d-9ce7-320a033c97c5",
+            "metricId": "906d1194-9fba-46a7-9b3f-a666a2cb5802",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:10Z",
+        "createdTime": "2021-06-09T23:03:44Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "426",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-240c77fccc8da545804b7f3baad0c5b3-af4afcaf4dc61646-00",
+        "traceparent": "00-e753ef10e04e034f8dc98f84b4e21e9a-0870be2eda36ff45-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "12ef5a9662dabbdf5d1437febc9357c3",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "configRKbQC0nV",
-        "metricId": "636e05e6-8df8-4c9d-9ce7-320a033c97c5",
+        "metricId": "906d1194-9fba-46a7-9b3f-a666a2cb5802",
         "wholeMetricConfiguration": {
           "conditionOperator": "AND",
           "smartDetectionCondition": {
@@ -166,24 +166,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b8fa52cc-e2dd-4b2a-b67d-7cd2ae97a34e",
+        "apim-request-id": "3c29e466-12ac-4599-a1da-405132926f53",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:10 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2462af46-bedc-4e1c-a1d2-ff930d32bc59",
+        "Date": "Wed, 09 Jun 2021 23:03:44 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1ea5b8b2-5a86-48e2-94d1-a22a1ec61d60",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "101",
-        "x-request-id": "b8fa52cc-e2dd-4b2a-b67d-7cd2ae97a34e"
+        "x-envoy-upstream-service-time": "125",
+        "x-request-id": "3c29e466-12ac-4599-a1da-405132926f53"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2462af46-bedc-4e1c-a1d2-ff930d32bc59",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1ea5b8b2-5a86-48e2-94d1-a22a1ec61d60",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-240c77fccc8da545804b7f3baad0c5b3-15d7849c8a90764a-00",
+        "traceparent": "00-e753ef10e04e034f8dc98f84b4e21e9a-5f116c72c8acad46-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "51c067d1f904ed16bbad149cc21a2cf4",
@@ -192,20 +192,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aa216191-b1ef-46f8-b684-0cd61a6e8151",
+        "apim-request-id": "a0ef3e56-5e31-4919-b41f-e51f3ab24ca4",
         "Content-Length": "600",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:11 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "95",
-        "x-request-id": "aa216191-b1ef-46f8-b684-0cd61a6e8151"
+        "x-envoy-upstream-service-time": "116",
+        "x-request-id": "a0ef3e56-5e31-4919-b41f-e51f3ab24ca4"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "2462af46-bedc-4e1c-a1d2-ff930d32bc59",
+        "anomalyDetectionConfigurationId": "1ea5b8b2-5a86-48e2-94d1-a22a1ec61d60",
         "name": "configRKbQC0nV",
         "description": "",
-        "metricId": "636e05e6-8df8-4c9d-9ce7-320a033c97c5",
+        "metricId": "906d1194-9fba-46a7-9b3f-a666a2cb5802",
         "wholeMetricConfiguration": {
           "conditionOperator": "AND",
           "smartDetectionCondition": {
@@ -232,12 +232,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2462af46-bedc-4e1c-a1d2-ff930d32bc59",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1ea5b8b2-5a86-48e2-94d1-a22a1ec61d60",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-47ddcbc3d41c934089a1e8b48791b5ea-7cdd5527a9fcbe49-00",
+        "traceparent": "00-2f0b8b6bc30c0847b2f465e2601d3ab5-61857738dd078043-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "153088d1ccc50b772785f2887c03d08d",
@@ -246,20 +246,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e71c6264-32e0-4675-836b-e2033f2af40a",
+        "apim-request-id": "9f299d0c-ec01-49de-9d93-255cb9c6bec1",
         "Content-Length": "600",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:11 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "93",
-        "x-request-id": "e71c6264-32e0-4675-836b-e2033f2af40a"
+        "x-envoy-upstream-service-time": "95",
+        "x-request-id": "9f299d0c-ec01-49de-9d93-255cb9c6bec1"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "2462af46-bedc-4e1c-a1d2-ff930d32bc59",
+        "anomalyDetectionConfigurationId": "1ea5b8b2-5a86-48e2-94d1-a22a1ec61d60",
         "name": "configRKbQC0nV",
         "description": "",
-        "metricId": "636e05e6-8df8-4c9d-9ce7-320a033c97c5",
+        "metricId": "906d1194-9fba-46a7-9b3f-a666a2cb5802",
         "wholeMetricConfiguration": {
           "conditionOperator": "AND",
           "smartDetectionCondition": {
@@ -286,12 +286,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2462af46-bedc-4e1c-a1d2-ff930d32bc59",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1ea5b8b2-5a86-48e2-94d1-a22a1ec61d60",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-49ad8c678ba33e40be44d2e1ab9bdd7d-5999954dc0593e46-00",
+        "traceparent": "00-7796dfc92022b245bb637aca58b73af4-13ef3f7a11a52049-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5e80a57971b39c904301562d4e43f942",
@@ -300,23 +300,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "05085136-0edd-4425-bc5a-7708c321ba60",
+        "apim-request-id": "b7036eea-a2a6-487b-8b11-fd1bf1983013",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:11 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "94",
-        "x-request-id": "05085136-0edd-4425-bc5a-7708c321ba60"
+        "x-envoy-upstream-service-time": "90",
+        "x-request-id": "b7036eea-a2a6-487b-8b11-fd1bf1983013"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/af7fd77a-1e47-4b3e-ba1b-5b9399ea08ea",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c9c84dd5-b832-46fe-ade7-68a30e91f18d",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-31e0159e276ee743acf9a459f4ec81e1-6b7236ff9053a64f-00",
+        "traceparent": "00-69ab07c556491a469df36eea465aa7eb-9a95ec42b259ea43-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "332d43e7416205fef0b52a7e078e71b8",
@@ -325,19 +325,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1955158d-1765-4f59-8a8a-5a7303a9d692",
+        "apim-request-id": "53ba7b42-d192-4080-a2dc-043c87086739",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:11 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "302",
-        "x-request-id": "1955158d-1765-4f59-8a8a-5a7303a9d692"
+        "x-envoy-upstream-service-time": "328",
+        "x-request-id": "53ba7b42-d192-4080-a2dc-043c87086739"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "523565680"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithChangeAndSmartConditionsAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithChangeAndSmartConditionsAsync.json
@@ -1,6 +1,131 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-61dcebbd249b064780e9432346a19ed3-4886abf5518f3c4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2eb9b0784558b349a2be39346d2b6df2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedl1Toi7c6",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "26dcab0a-2da3-4062-9650-6cdad2da4f91",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:10 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/af7fd77a-1e47-4b3e-ba1b-5b9399ea08ea",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "656",
+        "x-request-id": "26dcab0a-2da3-4062-9650-6cdad2da4f91"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/af7fd77a-1e47-4b3e-ba1b-5b9399ea08ea",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-61dcebbd249b064780e9432346a19ed3-f891e1ba64d1c949-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c71c9468b47051de6e07414f9cb4028c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "12a8dcc8-d3fd-4e9a-a960-0394e0961d1c",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:10 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "12a8dcc8-d3fd-4e9a-a960-0394e0961d1c"
+      },
+      "ResponseBody": {
+        "dataFeedId": "af7fd77a-1e47-4b3e-ba1b-5b9399ea08ea",
+        "dataFeedName": "dataFeedl1Toi7c6",
+        "metrics": [
+          {
+            "metricId": "636e05e6-8df8-4c9d-9ce7-320a033c97c5",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:10Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,18 +133,15 @@
         "Content-Length": "426",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-24433cc3a442c54c8880c441f779a306-02e7a2c4965b6f40-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-240c77fccc8da545804b7f3baad0c5b3-af4afcaf4dc61646-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2eb9b0784558b349a2be39346d2b6df2",
+        "x-ms-client-request-id": "12ef5a9662dabbdf5d1437febc9357c3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configl1Toi7c6",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "name": "configRKbQC0nV",
+        "metricId": "636e05e6-8df8-4c9d-9ce7-320a033c97c5",
         "wholeMetricConfiguration": {
           "conditionOperator": "AND",
           "smartDetectionCondition": {
@@ -44,49 +166,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2d9eb6e6-cbac-44a3-8d6b-f8b8d8d072d6",
+        "apim-request-id": "b8fa52cc-e2dd-4b2a-b67d-7cd2ae97a34e",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:25 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8ca451f7-d8ff-4c86-b154-aa1769eece5b",
+        "Date": "Wed, 09 Jun 2021 19:46:10 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2462af46-bedc-4e1c-a1d2-ff930d32bc59",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "110",
-        "X-Request-ID": "2d9eb6e6-cbac-44a3-8d6b-f8b8d8d072d6"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "101",
+        "x-request-id": "b8fa52cc-e2dd-4b2a-b67d-7cd2ae97a34e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8ca451f7-d8ff-4c86-b154-aa1769eece5b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2462af46-bedc-4e1c-a1d2-ff930d32bc59",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-24433cc3a442c54c8880c441f779a306-172c6faf295c164c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-240c77fccc8da545804b7f3baad0c5b3-15d7849c8a90764a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c71c9468b47051de6e07414f9cb4028c",
+        "x-ms-client-request-id": "51c067d1f904ed16bbad149cc21a2cf4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9475ec8b-9b9c-486f-aca6-653f2ec4cf74",
+        "apim-request-id": "aa216191-b1ef-46f8-b684-0cd61a6e8151",
         "Content-Length": "600",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:25 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "90",
-        "X-Request-ID": "9475ec8b-9b9c-486f-aca6-653f2ec4cf74"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "95",
+        "x-request-id": "aa216191-b1ef-46f8-b684-0cd61a6e8151"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "8ca451f7-d8ff-4c86-b154-aa1769eece5b",
-        "name": "configl1Toi7c6",
+        "anomalyDetectionConfigurationId": "2462af46-bedc-4e1c-a1d2-ff930d32bc59",
+        "name": "configRKbQC0nV",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "636e05e6-8df8-4c9d-9ce7-320a033c97c5",
         "wholeMetricConfiguration": {
           "conditionOperator": "AND",
           "smartDetectionCondition": {
@@ -113,37 +232,34 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8ca451f7-d8ff-4c86-b154-aa1769eece5b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2462af46-bedc-4e1c-a1d2-ff930d32bc59",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5fe7ca481dba474bbee04341c9a3c091-2eda4a8643b40a4e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-47ddcbc3d41c934089a1e8b48791b5ea-7cdd5527a9fcbe49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "5269d12073c694c3965aef12da62dfbb",
+        "x-ms-client-request-id": "153088d1ccc50b772785f2887c03d08d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "79741882-e701-49f6-8102-a2f202d19e2c",
+        "apim-request-id": "e71c6264-32e0-4675-836b-e2033f2af40a",
         "Content-Length": "600",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:25 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "96",
-        "X-Request-ID": "79741882-e701-49f6-8102-a2f202d19e2c"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "93",
+        "x-request-id": "e71c6264-32e0-4675-836b-e2033f2af40a"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "8ca451f7-d8ff-4c86-b154-aa1769eece5b",
-        "name": "configl1Toi7c6",
+        "anomalyDetectionConfigurationId": "2462af46-bedc-4e1c-a1d2-ff930d32bc59",
+        "name": "configRKbQC0nV",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "636e05e6-8df8-4c9d-9ce7-320a033c97c5",
         "wholeMetricConfiguration": {
           "conditionOperator": "AND",
           "smartDetectionCondition": {
@@ -170,37 +286,58 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8ca451f7-d8ff-4c86-b154-aa1769eece5b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2462af46-bedc-4e1c-a1d2-ff930d32bc59",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3e5bd5028b37344cbd722dcfdf7bc0cd-91323644d2896042-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-49ad8c678ba33e40be44d2e1ab9bdd7d-5999954dc0593e46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "fe37145d93bcc357d167c05104f916ed",
+        "x-ms-client-request-id": "5e80a57971b39c904301562d4e43f942",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c14c557f-ef93-45e0-88a3-c7f485540086",
+        "apim-request-id": "05085136-0edd-4425-bc5a-7708c321ba60",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:25 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "100",
-        "X-Request-ID": "c14c557f-ef93-45e0-88a3-c7f485540086"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "94",
+        "x-request-id": "05085136-0edd-4425-bc5a-7708c321ba60"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/af7fd77a-1e47-4b3e-ba1b-5b9399ea08ea",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-31e0159e276ee743acf9a459f4ec81e1-6b7236ff9053a64f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "332d43e7416205fef0b52a7e078e71b8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "1955158d-1765-4f59-8a8a-5a7303a9d692",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "302",
+        "x-request-id": "1955158d-1765-4f59-8a8a-5a7303a9d692"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "523565680"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(False).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(False).json
@@ -1,26 +1,148 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "291",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ca2b2e11c3fc1543a96433384474ae63-7b85bfd7bea9d047-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-02000e013ba86e4dabc510d95cb301a6-6aa2b7d093272341-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2ca5d422939acf6a093597a0de17ece3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configlTkH8fQx",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedlTkH8fQx",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "30e63ca1-742f-4b8d-9a3c-eeb87323388f",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:45:54 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d99582cf-f4b4-423d-9ccb-dffd1a5c3b5f",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "602",
+        "x-request-id": "30e63ca1-742f-4b8d-9a3c-eeb87323388f"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d99582cf-f4b4-423d-9ccb-dffd1a5c3b5f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-02000e013ba86e4dabc510d95cb301a6-7470b1ba52b9494a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f7a83aefa5903813c8031c7b55256c9d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b82b4f5a-a18a-4dd6-8747-ae2d466a92a7",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:45:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "300",
+        "x-request-id": "b82b4f5a-a18a-4dd6-8747-ae2d466a92a7"
+      },
+      "ResponseBody": {
+        "dataFeedId": "d99582cf-f4b4-423d-9ccb-dffd1a5c3b5f",
+        "dataFeedName": "dataFeedlTkH8fQx",
+        "metrics": [
+          {
+            "metricId": "5a8ed145-9980-4b5f-916c-412e3e9e2c55",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:45:54Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "300",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4345c2280c0e9143a61b3f7606c0eb4a-0e7aff4eff9c6d4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "bcbcbed77fc2f1797f7b83fc3e49917c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configxmfLGtxX",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "5a8ed145-9980-4b5f-916c-412e3e9e2c55",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -34,49 +156,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e47d2dca-1adf-497a-ac9b-3999475c4bf0",
+        "apim-request-id": "e1cf2461-6f9f-4cd2-972d-33226ca345dc",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:22 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d270cfb1-6dc5-4987-842f-fd233aff8617",
+        "Date": "Wed, 09 Jun 2021 19:45:55 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/24c12d97-7990-4d2e-ab6e-f7c176ea5450",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "108",
-        "X-Request-ID": "e47d2dca-1adf-497a-ac9b-3999475c4bf0"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "117",
+        "x-request-id": "e1cf2461-6f9f-4cd2-972d-33226ca345dc"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d270cfb1-6dc5-4987-842f-fd233aff8617",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/24c12d97-7990-4d2e-ab6e-f7c176ea5450",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ca2b2e11c3fc1543a96433384474ae63-bb0c60b198d3ce41-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-4345c2280c0e9143a61b3f7606c0eb4a-eef559322a20f447-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f7a83aefa5903813c8031c7b55256c9d",
+        "x-ms-client-request-id": "96636cc0ef77e37ac8fa968d5e0c345c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9601818c-0f73-4429-8603-b94760d1f75d",
-        "Content-Length": "444",
+        "apim-request-id": "d9c1830c-df6b-44b0-9fb2-a3f70c50f9ee",
+        "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:22 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "135",
-        "X-Request-ID": "9601818c-0f73-4429-8603-b94760d1f75d"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "94",
+        "x-request-id": "d9c1830c-df6b-44b0-9fb2-a3f70c50f9ee"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "d270cfb1-6dc5-4987-842f-fd233aff8617",
-        "name": "configlTkH8fQx",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "anomalyDetectionConfigurationId": "24c12d97-7990-4d2e-ab6e-f7c176ea5450",
+        "name": "configxmfLGtxX",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "5a8ed145-9980-4b5f-916c-412e3e9e2c55",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -92,37 +211,34 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d270cfb1-6dc5-4987-842f-fd233aff8617",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/24c12d97-7990-4d2e-ab6e-f7c176ea5450",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a939fe5f55e81946972447fd799b4112-ddc987457ed3644f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-9d205d5e4947b547acf608ac98fe8de2-cbcd973a2e2a974a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e0b8500992af4c65d7bebcbcc27f79f1",
+        "x-ms-client-request-id": "d21f5bd557e94875892bfbd9a1705fc0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e92501b3-cd5a-4f92-bf9c-df6f93f6f29a",
-        "Content-Length": "444",
+        "apim-request-id": "1545eb85-9a63-44f4-bccd-879fab512da6",
+        "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:22 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "92",
-        "X-Request-ID": "e92501b3-cd5a-4f92-bf9c-df6f93f6f29a"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "184",
+        "x-request-id": "1545eb85-9a63-44f4-bccd-879fab512da6"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "d270cfb1-6dc5-4987-842f-fd233aff8617",
-        "name": "configlTkH8fQx",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "anomalyDetectionConfigurationId": "24c12d97-7990-4d2e-ab6e-f7c176ea5450",
+        "name": "configxmfLGtxX",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "5a8ed145-9980-4b5f-916c-412e3e9e2c55",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -138,37 +254,58 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d270cfb1-6dc5-4987-842f-fd233aff8617",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/24c12d97-7990-4d2e-ab6e-f7c176ea5450",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1e6826597f1ff047a81f0a943ea134f9-9d810c443b4f9440-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-2526099a97f9c144ab2424b6800bd0ab-441441ee42e9684f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "fc837b7f493e7c91c06c639677ef7ae3",
+        "x-ms-client-request-id": "421f3cbfce2fe8d544d8f3c8e9ec9273",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "164b9f8a-89d4-4fb9-986b-52f9e638b6c9",
+        "apim-request-id": "ae881237-9aab-41cd-97e9-bb77641f1e86",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:22 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "94",
-        "X-Request-ID": "164b9f8a-89d4-4fb9-986b-52f9e638b6c9"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "112",
+        "x-request-id": "ae881237-9aab-41cd-97e9-bb77641f1e86"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d99582cf-f4b4-423d-9ccb-dffd1a5c3b5f",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c0d815406ecf7d45a81075859da55146-f17562da8624174f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e2272646be296993f61b0d4bf3a04157",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "da5d68c2-61b0-4939-8659-36b34a26d9b3",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:45:56 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "328",
+        "x-request-id": "da5d68c2-61b0-4939-8659-36b34a26d9b3"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "210382487"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(False).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(False).json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-02000e013ba86e4dabc510d95cb301a6-6aa2b7d093272341-00",
+        "traceparent": "00-0a0807e3be7df2489cf3ecd90277cd1d-0904a7446bbf5048-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2ca5d422939acf6a093597a0de17ece3",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "30e63ca1-742f-4b8d-9a3c-eeb87323388f",
+        "apim-request-id": "4889fd44-efaa-4148-8f1f-45ef0440f24f",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:54 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d99582cf-f4b4-423d-9ccb-dffd1a5c3b5f",
+        "Date": "Wed, 09 Jun 2021 23:03:28 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/27145c6a-a9e2-41ab-99df-2e536a63e2d7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "602",
-        "x-request-id": "30e63ca1-742f-4b8d-9a3c-eeb87323388f"
+        "x-envoy-upstream-service-time": "392",
+        "x-request-id": "4889fd44-efaa-4148-8f1f-45ef0440f24f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d99582cf-f4b4-423d-9ccb-dffd1a5c3b5f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/27145c6a-a9e2-41ab-99df-2e536a63e2d7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-02000e013ba86e4dabc510d95cb301a6-7470b1ba52b9494a-00",
+        "traceparent": "00-0a0807e3be7df2489cf3ecd90277cd1d-bea06b02ae577f4e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f7a83aefa5903813c8031c7b55256c9d",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b82b4f5a-a18a-4dd6-8747-ae2d466a92a7",
+        "apim-request-id": "75832ae3-50b4-4250-a86d-648956048f68",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:54 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "300",
-        "x-request-id": "b82b4f5a-a18a-4dd6-8747-ae2d466a92a7"
+        "x-envoy-upstream-service-time": "161",
+        "x-request-id": "75832ae3-50b4-4250-a86d-648956048f68"
       },
       "ResponseBody": {
-        "dataFeedId": "d99582cf-f4b4-423d-9ccb-dffd1a5c3b5f",
+        "dataFeedId": "27145c6a-a9e2-41ab-99df-2e536a63e2d7",
         "dataFeedName": "dataFeedlTkH8fQx",
         "metrics": [
           {
-            "metricId": "5a8ed145-9980-4b5f-916c-412e3e9e2c55",
+            "metricId": "a0fc0a3e-2268-4971-8f0d-f28d5fdae91c",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:45:54Z",
+        "createdTime": "2021-06-09T23:03:29Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "300",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4345c2280c0e9143a61b3f7606c0eb4a-0e7aff4eff9c6d4d-00",
+        "traceparent": "00-87d641416271d94db49b370d815af1bb-8852c2ac05cfda4c-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bcbcbed77fc2f1797f7b83fc3e49917c",
@@ -142,7 +142,7 @@
       "RequestBody": {
         "name": "configxmfLGtxX",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "5a8ed145-9980-4b5f-916c-412e3e9e2c55",
+        "metricId": "a0fc0a3e-2268-4971-8f0d-f28d5fdae91c",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -156,24 +156,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e1cf2461-6f9f-4cd2-972d-33226ca345dc",
+        "apim-request-id": "66986c6e-6873-4468-be89-35b9b6bcb1c6",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:55 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/24c12d97-7990-4d2e-ab6e-f7c176ea5450",
+        "Date": "Wed, 09 Jun 2021 23:03:29 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/81a12862-f503-4396-a57b-7eeb2e16e239",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "117",
-        "x-request-id": "e1cf2461-6f9f-4cd2-972d-33226ca345dc"
+        "x-envoy-upstream-service-time": "123",
+        "x-request-id": "66986c6e-6873-4468-be89-35b9b6bcb1c6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/24c12d97-7990-4d2e-ab6e-f7c176ea5450",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/81a12862-f503-4396-a57b-7eeb2e16e239",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4345c2280c0e9143a61b3f7606c0eb4a-eef559322a20f447-00",
+        "traceparent": "00-87d641416271d94db49b370d815af1bb-f524a207bdce034d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "96636cc0ef77e37ac8fa968d5e0c345c",
@@ -182,20 +182,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d9c1830c-df6b-44b0-9fb2-a3f70c50f9ee",
+        "apim-request-id": "0e04a7c9-4c58-46dc-a562-d838b74e4b10",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:55 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "94",
-        "x-request-id": "d9c1830c-df6b-44b0-9fb2-a3f70c50f9ee"
+        "x-envoy-upstream-service-time": "99",
+        "x-request-id": "0e04a7c9-4c58-46dc-a562-d838b74e4b10"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "24c12d97-7990-4d2e-ab6e-f7c176ea5450",
+        "anomalyDetectionConfigurationId": "81a12862-f503-4396-a57b-7eeb2e16e239",
         "name": "configxmfLGtxX",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "5a8ed145-9980-4b5f-916c-412e3e9e2c55",
+        "metricId": "a0fc0a3e-2268-4971-8f0d-f28d5fdae91c",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -211,12 +211,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/24c12d97-7990-4d2e-ab6e-f7c176ea5450",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/81a12862-f503-4396-a57b-7eeb2e16e239",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9d205d5e4947b547acf608ac98fe8de2-cbcd973a2e2a974a-00",
+        "traceparent": "00-c45fa39577479f4683b90364c5858939-13e634f0fe201947-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d21f5bd557e94875892bfbd9a1705fc0",
@@ -225,20 +225,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1545eb85-9a63-44f4-bccd-879fab512da6",
+        "apim-request-id": "42f86db9-de35-4c6e-bd51-7a3b739a1424",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:55 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "184",
-        "x-request-id": "1545eb85-9a63-44f4-bccd-879fab512da6"
+        "x-envoy-upstream-service-time": "99",
+        "x-request-id": "42f86db9-de35-4c6e-bd51-7a3b739a1424"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "24c12d97-7990-4d2e-ab6e-f7c176ea5450",
+        "anomalyDetectionConfigurationId": "81a12862-f503-4396-a57b-7eeb2e16e239",
         "name": "configxmfLGtxX",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "5a8ed145-9980-4b5f-916c-412e3e9e2c55",
+        "metricId": "a0fc0a3e-2268-4971-8f0d-f28d5fdae91c",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -254,12 +254,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/24c12d97-7990-4d2e-ab6e-f7c176ea5450",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/81a12862-f503-4396-a57b-7eeb2e16e239",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2526099a97f9c144ab2424b6800bd0ab-441441ee42e9684f-00",
+        "traceparent": "00-1f59904484d4704282f4ea250eff4770-4a7d9134a2d96c40-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "421f3cbfce2fe8d544d8f3c8e9ec9273",
@@ -268,23 +268,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ae881237-9aab-41cd-97e9-bb77641f1e86",
+        "apim-request-id": "d46bf952-6876-4451-885f-718efa295039",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:55 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "112",
-        "x-request-id": "ae881237-9aab-41cd-97e9-bb77641f1e86"
+        "x-envoy-upstream-service-time": "109",
+        "x-request-id": "d46bf952-6876-4451-885f-718efa295039"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d99582cf-f4b4-423d-9ccb-dffd1a5c3b5f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/27145c6a-a9e2-41ab-99df-2e536a63e2d7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c0d815406ecf7d45a81075859da55146-f17562da8624174f-00",
+        "traceparent": "00-0ae6f52981b88240bb734d972f95e891-5c5a00e3732e544b-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e2272646be296993f61b0d4bf3a04157",
@@ -293,19 +293,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "da5d68c2-61b0-4939-8659-36b34a26d9b3",
+        "apim-request-id": "1ea580fc-345f-47d4-b21a-f79f03ebc1dd",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:56 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "328",
-        "x-request-id": "da5d68c2-61b0-4939-8659-36b34a26d9b3"
+        "x-envoy-upstream-service-time": "343",
+        "x-request-id": "1ea580fc-345f-47d4-b21a-f79f03ebc1dd"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "210382487"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(False)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(False)Async.json
@@ -1,26 +1,148 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "291",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-378065bac336b94c819b6bfcec82dd22-00a31ecbf114894e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-2a3ef88050c3444a83f1e77cfb9a2aa8-d1bae41f499e9c46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b4e98f7b817bc1d3a392282cab35f636",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configHYYpIhhd",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedHYYpIhhd",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "80ed37f4-8aa0-446f-8f62-5cff65666d26",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19a0b24f-9f6f-45f4-b708-27d6c3483a80",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "632",
+        "x-request-id": "80ed37f4-8aa0-446f-8f62-5cff65666d26"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19a0b24f-9f6f-45f4-b708-27d6c3483a80",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2a3ef88050c3444a83f1e77cfb9a2aa8-a0455ecfd1f9c045-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b8f0908ea2dd6c264f7c649735da41de",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "87571af2-bcfd-4178-9569-343535823174",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "154",
+        "x-request-id": "87571af2-bcfd-4178-9569-343535823174"
+      },
+      "ResponseBody": {
+        "dataFeedId": "19a0b24f-9f6f-45f4-b708-27d6c3483a80",
+        "dataFeedName": "dataFeedHYYpIhhd",
+        "metrics": [
+          {
+            "metricId": "e99e2393-cf6a-4f00-af59-e3e4621eb874",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:23Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "300",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-aca231748ff3984097b9db9290683b2a-16855db105c8794e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "25ed2183d40e2a31dc57ee8de74ab8d8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configJNjHbsWv",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "e99e2393-cf6a-4f00-af59-e3e4621eb874",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -34,49 +156,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6d79c7fb-546e-452e-9872-4e593d1efc1c",
+        "apim-request-id": "f5a5c47e-9321-4ad7-9962-322759d124c9",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:31 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9f409bb6-15c2-48a4-82a3-4f95c4b011f6",
+        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "89",
-        "X-Request-ID": "6d79c7fb-546e-452e-9872-4e593d1efc1c"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "104",
+        "x-request-id": "f5a5c47e-9321-4ad7-9962-322759d124c9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9f409bb6-15c2-48a4-82a3-4f95c4b011f6",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-378065bac336b94c819b6bfcec82dd22-395f16bc26213d45-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-aca231748ff3984097b9db9290683b2a-f1cbfe266acad648-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b8f0908ea2dd6c264f7c649735da41de",
+        "x-ms-client-request-id": "fe647d683b1cc88b5049ae402f4f211f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aa6c170b-5d7d-427b-8f5e-e7fc5c5c541a",
-        "Content-Length": "444",
+        "apim-request-id": "d8eda4d1-bb35-45e6-8e4a-2f9af0191a48",
+        "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:31 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "92",
-        "X-Request-ID": "aa6c170b-5d7d-427b-8f5e-e7fc5c5c541a"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "93",
+        "x-request-id": "d8eda4d1-bb35-45e6-8e4a-2f9af0191a48"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "9f409bb6-15c2-48a4-82a3-4f95c4b011f6",
-        "name": "configHYYpIhhd",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "anomalyDetectionConfigurationId": "c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
+        "name": "configJNjHbsWv",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "e99e2393-cf6a-4f00-af59-e3e4621eb874",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -92,37 +211,34 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9f409bb6-15c2-48a4-82a3-4f95c4b011f6",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cdb5535d88aae9428cd8db13634d082e-ec6c64ce78787549-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-b85beda1f962a545a5b590b094180284-3c956b92af457449-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a7056a7e6e1494e78321ed250ed4312a",
+        "x-ms-client-request-id": "bb345ba901b57a5d4b39bbdeecb3f634",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "70881445-9b72-453e-bf1b-1e8974d27dcc",
-        "Content-Length": "444",
+        "apim-request-id": "6c1fdc1e-9f4e-4a03-a81a-ba4a5478a9ec",
+        "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:31 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "82",
-        "X-Request-ID": "70881445-9b72-453e-bf1b-1e8974d27dcc"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "99",
+        "x-request-id": "6c1fdc1e-9f4e-4a03-a81a-ba4a5478a9ec"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "9f409bb6-15c2-48a4-82a3-4f95c4b011f6",
-        "name": "configHYYpIhhd",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "anomalyDetectionConfigurationId": "c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
+        "name": "configJNjHbsWv",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "e99e2393-cf6a-4f00-af59-e3e4621eb874",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -138,37 +254,58 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9f409bb6-15c2-48a4-82a3-4f95c4b011f6",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b9aea4332dee6f4984601391e4152619-e7fbfbe5b625414f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-a038de52ad2e0c44a1659744d4ab01b6-8475628e212c5146-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8dee57dc4ae7d8b8687d64fe1c3b8bc8",
+        "x-ms-client-request-id": "973e2cb1e80a47779625d4c526f0fb8d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2bc1c48e-49ee-4c64-8731-35dfb2218a07",
+        "apim-request-id": "8c9fb1cb-7699-4478-afb2-ced7f375abc2",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:31 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "99",
-        "X-Request-ID": "2bc1c48e-49ee-4c64-8731-35dfb2218a07"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "98",
+        "x-request-id": "8c9fb1cb-7699-4478-afb2-ced7f375abc2"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19a0b24f-9f6f-45f4-b708-27d6c3483a80",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a975ee995a8144a81c9e0d0ae286582-a10a0ba45bbb6c46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8be4ce35fc1567231fe9b2e380acdb9c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "56a1915c-a4bc-464b-bfe0-a536a22c0340",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "298",
+        "x-request-id": "56a1915c-a4bc-464b-bfe0-a536a22c0340"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "931946336"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(False)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(False)Async.json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2a3ef88050c3444a83f1e77cfb9a2aa8-d1bae41f499e9c46-00",
+        "traceparent": "00-c2fbe943139774419f488c3f2c38f678-3a74e05bb196b045-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b4e98f7b817bc1d3a392282cab35f636",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "80ed37f4-8aa0-446f-8f62-5cff65666d26",
+        "apim-request-id": "a281fcf6-3de1-4b4c-b259-59396d4addd8",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19a0b24f-9f6f-45f4-b708-27d6c3483a80",
+        "Date": "Wed, 09 Jun 2021 23:03:51 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0abc58a8-3d4e-4b96-8325-7f2e00f58b47",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "632",
-        "x-request-id": "80ed37f4-8aa0-446f-8f62-5cff65666d26"
+        "x-envoy-upstream-service-time": "556",
+        "x-request-id": "a281fcf6-3de1-4b4c-b259-59396d4addd8"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19a0b24f-9f6f-45f4-b708-27d6c3483a80",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0abc58a8-3d4e-4b96-8325-7f2e00f58b47",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2a3ef88050c3444a83f1e77cfb9a2aa8-a0455ecfd1f9c045-00",
+        "traceparent": "00-c2fbe943139774419f488c3f2c38f678-900ef64de6d7a94f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b8f0908ea2dd6c264f7c649735da41de",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "87571af2-bcfd-4178-9569-343535823174",
+        "apim-request-id": "544c5b74-12fd-4282-953b-dacbd1bca1c2",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "154",
-        "x-request-id": "87571af2-bcfd-4178-9569-343535823174"
+        "x-envoy-upstream-service-time": "181",
+        "x-request-id": "544c5b74-12fd-4282-953b-dacbd1bca1c2"
       },
       "ResponseBody": {
-        "dataFeedId": "19a0b24f-9f6f-45f4-b708-27d6c3483a80",
+        "dataFeedId": "0abc58a8-3d4e-4b96-8325-7f2e00f58b47",
         "dataFeedName": "dataFeedHYYpIhhd",
         "metrics": [
           {
-            "metricId": "e99e2393-cf6a-4f00-af59-e3e4621eb874",
+            "metricId": "e9015909-7d5e-4afb-ac5e-48893f398219",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:23Z",
+        "createdTime": "2021-06-09T23:03:51Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "300",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-aca231748ff3984097b9db9290683b2a-16855db105c8794e-00",
+        "traceparent": "00-d284d59988e1c74d8187eb309bc8c40c-4e29e328b681cd4f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "25ed2183d40e2a31dc57ee8de74ab8d8",
@@ -142,7 +142,7 @@
       "RequestBody": {
         "name": "configJNjHbsWv",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "e99e2393-cf6a-4f00-af59-e3e4621eb874",
+        "metricId": "e9015909-7d5e-4afb-ac5e-48893f398219",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -156,24 +156,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f5a5c47e-9321-4ad7-9962-322759d124c9",
+        "apim-request-id": "e054665f-59d3-49ea-9b79-c79283c99944",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
+        "Date": "Wed, 09 Jun 2021 23:03:52 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3f76a5e-6d03-489f-9c1f-bce406f14b00",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "104",
-        "x-request-id": "f5a5c47e-9321-4ad7-9962-322759d124c9"
+        "x-envoy-upstream-service-time": "109",
+        "x-request-id": "e054665f-59d3-49ea-9b79-c79283c99944"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3f76a5e-6d03-489f-9c1f-bce406f14b00",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-aca231748ff3984097b9db9290683b2a-f1cbfe266acad648-00",
+        "traceparent": "00-d284d59988e1c74d8187eb309bc8c40c-ad8ae731fb8e5142-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fe647d683b1cc88b5049ae402f4f211f",
@@ -182,20 +182,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d8eda4d1-bb35-45e6-8e4a-2f9af0191a48",
+        "apim-request-id": "f4389bcb-5a1e-4c7d-b49f-34a0bf4e3963",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "93",
-        "x-request-id": "d8eda4d1-bb35-45e6-8e4a-2f9af0191a48"
+        "x-envoy-upstream-service-time": "91",
+        "x-request-id": "f4389bcb-5a1e-4c7d-b49f-34a0bf4e3963"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
+        "anomalyDetectionConfigurationId": "b3f76a5e-6d03-489f-9c1f-bce406f14b00",
         "name": "configJNjHbsWv",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "e99e2393-cf6a-4f00-af59-e3e4621eb874",
+        "metricId": "e9015909-7d5e-4afb-ac5e-48893f398219",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -211,12 +211,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3f76a5e-6d03-489f-9c1f-bce406f14b00",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b85beda1f962a545a5b590b094180284-3c956b92af457449-00",
+        "traceparent": "00-6cb5c6ff0cf50d42a2561d2de40e11e5-ce0c3504c98b7547-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bb345ba901b57a5d4b39bbdeecb3f634",
@@ -225,20 +225,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6c1fdc1e-9f4e-4a03-a81a-ba4a5478a9ec",
+        "apim-request-id": "fda4a367-a351-48f1-897d-00fc7e37573d",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "99",
-        "x-request-id": "6c1fdc1e-9f4e-4a03-a81a-ba4a5478a9ec"
+        "x-envoy-upstream-service-time": "82",
+        "x-request-id": "fda4a367-a351-48f1-897d-00fc7e37573d"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
+        "anomalyDetectionConfigurationId": "b3f76a5e-6d03-489f-9c1f-bce406f14b00",
         "name": "configJNjHbsWv",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "e99e2393-cf6a-4f00-af59-e3e4621eb874",
+        "metricId": "e9015909-7d5e-4afb-ac5e-48893f398219",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -254,12 +254,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c5264a13-6b97-45a8-8bc4-a396a9c54cc7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3f76a5e-6d03-489f-9c1f-bce406f14b00",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a038de52ad2e0c44a1659744d4ab01b6-8475628e212c5146-00",
+        "traceparent": "00-84efbb41eb8ae64fb61da0566ca10bf7-7476c9c7cf7b6b4d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "973e2cb1e80a47779625d4c526f0fb8d",
@@ -268,23 +268,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8c9fb1cb-7699-4478-afb2-ced7f375abc2",
+        "apim-request-id": "1ee2dec1-bb1b-46aa-8d00-86a7bf53a1db",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:23 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "98",
-        "x-request-id": "8c9fb1cb-7699-4478-afb2-ced7f375abc2"
+        "x-envoy-upstream-service-time": "96",
+        "x-request-id": "1ee2dec1-bb1b-46aa-8d00-86a7bf53a1db"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19a0b24f-9f6f-45f4-b708-27d6c3483a80",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0abc58a8-3d4e-4b96-8325-7f2e00f58b47",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1a975ee995a8144a81c9e0d0ae286582-a10a0ba45bbb6c46-00",
+        "traceparent": "00-0c453a2b1b3efa45be50bf47d54b9d1c-40f90a1d1e4d9249-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8be4ce35fc1567231fe9b2e380acdb9c",
@@ -293,19 +293,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "56a1915c-a4bc-464b-bfe0-a536a22c0340",
+        "apim-request-id": "ae89207b-8547-4c6f-92a8-55a22d1add4e",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:24 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "298",
-        "x-request-id": "56a1915c-a4bc-464b-bfe0-a536a22c0340"
+        "x-envoy-upstream-service-time": "291",
+        "x-request-id": "ae89207b-8547-4c6f-92a8-55a22d1add4e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "931946336"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True).json
@@ -1,25 +1,148 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "291",
+        "Content-Length": "312",
         "Content-Type": "application/json",
-        "traceparent": "00-78b97f2f0dcf3547a71a123a19cecd44-551225a49b7dce4f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e45d5d82ce0a094dbb65d30b79851c1b-f7c187b9ef330a47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c4356899a592ddcf9fece7f6ab1d765a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configQemmjwy9",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedQemmjwy9",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "6414370b-d9f0-4312-a5ec-5b165945633e",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:45:47 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a12e877c-7898-466f-b86f-1c40506e7ab0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "422",
+        "x-request-id": "6414370b-d9f0-4312-a5ec-5b165945633e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a12e877c-7898-466f-b86f-1c40506e7ab0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e45d5d82ce0a094dbb65d30b79851c1b-140ae7b6e4469f48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6b8e2df8a6197cb6e3175c37d4a3e2b9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ee76b0ba-2b33-4d4d-aec8-82a21a505533",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:45:47 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "163",
+        "x-request-id": "ee76b0ba-2b33-4d4d-aec8-82a21a505533"
+      },
+      "ResponseBody": {
+        "dataFeedId": "a12e877c-7898-466f-b86f-1c40506e7ab0",
+        "dataFeedName": "dataFeedQemmjwy9",
+        "metrics": [
+          {
+            "metricId": "985da3b4-766d-47a4-8219-70597a0d7235",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:45:47Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "300",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-adb20467010c924ca2a222b92ad2315d-e517ae23bfbff444-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c7b52ff8f6235f59803f406120c631f2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configkElCSrFg",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "985da3b4-766d-47a4-8219-70597a0d7235",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -33,48 +156,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "9686f994-b069-4f2e-8ced-f2b174668c1c",
+        "apim-request-id": "8cd1ad81-5c08-402b-9501-3ee29615ab4d",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:21 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1b673ef7-1fcb-4ca5-a416-e80b19a774e0",
+        "Date": "Wed, 09 Jun 2021 19:45:53 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "46",
-        "X-Request-ID": "9686f994-b069-4f2e-8ced-f2b174668c1c"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5134",
+        "x-request-id": "8cd1ad81-5c08-402b-9501-3ee29615ab4d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1b673ef7-1fcb-4ca5-a416-e80b19a774e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-78b97f2f0dcf3547a71a123a19cecd44-5a3d29e2730d5549-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "6b8e2df8a6197cb6e3175c37d4a3e2b9",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-adb20467010c924ca2a222b92ad2315d-16d4f3c58c70e34d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7be1b9b29848fc090a2da53b011bc2d5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6dc0ea95-f033-4359-a404-f450ff24cedb",
-        "Content-Length": "444",
+        "apim-request-id": "47e15d3f-4efb-453b-b71b-4e7eabfcef82",
+        "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:22 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30",
-        "X-Request-ID": "6dc0ea95-f033-4359-a404-f450ff24cedb"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "91",
+        "x-request-id": "47e15d3f-4efb-453b-b71b-4e7eabfcef82"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "1b673ef7-1fcb-4ca5-a416-e80b19a774e0",
-        "name": "configQemmjwy9",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "anomalyDetectionConfigurationId": "cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
+        "name": "configkElCSrFg",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "985da3b4-766d-47a4-8219-70597a0d7235",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -90,36 +211,34 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1b673ef7-1fcb-4ca5-a416-e80b19a774e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-4cf8de0397e4d6468d1eb685dc009b53-88a8c07b06a20e44-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "5b1c705022976292f82fb5c723f6595f",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1676288c40a86348906343b43a950753-91c09d31e230bc42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e9722c9beff1ec59befdb6956281988a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a70a96ac-3aca-46f4-b5ae-db48cc2875a1",
-        "Content-Length": "444",
+        "apim-request-id": "3dd4df16-6e45-4799-9cef-a68b16d4cb83",
+        "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:22 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32",
-        "X-Request-ID": "a70a96ac-3aca-46f4-b5ae-db48cc2875a1"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "98",
+        "x-request-id": "3dd4df16-6e45-4799-9cef-a68b16d4cb83"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "1b673ef7-1fcb-4ca5-a416-e80b19a774e0",
-        "name": "configQemmjwy9",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "anomalyDetectionConfigurationId": "cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
+        "name": "configkElCSrFg",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "985da3b4-766d-47a4-8219-70597a0d7235",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -135,36 +254,60 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1b673ef7-1fcb-4ca5-a416-e80b19a774e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-06bd517cfb5a95428c940fd23b74141d-ab6a5b7e32039e41-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "61403f80c620f231b2b9e17b489809fc",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7d0be5a49ddbc14683907e629f08d538-cdec9d2762d7a14e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "dea8293e1641601926b9bdf5501d5e64",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "272e8e49-1d70-4606-bfaf-e73ddaea1d3f",
+        "apim-request-id": "7fdb8a79-4a86-4ced-a0cd-ac9780d79e19",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:22 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "37",
-        "X-Request-ID": "272e8e49-1d70-4606-bfaf-e73ddaea1d3f"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "107",
+        "x-request-id": "7fdb8a79-4a86-4ced-a0cd-ac9780d79e19"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a12e877c-7898-466f-b86f-1c40506e7ab0",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-665e696b38215a45bd7558888ad938ec-85e916ad18359c49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f4c56a7c4853c2015ff4bd4be1739988",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "68e1f305-6f7f-4bd1-9be0-f72f6537e6df",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:45:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "310",
+        "x-request-id": "68e1f305-6f7f-4bd1-9be0-f72f6537e6df"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "1983154513"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True).json
@@ -5,12 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
+        "Authorization": "Sanitized",
         "Content-Length": "312",
         "Content-Type": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e45d5d82ce0a094dbb65d30b79851c1b-f7c187b9ef330a47-00",
+        "traceparent": "00-a39f6b74f3c6744a976b62064ce181bf-5b15fed178cddd4c-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c4356899a592ddcf9fece7f6ab1d765a",
         "x-ms-return-client-request-id": "true"
       },
@@ -39,47 +38,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6414370b-d9f0-4312-a5ec-5b165945633e",
+        "apim-request-id": "2d3be348-9d8e-4c27-b6ca-1644bc85ab1e",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:47 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a12e877c-7898-466f-b86f-1c40506e7ab0",
+        "Date": "Wed, 09 Jun 2021 21:38:19 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fcebf2f-1aa4-4b35-9ffa-d54ba96e28a4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "422",
-        "x-request-id": "6414370b-d9f0-4312-a5ec-5b165945633e"
+        "x-envoy-upstream-service-time": "845",
+        "x-request-id": "2d3be348-9d8e-4c27-b6ca-1644bc85ab1e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a12e877c-7898-466f-b86f-1c40506e7ab0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fcebf2f-1aa4-4b35-9ffa-d54ba96e28a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e45d5d82ce0a094dbb65d30b79851c1b-140ae7b6e4469f48-00",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a39f6b74f3c6744a976b62064ce181bf-6f8b58a8dafb994d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6b8e2df8a6197cb6e3175c37d4a3e2b9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ee76b0ba-2b33-4d4d-aec8-82a21a505533",
-        "Content-Length": "1010",
+        "apim-request-id": "b2605dc2-de32-440d-957d-2e9e909bd7d2",
+        "Content-Length": "1052",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:47 GMT",
+        "Date": "Wed, 09 Jun 2021 21:38:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "163",
-        "x-request-id": "ee76b0ba-2b33-4d4d-aec8-82a21a505533"
+        "x-envoy-upstream-service-time": "5203",
+        "x-request-id": "b2605dc2-de32-440d-957d-2e9e909bd7d2"
       },
       "ResponseBody": {
-        "dataFeedId": "a12e877c-7898-466f-b86f-1c40506e7ab0",
+        "dataFeedId": "0fcebf2f-1aa4-4b35-9ffa-d54ba96e28a4",
         "dataFeedName": "dataFeedQemmjwy9",
         "metrics": [
           {
-            "metricId": "985da3b4-766d-47a4-8219-70597a0d7235",
+            "metricId": "0f55fe17-d179-4df4-a198-fd7442a1b5be",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -111,12 +109,12 @@
         "maxConcurrency": -1,
         "viewMode": "Private",
         "admins": [
-          "foo@contoso.com"
+          "94dc466b-52e4-4678-892d-70a0c45c5f42"
         ],
         "viewers": [],
-        "creator": "foo@contoso.com",
+        "creator": "94dc466b-52e4-4678-892d-70a0c45c5f42",
         "status": "Active",
-        "createdTime": "2021-06-09T19:45:47Z",
+        "createdTime": "2021-06-09T21:38:19Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -130,19 +128,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
+        "Authorization": "Sanitized",
         "Content-Length": "300",
         "Content-Type": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-adb20467010c924ca2a222b92ad2315d-e517ae23bfbff444-00",
+        "traceparent": "00-89e84a0fa94dd1468b7a3480b4255156-11c89cba1f961b4a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c7b52ff8f6235f59803f406120c631f2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "name": "configkElCSrFg",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "985da3b4-766d-47a4-8219-70597a0d7235",
+        "metricId": "0f55fe17-d179-4df4-a198-fd7442a1b5be",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -156,46 +153,45 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8cd1ad81-5c08-402b-9501-3ee29615ab4d",
+        "apim-request-id": "b4f10ffd-d5a2-4890-9276-5d9d1cbc6e86",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:53 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
+        "Date": "Wed, 09 Jun 2021 21:38:30 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e9164717-5246-4d0f-a5d3-4e428fb48a31",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5134",
-        "x-request-id": "8cd1ad81-5c08-402b-9501-3ee29615ab4d"
+        "x-envoy-upstream-service-time": "5162",
+        "x-request-id": "b4f10ffd-d5a2-4890-9276-5d9d1cbc6e86"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e9164717-5246-4d0f-a5d3-4e428fb48a31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-adb20467010c924ca2a222b92ad2315d-16d4f3c58c70e34d-00",
+        "Authorization": "Sanitized",
+        "traceparent": "00-89e84a0fa94dd1468b7a3480b4255156-2356e96f4350bc43-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7be1b9b29848fc090a2da53b011bc2d5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "47e15d3f-4efb-453b-b71b-4e7eabfcef82",
+        "apim-request-id": "a84f70e6-0929-4228-ab1c-d618a7b685b2",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:53 GMT",
+        "Date": "Wed, 09 Jun 2021 21:38:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "91",
-        "x-request-id": "47e15d3f-4efb-453b-b71b-4e7eabfcef82"
+        "x-envoy-upstream-service-time": "125",
+        "x-request-id": "a84f70e6-0929-4228-ab1c-d618a7b685b2"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
+        "anomalyDetectionConfigurationId": "e9164717-5246-4d0f-a5d3-4e428fb48a31",
         "name": "configkElCSrFg",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "985da3b4-766d-47a4-8219-70597a0d7235",
+        "metricId": "0f55fe17-d179-4df4-a198-fd7442a1b5be",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -211,34 +207,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e9164717-5246-4d0f-a5d3-4e428fb48a31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1676288c40a86348906343b43a950753-91c09d31e230bc42-00",
+        "Authorization": "Sanitized",
+        "traceparent": "00-30bc2840caf3bd40804d689479035bea-b30d75e933ff3e4a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e9722c9beff1ec59befdb6956281988a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3dd4df16-6e45-4799-9cef-a68b16d4cb83",
+        "apim-request-id": "1135208c-cd87-47bd-abbc-a56fd4c70d25",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:53 GMT",
+        "Date": "Wed, 09 Jun 2021 21:38:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "98",
-        "x-request-id": "3dd4df16-6e45-4799-9cef-a68b16d4cb83"
+        "x-envoy-upstream-service-time": "53",
+        "x-request-id": "1135208c-cd87-47bd-abbc-a56fd4c70d25"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
+        "anomalyDetectionConfigurationId": "e9164717-5246-4d0f-a5d3-4e428fb48a31",
         "name": "configkElCSrFg",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "985da3b4-766d-47a4-8219-70597a0d7235",
+        "metricId": "0f55fe17-d179-4df4-a198-fd7442a1b5be",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -254,60 +249,56 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cc117ee9-2feb-4b74-bbef-76fa2fb004ca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e9164717-5246-4d0f-a5d3-4e428fb48a31",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7d0be5a49ddbc14683907e629f08d538-cdec9d2762d7a14e-00",
+        "Authorization": "Sanitized",
+        "traceparent": "00-57bb576bb3b7e640a296adc1f54a67a9-6ff74d8ed2b6d049-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dea8293e1641601926b9bdf5501d5e64",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7fdb8a79-4a86-4ced-a0cd-ac9780d79e19",
+        "apim-request-id": "fa151e89-15eb-4b0a-a35c-f2e53e8706c6",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:53 GMT",
+        "Date": "Wed, 09 Jun 2021 21:38:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "107",
-        "x-request-id": "7fdb8a79-4a86-4ced-a0cd-ac9780d79e19"
+        "x-envoy-upstream-service-time": "212",
+        "x-request-id": "fa151e89-15eb-4b0a-a35c-f2e53e8706c6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a12e877c-7898-466f-b86f-1c40506e7ab0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fcebf2f-1aa4-4b35-9ffa-d54ba96e28a4",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-665e696b38215a45bd7558888ad938ec-85e916ad18359c49-00",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9a6a699df6b02e48bda8699acfd157f7-141a082ecf23e544-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f4c56a7c4853c2015ff4bd4be1739988",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "68e1f305-6f7f-4bd1-9be0-f72f6537e6df",
+        "apim-request-id": "7809a1b3-c01a-41d3-8699-72e3bea622f6",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:53 GMT",
+        "Date": "Wed, 09 Jun 2021 21:38:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "310",
-        "x-request-id": "68e1f305-6f7f-4bd1-9be0-f72f6537e6df"
+        "x-envoy-upstream-service-time": "5355",
+        "x-request-id": "7809a1b3-c01a-41d3-8699-72e3bea622f6"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
-    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "1983154513"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True).json
@@ -8,7 +8,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "312",
         "Content-Type": "application/json",
-        "traceparent": "00-a39f6b74f3c6744a976b62064ce181bf-5b15fed178cddd4c-00",
+        "traceparent": "00-56b8289bd98e2d49a3c943903bbf4194-9a2fcd2c5c98d644-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "c4356899a592ddcf9fece7f6ab1d765a",
         "x-ms-return-client-request-id": "true"
@@ -28,7 +28,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -38,24 +38,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2d3be348-9d8e-4c27-b6ca-1644bc85ab1e",
+        "apim-request-id": "71c45969-a3a5-4d5c-b2c9-fbc1441f2c8c",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 21:38:19 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fcebf2f-1aa4-4b35-9ffa-d54ba96e28a4",
+        "Date": "Wed, 09 Jun 2021 23:03:26 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac57337f-0179-4903-8f66-7ed6c51b6e27",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "845",
-        "x-request-id": "2d3be348-9d8e-4c27-b6ca-1644bc85ab1e"
+        "x-envoy-upstream-service-time": "613",
+        "x-request-id": "71c45969-a3a5-4d5c-b2c9-fbc1441f2c8c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fcebf2f-1aa4-4b35-9ffa-d54ba96e28a4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac57337f-0179-4903-8f66-7ed6c51b6e27",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-a39f6b74f3c6744a976b62064ce181bf-6f8b58a8dafb994d-00",
+        "traceparent": "00-56b8289bd98e2d49a3c943903bbf4194-4e7e897c3f23f047-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "6b8e2df8a6197cb6e3175c37d4a3e2b9",
         "x-ms-return-client-request-id": "true"
@@ -63,21 +63,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b2605dc2-de32-440d-957d-2e9e909bd7d2",
+        "apim-request-id": "ad7bb700-9e1d-499c-a6c3-f122cc0c9c6b",
         "Content-Length": "1052",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 21:38:25 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5203",
-        "x-request-id": "b2605dc2-de32-440d-957d-2e9e909bd7d2"
+        "x-envoy-upstream-service-time": "106",
+        "x-request-id": "ad7bb700-9e1d-499c-a6c3-f122cc0c9c6b"
       },
       "ResponseBody": {
-        "dataFeedId": "0fcebf2f-1aa4-4b35-9ffa-d54ba96e28a4",
+        "dataFeedId": "ac57337f-0179-4903-8f66-7ed6c51b6e27",
         "dataFeedName": "dataFeedQemmjwy9",
         "metrics": [
           {
-            "metricId": "0f55fe17-d179-4df4-a198-fd7442a1b5be",
+            "metricId": "b9c66659-cdfa-425f-9b17-ae3d02919402",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -85,8 +85,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -114,7 +114,7 @@
         "viewers": [],
         "creator": "94dc466b-52e4-4678-892d-70a0c45c5f42",
         "status": "Active",
-        "createdTime": "2021-06-09T21:38:19Z",
+        "createdTime": "2021-06-09T23:03:27Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -131,7 +131,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "300",
         "Content-Type": "application/json",
-        "traceparent": "00-89e84a0fa94dd1468b7a3480b4255156-11c89cba1f961b4a-00",
+        "traceparent": "00-82ea2ba7b1a0f6419fbccce8c3d8295a-6f74ed45f766644b-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "c7b52ff8f6235f59803f406120c631f2",
         "x-ms-return-client-request-id": "true"
@@ -139,7 +139,7 @@
       "RequestBody": {
         "name": "configkElCSrFg",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "0f55fe17-d179-4df4-a198-fd7442a1b5be",
+        "metricId": "b9c66659-cdfa-425f-9b17-ae3d02919402",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -153,24 +153,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b4f10ffd-d5a2-4890-9276-5d9d1cbc6e86",
+        "apim-request-id": "8396eb1a-378b-47d1-9495-5327f16d082a",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 21:38:30 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e9164717-5246-4d0f-a5d3-4e428fb48a31",
+        "Date": "Wed, 09 Jun 2021 23:03:27 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/41bdd103-3aad-4937-a7e9-ab970abe9bce",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5162",
-        "x-request-id": "b4f10ffd-d5a2-4890-9276-5d9d1cbc6e86"
+        "x-envoy-upstream-service-time": "83",
+        "x-request-id": "8396eb1a-378b-47d1-9495-5327f16d082a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e9164717-5246-4d0f-a5d3-4e428fb48a31",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/41bdd103-3aad-4937-a7e9-ab970abe9bce",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-89e84a0fa94dd1468b7a3480b4255156-2356e96f4350bc43-00",
+        "traceparent": "00-82ea2ba7b1a0f6419fbccce8c3d8295a-e94b8e049703dd46-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "7be1b9b29848fc090a2da53b011bc2d5",
         "x-ms-return-client-request-id": "true"
@@ -178,20 +178,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a84f70e6-0929-4228-ab1c-d618a7b685b2",
+        "apim-request-id": "1c3f62b0-e8b6-41df-9c63-7a0083979111",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 21:38:30 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "125",
-        "x-request-id": "a84f70e6-0929-4228-ab1c-d618a7b685b2"
+        "x-envoy-upstream-service-time": "64",
+        "x-request-id": "1c3f62b0-e8b6-41df-9c63-7a0083979111"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "e9164717-5246-4d0f-a5d3-4e428fb48a31",
+        "anomalyDetectionConfigurationId": "41bdd103-3aad-4937-a7e9-ab970abe9bce",
         "name": "configkElCSrFg",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "0f55fe17-d179-4df4-a198-fd7442a1b5be",
+        "metricId": "b9c66659-cdfa-425f-9b17-ae3d02919402",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -207,12 +207,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e9164717-5246-4d0f-a5d3-4e428fb48a31",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/41bdd103-3aad-4937-a7e9-ab970abe9bce",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-30bc2840caf3bd40804d689479035bea-b30d75e933ff3e4a-00",
+        "traceparent": "00-69c09b28b62c48439d6197473c633352-632d34c919640147-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "e9722c9beff1ec59befdb6956281988a",
         "x-ms-return-client-request-id": "true"
@@ -220,20 +220,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1135208c-cd87-47bd-abbc-a56fd4c70d25",
+        "apim-request-id": "860b3482-3e57-425f-83a4-0a6350f635ec",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 21:38:30 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "53",
-        "x-request-id": "1135208c-cd87-47bd-abbc-a56fd4c70d25"
+        "x-envoy-upstream-service-time": "64",
+        "x-request-id": "860b3482-3e57-425f-83a4-0a6350f635ec"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "e9164717-5246-4d0f-a5d3-4e428fb48a31",
+        "anomalyDetectionConfigurationId": "41bdd103-3aad-4937-a7e9-ab970abe9bce",
         "name": "configkElCSrFg",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "0f55fe17-d179-4df4-a198-fd7442a1b5be",
+        "metricId": "b9c66659-cdfa-425f-9b17-ae3d02919402",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -249,12 +249,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e9164717-5246-4d0f-a5d3-4e428fb48a31",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/41bdd103-3aad-4937-a7e9-ab970abe9bce",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-57bb576bb3b7e640a296adc1f54a67a9-6ff74d8ed2b6d049-00",
+        "traceparent": "00-190599a36d84ba4081e1fb422fab3388-160f7c31570ea04f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "dea8293e1641601926b9bdf5501d5e64",
         "x-ms-return-client-request-id": "true"
@@ -262,23 +262,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "fa151e89-15eb-4b0a-a35c-f2e53e8706c6",
+        "apim-request-id": "c06041e9-210f-4f17-a144-7980fc443ed8",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 21:38:31 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "212",
-        "x-request-id": "fa151e89-15eb-4b0a-a35c-f2e53e8706c6"
+        "x-envoy-upstream-service-time": "100",
+        "x-request-id": "c06041e9-210f-4f17-a144-7980fc443ed8"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fcebf2f-1aa4-4b35-9ffa-d54ba96e28a4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac57337f-0179-4903-8f66-7ed6c51b6e27",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9a6a699df6b02e48bda8699acfd157f7-141a082ecf23e544-00",
+        "traceparent": "00-9d3c3bd1c2c7d84393e919e586de4912-612273ccca178240-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "f4c56a7c4853c2015ff4bd4be1739988",
         "x-ms-return-client-request-id": "true"
@@ -286,19 +286,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7809a1b3-c01a-41d3-8699-72e3bea622f6",
+        "apim-request-id": "5da1a857-3ab5-4758-8211-27eff5ab3d7f",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 21:38:37 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5355",
-        "x-request-id": "7809a1b3-c01a-41d3-8699-72e3bea622f6"
+        "x-envoy-upstream-service-time": "234",
+        "x-request-id": "5da1a857-3ab5-4758-8211-27eff5ab3d7f"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "RandomSeed": "1983154513"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True)Async.json
@@ -8,7 +8,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "312",
         "Content-Type": "application/json",
-        "traceparent": "00-5795b7a469b0a24fa855cdf52f0baf42-05cac9ffef43ca43-00",
+        "traceparent": "00-434aa9e4f75b004b8743f2ffc8fcf714-288441d2284edf45-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "5276d35ea2a106c36a74d272afe1b35e",
         "x-ms-return-client-request-id": "true"
@@ -28,7 +28,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -38,24 +38,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b09f4e57-38d8-4e43-af3b-4835a1e1688d",
+        "apim-request-id": "4c4c39e9-2faf-4916-8754-22e117400c81",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 21:38:38 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0b27dca4-5cbe-4415-ae8e-4c9405ea0c54",
+        "Date": "Wed, 09 Jun 2021 23:03:50 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1d784500-71eb-4bbf-9a29-c9f810327242",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "451",
-        "x-request-id": "b09f4e57-38d8-4e43-af3b-4835a1e1688d"
+        "x-envoy-upstream-service-time": "527",
+        "x-request-id": "4c4c39e9-2faf-4916-8754-22e117400c81"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0b27dca4-5cbe-4415-ae8e-4c9405ea0c54",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1d784500-71eb-4bbf-9a29-c9f810327242",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5795b7a469b0a24fa855cdf52f0baf42-b12afbb512d1d740-00",
+        "traceparent": "00-434aa9e4f75b004b8743f2ffc8fcf714-c557aaff34d29d48-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "e45af92997dff9b0e1b806cf3021d8a8",
         "x-ms-return-client-request-id": "true"
@@ -63,21 +63,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aafea568-b1f3-4616-a2e6-b233e33de26f",
+        "apim-request-id": "a404642e-5799-45b7-82c6-94b601c09aca",
         "Content-Length": "1052",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 21:38:38 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "268",
-        "x-request-id": "aafea568-b1f3-4616-a2e6-b233e33de26f"
+        "x-envoy-upstream-service-time": "106",
+        "x-request-id": "a404642e-5799-45b7-82c6-94b601c09aca"
       },
       "ResponseBody": {
-        "dataFeedId": "0b27dca4-5cbe-4415-ae8e-4c9405ea0c54",
+        "dataFeedId": "1d784500-71eb-4bbf-9a29-c9f810327242",
         "dataFeedName": "dataFeeddCb4so5C",
         "metrics": [
           {
-            "metricId": "e41ec4df-e565-4261-b2a7-04f73524c41d",
+            "metricId": "f27b679d-90d1-43d8-8146-edf628f64695",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -85,8 +85,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -114,7 +114,7 @@
         "viewers": [],
         "creator": "94dc466b-52e4-4678-892d-70a0c45c5f42",
         "status": "Active",
-        "createdTime": "2021-06-09T21:38:37Z",
+        "createdTime": "2021-06-09T23:03:50Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -131,7 +131,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "300",
         "Content-Type": "application/json",
-        "traceparent": "00-2676dd08d771e844a06bf1470dce8d36-b4bba88f15632346-00",
+        "traceparent": "00-9c4049d214e4584a952d9c5bf592a6d3-9db1853c459abc48-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "2c757348c66ae0f321e6041a403105c7",
         "x-ms-return-client-request-id": "true"
@@ -139,7 +139,7 @@
       "RequestBody": {
         "name": "configuumxr2vU",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "e41ec4df-e565-4261-b2a7-04f73524c41d",
+        "metricId": "f27b679d-90d1-43d8-8146-edf628f64695",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -153,24 +153,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "668c2b6c-cc41-4132-8bab-b4b44ebcab77",
+        "apim-request-id": "0923cb55-aa02-4e76-9619-f80968a0add5",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 21:38:38 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/326c9a26-a7ce-4973-9510-e490efd1fdd4",
+        "Date": "Wed, 09 Jun 2021 23:03:50 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9820e728-5620-45ea-a9fa-45329d70efdf",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "191",
-        "x-request-id": "668c2b6c-cc41-4132-8bab-b4b44ebcab77"
+        "x-envoy-upstream-service-time": "83",
+        "x-request-id": "0923cb55-aa02-4e76-9619-f80968a0add5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/326c9a26-a7ce-4973-9510-e490efd1fdd4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9820e728-5620-45ea-a9fa-45329d70efdf",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-2676dd08d771e844a06bf1470dce8d36-310fff74f5b21b42-00",
+        "traceparent": "00-9c4049d214e4584a952d9c5bf592a6d3-859f605afb951044-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "e9717c23f39b49d69c294d78167c9824",
         "x-ms-return-client-request-id": "true"
@@ -178,20 +178,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "135f76c7-6e3c-451c-bbcc-64cb4bad60f9",
+        "apim-request-id": "7c1ce148-781d-47c6-a0e2-9cbc1b2c8578",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 21:38:38 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "150",
-        "x-request-id": "135f76c7-6e3c-451c-bbcc-64cb4bad60f9"
+        "x-envoy-upstream-service-time": "64",
+        "x-request-id": "7c1ce148-781d-47c6-a0e2-9cbc1b2c8578"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "326c9a26-a7ce-4973-9510-e490efd1fdd4",
+        "anomalyDetectionConfigurationId": "9820e728-5620-45ea-a9fa-45329d70efdf",
         "name": "configuumxr2vU",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "e41ec4df-e565-4261-b2a7-04f73524c41d",
+        "metricId": "f27b679d-90d1-43d8-8146-edf628f64695",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -207,12 +207,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/326c9a26-a7ce-4973-9510-e490efd1fdd4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9820e728-5620-45ea-a9fa-45329d70efdf",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-62289d5095c7d54faf084b9896cd4edd-0a560f95a39e9344-00",
+        "traceparent": "00-21323b7a5c7542429e0195767f4145a5-cda7ed6aa904f045-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "6c9bfeef84211a8fc425ae491cbd68f4",
         "x-ms-return-client-request-id": "true"
@@ -220,20 +220,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bb5609f1-838c-4fd8-a0ce-e9970cad47ef",
+        "apim-request-id": "fc33853a-21f0-4388-b86b-2d8989fbc6f2",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 21:38:38 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "162",
-        "x-request-id": "bb5609f1-838c-4fd8-a0ce-e9970cad47ef"
+        "x-envoy-upstream-service-time": "57",
+        "x-request-id": "fc33853a-21f0-4388-b86b-2d8989fbc6f2"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "326c9a26-a7ce-4973-9510-e490efd1fdd4",
+        "anomalyDetectionConfigurationId": "9820e728-5620-45ea-a9fa-45329d70efdf",
         "name": "configuumxr2vU",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "e41ec4df-e565-4261-b2a7-04f73524c41d",
+        "metricId": "f27b679d-90d1-43d8-8146-edf628f64695",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -249,12 +249,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/326c9a26-a7ce-4973-9510-e490efd1fdd4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9820e728-5620-45ea-a9fa-45329d70efdf",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-33495dcc298c9d4eaf138671489de4e2-6dcf213d65f3444c-00",
+        "traceparent": "00-1ef38bc53cb9a643a33618dc3829665b-c62fd6d37c71be43-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "49130232209355c09d2b9040797bc9a4",
         "x-ms-return-client-request-id": "true"
@@ -262,23 +262,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "46b5012c-61da-4741-96d0-4cfef9b74fc4",
+        "apim-request-id": "430aaf0a-d4c5-40c4-b43b-f30fa7697bc2",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 21:38:39 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "115",
-        "x-request-id": "46b5012c-61da-4741-96d0-4cfef9b74fc4"
+        "x-envoy-upstream-service-time": "71",
+        "x-request-id": "430aaf0a-d4c5-40c4-b43b-f30fa7697bc2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0b27dca4-5cbe-4415-ae8e-4c9405ea0c54",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1d784500-71eb-4bbf-9a29-c9f810327242",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-085f4c0c2e21f64f855ff13a93424a64-494b37dfe488d148-00",
+        "traceparent": "00-3d62dd15de3f4343a51018a952fbaa8e-f2b37905e2464c44-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "422bdf4e98959ea5ed562475458d2cde",
         "x-ms-return-client-request-id": "true"
@@ -286,19 +286,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "eb87c304-6fe5-41e9-9b45-46641837fd9c",
+        "apim-request-id": "1f63cba5-9bc2-4d16-b097-27c8ff1f6eb8",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 21:38:44 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5454",
-        "x-request-id": "eb87c304-6fe5-41e9-9b45-46641837fd9c"
+        "x-envoy-upstream-service-time": "250",
+        "x-request-id": "1f63cba5-9bc2-4d16-b097-27c8ff1f6eb8"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "RandomSeed": "2016156446"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True)Async.json
@@ -5,12 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
+        "Authorization": "Sanitized",
         "Content-Length": "312",
         "Content-Type": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-acc41709a676e04d8c57dc90fecf315c-ab14217756110a41-00",
+        "traceparent": "00-5795b7a469b0a24fa855cdf52f0baf42-05cac9ffef43ca43-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5276d35ea2a106c36a74d272afe1b35e",
         "x-ms-return-client-request-id": "true"
       },
@@ -39,47 +38,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "93dcc961-4fd2-4ae6-87f8-5141d054c467",
+        "apim-request-id": "b09f4e57-38d8-4e43-af3b-4835a1e1688d",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:16 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97331ec8-c381-426c-91dd-4578f20c8038",
+        "Date": "Wed, 09 Jun 2021 21:38:38 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0b27dca4-5cbe-4415-ae8e-4c9405ea0c54",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "747",
-        "x-request-id": "93dcc961-4fd2-4ae6-87f8-5141d054c467"
+        "x-envoy-upstream-service-time": "451",
+        "x-request-id": "b09f4e57-38d8-4e43-af3b-4835a1e1688d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97331ec8-c381-426c-91dd-4578f20c8038",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0b27dca4-5cbe-4415-ae8e-4c9405ea0c54",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-acc41709a676e04d8c57dc90fecf315c-3de7b931bdace44a-00",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5795b7a469b0a24fa855cdf52f0baf42-b12afbb512d1d740-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e45af92997dff9b0e1b806cf3021d8a8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f7d7b4bb-c9cc-4c72-a635-ab0ffb2766e9",
-        "Content-Length": "1010",
+        "apim-request-id": "aafea568-b1f3-4616-a2e6-b233e33de26f",
+        "Content-Length": "1052",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:16 GMT",
+        "Date": "Wed, 09 Jun 2021 21:38:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "159",
-        "x-request-id": "f7d7b4bb-c9cc-4c72-a635-ab0ffb2766e9"
+        "x-envoy-upstream-service-time": "268",
+        "x-request-id": "aafea568-b1f3-4616-a2e6-b233e33de26f"
       },
       "ResponseBody": {
-        "dataFeedId": "97331ec8-c381-426c-91dd-4578f20c8038",
+        "dataFeedId": "0b27dca4-5cbe-4415-ae8e-4c9405ea0c54",
         "dataFeedName": "dataFeeddCb4so5C",
         "metrics": [
           {
-            "metricId": "6d65f110-ac77-4bf6-8a5b-9135edb8bfa7",
+            "metricId": "e41ec4df-e565-4261-b2a7-04f73524c41d",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -111,12 +109,12 @@
         "maxConcurrency": -1,
         "viewMode": "Private",
         "admins": [
-          "foo@contoso.com"
+          "94dc466b-52e4-4678-892d-70a0c45c5f42"
         ],
         "viewers": [],
-        "creator": "foo@contoso.com",
+        "creator": "94dc466b-52e4-4678-892d-70a0c45c5f42",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:16Z",
+        "createdTime": "2021-06-09T21:38:37Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -130,19 +128,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
+        "Authorization": "Sanitized",
         "Content-Length": "300",
         "Content-Type": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-689d3d638440084bb565dd4f1324f1c0-b166e1c61904544f-00",
+        "traceparent": "00-2676dd08d771e844a06bf1470dce8d36-b4bba88f15632346-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2c757348c66ae0f321e6041a403105c7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "name": "configuumxr2vU",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "6d65f110-ac77-4bf6-8a5b-9135edb8bfa7",
+        "metricId": "e41ec4df-e565-4261-b2a7-04f73524c41d",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -156,46 +153,45 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "0db8851d-d2a5-42e1-8da5-1b03f2956bf6",
+        "apim-request-id": "668c2b6c-cc41-4132-8bab-b4b44ebcab77",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:16 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cef51fa-d1db-4266-86b4-25f0cffe7264",
+        "Date": "Wed, 09 Jun 2021 21:38:38 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/326c9a26-a7ce-4973-9510-e490efd1fdd4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "144",
-        "x-request-id": "0db8851d-d2a5-42e1-8da5-1b03f2956bf6"
+        "x-envoy-upstream-service-time": "191",
+        "x-request-id": "668c2b6c-cc41-4132-8bab-b4b44ebcab77"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cef51fa-d1db-4266-86b4-25f0cffe7264",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/326c9a26-a7ce-4973-9510-e490efd1fdd4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-689d3d638440084bb565dd4f1324f1c0-55fc0cddcfba4c42-00",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2676dd08d771e844a06bf1470dce8d36-310fff74f5b21b42-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e9717c23f39b49d69c294d78167c9824",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a80f2faa-491d-4269-843f-b547fa8e2b58",
+        "apim-request-id": "135f76c7-6e3c-451c-bbcc-64cb4bad60f9",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:16 GMT",
+        "Date": "Wed, 09 Jun 2021 21:38:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "85",
-        "x-request-id": "a80f2faa-491d-4269-843f-b547fa8e2b58"
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "135f76c7-6e3c-451c-bbcc-64cb4bad60f9"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "0cef51fa-d1db-4266-86b4-25f0cffe7264",
+        "anomalyDetectionConfigurationId": "326c9a26-a7ce-4973-9510-e490efd1fdd4",
         "name": "configuumxr2vU",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "6d65f110-ac77-4bf6-8a5b-9135edb8bfa7",
+        "metricId": "e41ec4df-e565-4261-b2a7-04f73524c41d",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -211,34 +207,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cef51fa-d1db-4266-86b4-25f0cffe7264",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/326c9a26-a7ce-4973-9510-e490efd1fdd4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0d233a171874114bb3dbc86756131595-ef62607899c9ab4b-00",
+        "Authorization": "Sanitized",
+        "traceparent": "00-62289d5095c7d54faf084b9896cd4edd-0a560f95a39e9344-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6c9bfeef84211a8fc425ae491cbd68f4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bb6e52c1-9292-409a-b087-5545134fd5be",
+        "apim-request-id": "bb5609f1-838c-4fd8-a0ce-e9970cad47ef",
         "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:16 GMT",
+        "Date": "Wed, 09 Jun 2021 21:38:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "98",
-        "x-request-id": "bb6e52c1-9292-409a-b087-5545134fd5be"
+        "x-envoy-upstream-service-time": "162",
+        "x-request-id": "bb5609f1-838c-4fd8-a0ce-e9970cad47ef"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "0cef51fa-d1db-4266-86b4-25f0cffe7264",
+        "anomalyDetectionConfigurationId": "326c9a26-a7ce-4973-9510-e490efd1fdd4",
         "name": "configuumxr2vU",
         "description": "This configuration was created to test the .NET client.",
-        "metricId": "6d65f110-ac77-4bf6-8a5b-9135edb8bfa7",
+        "metricId": "e41ec4df-e565-4261-b2a7-04f73524c41d",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -254,60 +249,56 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cef51fa-d1db-4266-86b4-25f0cffe7264",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/326c9a26-a7ce-4973-9510-e490efd1fdd4",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1db8c9450e33fb4aa4614867472125aa-71d7d04949f96743-00",
+        "Authorization": "Sanitized",
+        "traceparent": "00-33495dcc298c9d4eaf138671489de4e2-6dcf213d65f3444c-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "49130232209355c09d2b9040797bc9a4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c25d04cd-1f9e-47c3-bdc0-610f664bddaf",
+        "apim-request-id": "46b5012c-61da-4741-96d0-4cfef9b74fc4",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:22 GMT",
+        "Date": "Wed, 09 Jun 2021 21:38:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5153",
-        "x-request-id": "c25d04cd-1f9e-47c3-bdc0-610f664bddaf"
+        "x-envoy-upstream-service-time": "115",
+        "x-request-id": "46b5012c-61da-4741-96d0-4cfef9b74fc4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97331ec8-c381-426c-91dd-4578f20c8038",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0b27dca4-5cbe-4415-ae8e-4c9405ea0c54",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-81ec2bdfeb0c4f4badbb1097881ff97f-11a8d69b69c8a24c-00",
+        "Authorization": "Sanitized",
+        "traceparent": "00-085f4c0c2e21f64f855ff13a93424a64-494b37dfe488d148-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "422bdf4e98959ea5ed562475458d2cde",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "53cdfca1-2c9c-4141-9807-70df1a4e9b79",
+        "apim-request-id": "eb87c304-6fe5-41e9-9b45-46641837fd9c",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:22 GMT",
+        "Date": "Wed, 09 Jun 2021 21:38:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "303",
-        "x-request-id": "53cdfca1-2c9c-4141-9807-70df1a4e9b79"
+        "x-envoy-upstream-service-time": "5454",
+        "x-request-id": "eb87c304-6fe5-41e9-9b45-46641837fd9c"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
-    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "2016156446"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithHardCondition(True)Async.json
@@ -1,25 +1,148 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "291",
+        "Content-Length": "312",
         "Content-Type": "application/json",
-        "traceparent": "00-f32fcfbb92c26e4bb59b3c7ff86ca764-1c3b7d1890c87f4b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-acc41709a676e04d8c57dc90fecf315c-ab14217756110a41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5276d35ea2a106c36a74d272afe1b35e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configdCb4so5C",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeeddCb4so5C",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "93dcc961-4fd2-4ae6-87f8-5141d054c467",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:16 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97331ec8-c381-426c-91dd-4578f20c8038",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "747",
+        "x-request-id": "93dcc961-4fd2-4ae6-87f8-5141d054c467"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97331ec8-c381-426c-91dd-4578f20c8038",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-acc41709a676e04d8c57dc90fecf315c-3de7b931bdace44a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e45af92997dff9b0e1b806cf3021d8a8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f7d7b4bb-c9cc-4c72-a635-ab0ffb2766e9",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "159",
+        "x-request-id": "f7d7b4bb-c9cc-4c72-a635-ab0ffb2766e9"
+      },
+      "ResponseBody": {
+        "dataFeedId": "97331ec8-c381-426c-91dd-4578f20c8038",
+        "dataFeedName": "dataFeeddCb4so5C",
+        "metrics": [
+          {
+            "metricId": "6d65f110-ac77-4bf6-8a5b-9135edb8bfa7",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:16Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "300",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-689d3d638440084bb565dd4f1324f1c0-b166e1c61904544f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2c757348c66ae0f321e6041a403105c7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configuumxr2vU",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "6d65f110-ac77-4bf6-8a5b-9135edb8bfa7",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -33,48 +156,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2acc1107-3e14-42e8-afae-b55723d25617",
+        "apim-request-id": "0db8851d-d2a5-42e1-8da5-1b03f2956bf6",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:30 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3c2ee632-07fb-4bfb-8bd2-63980e5fe034",
+        "Date": "Wed, 09 Jun 2021 19:46:16 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cef51fa-d1db-4266-86b4-25f0cffe7264",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "38",
-        "X-Request-ID": "2acc1107-3e14-42e8-afae-b55723d25617"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "144",
+        "x-request-id": "0db8851d-d2a5-42e1-8da5-1b03f2956bf6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3c2ee632-07fb-4bfb-8bd2-63980e5fe034",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cef51fa-d1db-4266-86b4-25f0cffe7264",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-f32fcfbb92c26e4bb59b3c7ff86ca764-0b5b0ba68a72a94f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "e45af92997dff9b0e1b806cf3021d8a8",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-689d3d638440084bb565dd4f1324f1c0-55fc0cddcfba4c42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e9717c23f39b49d69c294d78167c9824",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "00d93321-a6bb-4180-9547-afc7ef4b22da",
-        "Content-Length": "444",
+        "apim-request-id": "a80f2faa-491d-4269-843f-b547fa8e2b58",
+        "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:30 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28",
-        "X-Request-ID": "00d93321-a6bb-4180-9547-afc7ef4b22da"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "85",
+        "x-request-id": "a80f2faa-491d-4269-843f-b547fa8e2b58"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "3c2ee632-07fb-4bfb-8bd2-63980e5fe034",
-        "name": "configdCb4so5C",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "anomalyDetectionConfigurationId": "0cef51fa-d1db-4266-86b4-25f0cffe7264",
+        "name": "configuumxr2vU",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "6d65f110-ac77-4bf6-8a5b-9135edb8bfa7",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -90,36 +211,34 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3c2ee632-07fb-4bfb-8bd2-63980e5fe034",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cef51fa-d1db-4266-86b4-25f0cffe7264",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-5869ce4501c1614e87f5271aa49a2ff4-f59e16725ee33449-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "36ca372504c55c094873752c6ac6f3e0",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0d233a171874114bb3dbc86756131595-ef62607899c9ab4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6c9bfeef84211a8fc425ae491cbd68f4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8d274bf7-d1ee-47b0-b730-42d828556a9c",
-        "Content-Length": "444",
+        "apim-request-id": "bb6e52c1-9292-409a-b087-5545134fd5be",
+        "Content-Length": "453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:30 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35",
-        "X-Request-ID": "8d274bf7-d1ee-47b0-b730-42d828556a9c"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "98",
+        "x-request-id": "bb6e52c1-9292-409a-b087-5545134fd5be"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "3c2ee632-07fb-4bfb-8bd2-63980e5fe034",
-        "name": "configdCb4so5C",
-        "description": "This hook was created to test the .NET client.",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "anomalyDetectionConfigurationId": "0cef51fa-d1db-4266-86b4-25f0cffe7264",
+        "name": "configuumxr2vU",
+        "description": "This configuration was created to test the .NET client.",
+        "metricId": "6d65f110-ac77-4bf6-8a5b-9135edb8bfa7",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -135,36 +254,60 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3c2ee632-07fb-4bfb-8bd2-63980e5fe034",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cef51fa-d1db-4266-86b4-25f0cffe7264",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-8f0d774fa99292438a8c18b6afbf0fd0-63f7cd376e72074e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "1a04e6213140c705237c71e99bf3d649",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1db8c9450e33fb4aa4614867472125aa-71d7d04949f96743-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "49130232209355c09d2b9040797bc9a4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2dd346ee-dbb6-4231-be2e-8d51fb1f0ef6",
+        "apim-request-id": "c25d04cd-1f9e-47c3-bdc0-610f664bddaf",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:30 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "46",
-        "X-Request-ID": "2dd346ee-dbb6-4231-be2e-8d51fb1f0ef6"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5153",
+        "x-request-id": "c25d04cd-1f9e-47c3-bdc0-610f664bddaf"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97331ec8-c381-426c-91dd-4578f20c8038",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-81ec2bdfeb0c4f4badbb1097881ff97f-11a8d69b69c8a24c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "422bdf4e98959ea5ed562475458d2cde",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "53cdfca1-2c9c-4141-9807-70df1a4e9b79",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:22 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "303",
+        "x-request-id": "53cdfca1-2c9c-4141-9807-70df1a4e9b79"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "2016156446"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesConditions.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesConditions.json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-04c833f8df3a7440b2334b11deb67ee7-64db69f7a401a04a-00",
+        "traceparent": "00-e6e63ed9d0d8414d8ad4553092fa1d84-537865aa660a4b4f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c386218ff1b7ed8e80936ccca61372fe",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "cbb3af8c-e65a-4127-92be-92a4ba529222",
+        "apim-request-id": "fe74bb9b-ef15-438d-95c2-f3219301eb11",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5b2267c6-3cfc-4f2e-8b9c-a393f622af06",
+        "Date": "Wed, 09 Jun 2021 23:03:21 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/764b17d9-6fe5-4dad-b21a-1ebbc7d5e28c",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "669",
-        "x-request-id": "cbb3af8c-e65a-4127-92be-92a4ba529222"
+        "x-envoy-upstream-service-time": "1480",
+        "x-request-id": "fe74bb9b-ef15-438d-95c2-f3219301eb11"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5b2267c6-3cfc-4f2e-8b9c-a393f622af06",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/764b17d9-6fe5-4dad-b21a-1ebbc7d5e28c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-04c833f8df3a7440b2334b11deb67ee7-e852b13f620c324a-00",
+        "traceparent": "00-e6e63ed9d0d8414d8ad4553092fa1d84-9a92b8eba633554f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1d1bb5332930da790246cc2a904d34b8",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f3a68184-62e4-4e04-aecf-888c03c961f2",
+        "apim-request-id": "b7e8248c-8764-4f9d-add2-5e8056b7f454",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:39 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "177",
-        "x-request-id": "f3a68184-62e4-4e04-aecf-888c03c961f2"
+        "x-envoy-upstream-service-time": "171",
+        "x-request-id": "b7e8248c-8764-4f9d-add2-5e8056b7f454"
       },
       "ResponseBody": {
-        "dataFeedId": "5b2267c6-3cfc-4f2e-8b9c-a393f622af06",
+        "dataFeedId": "764b17d9-6fe5-4dad-b21a-1ebbc7d5e28c",
         "dataFeedName": "dataFeed0dbZeJSe",
         "metrics": [
           {
-            "metricId": "092d1b98-6cab-4a19-a5a4-a2948497b6f5",
+            "metricId": "9a3aa0ee-02cb-4247-8e49-dbeb45e4212b",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:45:39Z",
+        "createdTime": "2021-06-09T23:03:21Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,33 +133,33 @@
         "Content-Length": "735",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c9b7fe309ad1d14db5c2e6281a03a3b5-2b51bc68711dfd4d-00",
+        "traceparent": "00-ea3a37bef7379548967fccf87caecaf0-4db5dee9bff74b45-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ead529f96b54397c6bfe958683f47e65",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "{\u0022name\u0022:\u0022configiACePTu1\u0022,\u0022metricId\u0022:\u0022092d1b98-6cab-4a19-a5a4-a2948497b6f5\u0022,\u0022wholeMetricConfiguration\u0022:{\u0022hardThresholdCondition\u0022:{\u0022lowerBound\u0022:10,\u0022upperBound\u0022:20,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:1,\u0022minRatio\u0022:2}}},\u0022seriesOverrideConfigurations\u0022:[{\u0022series\u0022:{\u0022dimension\u0022:{\u0022DimensionA\u0022:\u0022Delhi\u0022,\u0022dimensionB\u0022:\u0022Handmade\u0022}},\u0022smartDetectionCondition\u0022:{\u0022sensitivity\u0022:30,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:3,\u0022minRatio\u0022:4}}},{\u0022series\u0022:{\u0022dimension\u0022:{\u0022DimensionA\u0022:\u0022Koltaka\u0022,\u0022dimensionB\u0022:\u0022Grocery \u0026 Gourmet Food\u0022}},\u0022changeThresholdCondition\u0022:{\u0022changePercentage\u0022:40,\u0022shiftPoint\u0022:12,\u0022withinRange\u0022:false,\u0022anomalyDetectorDirection\u0022:\u0022Up\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:5,\u0022minRatio\u0022:6}}}]}",
+      "RequestBody": "{\u0022name\u0022:\u0022configiACePTu1\u0022,\u0022metricId\u0022:\u00229a3aa0ee-02cb-4247-8e49-dbeb45e4212b\u0022,\u0022wholeMetricConfiguration\u0022:{\u0022hardThresholdCondition\u0022:{\u0022lowerBound\u0022:10,\u0022upperBound\u0022:20,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:1,\u0022minRatio\u0022:2}}},\u0022seriesOverrideConfigurations\u0022:[{\u0022series\u0022:{\u0022dimension\u0022:{\u0022dimensionA\u0022:\u0022Delhi\u0022,\u0022dimensionB\u0022:\u0022Handmade\u0022}},\u0022smartDetectionCondition\u0022:{\u0022sensitivity\u0022:30,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:3,\u0022minRatio\u0022:4}}},{\u0022series\u0022:{\u0022dimension\u0022:{\u0022dimensionA\u0022:\u0022Koltaka\u0022,\u0022dimensionB\u0022:\u0022Grocery \u0026 Gourmet Food\u0022}},\u0022changeThresholdCondition\u0022:{\u0022changePercentage\u0022:40,\u0022shiftPoint\u0022:12,\u0022withinRange\u0022:false,\u0022anomalyDetectorDirection\u0022:\u0022Up\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:5,\u0022minRatio\u0022:6}}}]}",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "72c21451-ac2a-4cee-a3f2-dcb8366f26fc",
+        "apim-request-id": "35c00faa-62d8-4208-a968-233ad0f783f4",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/97584f08-cf2b-426e-b0ce-5a1b508e7a77",
+        "Date": "Wed, 09 Jun 2021 23:03:21 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/6623ba52-b915-401b-8a44-55aa021a5fc5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "202",
-        "x-request-id": "72c21451-ac2a-4cee-a3f2-dcb8366f26fc"
+        "x-envoy-upstream-service-time": "190",
+        "x-request-id": "35c00faa-62d8-4208-a968-233ad0f783f4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/97584f08-cf2b-426e-b0ce-5a1b508e7a77",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/6623ba52-b915-401b-8a44-55aa021a5fc5",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c9b7fe309ad1d14db5c2e6281a03a3b5-aa82a45ee8348b46-00",
+        "traceparent": "00-ea3a37bef7379548967fccf87caecaf0-6e911cf80ffea546-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "71c0aca76325325c5eb3c1d78e8411c7",
@@ -168,20 +168,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "692668e5-89ee-4cbe-8663-59772c42dc6e",
+        "apim-request-id": "683971e8-5983-4f22-8907-7056aae54267",
         "Content-Length": "881",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:39 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "92",
-        "x-request-id": "692668e5-89ee-4cbe-8663-59772c42dc6e"
+        "x-envoy-upstream-service-time": "104",
+        "x-request-id": "683971e8-5983-4f22-8907-7056aae54267"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "97584f08-cf2b-426e-b0ce-5a1b508e7a77",
+        "anomalyDetectionConfigurationId": "6623ba52-b915-401b-8a44-55aa021a5fc5",
         "name": "configiACePTu1",
         "description": "",
-        "metricId": "092d1b98-6cab-4a19-a5a4-a2948497b6f5",
+        "metricId": "9a3aa0ee-02cb-4247-8e49-dbeb45e4212b",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -198,7 +198,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -214,7 +214,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Koltaka",
+                "dimensionA": "Koltaka",
                 "dimensionB": "Grocery \u0026 Gourmet Food"
               }
             },
@@ -233,12 +233,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/97584f08-cf2b-426e-b0ce-5a1b508e7a77",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/6623ba52-b915-401b-8a44-55aa021a5fc5",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a473ac812e470a46a3291218a12c91bc-e7edac6a26228d42-00",
+        "traceparent": "00-f25585242afc7e4582fe09734d5a9b4e-c6ae687b7dee1741-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0623d30a8f549786c992bf91b8ae3516",
@@ -247,20 +247,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6114bda3-c53c-4728-81c0-8629147bc466",
+        "apim-request-id": "4985d53c-957f-49da-a3db-31be3fed12fe",
         "Content-Length": "881",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:44 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5155",
-        "x-request-id": "6114bda3-c53c-4728-81c0-8629147bc466"
+        "x-envoy-upstream-service-time": "101",
+        "x-request-id": "4985d53c-957f-49da-a3db-31be3fed12fe"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "97584f08-cf2b-426e-b0ce-5a1b508e7a77",
+        "anomalyDetectionConfigurationId": "6623ba52-b915-401b-8a44-55aa021a5fc5",
         "name": "configiACePTu1",
         "description": "",
-        "metricId": "092d1b98-6cab-4a19-a5a4-a2948497b6f5",
+        "metricId": "9a3aa0ee-02cb-4247-8e49-dbeb45e4212b",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -277,7 +277,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -293,7 +293,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Koltaka",
+                "dimensionA": "Koltaka",
                 "dimensionB": "Grocery \u0026 Gourmet Food"
               }
             },
@@ -312,12 +312,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/97584f08-cf2b-426e-b0ce-5a1b508e7a77",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/6623ba52-b915-401b-8a44-55aa021a5fc5",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6b09c5a9d9a948459a704f42062e4cc4-6c7b720f68f2c24f-00",
+        "traceparent": "00-e7ddf6a7ebed44498819f8dc46bc1fa1-118a0b0ef7929645-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "41461f5038aa9522cda28ca0a9a4abe6",
@@ -326,23 +326,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "24ffe78f-c334-4106-8cd2-a8ec6e8ee4d8",
+        "apim-request-id": "8881dfea-3572-4e50-a550-36823958d779",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:44 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "113",
-        "x-request-id": "24ffe78f-c334-4106-8cd2-a8ec6e8ee4d8"
+        "x-envoy-upstream-service-time": "126",
+        "x-request-id": "8881dfea-3572-4e50-a550-36823958d779"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5b2267c6-3cfc-4f2e-8b9c-a393f622af06",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/764b17d9-6fe5-4dad-b21a-1ebbc7d5e28c",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c98422a03e2f7440bf42706fe8e9809a-bedf67b54608304e-00",
+        "traceparent": "00-7ef6448698edc740a64c0d97a0cafb58-a328ba6011ba394d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "af7bcded77d018112529a893a4ca7aaf",
@@ -351,19 +351,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "90733493-3368-482e-8a69-57015515c074",
+        "apim-request-id": "b6962860-5dda-4170-b025-7619d60528dd",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:44 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "302",
-        "x-request-id": "90733493-3368-482e-8a69-57015515c074"
+        "x-envoy-upstream-service-time": "285",
+        "x-request-id": "b6962860-5dda-4170-b025-7619d60528dd"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "1254168855"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesConditions.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesConditions.json
@@ -1,47 +1,63 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "719",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e0c1796131348a47b126d39219c0e100-8df6a5733fba494a-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-04c833f8df3a7440b2334b11deb67ee7-64db69f7a401a04a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c386218ff1b7ed8e80936ccca61372fe",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "{\u0022name\u0022:\u0022config0dbZeJSe\u0022,\u0022metricId\u0022:\u002227e3015f-04fd-44ba-a20b-bc529a0aebae\u0022,\u0022wholeMetricConfiguration\u0022:{\u0022hardThresholdCondition\u0022:{\u0022lowerBound\u0022:10,\u0022upperBound\u0022:20,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:1,\u0022minRatio\u0022:2}}},\u0022seriesOverrideConfigurations\u0022:[{\u0022series\u0022:{\u0022dimension\u0022:{\u0022city\u0022:\u0022Delhi\u0022,\u0022category\u0022:\u0022Handmade\u0022}},\u0022smartDetectionCondition\u0022:{\u0022sensitivity\u0022:30,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:3,\u0022minRatio\u0022:4}}},{\u0022series\u0022:{\u0022dimension\u0022:{\u0022city\u0022:\u0022Koltaka\u0022,\u0022category\u0022:\u0022Grocery \u0026 Gourmet Food\u0022}},\u0022changeThresholdCondition\u0022:{\u0022changePercentage\u0022:40,\u0022shiftPoint\u0022:12,\u0022withinRange\u0022:false,\u0022anomalyDetectorDirection\u0022:\u0022Up\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:5,\u0022minRatio\u0022:6}}}]}",
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeed0dbZeJSe",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b6e0337b-60fb-4477-af79-af0272b56a69",
+        "apim-request-id": "cbb3af8c-e65a-4127-92be-92a4ba529222",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:17 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb5b5bf2-8818-4c41-a698-f372ff1bff87",
+        "Date": "Wed, 09 Jun 2021 19:45:39 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5b2267c6-3cfc-4f2e-8b9c-a393f622af06",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "177",
-        "X-Request-ID": "b6e0337b-60fb-4477-af79-af0272b56a69"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "669",
+        "x-request-id": "cbb3af8c-e65a-4127-92be-92a4ba529222"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb5b5bf2-8818-4c41-a698-f372ff1bff87",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5b2267c6-3cfc-4f2e-8b9c-a393f622af06",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e0c1796131348a47b126d39219c0e100-f078ca1992cef240-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-04c833f8df3a7440b2334b11deb67ee7-e852b13f620c324a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1d1bb5332930da790246cc2a904d34b8",
         "x-ms-return-client-request-id": "true"
@@ -49,102 +65,123 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cde98562-85c4-4a01-94f9-0869a728e4a5",
-        "Content-Length": "865",
+        "apim-request-id": "f3a68184-62e4-4e04-aecf-888c03c961f2",
+        "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:17 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "89",
-        "X-Request-ID": "cde98562-85c4-4a01-94f9-0869a728e4a5"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "177",
+        "x-request-id": "f3a68184-62e4-4e04-aecf-888c03c961f2"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "fb5b5bf2-8818-4c41-a698-f372ff1bff87",
-        "name": "config0dbZeJSe",
-        "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-        "wholeMetricConfiguration": {
-          "hardThresholdCondition": {
-            "lowerBound": 10.0,
-            "upperBound": 20.0,
-            "anomalyDetectorDirection": "Both",
-            "suppressCondition": {
-              "minNumber": 1,
-              "minRatio": 2.0
-            }
-          }
-        },
-        "dimensionGroupOverrideConfigurations": [],
-        "seriesOverrideConfigurations": [
+        "dataFeedId": "5b2267c6-3cfc-4f2e-8b9c-a393f622af06",
+        "dataFeedName": "dataFeed0dbZeJSe",
+        "metrics": [
           {
-            "series": {
-              "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
-              }
-            },
-            "smartDetectionCondition": {
-              "sensitivity": 30.0,
-              "anomalyDetectorDirection": "Both",
-              "suppressCondition": {
-                "minNumber": 3,
-                "minRatio": 4.0
-              }
-            }
+            "metricId": "092d1b98-6cab-4a19-a5a4-a2948497b6f5",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
           },
           {
-            "series": {
-              "dimension": {
-                "city": "Koltaka",
-                "category": "Grocery \u0026 Gourmet Food"
-              }
-            },
-            "changeThresholdCondition": {
-              "changePercentage": 40.0,
-              "shiftPoint": 12,
-              "anomalyDetectorDirection": "Up",
-              "withinRange": false,
-              "suppressCondition": {
-                "minNumber": 5,
-                "minRatio": 6.0
-              }
-            }
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
           }
-        ]
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:45:39Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb5b5bf2-8818-4c41-a698-f372ff1bff87",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "735",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c9b7fe309ad1d14db5c2e6281a03a3b5-2b51bc68711dfd4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ead529f96b54397c6bfe958683f47e65",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "{\u0022name\u0022:\u0022configiACePTu1\u0022,\u0022metricId\u0022:\u0022092d1b98-6cab-4a19-a5a4-a2948497b6f5\u0022,\u0022wholeMetricConfiguration\u0022:{\u0022hardThresholdCondition\u0022:{\u0022lowerBound\u0022:10,\u0022upperBound\u0022:20,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:1,\u0022minRatio\u0022:2}}},\u0022seriesOverrideConfigurations\u0022:[{\u0022series\u0022:{\u0022dimension\u0022:{\u0022DimensionA\u0022:\u0022Delhi\u0022,\u0022dimensionB\u0022:\u0022Handmade\u0022}},\u0022smartDetectionCondition\u0022:{\u0022sensitivity\u0022:30,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:3,\u0022minRatio\u0022:4}}},{\u0022series\u0022:{\u0022dimension\u0022:{\u0022DimensionA\u0022:\u0022Koltaka\u0022,\u0022dimensionB\u0022:\u0022Grocery \u0026 Gourmet Food\u0022}},\u0022changeThresholdCondition\u0022:{\u0022changePercentage\u0022:40,\u0022shiftPoint\u0022:12,\u0022withinRange\u0022:false,\u0022anomalyDetectorDirection\u0022:\u0022Up\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:5,\u0022minRatio\u0022:6}}}]}",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "72c21451-ac2a-4cee-a3f2-dcb8366f26fc",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:45:39 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/97584f08-cf2b-426e-b0ce-5a1b508e7a77",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "202",
+        "x-request-id": "72c21451-ac2a-4cee-a3f2-dcb8366f26fc"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/97584f08-cf2b-426e-b0ce-5a1b508e7a77",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2b881f0c99efd5448f36b5e1cb2ddc2b-56003f09369e444d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-c9b7fe309ad1d14db5c2e6281a03a3b5-aa82a45ee8348b46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ed85cf0a6bed47aaf929d5ea546b7c39",
+        "x-ms-client-request-id": "71c0aca76325325c5eb3c1d78e8411c7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a45e763-e99a-4279-a105-a23622d7447e",
-        "Content-Length": "865",
+        "apim-request-id": "692668e5-89ee-4cbe-8663-59772c42dc6e",
+        "Content-Length": "881",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:17 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "94",
-        "X-Request-ID": "6a45e763-e99a-4279-a105-a23622d7447e"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "92",
+        "x-request-id": "692668e5-89ee-4cbe-8663-59772c42dc6e"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "fb5b5bf2-8818-4c41-a698-f372ff1bff87",
-        "name": "config0dbZeJSe",
+        "anomalyDetectionConfigurationId": "97584f08-cf2b-426e-b0ce-5a1b508e7a77",
+        "name": "configiACePTu1",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "092d1b98-6cab-4a19-a5a4-a2948497b6f5",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -161,8 +198,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -177,8 +214,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Koltaka",
-                "category": "Grocery \u0026 Gourmet Food"
+                "DimensionA": "Koltaka",
+                "dimensionB": "Grocery \u0026 Gourmet Food"
               }
             },
             "changeThresholdCondition": {
@@ -196,37 +233,137 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb5b5bf2-8818-4c41-a698-f372ff1bff87",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/97584f08-cf2b-426e-b0ce-5a1b508e7a77",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a473ac812e470a46a3291218a12c91bc-e7edac6a26228d42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0623d30a8f549786c992bf91b8ae3516",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6114bda3-c53c-4728-81c0-8629147bc466",
+        "Content-Length": "881",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:45:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5155",
+        "x-request-id": "6114bda3-c53c-4728-81c0-8629147bc466"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "97584f08-cf2b-426e-b0ce-5a1b508e7a77",
+        "name": "configiACePTu1",
+        "description": "",
+        "metricId": "092d1b98-6cab-4a19-a5a4-a2948497b6f5",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "lowerBound": 10.0,
+            "upperBound": 20.0,
+            "anomalyDetectorDirection": "Both",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 2.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": [
+          {
+            "series": {
+              "dimension": {
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
+              }
+            },
+            "smartDetectionCondition": {
+              "sensitivity": 30.0,
+              "anomalyDetectorDirection": "Both",
+              "suppressCondition": {
+                "minNumber": 3,
+                "minRatio": 4.0
+              }
+            }
+          },
+          {
+            "series": {
+              "dimension": {
+                "DimensionA": "Koltaka",
+                "dimensionB": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "changeThresholdCondition": {
+              "changePercentage": 40.0,
+              "shiftPoint": 12,
+              "anomalyDetectorDirection": "Up",
+              "withinRange": false,
+              "suppressCondition": {
+                "minNumber": 5,
+                "minRatio": 6.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/97584f08-cf2b-426e-b0ce-5a1b508e7a77",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9b23c9d14f502849873644db4dc213b5-f9fd41e3b194584c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-6b09c5a9d9a948459a704f42062e4cc4-6c7b720f68f2c24f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8695fe6bf483657ea7acc07125635c32",
+        "x-ms-client-request-id": "41461f5038aa9522cda28ca0a9a4abe6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4d4fe126-3078-46ea-94db-f51be2b6d10d",
+        "apim-request-id": "24ffe78f-c334-4106-8cd2-a8ec6e8ee4d8",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:17 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "144",
-        "X-Request-ID": "4d4fe126-3078-46ea-94db-f51be2b6d10d"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "113",
+        "x-request-id": "24ffe78f-c334-4106-8cd2-a8ec6e8ee4d8"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5b2267c6-3cfc-4f2e-8b9c-a393f622af06",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c98422a03e2f7440bf42706fe8e9809a-bedf67b54608304e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "af7bcded77d018112529a893a4ca7aaf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "90733493-3368-482e-8a69-57015515c074",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:45:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "302",
+        "x-request-id": "90733493-3368-482e-8a69-57015515c074"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "1254168855"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesConditionsAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesConditionsAsync.json
@@ -1,47 +1,63 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "719",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3112081f064715409307d96ec6e6ce93-b68f4d44fa2e8340-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-ebdb99443911d248b91659b175545422-e790928f1b93804b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "faafdc09586e1851afb018424d0af9ee",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "{\u0022name\u0022:\u0022configqqScA538\u0022,\u0022metricId\u0022:\u002227e3015f-04fd-44ba-a20b-bc529a0aebae\u0022,\u0022wholeMetricConfiguration\u0022:{\u0022hardThresholdCondition\u0022:{\u0022lowerBound\u0022:10,\u0022upperBound\u0022:20,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:1,\u0022minRatio\u0022:2}}},\u0022seriesOverrideConfigurations\u0022:[{\u0022series\u0022:{\u0022dimension\u0022:{\u0022city\u0022:\u0022Delhi\u0022,\u0022category\u0022:\u0022Handmade\u0022}},\u0022smartDetectionCondition\u0022:{\u0022sensitivity\u0022:30,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:3,\u0022minRatio\u0022:4}}},{\u0022series\u0022:{\u0022dimension\u0022:{\u0022city\u0022:\u0022Koltaka\u0022,\u0022category\u0022:\u0022Grocery \u0026 Gourmet Food\u0022}},\u0022changeThresholdCondition\u0022:{\u0022changePercentage\u0022:40,\u0022shiftPoint\u0022:12,\u0022withinRange\u0022:false,\u0022anomalyDetectorDirection\u0022:\u0022Up\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:5,\u0022minRatio\u0022:6}}}]}",
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedqqScA538",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "dec682fe-5ced-43ef-ae55-bcd34110d63e",
+        "apim-request-id": "acfd4bb2-49c5-49c4-a882-bf9f74939613",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:26 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c1e77155-61c1-4c70-9d56-f1c0d0b5cc9b",
+        "Date": "Wed, 09 Jun 2021 19:46:12 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9120a686-0aaf-41e0-b86c-81815c05603d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "176",
-        "X-Request-ID": "dec682fe-5ced-43ef-ae55-bcd34110d63e"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "631",
+        "x-request-id": "acfd4bb2-49c5-49c4-a882-bf9f74939613"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c1e77155-61c1-4c70-9d56-f1c0d0b5cc9b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9120a686-0aaf-41e0-b86c-81815c05603d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3112081f064715409307d96ec6e6ce93-6f94489caa1bdb41-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-ebdb99443911d248b91659b175545422-012af76ea21fc94e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "650c83fac415315b08da84256ab01572",
         "x-ms-return-client-request-id": "true"
@@ -49,102 +65,123 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e8a7acc5-4352-4b2f-a9ff-4dd8feb9e8fa",
-        "Content-Length": "865",
+        "apim-request-id": "0a0788c5-4c96-4f3b-a71d-26dc12129a07",
+        "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:26 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "110",
-        "X-Request-ID": "e8a7acc5-4352-4b2f-a9ff-4dd8feb9e8fa"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "218",
+        "x-request-id": "0a0788c5-4c96-4f3b-a71d-26dc12129a07"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "c1e77155-61c1-4c70-9d56-f1c0d0b5cc9b",
-        "name": "configqqScA538",
-        "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-        "wholeMetricConfiguration": {
-          "hardThresholdCondition": {
-            "lowerBound": 10.0,
-            "upperBound": 20.0,
-            "anomalyDetectorDirection": "Both",
-            "suppressCondition": {
-              "minNumber": 1,
-              "minRatio": 2.0
-            }
-          }
-        },
-        "dimensionGroupOverrideConfigurations": [],
-        "seriesOverrideConfigurations": [
+        "dataFeedId": "9120a686-0aaf-41e0-b86c-81815c05603d",
+        "dataFeedName": "dataFeedqqScA538",
+        "metrics": [
           {
-            "series": {
-              "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
-              }
-            },
-            "smartDetectionCondition": {
-              "sensitivity": 30.0,
-              "anomalyDetectorDirection": "Both",
-              "suppressCondition": {
-                "minNumber": 3,
-                "minRatio": 4.0
-              }
-            }
+            "metricId": "86799ad1-adb6-45df-9c5f-7e72e4094bf6",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
           },
           {
-            "series": {
-              "dimension": {
-                "city": "Koltaka",
-                "category": "Grocery \u0026 Gourmet Food"
-              }
-            },
-            "changeThresholdCondition": {
-              "changePercentage": 40.0,
-              "shiftPoint": 12,
-              "anomalyDetectorDirection": "Up",
-              "withinRange": false,
-              "suppressCondition": {
-                "minNumber": 5,
-                "minRatio": 6.0
-              }
-            }
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
           }
-        ]
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:12Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c1e77155-61c1-4c70-9d56-f1c0d0b5cc9b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "735",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-dd284f3a3f85db4dbc4e43164ca3a2c4-65b3f11c181e8e47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "690362e430e4d34f304b23f7b6725d45",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "{\u0022name\u0022:\u0022configxIxABLlr\u0022,\u0022metricId\u0022:\u002286799ad1-adb6-45df-9c5f-7e72e4094bf6\u0022,\u0022wholeMetricConfiguration\u0022:{\u0022hardThresholdCondition\u0022:{\u0022lowerBound\u0022:10,\u0022upperBound\u0022:20,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:1,\u0022minRatio\u0022:2}}},\u0022seriesOverrideConfigurations\u0022:[{\u0022series\u0022:{\u0022dimension\u0022:{\u0022DimensionA\u0022:\u0022Delhi\u0022,\u0022dimensionB\u0022:\u0022Handmade\u0022}},\u0022smartDetectionCondition\u0022:{\u0022sensitivity\u0022:30,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:3,\u0022minRatio\u0022:4}}},{\u0022series\u0022:{\u0022dimension\u0022:{\u0022DimensionA\u0022:\u0022Koltaka\u0022,\u0022dimensionB\u0022:\u0022Grocery \u0026 Gourmet Food\u0022}},\u0022changeThresholdCondition\u0022:{\u0022changePercentage\u0022:40,\u0022shiftPoint\u0022:12,\u0022withinRange\u0022:false,\u0022anomalyDetectorDirection\u0022:\u0022Up\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:5,\u0022minRatio\u0022:6}}}]}",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "aa9e46d9-ee9d-4474-8283-28ddda128b12",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:12 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/02f9942d-8593-4ed2-8691-23edf4673590",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "214",
+        "x-request-id": "aa9e46d9-ee9d-4474-8283-28ddda128b12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/02f9942d-8593-4ed2-8691-23edf4673590",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9bc5aa41b831414094b74fd0640b0ac1-1dc618dc055e2941-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-dd284f3a3f85db4dbc4e43164ca3a2c4-569b0b664a85304f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "75ad7adab95bc468e4620369e4304fd3",
+        "x-ms-client-request-id": "93f17e802cd3ffae9aa667d35c849340",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "217fdef4-5839-4f5d-9c6c-a350e2e29d24",
-        "Content-Length": "865",
+        "apim-request-id": "4cd6be8c-53e9-44af-96bd-52107d06aa97",
+        "Content-Length": "881",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:26 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "93",
-        "X-Request-ID": "217fdef4-5839-4f5d-9c6c-a350e2e29d24"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "91",
+        "x-request-id": "4cd6be8c-53e9-44af-96bd-52107d06aa97"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "c1e77155-61c1-4c70-9d56-f1c0d0b5cc9b",
-        "name": "configqqScA538",
+        "anomalyDetectionConfigurationId": "02f9942d-8593-4ed2-8691-23edf4673590",
+        "name": "configxIxABLlr",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "86799ad1-adb6-45df-9c5f-7e72e4094bf6",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -161,8 +198,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -177,8 +214,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Koltaka",
-                "category": "Grocery \u0026 Gourmet Food"
+                "DimensionA": "Koltaka",
+                "dimensionB": "Grocery \u0026 Gourmet Food"
               }
             },
             "changeThresholdCondition": {
@@ -196,37 +233,137 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c1e77155-61c1-4c70-9d56-f1c0d0b5cc9b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/02f9942d-8593-4ed2-8691-23edf4673590",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6fc1c0c28a065a4ea460e925bd6bfdbb-1a70bde899ba7645-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b381481af2c0d84d8bb1f51e8c1ebc67",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c3fe13bf-0711-4589-a685-fea5f7a50680",
+        "Content-Length": "881",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "85",
+        "x-request-id": "c3fe13bf-0711-4589-a685-fea5f7a50680"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "02f9942d-8593-4ed2-8691-23edf4673590",
+        "name": "configxIxABLlr",
+        "description": "",
+        "metricId": "86799ad1-adb6-45df-9c5f-7e72e4094bf6",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "lowerBound": 10.0,
+            "upperBound": 20.0,
+            "anomalyDetectorDirection": "Both",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 2.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": [
+          {
+            "series": {
+              "dimension": {
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
+              }
+            },
+            "smartDetectionCondition": {
+              "sensitivity": 30.0,
+              "anomalyDetectorDirection": "Both",
+              "suppressCondition": {
+                "minNumber": 3,
+                "minRatio": 4.0
+              }
+            }
+          },
+          {
+            "series": {
+              "dimension": {
+                "DimensionA": "Koltaka",
+                "dimensionB": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "changeThresholdCondition": {
+              "changePercentage": 40.0,
+              "shiftPoint": 12,
+              "anomalyDetectorDirection": "Up",
+              "withinRange": false,
+              "suppressCondition": {
+                "minNumber": 5,
+                "minRatio": 6.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/02f9942d-8593-4ed2-8691-23edf4673590",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c3031344c10fee44b3f5a43059c5f501-8e99ae49c603654c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-c34d826902f992449e2647e36363c4ec-446d7bc140d4314e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f7234b3072b6455d807ef193d32caeff",
+        "x-ms-client-request-id": "dcf4681cd4c7b7f1b304cf3ec87b76ac",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d658b1db-0f5e-492c-8930-5cb44bfa2268",
+        "apim-request-id": "987f55c2-fd06-4f0a-8c59-2eb818898979",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:26 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "101",
-        "X-Request-ID": "d658b1db-0f5e-492c-8930-5cb44bfa2268"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "100",
+        "x-request-id": "987f55c2-fd06-4f0a-8c59-2eb818898979"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9120a686-0aaf-41e0-b86c-81815c05603d",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-dbf5aca311221049a8c01500024082a4-c8feb623a9e8dd46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6ddce2b8a9f18e84301908213790727c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "ef3c1a94-574d-49a8-896e-b150c81ef7a4",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "306",
+        "x-request-id": "ef3c1a94-574d-49a8-896e-b150c81ef7a4"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "785880626"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesConditionsAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesConditionsAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ebdb99443911d248b91659b175545422-e790928f1b93804b-00",
+        "traceparent": "00-473de526149cd643877da0eea743cbd9-54b2fbfb7c00f843-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "faafdc09586e1851afb018424d0af9ee",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "acfd4bb2-49c5-49c4-a882-bf9f74939613",
+        "apim-request-id": "4d885a0b-8888-449c-9234-df5839f1fdf6",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:12 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9120a686-0aaf-41e0-b86c-81815c05603d",
+        "Date": "Wed, 09 Jun 2021 23:03:46 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ec0181e5-42e4-45c1-8193-b3c539ad6416",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "631",
-        "x-request-id": "acfd4bb2-49c5-49c4-a882-bf9f74939613"
+        "x-envoy-upstream-service-time": "543",
+        "x-request-id": "4d885a0b-8888-449c-9234-df5839f1fdf6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9120a686-0aaf-41e0-b86c-81815c05603d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ec0181e5-42e4-45c1-8193-b3c539ad6416",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ebdb99443911d248b91659b175545422-012af76ea21fc94e-00",
+        "traceparent": "00-473de526149cd643877da0eea743cbd9-e45fdfddec629e4a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "650c83fac415315b08da84256ab01572",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0a0788c5-4c96-4f3b-a71d-26dc12129a07",
+        "apim-request-id": "3387706b-fb39-4724-9b8e-552645ecbb7f",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:12 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "218",
-        "x-request-id": "0a0788c5-4c96-4f3b-a71d-26dc12129a07"
+        "x-envoy-upstream-service-time": "159",
+        "x-request-id": "3387706b-fb39-4724-9b8e-552645ecbb7f"
       },
       "ResponseBody": {
-        "dataFeedId": "9120a686-0aaf-41e0-b86c-81815c05603d",
+        "dataFeedId": "ec0181e5-42e4-45c1-8193-b3c539ad6416",
         "dataFeedName": "dataFeedqqScA538",
         "metrics": [
           {
-            "metricId": "86799ad1-adb6-45df-9c5f-7e72e4094bf6",
+            "metricId": "090a0b92-f39e-44e4-a508-cad3181b4648",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:12Z",
+        "createdTime": "2021-06-09T23:03:46Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,33 +133,33 @@
         "Content-Length": "735",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dd284f3a3f85db4dbc4e43164ca3a2c4-65b3f11c181e8e47-00",
+        "traceparent": "00-0b8b3ba43a9a6e489b23ef5e957dfa6b-6fefa9f172554a40-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "690362e430e4d34f304b23f7b6725d45",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "{\u0022name\u0022:\u0022configxIxABLlr\u0022,\u0022metricId\u0022:\u002286799ad1-adb6-45df-9c5f-7e72e4094bf6\u0022,\u0022wholeMetricConfiguration\u0022:{\u0022hardThresholdCondition\u0022:{\u0022lowerBound\u0022:10,\u0022upperBound\u0022:20,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:1,\u0022minRatio\u0022:2}}},\u0022seriesOverrideConfigurations\u0022:[{\u0022series\u0022:{\u0022dimension\u0022:{\u0022DimensionA\u0022:\u0022Delhi\u0022,\u0022dimensionB\u0022:\u0022Handmade\u0022}},\u0022smartDetectionCondition\u0022:{\u0022sensitivity\u0022:30,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:3,\u0022minRatio\u0022:4}}},{\u0022series\u0022:{\u0022dimension\u0022:{\u0022DimensionA\u0022:\u0022Koltaka\u0022,\u0022dimensionB\u0022:\u0022Grocery \u0026 Gourmet Food\u0022}},\u0022changeThresholdCondition\u0022:{\u0022changePercentage\u0022:40,\u0022shiftPoint\u0022:12,\u0022withinRange\u0022:false,\u0022anomalyDetectorDirection\u0022:\u0022Up\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:5,\u0022minRatio\u0022:6}}}]}",
+      "RequestBody": "{\u0022name\u0022:\u0022configxIxABLlr\u0022,\u0022metricId\u0022:\u0022090a0b92-f39e-44e4-a508-cad3181b4648\u0022,\u0022wholeMetricConfiguration\u0022:{\u0022hardThresholdCondition\u0022:{\u0022lowerBound\u0022:10,\u0022upperBound\u0022:20,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:1,\u0022minRatio\u0022:2}}},\u0022seriesOverrideConfigurations\u0022:[{\u0022series\u0022:{\u0022dimension\u0022:{\u0022dimensionA\u0022:\u0022Delhi\u0022,\u0022dimensionB\u0022:\u0022Handmade\u0022}},\u0022smartDetectionCondition\u0022:{\u0022sensitivity\u0022:30,\u0022anomalyDetectorDirection\u0022:\u0022Both\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:3,\u0022minRatio\u0022:4}}},{\u0022series\u0022:{\u0022dimension\u0022:{\u0022dimensionA\u0022:\u0022Koltaka\u0022,\u0022dimensionB\u0022:\u0022Grocery \u0026 Gourmet Food\u0022}},\u0022changeThresholdCondition\u0022:{\u0022changePercentage\u0022:40,\u0022shiftPoint\u0022:12,\u0022withinRange\u0022:false,\u0022anomalyDetectorDirection\u0022:\u0022Up\u0022,\u0022suppressCondition\u0022:{\u0022minNumber\u0022:5,\u0022minRatio\u0022:6}}}]}",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "aa9e46d9-ee9d-4474-8283-28ddda128b12",
+        "apim-request-id": "87c4d16e-47a2-4038-a5ef-73703b16627e",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:12 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/02f9942d-8593-4ed2-8691-23edf4673590",
+        "Date": "Wed, 09 Jun 2021 23:03:46 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f5f95053-2e9b-42d1-b97d-69e400829881",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "214",
-        "x-request-id": "aa9e46d9-ee9d-4474-8283-28ddda128b12"
+        "x-envoy-upstream-service-time": "201",
+        "x-request-id": "87c4d16e-47a2-4038-a5ef-73703b16627e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/02f9942d-8593-4ed2-8691-23edf4673590",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f5f95053-2e9b-42d1-b97d-69e400829881",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dd284f3a3f85db4dbc4e43164ca3a2c4-569b0b664a85304f-00",
+        "traceparent": "00-0b8b3ba43a9a6e489b23ef5e957dfa6b-dff3c79f729a4d4d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "93f17e802cd3ffae9aa667d35c849340",
@@ -168,20 +168,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4cd6be8c-53e9-44af-96bd-52107d06aa97",
+        "apim-request-id": "632b22e6-bbbf-4377-a681-3455b8421f5c",
         "Content-Length": "881",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:13 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "91",
-        "x-request-id": "4cd6be8c-53e9-44af-96bd-52107d06aa97"
+        "x-envoy-upstream-service-time": "86",
+        "x-request-id": "632b22e6-bbbf-4377-a681-3455b8421f5c"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "02f9942d-8593-4ed2-8691-23edf4673590",
+        "anomalyDetectionConfigurationId": "f5f95053-2e9b-42d1-b97d-69e400829881",
         "name": "configxIxABLlr",
         "description": "",
-        "metricId": "86799ad1-adb6-45df-9c5f-7e72e4094bf6",
+        "metricId": "090a0b92-f39e-44e4-a508-cad3181b4648",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -198,7 +198,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -214,7 +214,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Koltaka",
+                "dimensionA": "Koltaka",
                 "dimensionB": "Grocery \u0026 Gourmet Food"
               }
             },
@@ -233,12 +233,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/02f9942d-8593-4ed2-8691-23edf4673590",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f5f95053-2e9b-42d1-b97d-69e400829881",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6fc1c0c28a065a4ea460e925bd6bfdbb-1a70bde899ba7645-00",
+        "traceparent": "00-e14c357003793c449d32929b5c9c3692-afae2b10f59de04e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b381481af2c0d84d8bb1f51e8c1ebc67",
@@ -247,20 +247,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c3fe13bf-0711-4589-a685-fea5f7a50680",
+        "apim-request-id": "697fac36-f02a-4a6f-98c6-78eb3112344e",
         "Content-Length": "881",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:13 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "85",
-        "x-request-id": "c3fe13bf-0711-4589-a685-fea5f7a50680"
+        "x-envoy-upstream-service-time": "91",
+        "x-request-id": "697fac36-f02a-4a6f-98c6-78eb3112344e"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "02f9942d-8593-4ed2-8691-23edf4673590",
+        "anomalyDetectionConfigurationId": "f5f95053-2e9b-42d1-b97d-69e400829881",
         "name": "configxIxABLlr",
         "description": "",
-        "metricId": "86799ad1-adb6-45df-9c5f-7e72e4094bf6",
+        "metricId": "090a0b92-f39e-44e4-a508-cad3181b4648",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -277,7 +277,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -293,7 +293,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Koltaka",
+                "dimensionA": "Koltaka",
                 "dimensionB": "Grocery \u0026 Gourmet Food"
               }
             },
@@ -312,12 +312,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/02f9942d-8593-4ed2-8691-23edf4673590",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f5f95053-2e9b-42d1-b97d-69e400829881",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c34d826902f992449e2647e36363c4ec-446d7bc140d4314e-00",
+        "traceparent": "00-d7e94c6fdbcb3241ab6482ed2ca03927-141fef45a5cd7c4c-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dcf4681cd4c7b7f1b304cf3ec87b76ac",
@@ -326,23 +326,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "987f55c2-fd06-4f0a-8c59-2eb818898979",
+        "apim-request-id": "4477282d-479b-40eb-ae22-4753c14c0783",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:13 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "100",
-        "x-request-id": "987f55c2-fd06-4f0a-8c59-2eb818898979"
+        "x-envoy-upstream-service-time": "91",
+        "x-request-id": "4477282d-479b-40eb-ae22-4753c14c0783"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9120a686-0aaf-41e0-b86c-81815c05603d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ec0181e5-42e4-45c1-8193-b3c539ad6416",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dbf5aca311221049a8c01500024082a4-c8feb623a9e8dd46-00",
+        "traceparent": "00-2639a8c6e4994c419b267db7f13613e3-fb5598b344b0e84b-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6ddce2b8a9f18e84301908213790727c",
@@ -351,19 +351,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ef3c1a94-574d-49a8-896e-b150c81ef7a4",
+        "apim-request-id": "93a3141a-f1e2-449f-a9dd-eac07c002cbf",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:13 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "x-envoy-upstream-service-time": "306",
-        "x-request-id": "ef3c1a94-574d-49a8-896e-b150c81ef7a4"
+        "x-request-id": "93a3141a-f1e2-449f-a9dd-eac07c002cbf"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "785880626"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesGroupConditions.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesGroupConditions.json
@@ -1,25 +1,147 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "651",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c2cddb9cc94aea4cb7591ace1d5e4f0d-82a66f6172935146-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-512be7cd2fde1649b03f1cafe58dbb43-0d0da4d952509241-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "656cd18a353425b4f8cddfbed51bef5d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configYGaiVwzS",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedYGaiVwzS",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "87bef97c-ddb5-4939-870d-c2fb5dc8316d",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:45:45 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e4d04fe-7827-495f-84b0-4c76d2f3d7e9",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "546",
+        "x-request-id": "87bef97c-ddb5-4939-870d-c2fb5dc8316d"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e4d04fe-7827-495f-84b0-4c76d2f3d7e9",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-512be7cd2fde1649b03f1cafe58dbb43-cddb0224a101d640-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ca077e7a316f2f42264717cd27d59ee3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "554083be-ce61-4115-ac61-15405c09b224",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:45:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "159",
+        "x-request-id": "554083be-ce61-4115-ac61-15405c09b224"
+      },
+      "ResponseBody": {
+        "dataFeedId": "7e4d04fe-7827-495f-84b0-4c76d2f3d7e9",
+        "dataFeedName": "dataFeedYGaiVwzS",
+        "metrics": [
+          {
+            "metricId": "292864e8-3625-4fb5-a421-4ab503a81a10",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:45:46Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "663",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e9d892846504ac43ab85f34f59874bcc-4c51f0160be3c745-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "901dfade075ff72098fc1dc75c87e258",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configLEooYU4b",
+        "metricId": "292864e8-3625-4fb5-a421-4ab503a81a10",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10,
@@ -34,7 +156,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Delhi"
+                "DimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -49,7 +171,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -67,49 +189,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "0e06f162-fe71-4f2a-8de8-0050f64fa65f",
+        "apim-request-id": "040253f0-14db-4bfa-95f2-b04c9a01f4c1",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:18 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/25b49fe6-44ec-4b20-be1e-1cc0d78e9b94",
+        "Date": "Wed, 09 Jun 2021 19:45:46 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/064c9ae0-099c-4907-923f-68d72c211bd0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "185",
-        "X-Request-ID": "0e06f162-fe71-4f2a-8de8-0050f64fa65f"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "180",
+        "x-request-id": "040253f0-14db-4bfa-95f2-b04c9a01f4c1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/25b49fe6-44ec-4b20-be1e-1cc0d78e9b94",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/064c9ae0-099c-4907-923f-68d72c211bd0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c2cddb9cc94aea4cb7591ace1d5e4f0d-ecdd69df522a3e42-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-e9d892846504ac43ab85f34f59874bcc-abadbe6cd221de40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ca077e7a316f2f42264717cd27d59ee3",
+        "x-ms-client-request-id": "ec3f3d8ee61d23fe2ffc73584c8ab477",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d72adcf1-499c-441a-a315-9af72ef19f97",
-        "Content-Length": "787",
+        "apim-request-id": "b81c1290-63a6-41b6-8d99-573493173413",
+        "Content-Length": "799",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:18 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "96",
-        "X-Request-ID": "d72adcf1-499c-441a-a315-9af72ef19f97"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "90",
+        "x-request-id": "b81c1290-63a6-41b6-8d99-573493173413"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "25b49fe6-44ec-4b20-be1e-1cc0d78e9b94",
-        "name": "configYGaiVwzS",
+        "anomalyDetectionConfigurationId": "064c9ae0-099c-4907-923f-68d72c211bd0",
+        "name": "configLEooYU4b",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "292864e8-3625-4fb5-a421-4ab503a81a10",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -124,7 +243,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Delhi"
+                "DimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -139,7 +258,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -158,37 +277,34 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/25b49fe6-44ec-4b20-be1e-1cc0d78e9b94",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/064c9ae0-099c-4907-923f-68d72c211bd0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6671e6c97f39534db9d053510bc2a5dd-6aafe435ce5ac742-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-3076d3bc9eb8164f9c57ee2dec0007d9-a57d90320801a24a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "64cf7d4b02a907eadefa1d905f0720f7",
+        "x-ms-client-request-id": "75eb0093b1131ed02720342bb7d687c3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b83b1fa7-34f7-4604-b00c-014bae8777a9",
-        "Content-Length": "787",
+        "apim-request-id": "549d0323-653a-4fea-942b-83acdf81fb59",
+        "Content-Length": "799",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:18 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "83",
-        "X-Request-ID": "b83b1fa7-34f7-4604-b00c-014bae8777a9"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "89",
+        "x-request-id": "549d0323-653a-4fea-942b-83acdf81fb59"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "25b49fe6-44ec-4b20-be1e-1cc0d78e9b94",
-        "name": "configYGaiVwzS",
+        "anomalyDetectionConfigurationId": "064c9ae0-099c-4907-923f-68d72c211bd0",
+        "name": "configLEooYU4b",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "292864e8-3625-4fb5-a421-4ab503a81a10",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -203,7 +319,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Delhi"
+                "DimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -218,7 +334,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -237,37 +353,58 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/25b49fe6-44ec-4b20-be1e-1cc0d78e9b94",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/064c9ae0-099c-4907-923f-68d72c211bd0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9c16b08d8a10ff40bfea086ccef3307f-e30b957beb07254e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-e88f58e9e0270849b8a961702bd8125a-252e1a03aeed2b4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c71dfc98875c58e28e3d3fec1de6fe23",
+        "x-ms-client-request-id": "6cd5769bfec2f7e9fbfa606294c7ab0e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "085a7f49-7394-4449-a723-29a6f8866c65",
+        "apim-request-id": "18c78092-d8d9-4d74-88e9-01be768e6c17",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:18 GMT",
+        "Date": "Wed, 09 Jun 2021 19:45:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "98",
-        "X-Request-ID": "085a7f49-7394-4449-a723-29a6f8866c65"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "95",
+        "x-request-id": "18c78092-d8d9-4d74-88e9-01be768e6c17"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e4d04fe-7827-495f-84b0-4c76d2f3d7e9",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-09f79c392e36c24491d59f01fc0f31e3-f992f5392831c846-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "5b34a5476c9bdd456c20c5fdb1d36b59",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "70e0012d-8f38-467b-bfea-f17b11b5ffd4",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:45:46 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "320",
+        "x-request-id": "70e0012d-8f38-467b-bfea-f17b11b5ffd4"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "401674915"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesGroupConditions.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesGroupConditions.json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-512be7cd2fde1649b03f1cafe58dbb43-0d0da4d952509241-00",
+        "traceparent": "00-440ccfe7c5011144a481db17a920174a-55faa0ae21b2b74c-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "656cd18a353425b4f8cddfbed51bef5d",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "87bef97c-ddb5-4939-870d-c2fb5dc8316d",
+        "apim-request-id": "84e285f4-c2cd-4480-9e01-0ced2fa349ed",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:45 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e4d04fe-7827-495f-84b0-4c76d2f3d7e9",
+        "Date": "Wed, 09 Jun 2021 23:03:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/89acbfe2-4374-498f-81db-763e2a0ec51f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "546",
-        "x-request-id": "87bef97c-ddb5-4939-870d-c2fb5dc8316d"
+        "x-envoy-upstream-service-time": "574",
+        "x-request-id": "84e285f4-c2cd-4480-9e01-0ced2fa349ed"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e4d04fe-7827-495f-84b0-4c76d2f3d7e9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/89acbfe2-4374-498f-81db-763e2a0ec51f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-512be7cd2fde1649b03f1cafe58dbb43-cddb0224a101d640-00",
+        "traceparent": "00-440ccfe7c5011144a481db17a920174a-e1f5e43855c7f947-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ca077e7a316f2f42264717cd27d59ee3",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "554083be-ce61-4115-ac61-15405c09b224",
+        "apim-request-id": "0a1db1d7-52f0-43c0-aca6-9cb39f6540f7",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:45 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "159",
-        "x-request-id": "554083be-ce61-4115-ac61-15405c09b224"
+        "x-envoy-upstream-service-time": "173",
+        "x-request-id": "0a1db1d7-52f0-43c0-aca6-9cb39f6540f7"
       },
       "ResponseBody": {
-        "dataFeedId": "7e4d04fe-7827-495f-84b0-4c76d2f3d7e9",
+        "dataFeedId": "89acbfe2-4374-498f-81db-763e2a0ec51f",
         "dataFeedName": "dataFeedYGaiVwzS",
         "metrics": [
           {
-            "metricId": "292864e8-3625-4fb5-a421-4ab503a81a10",
+            "metricId": "47799fe8-b90d-4a47-8942-76c88c17f089",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:45:46Z",
+        "createdTime": "2021-06-09T23:03:23Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "663",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e9d892846504ac43ab85f34f59874bcc-4c51f0160be3c745-00",
+        "traceparent": "00-7cf9089a195def4f88e5817a4d58d3f7-6a022b48f872164d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "901dfade075ff72098fc1dc75c87e258",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "configLEooYU4b",
-        "metricId": "292864e8-3625-4fb5-a421-4ab503a81a10",
+        "metricId": "47799fe8-b90d-4a47-8942-76c88c17f089",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10,
@@ -156,7 +156,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Delhi"
+                "dimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -171,7 +171,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -189,24 +189,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "040253f0-14db-4bfa-95f2-b04c9a01f4c1",
+        "apim-request-id": "6ed431c9-5631-49b3-a648-b7f663bf743c",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:46 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/064c9ae0-099c-4907-923f-68d72c211bd0",
+        "Date": "Wed, 09 Jun 2021 23:03:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/5e6a2afb-1a94-4b9b-8d2e-2a1c2423d3ce",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "180",
-        "x-request-id": "040253f0-14db-4bfa-95f2-b04c9a01f4c1"
+        "x-envoy-upstream-service-time": "182",
+        "x-request-id": "6ed431c9-5631-49b3-a648-b7f663bf743c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/064c9ae0-099c-4907-923f-68d72c211bd0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/5e6a2afb-1a94-4b9b-8d2e-2a1c2423d3ce",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e9d892846504ac43ab85f34f59874bcc-abadbe6cd221de40-00",
+        "traceparent": "00-7cf9089a195def4f88e5817a4d58d3f7-1c68d947fd13884e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ec3f3d8ee61d23fe2ffc73584c8ab477",
@@ -215,20 +215,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b81c1290-63a6-41b6-8d99-573493173413",
+        "apim-request-id": "824ce217-7682-484f-be4d-5ee4d019381f",
         "Content-Length": "799",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:46 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "90",
-        "x-request-id": "b81c1290-63a6-41b6-8d99-573493173413"
+        "x-envoy-upstream-service-time": "98",
+        "x-request-id": "824ce217-7682-484f-be4d-5ee4d019381f"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "064c9ae0-099c-4907-923f-68d72c211bd0",
+        "anomalyDetectionConfigurationId": "5e6a2afb-1a94-4b9b-8d2e-2a1c2423d3ce",
         "name": "configLEooYU4b",
         "description": "",
-        "metricId": "292864e8-3625-4fb5-a421-4ab503a81a10",
+        "metricId": "47799fe8-b90d-4a47-8942-76c88c17f089",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -243,7 +243,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Delhi"
+                "dimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -258,7 +258,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -277,12 +277,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/064c9ae0-099c-4907-923f-68d72c211bd0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/5e6a2afb-1a94-4b9b-8d2e-2a1c2423d3ce",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3076d3bc9eb8164f9c57ee2dec0007d9-a57d90320801a24a-00",
+        "traceparent": "00-e83d161eef249042b7ded6b7ded01eef-9808eaa47407cc4d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "75eb0093b1131ed02720342bb7d687c3",
@@ -291,20 +291,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "549d0323-653a-4fea-942b-83acdf81fb59",
+        "apim-request-id": "e54095b8-ca65-43b9-a2d2-a274603ccbe8",
         "Content-Length": "799",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:46 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "89",
-        "x-request-id": "549d0323-653a-4fea-942b-83acdf81fb59"
+        "x-envoy-upstream-service-time": "107",
+        "x-request-id": "e54095b8-ca65-43b9-a2d2-a274603ccbe8"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "064c9ae0-099c-4907-923f-68d72c211bd0",
+        "anomalyDetectionConfigurationId": "5e6a2afb-1a94-4b9b-8d2e-2a1c2423d3ce",
         "name": "configLEooYU4b",
         "description": "",
-        "metricId": "292864e8-3625-4fb5-a421-4ab503a81a10",
+        "metricId": "47799fe8-b90d-4a47-8942-76c88c17f089",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -319,7 +319,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Delhi"
+                "dimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -334,7 +334,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -353,12 +353,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/064c9ae0-099c-4907-923f-68d72c211bd0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/5e6a2afb-1a94-4b9b-8d2e-2a1c2423d3ce",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e88f58e9e0270849b8a961702bd8125a-252e1a03aeed2b4b-00",
+        "traceparent": "00-9f67ee6e5c952643b4de3e9ea197c861-a3e60eb16b559d4e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6cd5769bfec2f7e9fbfa606294c7ab0e",
@@ -367,23 +367,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "18c78092-d8d9-4d74-88e9-01be768e6c17",
+        "apim-request-id": "1e3d63fc-d9f0-4e31-a556-41598bdbb06d",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:46 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "95",
-        "x-request-id": "18c78092-d8d9-4d74-88e9-01be768e6c17"
+        "x-envoy-upstream-service-time": "105",
+        "x-request-id": "1e3d63fc-d9f0-4e31-a556-41598bdbb06d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e4d04fe-7827-495f-84b0-4c76d2f3d7e9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/89acbfe2-4374-498f-81db-763e2a0ec51f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-09f79c392e36c24491d59f01fc0f31e3-f992f5392831c846-00",
+        "traceparent": "00-0df0bf662d672945823d8f9597e93922-a5019dd915d4c240-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5b34a5476c9bdd456c20c5fdb1d36b59",
@@ -392,19 +392,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "70e0012d-8f38-467b-bfea-f17b11b5ffd4",
+        "apim-request-id": "dbadf5b3-45d7-4a61-910d-66f650ed6ea2",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:46 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "320",
-        "x-request-id": "70e0012d-8f38-467b-bfea-f17b11b5ffd4"
+        "x-envoy-upstream-service-time": "362",
+        "x-request-id": "dbadf5b3-45d7-4a61-910d-66f650ed6ea2"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "401674915"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesGroupConditionsAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesGroupConditionsAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-03ee16f53300b846acc03effcc3ea5bd-001fd869000fd14e-00",
+        "traceparent": "00-9ec6949800caca4a8604d6be9e2d8241-600db8eef43f7e47-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2042946b9f86aaeecd515698e28e6fc0",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ffcff793-62fb-42bf-a66f-706d4be417c7",
+        "apim-request-id": "28346e4b-5975-4240-adae-9d66982768eb",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:14 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e6c6a798-d9ad-4417-9d90-b12cbb8413c7",
+        "Date": "Wed, 09 Jun 2021 23:03:48 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b79a3e9d-ddd8-41b7-a617-6b597cebdcbd",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "612",
-        "x-request-id": "ffcff793-62fb-42bf-a66f-706d4be417c7"
+        "x-envoy-upstream-service-time": "561",
+        "x-request-id": "28346e4b-5975-4240-adae-9d66982768eb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e6c6a798-d9ad-4417-9d90-b12cbb8413c7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b79a3e9d-ddd8-41b7-a617-6b597cebdcbd",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-03ee16f53300b846acc03effcc3ea5bd-f924cb48f8d21a48-00",
+        "traceparent": "00-9ec6949800caca4a8604d6be9e2d8241-1b610ab5626a7b44-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7b6fed7b4fbe189d44864c1970c02ed4",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "74d52cb4-c984-4ef7-9459-6706de06e084",
+        "apim-request-id": "e572977d-ccbe-417c-a163-751ae5fbda78",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:14 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "x-envoy-upstream-service-time": "148",
-        "x-request-id": "74d52cb4-c984-4ef7-9459-6706de06e084"
+        "x-request-id": "e572977d-ccbe-417c-a163-751ae5fbda78"
       },
       "ResponseBody": {
-        "dataFeedId": "e6c6a798-d9ad-4417-9d90-b12cbb8413c7",
+        "dataFeedId": "b79a3e9d-ddd8-41b7-a617-6b597cebdcbd",
         "dataFeedName": "dataFeed1oRulW2B",
         "metrics": [
           {
-            "metricId": "4a07fde4-2d7a-4ee6-8cdf-3a9082d0ab83",
+            "metricId": "8be9a9b4-fdd6-4e9b-90dd-6fe1a069f9bb",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:14Z",
+        "createdTime": "2021-06-09T23:03:48Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "663",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-baa6bf22d3a15d4cb8382fb7a196059a-bcbefcf16473a44a-00",
+        "traceparent": "00-757c9605a910894a8cba0a43d508d619-4e186e01868efb4a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1de9a97b72e509a4b385da9afd0aa91b",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "configQ9DLUXVw",
-        "metricId": "4a07fde4-2d7a-4ee6-8cdf-3a9082d0ab83",
+        "metricId": "8be9a9b4-fdd6-4e9b-90dd-6fe1a069f9bb",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10,
@@ -156,7 +156,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Delhi"
+                "dimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -171,7 +171,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -189,24 +189,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2638bba3-f3a1-4ca8-941c-4d003b069ac4",
+        "apim-request-id": "97b17918-38df-405d-a0ed-0690333e6270",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:14 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3b91504-7a61-4be0-8b03-57def4354d5a",
+        "Date": "Wed, 09 Jun 2021 23:03:48 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/98a12db0-fd27-433c-9538-8ecff1e46447",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "175",
-        "x-request-id": "2638bba3-f3a1-4ca8-941c-4d003b069ac4"
+        "x-envoy-upstream-service-time": "184",
+        "x-request-id": "97b17918-38df-405d-a0ed-0690333e6270"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3b91504-7a61-4be0-8b03-57def4354d5a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/98a12db0-fd27-433c-9538-8ecff1e46447",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-baa6bf22d3a15d4cb8382fb7a196059a-4aa52e004a032747-00",
+        "traceparent": "00-757c9605a910894a8cba0a43d508d619-21adcf78b15e6c49-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ffdc2af6d5530d392282a544166c7116",
@@ -215,20 +215,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "321f4fc0-86db-43d8-82a1-ba8e2e31e646",
+        "apim-request-id": "f8e5274a-8e12-45d7-9e76-53c296b4415f",
         "Content-Length": "799",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:14 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "95",
-        "x-request-id": "321f4fc0-86db-43d8-82a1-ba8e2e31e646"
+        "x-envoy-upstream-service-time": "84",
+        "x-request-id": "f8e5274a-8e12-45d7-9e76-53c296b4415f"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "b3b91504-7a61-4be0-8b03-57def4354d5a",
+        "anomalyDetectionConfigurationId": "98a12db0-fd27-433c-9538-8ecff1e46447",
         "name": "configQ9DLUXVw",
         "description": "",
-        "metricId": "4a07fde4-2d7a-4ee6-8cdf-3a9082d0ab83",
+        "metricId": "8be9a9b4-fdd6-4e9b-90dd-6fe1a069f9bb",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -243,7 +243,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Delhi"
+                "dimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -258,7 +258,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -277,12 +277,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3b91504-7a61-4be0-8b03-57def4354d5a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/98a12db0-fd27-433c-9538-8ecff1e46447",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-02f32267d0366a449d8bd4c5e1822a59-54eaecea5f5ec847-00",
+        "traceparent": "00-e3f1dba3525f7840a76b77dbcc108398-ace009addb260341-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "15ffb7318066d133e14266eae594d6e7",
@@ -291,20 +291,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5fffcfb2-b3a3-4486-8419-91510f176ed6",
+        "apim-request-id": "8acabc6e-f2ca-4e35-b540-e47ef8bf4eab",
         "Content-Length": "799",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:14 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "122",
-        "x-request-id": "5fffcfb2-b3a3-4486-8419-91510f176ed6"
+        "x-envoy-upstream-service-time": "85",
+        "x-request-id": "8acabc6e-f2ca-4e35-b540-e47ef8bf4eab"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "b3b91504-7a61-4be0-8b03-57def4354d5a",
+        "anomalyDetectionConfigurationId": "98a12db0-fd27-433c-9538-8ecff1e46447",
         "name": "configQ9DLUXVw",
         "description": "",
-        "metricId": "4a07fde4-2d7a-4ee6-8cdf-3a9082d0ab83",
+        "metricId": "8be9a9b4-fdd6-4e9b-90dd-6fe1a069f9bb",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -319,7 +319,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Delhi"
+                "dimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -334,7 +334,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -353,12 +353,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3b91504-7a61-4be0-8b03-57def4354d5a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/98a12db0-fd27-433c-9538-8ecff1e46447",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-30e6d4d6482c624f86f90f9cc5878d2a-f4c72bfc06c7f148-00",
+        "traceparent": "00-4001d80e478d4440995052ded5d90aa0-51b246f9d2712a4c-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "250c5bf4bc88a6656fdcfa62cd60f246",
@@ -367,23 +367,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1c621037-e2f3-4e2d-b44f-d63215eb9ed1",
+        "apim-request-id": "507dbbeb-1dac-40a5-b510-ad65cbc7646d",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:15 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "169",
-        "x-request-id": "1c621037-e2f3-4e2d-b44f-d63215eb9ed1"
+        "x-envoy-upstream-service-time": "103",
+        "x-request-id": "507dbbeb-1dac-40a5-b510-ad65cbc7646d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e6c6a798-d9ad-4417-9d90-b12cbb8413c7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b79a3e9d-ddd8-41b7-a617-6b597cebdcbd",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-026e28d9812909449cbc7c5b4b9d336f-7030160f1ddf6947-00",
+        "traceparent": "00-05b79261bc229d4382f8784fa663e5d8-9609010eabf06d4d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4669c313930a76b4f60a1e106e4e278e",
@@ -392,19 +392,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5cfe99c1-be69-4536-aa00-c0a889a058ac",
+        "apim-request-id": "e6ecd238-9eef-4d55-b7f7-c75759fbeef5",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:15 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "315",
-        "x-request-id": "5cfe99c1-be69-4536-aa00-c0a889a058ac"
+        "x-envoy-upstream-service-time": "321",
+        "x-request-id": "e6ecd238-9eef-4d55-b7f7-c75759fbeef5"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "97486823"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesGroupConditionsAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/CreateAndGetDetectionConfigurationWithSeriesGroupConditionsAsync.json
@@ -1,25 +1,147 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "651",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-634ed3e0d1b7be4a8d059af3b6238742-152de4ef56813142-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-03ee16f53300b846acc03effcc3ea5bd-001fd869000fd14e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2042946b9f86aaeecd515698e28e6fc0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "config1oRulW2B",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeed1oRulW2B",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "ffcff793-62fb-42bf-a66f-706d4be417c7",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:14 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e6c6a798-d9ad-4417-9d90-b12cbb8413c7",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "612",
+        "x-request-id": "ffcff793-62fb-42bf-a66f-706d4be417c7"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e6c6a798-d9ad-4417-9d90-b12cbb8413c7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-03ee16f53300b846acc03effcc3ea5bd-f924cb48f8d21a48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7b6fed7b4fbe189d44864c1970c02ed4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "74d52cb4-c984-4ef7-9459-6706de06e084",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "148",
+        "x-request-id": "74d52cb4-c984-4ef7-9459-6706de06e084"
+      },
+      "ResponseBody": {
+        "dataFeedId": "e6c6a798-d9ad-4417-9d90-b12cbb8413c7",
+        "dataFeedName": "dataFeed1oRulW2B",
+        "metrics": [
+          {
+            "metricId": "4a07fde4-2d7a-4ee6-8cdf-3a9082d0ab83",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:14Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "663",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-baa6bf22d3a15d4cb8382fb7a196059a-bcbefcf16473a44a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1de9a97b72e509a4b385da9afd0aa91b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configQ9DLUXVw",
+        "metricId": "4a07fde4-2d7a-4ee6-8cdf-3a9082d0ab83",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10,
@@ -34,7 +156,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Delhi"
+                "DimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -49,7 +171,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -67,49 +189,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b0466222-d412-431e-a282-9ada11359034",
+        "apim-request-id": "2638bba3-f3a1-4ca8-941c-4d003b069ac4",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:27 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/7d8c07bb-2a31-43a8-bf16-3982ee821f58",
+        "Date": "Wed, 09 Jun 2021 19:46:14 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3b91504-7a61-4be0-8b03-57def4354d5a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "174",
-        "X-Request-ID": "b0466222-d412-431e-a282-9ada11359034"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "175",
+        "x-request-id": "2638bba3-f3a1-4ca8-941c-4d003b069ac4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/7d8c07bb-2a31-43a8-bf16-3982ee821f58",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3b91504-7a61-4be0-8b03-57def4354d5a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-634ed3e0d1b7be4a8d059af3b6238742-34d141c9abb93946-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-baa6bf22d3a15d4cb8382fb7a196059a-4aa52e004a032747-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7b6fed7b4fbe189d44864c1970c02ed4",
+        "x-ms-client-request-id": "ffdc2af6d5530d392282a544166c7116",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cbaa4494-bcbb-4383-9a55-515795fd3d4b",
-        "Content-Length": "787",
+        "apim-request-id": "321f4fc0-86db-43d8-82a1-ba8e2e31e646",
+        "Content-Length": "799",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:27 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "76",
-        "X-Request-ID": "cbaa4494-bcbb-4383-9a55-515795fd3d4b"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "95",
+        "x-request-id": "321f4fc0-86db-43d8-82a1-ba8e2e31e646"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "7d8c07bb-2a31-43a8-bf16-3982ee821f58",
-        "name": "config1oRulW2B",
+        "anomalyDetectionConfigurationId": "b3b91504-7a61-4be0-8b03-57def4354d5a",
+        "name": "configQ9DLUXVw",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "4a07fde4-2d7a-4ee6-8cdf-3a9082d0ab83",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -124,7 +243,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Delhi"
+                "DimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -139,7 +258,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -158,37 +277,34 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/7d8c07bb-2a31-43a8-bf16-3982ee821f58",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3b91504-7a61-4be0-8b03-57def4354d5a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b5628f51dfe0c7489108ba6fde62feac-278e768f50185e4f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-02f32267d0366a449d8bd4c5e1822a59-54eaecea5f5ec847-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "03779df2644fb8bc7ba9e91de572a409",
+        "x-ms-client-request-id": "15ffb7318066d133e14266eae594d6e7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "89eacfa8-2940-41fe-a68f-4008e01e8564",
-        "Content-Length": "787",
+        "apim-request-id": "5fffcfb2-b3a3-4486-8419-91510f176ed6",
+        "Content-Length": "799",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 17:53:27 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "85",
-        "X-Request-ID": "89eacfa8-2940-41fe-a68f-4008e01e8564"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "122",
+        "x-request-id": "5fffcfb2-b3a3-4486-8419-91510f176ed6"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "7d8c07bb-2a31-43a8-bf16-3982ee821f58",
-        "name": "config1oRulW2B",
+        "anomalyDetectionConfigurationId": "b3b91504-7a61-4be0-8b03-57def4354d5a",
+        "name": "configQ9DLUXVw",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "4a07fde4-2d7a-4ee6-8cdf-3a9082d0ab83",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "lowerBound": 10.0,
@@ -203,7 +319,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Delhi"
+                "DimensionA": "Delhi"
               }
             },
             "smartDetectionCondition": {
@@ -218,7 +334,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -237,37 +353,58 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/7d8c07bb-2a31-43a8-bf16-3982ee821f58",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b3b91504-7a61-4be0-8b03-57def4354d5a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7c26ea145f4ba44394c890ee9ad5542d-bf2085ceee233648-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-30e6d4d6482c624f86f90f9cc5878d2a-f4c72bfc06c7f148-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9ada85b30afd1ba9f62adcff53d5390d",
+        "x-ms-client-request-id": "250c5bf4bc88a6656fdcfa62cd60f246",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "85e5fcf3-791f-411a-8a7b-8f438d8cb30b",
+        "apim-request-id": "1c621037-e2f3-4e2d-b44f-d63215eb9ed1",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 17:53:27 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "101",
-        "X-Request-ID": "85e5fcf3-791f-411a-8a7b-8f438d8cb30b"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "169",
+        "x-request-id": "1c621037-e2f3-4e2d-b44f-d63215eb9ed1"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e6c6a798-d9ad-4417-9d90-b12cbb8413c7",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-026e28d9812909449cbc7c5b4b9d336f-7030160f1ddf6947-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "4669c313930a76b4f60a1e106e4e278e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "5cfe99c1-be69-4536-aa00-c0a889a058ac",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "315",
+        "x-request-id": "5cfe99c1-be69-4536-aa00-c0a889a058ac"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "97486823"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(False).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(False).json
@@ -1,6 +1,131 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6d7b3d931e8f3248b600f5814b4257fe-a4ca8c9103beda40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8518f2a35ac7af06061bf6f6648b803e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedXnw1uvQU",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "67424dfd-e60c-4031-a479-336aa9238b85",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ca3cdc13-be47-4956-b7e3-d376e9fa8b5c",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "690",
+        "x-request-id": "67424dfd-e60c-4031-a479-336aa9238b85"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ca3cdc13-be47-4956-b7e3-d376e9fa8b5c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6d7b3d931e8f3248b600f5814b4257fe-e68bc3646a491f4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6475b9c9c5f2bb55da0284ce14870b6f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "777b83c2-abdd-4540-b4f3-cc0acb59e47f",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "160",
+        "x-request-id": "777b83c2-abdd-4540-b4f3-cc0acb59e47f"
+      },
+      "ResponseBody": {
+        "dataFeedId": "ca3cdc13-be47-4956-b7e3-d376e9fa8b5c",
+        "dataFeedName": "dataFeedXnw1uvQU",
+        "metrics": [
+          {
+            "metricId": "97a981c9-9f97-48f7-9819-4b4de41d88e3",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:04Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,18 +133,15 @@
         "Content-Length": "228",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2ef660d078d9c14ca6dd326650e3dff6-2e16bca9627d4e45-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-465fa6ee1e8b6c4e82e7b4ab11afcbb9-07ad918964e6ff43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8518f2a35ac7af06061bf6f6648b803e",
+        "x-ms-client-request-id": "6d5d4810359803d97ce31d15ab9e33dd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configXnw1uvQU",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "name": "configsveRu7KL",
+        "metricId": "97a981c9-9f97-48f7-9819-4b4de41d88e3",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -33,49 +155,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2c433f11-14e9-4b21-b8f4-577e5c7c4c75",
+        "apim-request-id": "859e3a6c-dd7d-46a9-8e45-4c15a017bd95",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 18:37:56 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3bc518e4-2437-4667-a990-eb4b8fca311d",
+        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8673139a-5964-4cc0-8603-41c7cf1fc106",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "117",
-        "X-Request-ID": "2c433f11-14e9-4b21-b8f4-577e5c7c4c75"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "104",
+        "x-request-id": "859e3a6c-dd7d-46a9-8e45-4c15a017bd95"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3bc518e4-2437-4667-a990-eb4b8fca311d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8673139a-5964-4cc0-8603-41c7cf1fc106",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2ef660d078d9c14ca6dd326650e3dff6-df459cd040511c47-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-465fa6ee1e8b6c4e82e7b4ab11afcbb9-2d017c5ad9ad5b49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6475b9c9c5f2bb55da0284ce14870b6f",
+        "x-ms-client-request-id": "c4ab5d9d38d67f9b1086aef442d58f1d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "37dea4bf-2854-400d-ab1f-7f6ef94b87f5",
+        "apim-request-id": "bac6c650-8751-46cc-9828-59a7c57b36b7",
         "Content-Length": "398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 18:37:56 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "88",
-        "X-Request-ID": "37dea4bf-2854-400d-ab1f-7f6ef94b87f5"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "83",
+        "x-request-id": "bac6c650-8751-46cc-9828-59a7c57b36b7"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "3bc518e4-2437-4667-a990-eb4b8fca311d",
-        "name": "configXnw1uvQU",
+        "anomalyDetectionConfigurationId": "8673139a-5964-4cc0-8603-41c7cf1fc106",
+        "name": "configsveRu7KL",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "97a981c9-9f97-48f7-9819-4b4de41d88e3",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -91,69 +210,87 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3bc518e4-2437-4667-a990-eb4b8fca311d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8673139a-5964-4cc0-8603-41c7cf1fc106",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0b5928f25f7ff84fbb2a21754e44c98e-a004188dba9ce741-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-6352e7e7104a2149956a822769cfd42b-703cd5e3fda67643-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ab496f48abaedbfc10485d6d9835d903",
+        "x-ms-client-request-id": "aa5399bde768a422288052306af5c3aa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e9fcdc5a-60e7-44db-a332-8cd5b2b69e39",
+        "apim-request-id": "48d91272-7c1c-4c3c-af60-c4cf337cfba7",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 18:37:56 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "90",
-        "X-Request-ID": "e9fcdc5a-60e7-44db-a332-8cd5b2b69e39"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "109",
+        "x-request-id": "48d91272-7c1c-4c3c-af60-c4cf337cfba7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3bc518e4-2437-4667-a990-eb4b8fca311d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8673139a-5964-4cc0-8603-41c7cf1fc106",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-59fbed5e4114d54487cb6b4e7915cb64-bdccf3cb4affcb43-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-0114e0a9d175d7459094894048bde9ba-7322e675d8821648-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "151de37c9eabdd339d5dabc4d6389b7f",
+        "x-ms-client-request-id": "510d6b3c3700d804acde5d1187e5c1a6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "5851dcdb-87e8-4ff1-b4a0-398372bf6590",
+        "apim-request-id": "807c20e3-edbd-4be4-a331-49f40c2de38a",
         "Content-Length": "124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 18:37:56 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "75",
-        "X-Request-ID": "5851dcdb-87e8-4ff1-b4a0-398372bf6590"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "64",
+        "x-request-id": "807c20e3-edbd-4be4-a331-49f40c2de38a"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyDetectionConfiguration. TraceId: 75aecef3-b675-4492-86dd-bcd8942c3051"
+        "message": "Not found this AnomalyDetectionConfiguration. TraceId: ecc5081d-74df-4f09-80ce-1a2674cfe259"
       }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ca3cdc13-be47-4956-b7e3-d376e9fa8b5c",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-cdfcb97344031a4492087b0e784abdce-dfbbd9c5ccb8cf46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1157ff54884ab6753a069c56e56a151a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "2b098aca-d8f4-4265-880d-df080144d35a",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "344",
+        "x-request-id": "2b098aca-d8f4-4265-880d-df080144d35a"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "432103228"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(False).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(False).json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6d7b3d931e8f3248b600f5814b4257fe-a4ca8c9103beda40-00",
+        "traceparent": "00-6d2d19e87c5a6747adede304fab20644-15cd6a2b02edaf43-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8518f2a35ac7af06061bf6f6648b803e",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "67424dfd-e60c-4031-a479-336aa9238b85",
+        "apim-request-id": "0e60d163-5551-4c93-a7fa-39b4d8154790",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ca3cdc13-be47-4956-b7e3-d376e9fa8b5c",
+        "Date": "Wed, 09 Jun 2021 23:03:32 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/12810751-ef8b-41e2-8e76-5b1922953387",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "690",
-        "x-request-id": "67424dfd-e60c-4031-a479-336aa9238b85"
+        "x-envoy-upstream-service-time": "452",
+        "x-request-id": "0e60d163-5551-4c93-a7fa-39b4d8154790"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ca3cdc13-be47-4956-b7e3-d376e9fa8b5c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/12810751-ef8b-41e2-8e76-5b1922953387",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6d7b3d931e8f3248b600f5814b4257fe-e68bc3646a491f4e-00",
+        "traceparent": "00-6d2d19e87c5a6747adede304fab20644-bce4155d6cc4b04d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6475b9c9c5f2bb55da0284ce14870b6f",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "777b83c2-abdd-4540-b4f3-cc0acb59e47f",
+        "apim-request-id": "91a57925-4183-4766-a428-aa99b2dbe882",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "160",
-        "x-request-id": "777b83c2-abdd-4540-b4f3-cc0acb59e47f"
+        "x-envoy-upstream-service-time": "154",
+        "x-request-id": "91a57925-4183-4766-a428-aa99b2dbe882"
       },
       "ResponseBody": {
-        "dataFeedId": "ca3cdc13-be47-4956-b7e3-d376e9fa8b5c",
+        "dataFeedId": "12810751-ef8b-41e2-8e76-5b1922953387",
         "dataFeedName": "dataFeedXnw1uvQU",
         "metrics": [
           {
-            "metricId": "97a981c9-9f97-48f7-9819-4b4de41d88e3",
+            "metricId": "3e6d1b9a-84c6-4ad3-b59f-688cc039abdb",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:04Z",
+        "createdTime": "2021-06-09T23:03:33Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "228",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-465fa6ee1e8b6c4e82e7b4ab11afcbb9-07ad918964e6ff43-00",
+        "traceparent": "00-138374797091454fa60555744a4dc9cd-49d55b48b7abac48-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6d5d4810359803d97ce31d15ab9e33dd",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "configsveRu7KL",
-        "metricId": "97a981c9-9f97-48f7-9819-4b4de41d88e3",
+        "metricId": "3e6d1b9a-84c6-4ad3-b59f-688cc039abdb",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -155,24 +155,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "859e3a6c-dd7d-46a9-8e45-4c15a017bd95",
+        "apim-request-id": "d12b5cdd-8d66-4228-bd72-e8e9babdd4f1",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8673139a-5964-4cc0-8603-41c7cf1fc106",
+        "Date": "Wed, 09 Jun 2021 23:03:32 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f88a0fe7-065b-4d4a-8c25-4457f687cb94",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "104",
-        "x-request-id": "859e3a6c-dd7d-46a9-8e45-4c15a017bd95"
+        "x-envoy-upstream-service-time": "99",
+        "x-request-id": "d12b5cdd-8d66-4228-bd72-e8e9babdd4f1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8673139a-5964-4cc0-8603-41c7cf1fc106",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f88a0fe7-065b-4d4a-8c25-4457f687cb94",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-465fa6ee1e8b6c4e82e7b4ab11afcbb9-2d017c5ad9ad5b49-00",
+        "traceparent": "00-138374797091454fa60555744a4dc9cd-7c47c781199f4949-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c4ab5d9d38d67f9b1086aef442d58f1d",
@@ -181,20 +181,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bac6c650-8751-46cc-9828-59a7c57b36b7",
+        "apim-request-id": "8b67ca83-0a46-488f-8a50-eff5641704c3",
         "Content-Length": "398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "83",
-        "x-request-id": "bac6c650-8751-46cc-9828-59a7c57b36b7"
+        "x-envoy-upstream-service-time": "84",
+        "x-request-id": "8b67ca83-0a46-488f-8a50-eff5641704c3"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "8673139a-5964-4cc0-8603-41c7cf1fc106",
+        "anomalyDetectionConfigurationId": "f88a0fe7-065b-4d4a-8c25-4457f687cb94",
         "name": "configsveRu7KL",
         "description": "",
-        "metricId": "97a981c9-9f97-48f7-9819-4b4de41d88e3",
+        "metricId": "3e6d1b9a-84c6-4ad3-b59f-688cc039abdb",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -210,12 +210,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8673139a-5964-4cc0-8603-41c7cf1fc106",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f88a0fe7-065b-4d4a-8c25-4457f687cb94",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6352e7e7104a2149956a822769cfd42b-703cd5e3fda67643-00",
+        "traceparent": "00-e3816f553f14164690097d459e2b5014-88f0bf1e55378944-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "aa5399bde768a422288052306af5c3aa",
@@ -224,23 +224,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "48d91272-7c1c-4c3c-af60-c4cf337cfba7",
+        "apim-request-id": "ea94dfb2-9c26-4997-93d7-9201ce87948c",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "109",
-        "x-request-id": "48d91272-7c1c-4c3c-af60-c4cf337cfba7"
+        "x-envoy-upstream-service-time": "105",
+        "x-request-id": "ea94dfb2-9c26-4997-93d7-9201ce87948c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8673139a-5964-4cc0-8603-41c7cf1fc106",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f88a0fe7-065b-4d4a-8c25-4457f687cb94",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0114e0a9d175d7459094894048bde9ba-7322e675d8821648-00",
+        "traceparent": "00-1da91c20b75b2b47870f0f9b230e76e5-fce366edbbc2014e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "510d6b3c3700d804acde5d1187e5c1a6",
@@ -249,27 +249,27 @@
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "807c20e3-edbd-4be4-a331-49f40c2de38a",
+        "apim-request-id": "1312356e-b251-47c1-8f6c-ea4d885cbaff",
         "Content-Length": "124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:03 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "64",
-        "x-request-id": "807c20e3-edbd-4be4-a331-49f40c2de38a"
+        "x-envoy-upstream-service-time": "66",
+        "x-request-id": "1312356e-b251-47c1-8f6c-ea4d885cbaff"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyDetectionConfiguration. TraceId: ecc5081d-74df-4f09-80ce-1a2674cfe259"
+        "message": "Not found this AnomalyDetectionConfiguration. TraceId: 60fc2e7f-c60d-46af-b544-fa2b2c89bc18"
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ca3cdc13-be47-4956-b7e3-d376e9fa8b5c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/12810751-ef8b-41e2-8e76-5b1922953387",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cdfcb97344031a4492087b0e784abdce-dfbbd9c5ccb8cf46-00",
+        "traceparent": "00-80d517f685d095469c19be84bc486262-128c9296b2c1ff4a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1157ff54884ab6753a069c56e56a151a",
@@ -278,19 +278,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2b098aca-d8f4-4265-880d-df080144d35a",
+        "apim-request-id": "d07fd923-b48d-49f5-9a86-8e82fe8f8dd1",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:04 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "344",
-        "x-request-id": "2b098aca-d8f4-4265-880d-df080144d35a"
+        "x-envoy-upstream-service-time": "307",
+        "x-request-id": "d07fd923-b48d-49f5-9a86-8e82fe8f8dd1"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "432103228"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(False)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(False)Async.json
@@ -1,6 +1,131 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ec14030a72216b43a2ec3cb0f566eac1-d3161ce28b56ae4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "bb24b4d748bf8a08391a66bb536f77d8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedeKMxFIGD",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "2ab2a906-4195-4a9a-b190-ccb521e4f8f9",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:26 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/41745861-a16d-49fd-bff0-27aadf65f3e5",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "726",
+        "x-request-id": "2ab2a906-4195-4a9a-b190-ccb521e4f8f9"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/41745861-a16d-49fd-bff0-27aadf65f3e5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ec14030a72216b43a2ec3cb0f566eac1-0eae1cf85e8ee148-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "26480bf05c1a9984b50b2ad92a030bc7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5170bc1b-3801-45e5-9be4-70cdc7483e61",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:26 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "149",
+        "x-request-id": "5170bc1b-3801-45e5-9be4-70cdc7483e61"
+      },
+      "ResponseBody": {
+        "dataFeedId": "41745861-a16d-49fd-bff0-27aadf65f3e5",
+        "dataFeedName": "dataFeedeKMxFIGD",
+        "metrics": [
+          {
+            "metricId": "c201fcb3-05de-4088-aae3-f8ca8f867c8f",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:26Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,18 +133,15 @@
         "Content-Length": "228",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0063580c10fa1a41945da06854c482d1-d5497ff84607b74b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-2528a523dcee404baa12395362a22636-2844ca7e65de724e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "bb24b4d748bf8a08391a66bb536f77d8",
+        "x-ms-client-request-id": "a3f00fcfd45d785b84ef403fe010a77a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configeKMxFIGD",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "name": "config83H9pWBn",
+        "metricId": "c201fcb3-05de-4088-aae3-f8ca8f867c8f",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -33,49 +155,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "116e98cf-0daa-4422-85cf-ef6816cba2de",
+        "apim-request-id": "fa4a734d-213b-4734-9f29-24e3ebad8c1e",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 18:37:57 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c184eef7-c6e2-463c-803e-bc034090de8b",
+        "Date": "Wed, 09 Jun 2021 19:46:26 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9b89192f-3379-486d-9d6a-768fed272a29",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "86",
-        "X-Request-ID": "116e98cf-0daa-4422-85cf-ef6816cba2de"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "99",
+        "x-request-id": "fa4a734d-213b-4734-9f29-24e3ebad8c1e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c184eef7-c6e2-463c-803e-bc034090de8b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9b89192f-3379-486d-9d6a-768fed272a29",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0063580c10fa1a41945da06854c482d1-2fcc87a39cae1b4d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-2528a523dcee404baa12395362a22636-4fd4f5196061364d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "26480bf05c1a9984b50b2ad92a030bc7",
+        "x-ms-client-request-id": "b3068a2f2f1d365f0f9e6db7570699b0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a3b3bfba-29e2-4c2c-9af9-9fffe5c55041",
+        "apim-request-id": "f0d4eb6e-de5e-429a-aa1e-a71cd02ec7fa",
         "Content-Length": "398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 18:37:58 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "85",
-        "X-Request-ID": "a3b3bfba-29e2-4c2c-9af9-9fffe5c55041"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "127",
+        "x-request-id": "f0d4eb6e-de5e-429a-aa1e-a71cd02ec7fa"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "c184eef7-c6e2-463c-803e-bc034090de8b",
-        "name": "configeKMxFIGD",
+        "anomalyDetectionConfigurationId": "9b89192f-3379-486d-9d6a-768fed272a29",
+        "name": "config83H9pWBn",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "c201fcb3-05de-4088-aae3-f8ca8f867c8f",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -91,69 +210,87 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c184eef7-c6e2-463c-803e-bc034090de8b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9b89192f-3379-486d-9d6a-768fed272a29",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9abfb0ea8f89dd40a52fecdae7dccdce-bf6e963f6d311045-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-a707715f6a0a084c949c612181506b1d-431a51a25586c046-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "70189b4d403fb1d2cf0ff0a35dd45b78",
+        "x-ms-client-request-id": "0a579739e16be03cafb1543ac3cbe73d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4d4b1cc3-98e4-4b8a-88c3-0d95e6937b6c",
+        "apim-request-id": "830ccd30-24ae-43a6-8c44-9f40cf4b62be",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 18:37:58 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "95",
-        "X-Request-ID": "4d4b1cc3-98e4-4b8a-88c3-0d95e6937b6c"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "105",
+        "x-request-id": "830ccd30-24ae-43a6-8c44-9f40cf4b62be"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/c184eef7-c6e2-463c-803e-bc034090de8b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9b89192f-3379-486d-9d6a-768fed272a29",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ea1f0f09cd95284abba5f2e526835b22-1acb1ccda6f83f4e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-4e3732904130e54a8376628199a2868d-928de397cb55e24d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "3f40ef8410e07aa72f8a06b31d2f5f36",
+        "x-ms-client-request-id": "b5419df41e3aa093afba93be67a3217e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "3deb870f-72a5-49b9-90ab-154f8b870402",
+        "apim-request-id": "c496a55e-3342-4139-bb4b-6eed3734d0b1",
         "Content-Length": "124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 18:37:58 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "62",
-        "X-Request-ID": "3deb870f-72a5-49b9-90ab-154f8b870402"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "65",
+        "x-request-id": "c496a55e-3342-4139-bb4b-6eed3734d0b1"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyDetectionConfiguration. TraceId: a4f3cdd6-1a21-4c56-8fa3-fbe209324fd8"
+        "message": "Not found this AnomalyDetectionConfiguration. TraceId: e2ece2e3-234a-46b1-82dc-f60633ec0a5f"
       }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/41745861-a16d-49fd-bff0-27aadf65f3e5",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-bd795023c6ab504297bd5500dfc93bcd-f6c166e76df8fb4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "49058f569db84e0f4d25046cda257243",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "26300c25-ebd7-4e42-beae-2bc19c44f56b",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "313",
+        "x-request-id": "26300c25-ebd7-4e42-beae-2bc19c44f56b"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "456922841"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(False)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(False)Async.json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ec14030a72216b43a2ec3cb0f566eac1-d3161ce28b56ae4e-00",
+        "traceparent": "00-438c09be893478418c78b18ade7823f5-683094dfbd212c4b-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bb24b4d748bf8a08391a66bb536f77d8",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2ab2a906-4195-4a9a-b190-ccb521e4f8f9",
+        "apim-request-id": "1fed99de-e811-4fd2-871d-4fd1ad9c2e0e",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:26 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/41745861-a16d-49fd-bff0-27aadf65f3e5",
+        "Date": "Wed, 09 Jun 2021 23:03:54 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/91c6c359-ea73-4b40-a344-981b9008aed8",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "726",
-        "x-request-id": "2ab2a906-4195-4a9a-b190-ccb521e4f8f9"
+        "x-envoy-upstream-service-time": "539",
+        "x-request-id": "1fed99de-e811-4fd2-871d-4fd1ad9c2e0e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/41745861-a16d-49fd-bff0-27aadf65f3e5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/91c6c359-ea73-4b40-a344-981b9008aed8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ec14030a72216b43a2ec3cb0f566eac1-0eae1cf85e8ee148-00",
+        "traceparent": "00-438c09be893478418c78b18ade7823f5-59f068e5f8db054f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "26480bf05c1a9984b50b2ad92a030bc7",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5170bc1b-3801-45e5-9be4-70cdc7483e61",
+        "apim-request-id": "68754684-acaa-4135-bb86-b44ee8a3fa38",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:26 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "149",
-        "x-request-id": "5170bc1b-3801-45e5-9be4-70cdc7483e61"
+        "x-envoy-upstream-service-time": "192",
+        "x-request-id": "68754684-acaa-4135-bb86-b44ee8a3fa38"
       },
       "ResponseBody": {
-        "dataFeedId": "41745861-a16d-49fd-bff0-27aadf65f3e5",
+        "dataFeedId": "91c6c359-ea73-4b40-a344-981b9008aed8",
         "dataFeedName": "dataFeedeKMxFIGD",
         "metrics": [
           {
-            "metricId": "c201fcb3-05de-4088-aae3-f8ca8f867c8f",
+            "metricId": "3f8c3b3a-7946-464a-983c-68e2c4d4de2d",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:26Z",
+        "createdTime": "2021-06-09T23:03:55Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "228",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2528a523dcee404baa12395362a22636-2844ca7e65de724e-00",
+        "traceparent": "00-14c793abd6ec3947bcd4ee7c0dbaa583-8e73120cd0f9a343-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a3f00fcfd45d785b84ef403fe010a77a",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "config83H9pWBn",
-        "metricId": "c201fcb3-05de-4088-aae3-f8ca8f867c8f",
+        "metricId": "3f8c3b3a-7946-464a-983c-68e2c4d4de2d",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -155,24 +155,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "fa4a734d-213b-4734-9f29-24e3ebad8c1e",
+        "apim-request-id": "22c82f8a-5f98-4714-adf6-39e6fbd9941a",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:26 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9b89192f-3379-486d-9d6a-768fed272a29",
+        "Date": "Wed, 09 Jun 2021 23:03:55 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bbdc57a4-7751-47b3-8f44-fa83432f114a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "99",
-        "x-request-id": "fa4a734d-213b-4734-9f29-24e3ebad8c1e"
+        "x-envoy-upstream-service-time": "195",
+        "x-request-id": "22c82f8a-5f98-4714-adf6-39e6fbd9941a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9b89192f-3379-486d-9d6a-768fed272a29",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bbdc57a4-7751-47b3-8f44-fa83432f114a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2528a523dcee404baa12395362a22636-4fd4f5196061364d-00",
+        "traceparent": "00-14c793abd6ec3947bcd4ee7c0dbaa583-7532013980451e49-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b3068a2f2f1d365f0f9e6db7570699b0",
@@ -181,20 +181,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f0d4eb6e-de5e-429a-aa1e-a71cd02ec7fa",
+        "apim-request-id": "ca68c654-f708-4fea-aae4-d4e347ecebeb",
         "Content-Length": "398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:26 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "127",
-        "x-request-id": "f0d4eb6e-de5e-429a-aa1e-a71cd02ec7fa"
+        "x-envoy-upstream-service-time": "5112",
+        "x-request-id": "ca68c654-f708-4fea-aae4-d4e347ecebeb"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "9b89192f-3379-486d-9d6a-768fed272a29",
+        "anomalyDetectionConfigurationId": "bbdc57a4-7751-47b3-8f44-fa83432f114a",
         "name": "config83H9pWBn",
         "description": "",
-        "metricId": "c201fcb3-05de-4088-aae3-f8ca8f867c8f",
+        "metricId": "3f8c3b3a-7946-464a-983c-68e2c4d4de2d",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -210,12 +210,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9b89192f-3379-486d-9d6a-768fed272a29",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bbdc57a4-7751-47b3-8f44-fa83432f114a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a707715f6a0a084c949c612181506b1d-431a51a25586c046-00",
+        "traceparent": "00-35107c4abbbd1949bc347ec8547e8f66-aa3baabbad790d41-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0a579739e16be03cafb1543ac3cbe73d",
@@ -224,23 +224,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "830ccd30-24ae-43a6-8c44-9f40cf4b62be",
+        "apim-request-id": "8ef652f9-b75c-4142-95b0-03fdc59aaf7f",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:27 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "105",
-        "x-request-id": "830ccd30-24ae-43a6-8c44-9f40cf4b62be"
+        "x-envoy-upstream-service-time": "120",
+        "x-request-id": "8ef652f9-b75c-4142-95b0-03fdc59aaf7f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9b89192f-3379-486d-9d6a-768fed272a29",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bbdc57a4-7751-47b3-8f44-fa83432f114a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4e3732904130e54a8376628199a2868d-928de397cb55e24d-00",
+        "traceparent": "00-bffc3d47deb938429d46286f6042dac7-0d6bb14d7aaa2840-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b5419df41e3aa093afba93be67a3217e",
@@ -249,27 +249,27 @@
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "c496a55e-3342-4139-bb4b-6eed3734d0b1",
+        "apim-request-id": "f378e5e9-1341-449c-935e-44926f5e3097",
         "Content-Length": "124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:27 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "65",
-        "x-request-id": "c496a55e-3342-4139-bb4b-6eed3734d0b1"
+        "x-envoy-upstream-service-time": "5083",
+        "x-request-id": "f378e5e9-1341-449c-935e-44926f5e3097"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyDetectionConfiguration. TraceId: e2ece2e3-234a-46b1-82dc-f60633ec0a5f"
+        "message": "Not found this AnomalyDetectionConfiguration. TraceId: c18eeb69-7f27-421b-8a22-64c829224b1c"
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/41745861-a16d-49fd-bff0-27aadf65f3e5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/91c6c359-ea73-4b40-a344-981b9008aed8",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bd795023c6ab504297bd5500dfc93bcd-f6c166e76df8fb4a-00",
+        "traceparent": "00-8a1707a3b422124dae980122f834fdb7-033b91f1e79bb840-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "49058f569db84e0f4d25046cda257243",
@@ -278,19 +278,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "26300c25-ebd7-4e42-beae-2bc19c44f56b",
+        "apim-request-id": "0ebc7e20-4b32-4433-809b-9e881c3204b5",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:27 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "313",
-        "x-request-id": "26300c25-ebd7-4e42-beae-2bc19c44f56b"
+        "x-envoy-upstream-service-time": "310",
+        "x-request-id": "0ebc7e20-4b32-4433-809b-9e881c3204b5"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "456922841"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(True).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(True).json
@@ -1,24 +1,147 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "228",
+        "Content-Length": "312",
         "Content-Type": "application/json",
-        "traceparent": "00-72271ed0d5df1b40b38e3e6690f0828c-dcf819cfcb741d44-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4885faa6b3cc01429226420cbb5f601c-6aacaf32471d0640-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "55b6153d670ac9a62252fe656f6acf3d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configbTwbcFKQ",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedbTwbcFKQ",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "52bd1f07-ddb9-449f-821e-ce7b0af5dadc",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:45:56 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/94dcd812-ee59-48ea-af87-0e3e9e080e7a",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "656",
+        "x-request-id": "52bd1f07-ddb9-449f-821e-ce7b0af5dadc"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/94dcd812-ee59-48ea-af87-0e3e9e080e7a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4885faa6b3cc01429226420cbb5f601c-e243a0cfae08084c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "699563792763290dfe7226068a7d2891",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e1718931-d946-477d-9575-67bb462e2b70",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:45:56 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "179",
+        "x-request-id": "e1718931-d946-477d-9575-67bb462e2b70"
+      },
+      "ResponseBody": {
+        "dataFeedId": "94dcd812-ee59-48ea-af87-0e3e9e080e7a",
+        "dataFeedName": "dataFeedbTwbcFKQ",
+        "metrics": [
+          {
+            "metricId": "91fcf38d-f1e4-4ea1-88ac-0cb58f779ed4",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:45:57Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "228",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-47b89160cf33e940964621948e335090-aadda83b0d85b045-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "baa9baadf7fbf16bd9f0c023f06ab916",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "confighhZZDfre",
+        "metricId": "91fcf38d-f1e4-4ea1-88ac-0cb58f779ed4",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -32,48 +155,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "44bf09ed-d517-42f4-b7ab-9a727d3c8c1d",
+        "apim-request-id": "c5db6f3e-ddac-4e81-be74-3f7f2cb67f7f",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 18:37:55 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cb940ca5-1d70-4689-a05b-1f8f8227a2fe",
+        "Date": "Wed, 09 Jun 2021 19:45:57 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1438886c-dc92-448c-98c1-4dee9df6c2fd",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "50",
-        "X-Request-ID": "44bf09ed-d517-42f4-b7ab-9a727d3c8c1d"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "109",
+        "x-request-id": "c5db6f3e-ddac-4e81-be74-3f7f2cb67f7f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cb940ca5-1d70-4689-a05b-1f8f8227a2fe",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1438886c-dc92-448c-98c1-4dee9df6c2fd",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-72271ed0d5df1b40b38e3e6690f0828c-4dd7b19d9ffd0541-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "699563792763290dfe7226068a7d2891",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-47b89160cf33e940964621948e335090-384293f63931b644-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "98568d089f41a43f2a6d71ec644a5fe7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "68a8bda4-09ac-41ac-871d-01694949b035",
+        "apim-request-id": "6a2d600d-2c78-43ef-bc6b-c90ca26e2b7c",
         "Content-Length": "398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 18:37:56 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "44",
-        "X-Request-ID": "68a8bda4-09ac-41ac-871d-01694949b035"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5096",
+        "x-request-id": "6a2d600d-2c78-43ef-bc6b-c90ca26e2b7c"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "cb940ca5-1d70-4689-a05b-1f8f8227a2fe",
-        "name": "configbTwbcFKQ",
+        "anomalyDetectionConfigurationId": "1438886c-dc92-448c-98c1-4dee9df6c2fd",
+        "name": "confighhZZDfre",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "91fcf38d-f1e4-4ea1-88ac-0cb58f779ed4",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -89,67 +210,89 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cb940ca5-1d70-4689-a05b-1f8f8227a2fe",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1438886c-dc92-448c-98c1-4dee9df6c2fd",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-da36474bc1ec7b478f52dec51f83a3b3-3267e23e57e77c42-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "850582f492dec8c8adbaa9bafbf76bf1",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-fc4f9c797cd05b4190bb64f5c692df39-ef41197961354846-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "a8bccc9a527d072d06352c99bd05a089",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "680c2403-3f95-4ec0-9351-1e38e878b73b",
+        "apim-request-id": "dc6e8100-0f04-41c6-82f3-46232511a392",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 18:37:56 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "45",
-        "X-Request-ID": "680c2403-3f95-4ec0-9351-1e38e878b73b"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "91",
+        "x-request-id": "dc6e8100-0f04-41c6-82f3-46232511a392"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/cb940ca5-1d70-4689-a05b-1f8f8227a2fe",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1438886c-dc92-448c-98c1-4dee9df6c2fd",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-780a9f683881d1439244d60ccae09269-956aa4b0c079c04c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "23c0f0d96af016b9088d5698419f3fa4",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3c582f63d42c344c8e3451106dece656-de067f3b2bbfe343-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "507deec8303c0d877b04908e867e8c8f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "93606f3b-e964-44a5-826d-b70b09b115a9",
+        "apim-request-id": "384bcdc9-c63a-480a-872c-d5e007688df5",
         "Content-Length": "124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 18:37:56 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23",
-        "X-Request-ID": "93606f3b-e964-44a5-826d-b70b09b115a9"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "71",
+        "x-request-id": "384bcdc9-c63a-480a-872c-d5e007688df5"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyDetectionConfiguration. TraceId: ba6bfd35-ed43-4a54-aa9e-140f59dacfd4"
+        "message": "Not found this AnomalyDetectionConfiguration. TraceId: b3da18cf-1e6d-4867-8827-330284b0ed8f"
       }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/94dcd812-ee59-48ea-af87-0e3e9e080e7a",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e2fdb306853b7346b3cac52492f7a2a5-4bb01d5d71ca3a4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2389d99110aeb599604e910b72a5e725",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "8a045432-9f4d-4b1e-96c7-60f2b673f066",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:02 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "297",
+        "x-request-id": "8a045432-9f4d-4b1e-96c7-60f2b673f066"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "115733193"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(True).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(True).json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4885faa6b3cc01429226420cbb5f601c-6aacaf32471d0640-00",
+        "traceparent": "00-236d6eb3965fa84f98da0aca2dd05346-58b106ae07e1e748-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "55b6153d670ac9a62252fe656f6acf3d",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "52bd1f07-ddb9-449f-821e-ce7b0af5dadc",
+        "apim-request-id": "ea77f724-8275-41ef-a853-a0d91919a232",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:56 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/94dcd812-ee59-48ea-af87-0e3e9e080e7a",
+        "Date": "Wed, 09 Jun 2021 23:03:30 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e32d81de-3cb1-4f7f-8722-4e42f592e1aa",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "656",
-        "x-request-id": "52bd1f07-ddb9-449f-821e-ce7b0af5dadc"
+        "x-envoy-upstream-service-time": "456",
+        "x-request-id": "ea77f724-8275-41ef-a853-a0d91919a232"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/94dcd812-ee59-48ea-af87-0e3e9e080e7a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e32d81de-3cb1-4f7f-8722-4e42f592e1aa",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4885faa6b3cc01429226420cbb5f601c-e243a0cfae08084c-00",
+        "traceparent": "00-236d6eb3965fa84f98da0aca2dd05346-fb94611bcd1ad64f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "699563792763290dfe7226068a7d2891",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e1718931-d946-477d-9575-67bb462e2b70",
+        "apim-request-id": "d5e8b64b-ae52-4338-960a-6bb13f137b10",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:45:56 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "179",
-        "x-request-id": "e1718931-d946-477d-9575-67bb462e2b70"
+        "x-envoy-upstream-service-time": "170",
+        "x-request-id": "d5e8b64b-ae52-4338-960a-6bb13f137b10"
       },
       "ResponseBody": {
-        "dataFeedId": "94dcd812-ee59-48ea-af87-0e3e9e080e7a",
+        "dataFeedId": "e32d81de-3cb1-4f7f-8722-4e42f592e1aa",
         "dataFeedName": "dataFeedbTwbcFKQ",
         "metrics": [
           {
-            "metricId": "91fcf38d-f1e4-4ea1-88ac-0cb58f779ed4",
+            "metricId": "94cf78e4-d344-43d7-81de-52364e68db89",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:45:57Z",
+        "createdTime": "2021-06-09T23:03:31Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "228",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-47b89160cf33e940964621948e335090-aadda83b0d85b045-00",
+        "traceparent": "00-36bf3b17f658c14f8846adba55489416-1ef45c1414fa3b4f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "baa9baadf7fbf16bd9f0c023f06ab916",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "confighhZZDfre",
-        "metricId": "91fcf38d-f1e4-4ea1-88ac-0cb58f779ed4",
+        "metricId": "94cf78e4-d344-43d7-81de-52364e68db89",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -155,24 +155,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c5db6f3e-ddac-4e81-be74-3f7f2cb67f7f",
+        "apim-request-id": "d1dda8db-6e53-435e-a92f-852f9fcb21e2",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:45:57 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1438886c-dc92-448c-98c1-4dee9df6c2fd",
+        "Date": "Wed, 09 Jun 2021 23:03:31 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8a424041-54e1-4ccf-ac00-bff393952247",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "109",
-        "x-request-id": "c5db6f3e-ddac-4e81-be74-3f7f2cb67f7f"
+        "x-envoy-upstream-service-time": "121",
+        "x-request-id": "d1dda8db-6e53-435e-a92f-852f9fcb21e2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1438886c-dc92-448c-98c1-4dee9df6c2fd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8a424041-54e1-4ccf-ac00-bff393952247",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-47b89160cf33e940964621948e335090-384293f63931b644-00",
+        "traceparent": "00-36bf3b17f658c14f8846adba55489416-bd1cb0adb12a7242-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "98568d089f41a43f2a6d71ec644a5fe7",
@@ -181,20 +181,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a2d600d-2c78-43ef-bc6b-c90ca26e2b7c",
+        "apim-request-id": "bb33fa47-46f2-46cd-b79f-43ce1cd006cc",
         "Content-Length": "398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:01 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5096",
-        "x-request-id": "6a2d600d-2c78-43ef-bc6b-c90ca26e2b7c"
+        "x-envoy-upstream-service-time": "98",
+        "x-request-id": "bb33fa47-46f2-46cd-b79f-43ce1cd006cc"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "1438886c-dc92-448c-98c1-4dee9df6c2fd",
+        "anomalyDetectionConfigurationId": "8a424041-54e1-4ccf-ac00-bff393952247",
         "name": "confighhZZDfre",
         "description": "",
-        "metricId": "91fcf38d-f1e4-4ea1-88ac-0cb58f779ed4",
+        "metricId": "94cf78e4-d344-43d7-81de-52364e68db89",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -210,12 +210,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1438886c-dc92-448c-98c1-4dee9df6c2fd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8a424041-54e1-4ccf-ac00-bff393952247",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fc4f9c797cd05b4190bb64f5c692df39-ef41197961354846-00",
+        "traceparent": "00-17dbe3991fbb2245aa5c9adabe4592a8-d352678752c37e4b-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a8bccc9a527d072d06352c99bd05a089",
@@ -224,23 +224,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "dc6e8100-0f04-41c6-82f3-46232511a392",
+        "apim-request-id": "0ffe37da-0491-4047-a56f-8cfd056ab876",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:02 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "91",
-        "x-request-id": "dc6e8100-0f04-41c6-82f3-46232511a392"
+        "x-envoy-upstream-service-time": "112",
+        "x-request-id": "0ffe37da-0491-4047-a56f-8cfd056ab876"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1438886c-dc92-448c-98c1-4dee9df6c2fd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/8a424041-54e1-4ccf-ac00-bff393952247",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3c582f63d42c344c8e3451106dece656-de067f3b2bbfe343-00",
+        "traceparent": "00-9e96f4c5648a484183f768b5e3decb46-2de9dbddee18d54d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "507deec8303c0d877b04908e867e8c8f",
@@ -249,27 +249,27 @@
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "384bcdc9-c63a-480a-872c-d5e007688df5",
+        "apim-request-id": "6f8d56b2-fba9-41eb-a998-b6fabfdaf6e2",
         "Content-Length": "124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:02 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "71",
-        "x-request-id": "384bcdc9-c63a-480a-872c-d5e007688df5"
+        "x-envoy-upstream-service-time": "72",
+        "x-request-id": "6f8d56b2-fba9-41eb-a998-b6fabfdaf6e2"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyDetectionConfiguration. TraceId: b3da18cf-1e6d-4867-8827-330284b0ed8f"
+        "message": "Not found this AnomalyDetectionConfiguration. TraceId: 39bde625-a139-411d-8db9-4b3ab2a95932"
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/94dcd812-ee59-48ea-af87-0e3e9e080e7a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e32d81de-3cb1-4f7f-8722-4e42f592e1aa",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e2fdb306853b7346b3cac52492f7a2a5-4bb01d5d71ca3a4e-00",
+        "traceparent": "00-42049b8857e87e41b1c231ea42e49b4c-3bc0c2f79ad6fe4d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2389d99110aeb599604e910b72a5e725",
@@ -278,19 +278,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8a045432-9f4d-4b1e-96c7-60f2b673f066",
+        "apim-request-id": "eaec8a4f-cac6-4a0b-9613-e8eb3064ede3",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:02 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "297",
-        "x-request-id": "8a045432-9f4d-4b1e-96c7-60f2b673f066"
+        "x-envoy-upstream-service-time": "308",
+        "x-request-id": "eaec8a4f-cac6-4a0b-9613-e8eb3064ede3"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "115733193"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(True)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(True)Async.json
@@ -1,24 +1,147 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "228",
+        "Content-Length": "312",
         "Content-Type": "application/json",
-        "traceparent": "00-8187a3f2f256de44a469edeb105ef787-ca7530ab024df044-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7b35eb5f50f9054090b0be0b53d0bdf4-834a2ed433fa1f49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9b24688b8a65f8e568f6ee14a48f6841",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configOnpIgiEu",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedOnpIgiEu",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "68594edb-a1fd-41b0-a87d-c456120011fd",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:24 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c100d98-3060-4354-9d32-5389cc362ea0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "554",
+        "x-request-id": "68594edb-a1fd-41b0-a87d-c456120011fd"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c100d98-3060-4354-9d32-5389cc362ea0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7b35eb5f50f9054090b0be0b53d0bdf4-6d95ae6fca3b1849-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2e2b78459314babcab01d66acd21b77a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4b6349da-ac49-44d4-b5b0-96350ba13d1f",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "215",
+        "x-request-id": "4b6349da-ac49-44d4-b5b0-96350ba13d1f"
+      },
+      "ResponseBody": {
+        "dataFeedId": "9c100d98-3060-4354-9d32-5389cc362ea0",
+        "dataFeedName": "dataFeedOnpIgiEu",
+        "metrics": [
+          {
+            "metricId": "d466438f-5677-4ff9-9c03-92f4fe74d35a",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:24Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "228",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6606717faa0aed4180384e5a5fe78aff-805b64ccc6a45449-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f3e93ee2f7bc3bd7e69c8375807bc6f8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configGYjEcdTI",
+        "metricId": "d466438f-5677-4ff9-9c03-92f4fe74d35a",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -32,48 +155,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "86bec4e0-4125-4cc2-9c75-84381c716e20",
+        "apim-request-id": "f2b820a7-ff37-4d30-a5d0-047127689348",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 18:37:57 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cffa11f-c4ef-459e-93fa-1b640f034638",
+        "Date": "Wed, 09 Jun 2021 19:46:24 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f2b86b01-0817-457e-88bf-67aefe4b9f0c",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "45",
-        "X-Request-ID": "86bec4e0-4125-4cc2-9c75-84381c716e20"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "98",
+        "x-request-id": "f2b820a7-ff37-4d30-a5d0-047127689348"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cffa11f-c4ef-459e-93fa-1b640f034638",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f2b86b01-0817-457e-88bf-67aefe4b9f0c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-8187a3f2f256de44a469edeb105ef787-93a1b4dd4268c84c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "2e2b78459314babcab01d66acd21b77a",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6606717faa0aed4180384e5a5fe78aff-32000f60de608341-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "64ef69ac7ab4462a3f7332ba5b6d91c8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ae409c1b-24c1-4e3f-b95e-072bd6d3d151",
+        "apim-request-id": "e3c21b21-8979-45d2-b939-1b1cfb27634f",
         "Content-Length": "398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 18:37:57 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31",
-        "X-Request-ID": "ae409c1b-24c1-4e3f-b95e-072bd6d3d151"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "85",
+        "x-request-id": "e3c21b21-8979-45d2-b939-1b1cfb27634f"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "0cffa11f-c4ef-459e-93fa-1b640f034638",
-        "name": "configOnpIgiEu",
+        "anomalyDetectionConfigurationId": "f2b86b01-0817-457e-88bf-67aefe4b9f0c",
+        "name": "configGYjEcdTI",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "d466438f-5677-4ff9-9c03-92f4fe74d35a",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -89,67 +210,89 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cffa11f-c4ef-459e-93fa-1b640f034638",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f2b86b01-0817-457e-88bf-67aefe4b9f0c",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-8295deead58b74479a4a6541eba61662-f77bdf49896dd544-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "fb34e9e27db061fbe23ee9f3bcf7d73b",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-75dfb267f7d84b4dbd4807bfc857173d-989b535883c1094a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d54bca7cc9aab3fe299a84309e41fa66",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4a4711c3-075c-4313-91a1-16aab127ff0d",
+        "apim-request-id": "041b1677-354f-4b33-9432-4a8a64489c9a",
         "Content-Length": "0",
-        "Date": "Fri, 05 Feb 2021 18:37:57 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "43",
-        "X-Request-ID": "4a4711c3-075c-4313-91a1-16aab127ff0d"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "90",
+        "x-request-id": "041b1677-354f-4b33-9432-4a8a64489c9a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0cffa11f-c4ef-459e-93fa-1b640f034638",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f2b86b01-0817-457e-88bf-67aefe4b9f0c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-ee65c5bb2455eb4f98d0ec78eb0e65a1-80dc0fa754ff9743-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "75839ce67b80f8c6ac69ef64b47a2a46",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-94ed8796a35007459161e36817351a49-34836e8c6278044d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "474f3c22968d67ac14a2b348c51ce078",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "cf3e46a3-58e6-4528-bc1c-91508c1cd427",
+        "apim-request-id": "92318786-5c4b-4c28-aacb-64b4dbbbca8f",
         "Content-Length": "124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Feb 2021 18:37:57 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "19",
-        "X-Request-ID": "cf3e46a3-58e6-4528-bc1c-91508c1cd427"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "69",
+        "x-request-id": "92318786-5c4b-4c28-aacb-64b4dbbbca8f"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyDetectionConfiguration. TraceId: ffd7ce25-bef9-4f00-aad3-114a438ca1d9"
+        "message": "Not found this AnomalyDetectionConfiguration. TraceId: 61b71458-9e6a-455f-bc95-bc18fe65cd81"
       }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c100d98-3060-4354-9d32-5389cc362ea0",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-8789c35d1813e2408caebbdea501e5a9-bc4ef06797183549-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b5f8bb0bf02fe24e6a3b3a19f6f9a8fe",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "a26dc2fe-4c2c-4bc5-9c64-df7d9d3426cf",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "307",
+        "x-request-id": "a26dc2fe-4c2c-4bc5-9c64-df7d9d3426cf"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "866127330"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(True)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/DeleteDetectionConfiguration(True)Async.json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7b35eb5f50f9054090b0be0b53d0bdf4-834a2ed433fa1f49-00",
+        "traceparent": "00-8e8d44bee6040a4eb05ba95a1622724a-e720d002912e794e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9b24688b8a65f8e568f6ee14a48f6841",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "68594edb-a1fd-41b0-a87d-c456120011fd",
+        "apim-request-id": "c114ba78-9551-47b4-ab58-b3f8358904de",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:24 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c100d98-3060-4354-9d32-5389cc362ea0",
+        "Date": "Wed, 09 Jun 2021 23:03:53 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57899b29-3480-4d34-8c39-08416f2b83f6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "554",
-        "x-request-id": "68594edb-a1fd-41b0-a87d-c456120011fd"
+        "x-envoy-upstream-service-time": "405",
+        "x-request-id": "c114ba78-9551-47b4-ab58-b3f8358904de"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c100d98-3060-4354-9d32-5389cc362ea0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57899b29-3480-4d34-8c39-08416f2b83f6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7b35eb5f50f9054090b0be0b53d0bdf4-6d95ae6fca3b1849-00",
+        "traceparent": "00-8e8d44bee6040a4eb05ba95a1622724a-c2a37c5397b54f49-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2e2b78459314babcab01d66acd21b77a",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4b6349da-ac49-44d4-b5b0-96350ba13d1f",
+        "apim-request-id": "e487a3d0-88c1-44f1-ba4e-7cc1b3c6f942",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:24 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "215",
-        "x-request-id": "4b6349da-ac49-44d4-b5b0-96350ba13d1f"
+        "x-envoy-upstream-service-time": "157",
+        "x-request-id": "e487a3d0-88c1-44f1-ba4e-7cc1b3c6f942"
       },
       "ResponseBody": {
-        "dataFeedId": "9c100d98-3060-4354-9d32-5389cc362ea0",
+        "dataFeedId": "57899b29-3480-4d34-8c39-08416f2b83f6",
         "dataFeedName": "dataFeedOnpIgiEu",
         "metrics": [
           {
-            "metricId": "d466438f-5677-4ff9-9c03-92f4fe74d35a",
+            "metricId": "c8294154-9ae5-46b1-8edf-8ce16352de0f",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:24Z",
+        "createdTime": "2021-06-09T23:03:53Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "228",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6606717faa0aed4180384e5a5fe78aff-805b64ccc6a45449-00",
+        "traceparent": "00-5cc21a12a2ec864ca4848109fd5fdeb5-3ac12ae2a47bde47-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f3e93ee2f7bc3bd7e69c8375807bc6f8",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "configGYjEcdTI",
-        "metricId": "d466438f-5677-4ff9-9c03-92f4fe74d35a",
+        "metricId": "c8294154-9ae5-46b1-8edf-8ce16352de0f",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10,
@@ -155,24 +155,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f2b820a7-ff37-4d30-a5d0-047127689348",
+        "apim-request-id": "88d43a39-bcd6-4381-8a96-728429668d44",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:24 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f2b86b01-0817-457e-88bf-67aefe4b9f0c",
+        "Date": "Wed, 09 Jun 2021 23:03:53 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/df74188b-84dd-43b2-bbd8-5c460b747919",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "98",
-        "x-request-id": "f2b820a7-ff37-4d30-a5d0-047127689348"
+        "x-envoy-upstream-service-time": "128",
+        "x-request-id": "88d43a39-bcd6-4381-8a96-728429668d44"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f2b86b01-0817-457e-88bf-67aefe4b9f0c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/df74188b-84dd-43b2-bbd8-5c460b747919",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6606717faa0aed4180384e5a5fe78aff-32000f60de608341-00",
+        "traceparent": "00-5cc21a12a2ec864ca4848109fd5fdeb5-5132b5d27097d844-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "64ef69ac7ab4462a3f7332ba5b6d91c8",
@@ -181,20 +181,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e3c21b21-8979-45d2-b939-1b1cfb27634f",
+        "apim-request-id": "dd1fd9fd-6ce1-4d4b-8eaf-08ca8e48e0e2",
         "Content-Length": "398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:25 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "x-envoy-upstream-service-time": "85",
-        "x-request-id": "e3c21b21-8979-45d2-b939-1b1cfb27634f"
+        "x-request-id": "dd1fd9fd-6ce1-4d4b-8eaf-08ca8e48e0e2"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "f2b86b01-0817-457e-88bf-67aefe4b9f0c",
+        "anomalyDetectionConfigurationId": "df74188b-84dd-43b2-bbd8-5c460b747919",
         "name": "configGYjEcdTI",
         "description": "",
-        "metricId": "d466438f-5677-4ff9-9c03-92f4fe74d35a",
+        "metricId": "c8294154-9ae5-46b1-8edf-8ce16352de0f",
         "wholeMetricConfiguration": {
           "hardThresholdCondition": {
             "upperBound": 10.0,
@@ -210,12 +210,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f2b86b01-0817-457e-88bf-67aefe4b9f0c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/df74188b-84dd-43b2-bbd8-5c460b747919",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-75dfb267f7d84b4dbd4807bfc857173d-989b535883c1094a-00",
+        "traceparent": "00-9509565d8696794394dd3f2335ff2246-32ee8edd39322142-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d54bca7cc9aab3fe299a84309e41fa66",
@@ -224,23 +224,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "041b1677-354f-4b33-9432-4a8a64489c9a",
+        "apim-request-id": "774e954c-7c93-448b-9c44-e13c3db01d3f",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:25 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "90",
-        "x-request-id": "041b1677-354f-4b33-9432-4a8a64489c9a"
+        "x-envoy-upstream-service-time": "117",
+        "x-request-id": "774e954c-7c93-448b-9c44-e13c3db01d3f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/f2b86b01-0817-457e-88bf-67aefe4b9f0c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/df74188b-84dd-43b2-bbd8-5c460b747919",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-94ed8796a35007459161e36817351a49-34836e8c6278044d-00",
+        "traceparent": "00-f0288059beed804e9966758b58c1deec-290c90e04eff2f4a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "474f3c22968d67ac14a2b348c51ce078",
@@ -249,27 +249,27 @@
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "92318786-5c4b-4c28-aacb-64b4dbbbca8f",
+        "apim-request-id": "6f716b88-c907-4a2e-9671-729303e9df00",
         "Content-Length": "124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:25 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "69",
-        "x-request-id": "92318786-5c4b-4c28-aacb-64b4dbbbca8f"
+        "x-envoy-upstream-service-time": "64",
+        "x-request-id": "6f716b88-c907-4a2e-9671-729303e9df00"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyDetectionConfiguration. TraceId: 61b71458-9e6a-455f-bc95-bc18fe65cd81"
+        "message": "Not found this AnomalyDetectionConfiguration. TraceId: dc1fadf5-27f6-430a-bc63-445b4153fd20"
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c100d98-3060-4354-9d32-5389cc362ea0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57899b29-3480-4d34-8c39-08416f2b83f6",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8789c35d1813e2408caebbdea501e5a9-bc4ef06797183549-00",
+        "traceparent": "00-6d6a4495594b3d4fb52810e80d953d8a-ed7d95b26485a145-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b5f8bb0bf02fe24e6a3b3a19f6f9a8fe",
@@ -278,19 +278,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a26dc2fe-4c2c-4bc5-9c64-df7d9d3426cf",
+        "apim-request-id": "43880f72-c20e-4d97-a8b7-e160064afe19",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:25 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "307",
-        "x-request-id": "a26dc2fe-4c2c-4bc5-9c64-df7d9d3426cf"
+        "x-envoy-upstream-service-time": "303",
+        "x-request-id": "43880f72-c20e-4d97-a8b7-e160064afe19"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "866127330"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(False).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(False).json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cc725e3b3ab5b94398d6ba7081ad492a-6f5785795bbb6a43-00",
+        "traceparent": "00-28d37da26c31874a94fef0dc82bd8363-897af67675186c44-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b0972cb3753e61bbd46851d3bb5ed2ea",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8eb87a1f-7ec3-4b3d-9d50-88b0fb2b6180",
+        "apim-request-id": "1bf82475-a3fd-48e7-8a0b-ee40920c9db0",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:08 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5719cf8b-4141-415f-977a-901247bc1e42",
+        "Date": "Wed, 09 Jun 2021 23:03:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be1cd0a2-af3a-447a-9291-f3e8807ba525",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "678",
-        "x-request-id": "8eb87a1f-7ec3-4b3d-9d50-88b0fb2b6180"
+        "x-envoy-upstream-service-time": "527",
+        "x-request-id": "1bf82475-a3fd-48e7-8a0b-ee40920c9db0"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5719cf8b-4141-415f-977a-901247bc1e42",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be1cd0a2-af3a-447a-9291-f3e8807ba525",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cc725e3b3ab5b94398d6ba7081ad492a-04d259582e85f440-00",
+        "traceparent": "00-28d37da26c31874a94fef0dc82bd8363-05142c725a6cf140-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a148f39f3b06e0202a691c6e132ecf6c",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "55244164-9d1b-4615-b3b8-992a6d956b8a",
+        "apim-request-id": "3ae767d2-0b3b-4054-9c9e-f41e79c136d7",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:08 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "153",
-        "x-request-id": "55244164-9d1b-4615-b3b8-992a6d956b8a"
+        "x-envoy-upstream-service-time": "168",
+        "x-request-id": "3ae767d2-0b3b-4054-9c9e-f41e79c136d7"
       },
       "ResponseBody": {
-        "dataFeedId": "5719cf8b-4141-415f-977a-901247bc1e42",
+        "dataFeedId": "be1cd0a2-af3a-447a-9291-f3e8807ba525",
         "dataFeedName": "dataFeedS8dmYdfe",
         "metrics": [
           {
-            "metricId": "2c647b6b-b56c-4235-a26a-69280ade149e",
+            "metricId": "9f18ac31-5fab-4b2d-8324-3470beb29af9",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:08Z",
+        "createdTime": "2021-06-09T23:03:36Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "872",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dcd29a0f659a3e4c9e1e0fd18a71c153-6e0fff99e1aea849-00",
+        "traceparent": "00-93b0aae2eeddfd438965ca34d5b3a1fe-f9c201a6c6e45b44-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ffa1e775cca136fca5aa66270bb49c77",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "configvAKZrVew",
-        "metricId": "2c647b6b-b56c-4235-a26a-69280ade149e",
+        "metricId": "9f18ac31-5fab-4b2d-8324-3470beb29af9",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -165,7 +165,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -184,7 +184,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -201,24 +201,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "807d248c-47a7-4956-91a8-5a58edd46370",
+        "apim-request-id": "8e8352e2-7562-4fef-9dfe-b98f8a84ce1f",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:08 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2840a27e-6e52-4dfe-a69c-96b69a6e376f",
+        "Date": "Wed, 09 Jun 2021 23:03:42 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d2639036-b318-4d03-a03d-e3982e8b9f82",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "178",
-        "x-request-id": "807d248c-47a7-4956-91a8-5a58edd46370"
+        "x-envoy-upstream-service-time": "5214",
+        "x-request-id": "8e8352e2-7562-4fef-9dfe-b98f8a84ce1f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2840a27e-6e52-4dfe-a69c-96b69a6e376f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d2639036-b318-4d03-a03d-e3982e8b9f82",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dcd29a0f659a3e4c9e1e0fd18a71c153-d75ae6832b3bd147-00",
+        "traceparent": "00-93b0aae2eeddfd438965ca34d5b3a1fe-3c12435e5f0e954d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d586b60b4c58a64e99e5d1aa0f0a2662",
@@ -227,20 +227,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3e89a5a9-f852-425c-b981-7c991cdf3df1",
+        "apim-request-id": "1cc5acc0-051c-4c30-9462-069ce2b78b0e",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:08 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "97",
-        "x-request-id": "3e89a5a9-f852-425c-b981-7c991cdf3df1"
+        "x-envoy-upstream-service-time": "87",
+        "x-request-id": "1cc5acc0-051c-4c30-9462-069ce2b78b0e"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "2840a27e-6e52-4dfe-a69c-96b69a6e376f",
+        "anomalyDetectionConfigurationId": "d2639036-b318-4d03-a03d-e3982e8b9f82",
         "name": "configvAKZrVew",
         "description": "",
-        "metricId": "2c647b6b-b56c-4235-a26a-69280ade149e",
+        "metricId": "9f18ac31-5fab-4b2d-8324-3470beb29af9",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -264,7 +264,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -283,7 +283,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -300,12 +300,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2840a27e-6e52-4dfe-a69c-96b69a6e376f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d2639036-b318-4d03-a03d-e3982e8b9f82",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6546e63c72aa884cbec4602976bc11c5-c2293eb9af82f44a-00",
+        "traceparent": "00-0f5fa7e317807442928a5f89595a3510-fa3ac3c9d11d5a4d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1f2cc135219a5e3e6ce6c868c8a7614d",
@@ -314,20 +314,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8941816e-35d0-473f-ae30-bd4a6cbab479",
+        "apim-request-id": "86897cf6-f022-444c-8640-4416d1646bc0",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:09 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "87",
-        "x-request-id": "8941816e-35d0-473f-ae30-bd4a6cbab479"
+        "x-envoy-upstream-service-time": "96",
+        "x-request-id": "86897cf6-f022-444c-8640-4416d1646bc0"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "2840a27e-6e52-4dfe-a69c-96b69a6e376f",
+        "anomalyDetectionConfigurationId": "d2639036-b318-4d03-a03d-e3982e8b9f82",
         "name": "configvAKZrVew",
         "description": "",
-        "metricId": "2c647b6b-b56c-4235-a26a-69280ade149e",
+        "metricId": "9f18ac31-5fab-4b2d-8324-3470beb29af9",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -351,7 +351,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -370,7 +370,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -387,14 +387,14 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2840a27e-6e52-4dfe-a69c-96b69a6e376f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d2639036-b318-4d03-a03d-e3982e8b9f82",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "839",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c980c6381b2c584d8a7fa1b2930ad809-8b7ca16c2469814c-00",
+        "traceparent": "00-36f4c9aab2e31a438e73a8157e7e7079-0c2b8ef6bf55fa43-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0cbbd774e8b6282e99fb65bcfb51279b",
@@ -426,7 +426,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -445,7 +445,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -462,20 +462,20 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8038c4d1-e261-4e27-a010-b008c960e174",
+        "apim-request-id": "2930b98a-d590-443a-b07a-ad9ba92bb8ad",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:09 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "246",
-        "x-request-id": "8038c4d1-e261-4e27-a010-b008c960e174"
+        "x-envoy-upstream-service-time": "245",
+        "x-request-id": "2930b98a-d590-443a-b07a-ad9ba92bb8ad"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "2840a27e-6e52-4dfe-a69c-96b69a6e376f",
+        "anomalyDetectionConfigurationId": "d2639036-b318-4d03-a03d-e3982e8b9f82",
         "name": "configvAKZrVew",
         "description": "",
-        "metricId": "2c647b6b-b56c-4235-a26a-69280ade149e",
+        "metricId": "9f18ac31-5fab-4b2d-8324-3470beb29af9",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -499,7 +499,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -518,7 +518,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -535,12 +535,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2840a27e-6e52-4dfe-a69c-96b69a6e376f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d2639036-b318-4d03-a03d-e3982e8b9f82",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ce10005cfa949649bd7c84803890d267-982ed9326d733c48-00",
+        "traceparent": "00-bf8efb24acb7584e9058d537420f23a6-3d79870050bdaf4e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "49f103837d88e9dd7727697283e5ddf1",
@@ -549,23 +549,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c5314750-5e5f-4fad-94d7-4a690ace7dc7",
+        "apim-request-id": "befda5af-44f6-45cf-9ffc-e31c7a564c90",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:09 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "92",
-        "x-request-id": "c5314750-5e5f-4fad-94d7-4a690ace7dc7"
+        "x-envoy-upstream-service-time": "104",
+        "x-request-id": "befda5af-44f6-45cf-9ffc-e31c7a564c90"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5719cf8b-4141-415f-977a-901247bc1e42",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be1cd0a2-af3a-447a-9291-f3e8807ba525",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b09fd4b78c3a234189c55cebab6c8e4d-aab2014bff84f34b-00",
+        "traceparent": "00-a522de55b76c6d4a919c7778d2ddcb3c-6ab19c933632c145-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "37368383194f4dac9303869fbc82631a",
@@ -574,19 +574,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "deae1907-6f1e-434f-8ddb-d7a44fb62abb",
+        "apim-request-id": "a3d39401-b802-45a5-9ddf-8d1b9433931e",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:09 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "287",
-        "x-request-id": "deae1907-6f1e-434f-8ddb-d7a44fb62abb"
+        "x-envoy-upstream-service-time": "307",
+        "x-request-id": "a3d39401-b802-45a5-9ddf-8d1b9433931e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "1760932433"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(False).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(False).json
@@ -1,22 +1,147 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "858",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-07fb357f7a453d44bb43f1224efcf314-c2271817f555b64a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-cc725e3b3ab5b94398d6ba7081ad492a-6f5785795bbb6a43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b0972cb3753e61bbd46851d3bb5ed2ea",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configS8dmYdfe",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedS8dmYdfe",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "8eb87a1f-7ec3-4b3d-9d50-88b0fb2b6180",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:08 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5719cf8b-4141-415f-977a-901247bc1e42",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "678",
+        "x-request-id": "8eb87a1f-7ec3-4b3d-9d50-88b0fb2b6180"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5719cf8b-4141-415f-977a-901247bc1e42",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-cc725e3b3ab5b94398d6ba7081ad492a-04d259582e85f440-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "a148f39f3b06e0202a691c6e132ecf6c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "55244164-9d1b-4615-b3b8-992a6d956b8a",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "153",
+        "x-request-id": "55244164-9d1b-4615-b3b8-992a6d956b8a"
+      },
+      "ResponseBody": {
+        "dataFeedId": "5719cf8b-4141-415f-977a-901247bc1e42",
+        "dataFeedName": "dataFeedS8dmYdfe",
+        "metrics": [
+          {
+            "metricId": "2c647b6b-b56c-4235-a26a-69280ade149e",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:08Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "872",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-dcd29a0f659a3e4c9e1e0fd18a71c153-6e0fff99e1aea849-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ffa1e775cca136fca5aa66270bb49c77",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configvAKZrVew",
+        "metricId": "2c647b6b-b56c-4235-a26a-69280ade149e",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -40,7 +165,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -59,8 +184,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -76,46 +201,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "bd7bcf0c-3369-4979-b55a-7067564346d5",
+        "apim-request-id": "807d248c-47a7-4956-91a8-5a58edd46370",
         "Content-Length": "0",
-        "Date": "Wed, 02 Jun 2021 11:50:21 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/52d81828-7096-4438-833d-0ed6efd6d4a4",
+        "Date": "Wed, 09 Jun 2021 19:46:08 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2840a27e-6e52-4dfe-a69c-96b69a6e376f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "406",
-        "x-request-id": "bd7bcf0c-3369-4979-b55a-7067564346d5"
+        "x-envoy-upstream-service-time": "178",
+        "x-request-id": "807d248c-47a7-4956-91a8-5a58edd46370"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/52d81828-7096-4438-833d-0ed6efd6d4a4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2840a27e-6e52-4dfe-a69c-96b69a6e376f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-07fb357f7a453d44bb43f1224efcf314-cefe5f9d372f2c47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-dcd29a0f659a3e4c9e1e0fd18a71c153-d75ae6832b3bd147-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a148f39f3b06e0202a691c6e132ecf6c",
+        "x-ms-client-request-id": "d586b60b4c58a64e99e5d1aa0f0a2662",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "474239ff-3de8-4701-aa52-2a37e21829c6",
-        "Content-Length": "964",
+        "apim-request-id": "3e89a5a9-f852-425c-b981-7c991cdf3df1",
+        "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:50:22 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "396",
-        "x-request-id": "474239ff-3de8-4701-aa52-2a37e21829c6"
+        "x-envoy-upstream-service-time": "97",
+        "x-request-id": "3e89a5a9-f852-425c-b981-7c991cdf3df1"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "52d81828-7096-4438-833d-0ed6efd6d4a4",
-        "name": "configS8dmYdfe",
+        "anomalyDetectionConfigurationId": "2840a27e-6e52-4dfe-a69c-96b69a6e376f",
+        "name": "configvAKZrVew",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "2c647b6b-b56c-4235-a26a-69280ade149e",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -139,7 +264,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -158,8 +283,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -175,34 +300,34 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/52d81828-7096-4438-833d-0ed6efd6d4a4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2840a27e-6e52-4dfe-a69c-96b69a6e376f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d6182bb70e5616438736c2e4560de100-e2eb0c0f95af1148-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6546e63c72aa884cbec4602976bc11c5-c2293eb9af82f44a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c74f11023cc386bd75e7a1ffa1ccfc36",
+        "x-ms-client-request-id": "1f2cc135219a5e3e6ce6c868c8a7614d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f1ad3e87-bf26-4094-860c-ea280b69b365",
-        "Content-Length": "964",
+        "apim-request-id": "8941816e-35d0-473f-ae30-bd4a6cbab479",
+        "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:50:22 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "146",
-        "x-request-id": "f1ad3e87-bf26-4094-860c-ea280b69b365"
+        "x-envoy-upstream-service-time": "87",
+        "x-request-id": "8941816e-35d0-473f-ae30-bd4a6cbab479"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "52d81828-7096-4438-833d-0ed6efd6d4a4",
-        "name": "configS8dmYdfe",
+        "anomalyDetectionConfigurationId": "2840a27e-6e52-4dfe-a69c-96b69a6e376f",
+        "name": "configvAKZrVew",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "2c647b6b-b56c-4235-a26a-69280ade149e",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -226,7 +351,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -245,8 +370,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -262,21 +387,21 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/52d81828-7096-4438-833d-0ed6efd6d4a4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2840a27e-6e52-4dfe-a69c-96b69a6e376f",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "825",
+        "Content-Length": "839",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-287598a8ba827442b26bb302bcf0f6c9-e1697f29618ed347-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-c980c6381b2c584d8a7fa1b2930ad809-8b7ca16c2469814c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2766aaa5b40b779c0bb686d5584c4ea6",
+        "x-ms-client-request-id": "0cbbd774e8b6282e99fb65bcfb51279b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configS8dmYdfe",
+        "name": "configvAKZrVew",
         "description": "",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
@@ -301,7 +426,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -320,8 +445,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -337,20 +462,20 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f4e48f87-ec5a-4486-8479-9df0bb44cd37",
-        "Content-Length": "964",
+        "apim-request-id": "8038c4d1-e261-4e27-a010-b008c960e174",
+        "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:50:22 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "337",
-        "x-request-id": "f4e48f87-ec5a-4486-8479-9df0bb44cd37"
+        "x-envoy-upstream-service-time": "246",
+        "x-request-id": "8038c4d1-e261-4e27-a010-b008c960e174"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "52d81828-7096-4438-833d-0ed6efd6d4a4",
-        "name": "configS8dmYdfe",
+        "anomalyDetectionConfigurationId": "2840a27e-6e52-4dfe-a69c-96b69a6e376f",
+        "name": "configvAKZrVew",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "2c647b6b-b56c-4235-a26a-69280ade149e",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -374,7 +499,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -393,8 +518,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -410,121 +535,58 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/52d81828-7096-4438-833d-0ed6efd6d4a4",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ac4ac63993a5f245ad5c25a8f270874a-1e3b75b095a2d044-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "aad1e5990a0f622635c12c1f9a213e5e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "045eddf0-84f8-4288-9316-cf4f0fc2e9ea",
-        "Content-Length": "964",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:50:23 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "116",
-        "x-request-id": "045eddf0-84f8-4288-9316-cf4f0fc2e9ea"
-      },
-      "ResponseBody": {
-        "anomalyDetectionConfigurationId": "52d81828-7096-4438-833d-0ed6efd6d4a4",
-        "name": "configS8dmYdfe",
-        "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-        "wholeMetricConfiguration": {
-          "conditionOperator": "OR",
-          "smartDetectionCondition": {
-            "sensitivity": 60.0,
-            "anomalyDetectorDirection": "Up",
-            "suppressCondition": {
-              "minNumber": 5,
-              "minRatio": 6.0
-            }
-          },
-          "hardThresholdCondition": {
-            "lowerBound": 12.0,
-            "anomalyDetectorDirection": "Down",
-            "suppressCondition": {
-              "minNumber": 1,
-              "minRatio": 2.0
-            }
-          }
-        },
-        "dimensionGroupOverrideConfigurations": [
-          {
-            "group": {
-              "dimension": {
-                "city": "Koltaka"
-              }
-            },
-            "changeThresholdCondition": {
-              "changePercentage": 40.0,
-              "shiftPoint": 12,
-              "anomalyDetectorDirection": "Up",
-              "withinRange": false,
-              "suppressCondition": {
-                "minNumber": 5,
-                "minRatio": 6.0
-              }
-            }
-          }
-        ],
-        "seriesOverrideConfigurations": [
-          {
-            "series": {
-              "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
-              }
-            },
-            "smartDetectionCondition": {
-              "sensitivity": 30.0,
-              "anomalyDetectorDirection": "Both",
-              "suppressCondition": {
-                "minNumber": 3,
-                "minRatio": 4.0
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/52d81828-7096-4438-833d-0ed6efd6d4a4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/2840a27e-6e52-4dfe-a69c-96b69a6e376f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-be06a5ad0b19b84f9747b82c07f7f268-f45ceb394b185b49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-ce10005cfa949649bd7c84803890d267-982ed9326d733c48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "68c8e66ca7c84d6174d7bb0cb6e82e28",
+        "x-ms-client-request-id": "49f103837d88e9dd7727697283e5ddf1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3ff59bca-838b-4aa2-aa74-b8de49b232fb",
+        "apim-request-id": "c5314750-5e5f-4fad-94d7-4a690ace7dc7",
         "Content-Length": "0",
-        "Date": "Wed, 02 Jun 2021 11:50:23 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "177",
-        "x-request-id": "3ff59bca-838b-4aa2-aa74-b8de49b232fb"
+        "x-envoy-upstream-service-time": "92",
+        "x-request-id": "c5314750-5e5f-4fad-94d7-4a690ace7dc7"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5719cf8b-4141-415f-977a-901247bc1e42",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b09fd4b78c3a234189c55cebab6c8e4d-aab2014bff84f34b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "37368383194f4dac9303869fbc82631a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "deae1907-6f1e-434f-8ddb-d7a44fb62abb",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:09 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "287",
+        "x-request-id": "deae1907-6f1e-434f-8ddb-d7a44fb62abb"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "1760932433"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(False)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(False)Async.json
@@ -1,22 +1,147 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "858",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5851f8baff938d488e2679f57f7dcfe6-a725d87e06dc4e4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-07c642bb3cb6d7419f232360e59d023e-a533d53802186b43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7840d24d9997aafc09851a1a4625dd06",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "config9OR03UcA",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeed9OR03UcA",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "17dcd819-ff22-4670-a40d-50f3de9e14c5",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:30 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0b2ce6c-b2d9-48f2-b7f6-4c4fd1eb561b",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "602",
+        "x-request-id": "17dcd819-ff22-4670-a40d-50f3de9e14c5"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0b2ce6c-b2d9-48f2-b7f6-4c4fd1eb561b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-07c642bb3cb6d7419f232360e59d023e-65734372829d3a41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6762f3a7ddc97f158dba8de0aa87e4c6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e12043f6-f084-49f2-8f28-b882cd69fc1d",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "146",
+        "x-request-id": "e12043f6-f084-49f2-8f28-b882cd69fc1d"
+      },
+      "ResponseBody": {
+        "dataFeedId": "e0b2ce6c-b2d9-48f2-b7f6-4c4fd1eb561b",
+        "dataFeedName": "dataFeed9OR03UcA",
+        "metrics": [
+          {
+            "metricId": "b8b22968-dac7-4be3-9a6c-e26b18a7cdf8",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:30Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "872",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-027d0f5564736242bbbbe4b897065832-12cd67cae95b8347-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "249ae5a842d0bbb90f619aea70027d70",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configEjjpJh0Q",
+        "metricId": "b8b22968-dac7-4be3-9a6c-e26b18a7cdf8",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -40,7 +165,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -59,8 +184,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -76,46 +201,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "783be1a2-fcd9-4e25-90df-29fccf55c56f",
+        "apim-request-id": "16689131-264f-4475-80b3-d2d2388c0df5",
         "Content-Length": "0",
-        "Date": "Wed, 02 Jun 2021 11:51:46 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3c9b9d05-2c15-4441-a019-153b8f80cecd",
+        "Date": "Wed, 09 Jun 2021 19:46:30 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/470b6208-11ee-4dcb-b245-cb12be05d998",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "246",
-        "x-request-id": "783be1a2-fcd9-4e25-90df-29fccf55c56f"
+        "x-envoy-upstream-service-time": "187",
+        "x-request-id": "16689131-264f-4475-80b3-d2d2388c0df5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3c9b9d05-2c15-4441-a019-153b8f80cecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/470b6208-11ee-4dcb-b245-cb12be05d998",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5851f8baff938d488e2679f57f7dcfe6-24039b6de7064a4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-027d0f5564736242bbbbe4b897065832-cda96624b379cb40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6762f3a7ddc97f158dba8de0aa87e4c6",
+        "x-ms-client-request-id": "dcebc1bd1c0b8200a1541dae1760e4fe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8fbc4ad5-94b5-49ea-b08f-b45f71870976",
-        "Content-Length": "964",
+        "apim-request-id": "94f67b67-16fc-4f72-805b-abb6d6a4178f",
+        "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:51:46 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "116",
-        "x-request-id": "8fbc4ad5-94b5-49ea-b08f-b45f71870976"
+        "x-envoy-upstream-service-time": "83",
+        "x-request-id": "94f67b67-16fc-4f72-805b-abb6d6a4178f"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "3c9b9d05-2c15-4441-a019-153b8f80cecd",
-        "name": "config9OR03UcA",
+        "anomalyDetectionConfigurationId": "470b6208-11ee-4dcb-b245-cb12be05d998",
+        "name": "configEjjpJh0Q",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "b8b22968-dac7-4be3-9a6c-e26b18a7cdf8",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -139,7 +264,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -158,8 +283,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -175,34 +300,34 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3c9b9d05-2c15-4441-a019-153b8f80cecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/470b6208-11ee-4dcb-b245-cb12be05d998",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cc2b188639cc9347b9dcb25d129db3f7-948404eab3e75241-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-5b21c66aa3bd784fbe4d039fe00778a3-cc73e3bd7c26be4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7d0d97fca82252b1a8e59a24d042b9bb",
+        "x-ms-client-request-id": "e4bf1042f0424aaf01d2d048ecf955f9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9654b344-2406-4db3-bc28-5744fb4fff10",
-        "Content-Length": "964",
+        "apim-request-id": "78d0d7b0-8d5c-405b-8c4c-970ce244caaf",
+        "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:51:46 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "110",
-        "x-request-id": "9654b344-2406-4db3-bc28-5744fb4fff10"
+        "x-envoy-upstream-service-time": "87",
+        "x-request-id": "78d0d7b0-8d5c-405b-8c4c-970ce244caaf"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "3c9b9d05-2c15-4441-a019-153b8f80cecd",
-        "name": "config9OR03UcA",
+        "anomalyDetectionConfigurationId": "470b6208-11ee-4dcb-b245-cb12be05d998",
+        "name": "configEjjpJh0Q",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "b8b22968-dac7-4be3-9a6c-e26b18a7cdf8",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -226,7 +351,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -245,8 +370,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -262,21 +387,21 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3c9b9d05-2c15-4441-a019-153b8f80cecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/470b6208-11ee-4dcb-b245-cb12be05d998",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "825",
+        "Content-Length": "839",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c981c54649d6f84d8aae69a18ed68b62-400316a4f5465447-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e080db0c503d9c4a9c1471caf78a1135-7ba4058cf54dde4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ea9a610f0270707dbdc1ebdc0b1c0082",
+        "x-ms-client-request-id": "61c09d1ad5bd8c46e417837b240aa4af",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "config9OR03UcA",
+        "name": "configEjjpJh0Q",
         "description": "",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
@@ -301,7 +426,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -320,8 +445,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -337,20 +462,20 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "28540a95-244a-4263-a777-d998a6380793",
-        "Content-Length": "964",
+        "apim-request-id": "cbe336fa-8d06-4098-aa95-dcbe885bc263",
+        "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:51:47 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "297",
-        "x-request-id": "28540a95-244a-4263-a777-d998a6380793"
+        "x-envoy-upstream-service-time": "256",
+        "x-request-id": "cbe336fa-8d06-4098-aa95-dcbe885bc263"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "3c9b9d05-2c15-4441-a019-153b8f80cecd",
-        "name": "config9OR03UcA",
+        "anomalyDetectionConfigurationId": "470b6208-11ee-4dcb-b245-cb12be05d998",
+        "name": "configEjjpJh0Q",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "b8b22968-dac7-4be3-9a6c-e26b18a7cdf8",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -374,7 +499,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -393,8 +518,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -410,121 +535,58 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3c9b9d05-2c15-4441-a019-153b8f80cecd",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5faaedfc4d6b6448ad754de9cbe39a94-073c3d46f0a61f40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ae1d54a16017fee44210bfe442f0af4a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ec75f2d6-9a0c-41a1-9db8-218c8bb778dd",
-        "Content-Length": "964",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:51:47 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "124",
-        "x-request-id": "ec75f2d6-9a0c-41a1-9db8-218c8bb778dd"
-      },
-      "ResponseBody": {
-        "anomalyDetectionConfigurationId": "3c9b9d05-2c15-4441-a019-153b8f80cecd",
-        "name": "config9OR03UcA",
-        "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-        "wholeMetricConfiguration": {
-          "conditionOperator": "OR",
-          "smartDetectionCondition": {
-            "sensitivity": 60.0,
-            "anomalyDetectorDirection": "Up",
-            "suppressCondition": {
-              "minNumber": 5,
-              "minRatio": 6.0
-            }
-          },
-          "hardThresholdCondition": {
-            "lowerBound": 12.0,
-            "anomalyDetectorDirection": "Down",
-            "suppressCondition": {
-              "minNumber": 1,
-              "minRatio": 2.0
-            }
-          }
-        },
-        "dimensionGroupOverrideConfigurations": [
-          {
-            "group": {
-              "dimension": {
-                "city": "Koltaka"
-              }
-            },
-            "changeThresholdCondition": {
-              "changePercentage": 40.0,
-              "shiftPoint": 12,
-              "anomalyDetectorDirection": "Up",
-              "withinRange": false,
-              "suppressCondition": {
-                "minNumber": 5,
-                "minRatio": 6.0
-              }
-            }
-          }
-        ],
-        "seriesOverrideConfigurations": [
-          {
-            "series": {
-              "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
-              }
-            },
-            "smartDetectionCondition": {
-              "sensitivity": 30.0,
-              "anomalyDetectorDirection": "Both",
-              "suppressCondition": {
-                "minNumber": 3,
-                "minRatio": 4.0
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3c9b9d05-2c15-4441-a019-153b8f80cecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/470b6208-11ee-4dcb-b245-cb12be05d998",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8857afcbf34e9744b13c21f20ced8e0c-898422df51d12f4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-68f40552b5ee284dafc8ae8b4738da04-c44db71d75ea4c41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "48d0d201f9ecf9551a9dc061bdd5468c",
+        "x-ms-client-request-id": "5fa89b7d9843cc2d11a0da394bb895a8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "9254947d-85b7-4fce-a70c-82b6feeddcfb",
+        "apim-request-id": "76535bb9-ddee-4e98-9613-23008ea738e5",
         "Content-Length": "0",
-        "Date": "Wed, 02 Jun 2021 11:51:47 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "127",
-        "x-request-id": "9254947d-85b7-4fce-a70c-82b6feeddcfb"
+        "x-envoy-upstream-service-time": "109",
+        "x-request-id": "76535bb9-ddee-4e98-9613-23008ea738e5"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0b2ce6c-b2d9-48f2-b7f6-4c4fd1eb561b",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9377619f41b3754482f20581cbf026bd-e303c9c37ca75e48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "799424fe839f6c41c933002a6d3325f6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "2e44d5b8-f9ea-480e-b03e-1c673de0175f",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:32 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "287",
+        "x-request-id": "2e44d5b8-f9ea-480e-b03e-1c673de0175f"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "634681064"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(False)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(False)Async.json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-07c642bb3cb6d7419f232360e59d023e-a533d53802186b43-00",
+        "traceparent": "00-71ae8e508b88be44a16c8a28afaca374-1874a03bec3db640-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7840d24d9997aafc09851a1a4625dd06",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "17dcd819-ff22-4670-a40d-50f3de9e14c5",
+        "apim-request-id": "93991dc0-a7c6-4395-a4b5-24abf07e9c64",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:30 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0b2ce6c-b2d9-48f2-b7f6-4c4fd1eb561b",
+        "Date": "Wed, 09 Jun 2021 23:04:09 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e2f0546f-c843-496c-a3d8-0676fa795cb0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "602",
-        "x-request-id": "17dcd819-ff22-4670-a40d-50f3de9e14c5"
+        "x-envoy-upstream-service-time": "467",
+        "x-request-id": "93991dc0-a7c6-4395-a4b5-24abf07e9c64"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0b2ce6c-b2d9-48f2-b7f6-4c4fd1eb561b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e2f0546f-c843-496c-a3d8-0676fa795cb0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-07c642bb3cb6d7419f232360e59d023e-65734372829d3a41-00",
+        "traceparent": "00-71ae8e508b88be44a16c8a28afaca374-42765ec0543e724f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6762f3a7ddc97f158dba8de0aa87e4c6",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e12043f6-f084-49f2-8f28-b882cd69fc1d",
+        "apim-request-id": "4b303a6a-f090-4df0-b16b-61f35ab07d8f",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:30 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "146",
-        "x-request-id": "e12043f6-f084-49f2-8f28-b882cd69fc1d"
+        "x-envoy-upstream-service-time": "203",
+        "x-request-id": "4b303a6a-f090-4df0-b16b-61f35ab07d8f"
       },
       "ResponseBody": {
-        "dataFeedId": "e0b2ce6c-b2d9-48f2-b7f6-4c4fd1eb561b",
+        "dataFeedId": "e2f0546f-c843-496c-a3d8-0676fa795cb0",
         "dataFeedName": "dataFeed9OR03UcA",
         "metrics": [
           {
-            "metricId": "b8b22968-dac7-4be3-9a6c-e26b18a7cdf8",
+            "metricId": "9feee10a-2367-4f26-af0b-64e9d4796ef1",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:30Z",
+        "createdTime": "2021-06-09T23:04:09Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "872",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-027d0f5564736242bbbbe4b897065832-12cd67cae95b8347-00",
+        "traceparent": "00-23d55e1aec0e994496003f5d4f52ef8b-c64f973563400e47-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "249ae5a842d0bbb90f619aea70027d70",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "configEjjpJh0Q",
-        "metricId": "b8b22968-dac7-4be3-9a6c-e26b18a7cdf8",
+        "metricId": "9feee10a-2367-4f26-af0b-64e9d4796ef1",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -165,7 +165,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -184,7 +184,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -201,24 +201,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "16689131-264f-4475-80b3-d2d2388c0df5",
+        "apim-request-id": "ee377802-b13f-493c-a549-4e89424d0474",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:30 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/470b6208-11ee-4dcb-b245-cb12be05d998",
+        "Date": "Wed, 09 Jun 2021 23:04:09 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/23356a11-2281-441c-8dc9-b16f5e09e1df",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "187",
-        "x-request-id": "16689131-264f-4475-80b3-d2d2388c0df5"
+        "x-envoy-upstream-service-time": "183",
+        "x-request-id": "ee377802-b13f-493c-a549-4e89424d0474"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/470b6208-11ee-4dcb-b245-cb12be05d998",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/23356a11-2281-441c-8dc9-b16f5e09e1df",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-027d0f5564736242bbbbe4b897065832-cda96624b379cb40-00",
+        "traceparent": "00-23d55e1aec0e994496003f5d4f52ef8b-85af4dc5dad4d048-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dcebc1bd1c0b8200a1541dae1760e4fe",
@@ -227,20 +227,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "94f67b67-16fc-4f72-805b-abb6d6a4178f",
+        "apim-request-id": "64912434-0f19-49af-b3e1-3092f9ef37dc",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:31 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "83",
-        "x-request-id": "94f67b67-16fc-4f72-805b-abb6d6a4178f"
+        "x-envoy-upstream-service-time": "92",
+        "x-request-id": "64912434-0f19-49af-b3e1-3092f9ef37dc"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "470b6208-11ee-4dcb-b245-cb12be05d998",
+        "anomalyDetectionConfigurationId": "23356a11-2281-441c-8dc9-b16f5e09e1df",
         "name": "configEjjpJh0Q",
         "description": "",
-        "metricId": "b8b22968-dac7-4be3-9a6c-e26b18a7cdf8",
+        "metricId": "9feee10a-2367-4f26-af0b-64e9d4796ef1",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -264,7 +264,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -283,7 +283,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -300,12 +300,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/470b6208-11ee-4dcb-b245-cb12be05d998",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/23356a11-2281-441c-8dc9-b16f5e09e1df",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5b21c66aa3bd784fbe4d039fe00778a3-cc73e3bd7c26be4f-00",
+        "traceparent": "00-972a5d39b07dd64082073796c52a0ff0-c8561e098677844a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e4bf1042f0424aaf01d2d048ecf955f9",
@@ -314,20 +314,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "78d0d7b0-8d5c-405b-8c4c-970ce244caaf",
+        "apim-request-id": "26b4f58e-62ca-419a-9a32-5b3f50a08cee",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:31 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "87",
-        "x-request-id": "78d0d7b0-8d5c-405b-8c4c-970ce244caaf"
+        "x-envoy-upstream-service-time": "83",
+        "x-request-id": "26b4f58e-62ca-419a-9a32-5b3f50a08cee"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "470b6208-11ee-4dcb-b245-cb12be05d998",
+        "anomalyDetectionConfigurationId": "23356a11-2281-441c-8dc9-b16f5e09e1df",
         "name": "configEjjpJh0Q",
         "description": "",
-        "metricId": "b8b22968-dac7-4be3-9a6c-e26b18a7cdf8",
+        "metricId": "9feee10a-2367-4f26-af0b-64e9d4796ef1",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -351,7 +351,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -370,7 +370,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -387,14 +387,14 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/470b6208-11ee-4dcb-b245-cb12be05d998",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/23356a11-2281-441c-8dc9-b16f5e09e1df",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "839",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e080db0c503d9c4a9c1471caf78a1135-7ba4058cf54dde4a-00",
+        "traceparent": "00-b6c179c5e19b9c469142b08fad04c2aa-eac029a07aba6b42-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "61c09d1ad5bd8c46e417837b240aa4af",
@@ -426,7 +426,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -445,7 +445,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -462,20 +462,20 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cbe336fa-8d06-4098-aa95-dcbe885bc263",
+        "apim-request-id": "43ac9534-9c72-41bf-a8bd-c1d23dd42ae2",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:31 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "256",
-        "x-request-id": "cbe336fa-8d06-4098-aa95-dcbe885bc263"
+        "x-envoy-upstream-service-time": "228",
+        "x-request-id": "43ac9534-9c72-41bf-a8bd-c1d23dd42ae2"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "470b6208-11ee-4dcb-b245-cb12be05d998",
+        "anomalyDetectionConfigurationId": "23356a11-2281-441c-8dc9-b16f5e09e1df",
         "name": "configEjjpJh0Q",
         "description": "",
-        "metricId": "b8b22968-dac7-4be3-9a6c-e26b18a7cdf8",
+        "metricId": "9feee10a-2367-4f26-af0b-64e9d4796ef1",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -499,7 +499,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -518,7 +518,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -535,12 +535,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/470b6208-11ee-4dcb-b245-cb12be05d998",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/23356a11-2281-441c-8dc9-b16f5e09e1df",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-68f40552b5ee284dafc8ae8b4738da04-c44db71d75ea4c41-00",
+        "traceparent": "00-f33146d78dddb74289f4b0385f641d99-c6c7cc8833340f45-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5fa89b7d9843cc2d11a0da394bb895a8",
@@ -549,23 +549,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "76535bb9-ddee-4e98-9613-23008ea738e5",
+        "apim-request-id": "db73e448-0fab-4798-8d83-3b9d377cf1f2",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:31 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "109",
-        "x-request-id": "76535bb9-ddee-4e98-9613-23008ea738e5"
+        "x-envoy-upstream-service-time": "99",
+        "x-request-id": "db73e448-0fab-4798-8d83-3b9d377cf1f2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0b2ce6c-b2d9-48f2-b7f6-4c4fd1eb561b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e2f0546f-c843-496c-a3d8-0676fa795cb0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9377619f41b3754482f20581cbf026bd-e303c9c37ca75e48-00",
+        "traceparent": "00-456b222dc189594bbdacfbc128421787-c544c72644eefd4e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "799424fe839f6c41c933002a6d3325f6",
@@ -574,19 +574,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2e44d5b8-f9ea-480e-b03e-1c673de0175f",
+        "apim-request-id": "b04225d8-6a91-440d-9c98-2d1ee8e518a8",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:32 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "287",
-        "x-request-id": "2e44d5b8-f9ea-480e-b03e-1c673de0175f"
+        "x-envoy-upstream-service-time": "291",
+        "x-request-id": "b04225d8-6a91-440d-9c98-2d1ee8e518a8"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "634681064"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(True).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(True).json
@@ -1,21 +1,147 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "858",
+        "Content-Length": "312",
         "Content-Type": "application/json",
-        "traceparent": "00-3ba317d53285e64cb86d94a3634090ee-74b27cc30e968440-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b692436b160b244eb30714378af4b32e-f98464204fd1d142-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "18a3d941380a038cf555a18dc01b1d16",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configvvfJ7FgJ",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedvvfJ7FgJ",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "12538b2c-64f0-449c-8d06-69a294e9c28e",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:05 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8a079c81-75ee-4882-8be2-f221b71aa74e",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "647",
+        "x-request-id": "12538b2c-64f0-449c-8d06-69a294e9c28e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8a079c81-75ee-4882-8be2-f221b71aa74e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b692436b160b244eb30714378af4b32e-1cb47579f7720a4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "faac52bf6e56e4ed880433800aa248b0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "72fffee6-b960-4936-ae9a-99620f981bc1",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "164",
+        "x-request-id": "72fffee6-b960-4936-ae9a-99620f981bc1"
+      },
+      "ResponseBody": {
+        "dataFeedId": "8a079c81-75ee-4882-8be2-f221b71aa74e",
+        "dataFeedName": "dataFeedvvfJ7FgJ",
+        "metrics": [
+          {
+            "metricId": "6a4b4f2c-1515-44a9-8433-935a3c0b7524",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:05Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "872",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e7136c70b31a2442b8695cb39d088ffc-4bb1571250fb8943-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d7ea94c7664bf36d4d60a5e758de95d2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configGwRKjMqC",
+        "metricId": "6a4b4f2c-1515-44a9-8433-935a3c0b7524",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -39,7 +165,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -58,8 +184,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -75,45 +201,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "4198d51b-76ee-4ee2-8636-ac06323d8bbc",
+        "apim-request-id": "fd037369-9380-4b22-9d77-c253b0cdd647",
         "Content-Length": "0",
-        "Date": "Wed, 02 Jun 2021 11:50:42 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9d44aad6-1b3d-46d5-8e89-6c2303e97ba5",
+        "Date": "Wed, 09 Jun 2021 19:46:05 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/475d1d1b-a9cf-424e-ab29-76e907354e1e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5471",
-        "x-request-id": "4198d51b-76ee-4ee2-8636-ac06323d8bbc"
+        "x-envoy-upstream-service-time": "170",
+        "x-request-id": "fd037369-9380-4b22-9d77-c253b0cdd647"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9d44aad6-1b3d-46d5-8e89-6c2303e97ba5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/475d1d1b-a9cf-424e-ab29-76e907354e1e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-3ba317d53285e64cb86d94a3634090ee-9d2d7c182f998f4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "faac52bf6e56e4ed880433800aa248b0",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e7136c70b31a2442b8695cb39d088ffc-f9a326d477970448-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0590beeb0b0552f80df0448824b137dc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e6d4f705-3c15-436e-b13f-4a4962a39e2f",
-        "Content-Length": "964",
+        "apim-request-id": "b420e633-4aa4-43d8-a47f-7a1a755d0247",
+        "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:50:42 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "154",
-        "x-request-id": "e6d4f705-3c15-436e-b13f-4a4962a39e2f"
+        "x-envoy-upstream-service-time": "104",
+        "x-request-id": "b420e633-4aa4-43d8-a47f-7a1a755d0247"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "9d44aad6-1b3d-46d5-8e89-6c2303e97ba5",
-        "name": "configvvfJ7FgJ",
+        "anomalyDetectionConfigurationId": "475d1d1b-a9cf-424e-ab29-76e907354e1e",
+        "name": "configGwRKjMqC",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "6a4b4f2c-1515-44a9-8433-935a3c0b7524",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -137,7 +264,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -156,8 +283,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -173,33 +300,34 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9d44aad6-1b3d-46d5-8e89-6c2303e97ba5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/475d1d1b-a9cf-424e-ab29-76e907354e1e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-bfa86eb85d545748b7de032462894871-0101c884872e2b45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6cf73748e3df1c6fc794ead74b666df3",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-63967612ff899f4e8db871f788fb7445-499ae0a1aa2b1744-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c23290e215832298963f32aafc61586a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b1add8a7-c7ef-473c-b523-37e6ad724cf9",
-        "Content-Length": "964",
+        "apim-request-id": "fadc0aa8-5bba-4be2-aa8c-da43ab9e6ca1",
+        "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:50:43 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "162",
-        "x-request-id": "b1add8a7-c7ef-473c-b523-37e6ad724cf9"
+        "x-envoy-upstream-service-time": "89",
+        "x-request-id": "fadc0aa8-5bba-4be2-aa8c-da43ab9e6ca1"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "9d44aad6-1b3d-46d5-8e89-6c2303e97ba5",
-        "name": "configvvfJ7FgJ",
+        "anomalyDetectionConfigurationId": "475d1d1b-a9cf-424e-ab29-76e907354e1e",
+        "name": "configGwRKjMqC",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "6a4b4f2c-1515-44a9-8433-935a3c0b7524",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -223,7 +351,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -242,8 +370,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -259,20 +387,21 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9d44aad6-1b3d-46d5-8e89-6c2303e97ba5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/475d1d1b-a9cf-424e-ab29-76e907354e1e",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "825",
+        "Content-Length": "839",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-41e08bc3f2bd1d4998a9809a424844e1-f698320dee0cbc49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e7a5604dde58d295ebbe9005050bf852",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4c0b74fdf75fc34497a76ab8a20920ea-301edda96e1a604d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "208024a26953bc169b97ca5b21e5cf9c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configvvfJ7FgJ",
+        "name": "configGwRKjMqC",
         "description": "",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
@@ -297,7 +426,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -316,8 +445,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -333,20 +462,20 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f4a23a01-d720-4615-ba53-1e4db468837f",
-        "Content-Length": "964",
+        "apim-request-id": "a45cd9c8-abca-4b8c-aa9a-54d19d899628",
+        "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:50:43 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "306",
-        "x-request-id": "f4a23a01-d720-4615-ba53-1e4db468837f"
+        "x-envoy-upstream-service-time": "260",
+        "x-request-id": "a45cd9c8-abca-4b8c-aa9a-54d19d899628"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "9d44aad6-1b3d-46d5-8e89-6c2303e97ba5",
-        "name": "configvvfJ7FgJ",
+        "anomalyDetectionConfigurationId": "475d1d1b-a9cf-424e-ab29-76e907354e1e",
+        "name": "configGwRKjMqC",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "6a4b4f2c-1515-44a9-8433-935a3c0b7524",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -370,7 +499,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -389,8 +518,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -406,119 +535,60 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9d44aad6-1b3d-46d5-8e89-6c2303e97ba5",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-c9d8a97c1cf68e48beb94131056bfbd1-d6e34b0ff1ba2846-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8844f00db124dc37e29032c283159822",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "548d8cff-fa38-4992-ae4c-add9325a867b",
-        "Content-Length": "964",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:50:43 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "111",
-        "x-request-id": "548d8cff-fa38-4992-ae4c-add9325a867b"
-      },
-      "ResponseBody": {
-        "anomalyDetectionConfigurationId": "9d44aad6-1b3d-46d5-8e89-6c2303e97ba5",
-        "name": "configvvfJ7FgJ",
-        "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-        "wholeMetricConfiguration": {
-          "conditionOperator": "OR",
-          "smartDetectionCondition": {
-            "sensitivity": 60.0,
-            "anomalyDetectorDirection": "Up",
-            "suppressCondition": {
-              "minNumber": 5,
-              "minRatio": 6.0
-            }
-          },
-          "hardThresholdCondition": {
-            "lowerBound": 12.0,
-            "anomalyDetectorDirection": "Down",
-            "suppressCondition": {
-              "minNumber": 1,
-              "minRatio": 2.0
-            }
-          }
-        },
-        "dimensionGroupOverrideConfigurations": [
-          {
-            "group": {
-              "dimension": {
-                "city": "Koltaka"
-              }
-            },
-            "changeThresholdCondition": {
-              "changePercentage": 40.0,
-              "shiftPoint": 12,
-              "anomalyDetectorDirection": "Up",
-              "withinRange": false,
-              "suppressCondition": {
-                "minNumber": 5,
-                "minRatio": 6.0
-              }
-            }
-          }
-        ],
-        "seriesOverrideConfigurations": [
-          {
-            "series": {
-              "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
-              }
-            },
-            "smartDetectionCondition": {
-              "sensitivity": 30.0,
-              "anomalyDetectorDirection": "Both",
-              "suppressCondition": {
-                "minNumber": 3,
-                "minRatio": 4.0
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9d44aad6-1b3d-46d5-8e89-6c2303e97ba5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/475d1d1b-a9cf-424e-ab29-76e907354e1e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-b75a2aca177de44c9f8017f1a6d2e1a7-28683fc92becb741-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "aa323f9661fc6a58a2248020536916bc",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7e13941b8b5a024da6dffaf9ca085222-68d75a0700d7c648-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c704c929d3abd64e256d6fc5d84e56ac",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "af112141-2803-42f2-bc0c-349bfec05a4a",
+        "apim-request-id": "5b6c4ce1-4983-406e-8781-8d59f601e76e",
         "Content-Length": "0",
-        "Date": "Wed, 02 Jun 2021 11:50:44 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "165",
-        "x-request-id": "af112141-2803-42f2-bc0c-349bfec05a4a"
+        "x-envoy-upstream-service-time": "105",
+        "x-request-id": "5b6c4ce1-4983-406e-8781-8d59f601e76e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8a079c81-75ee-4882-8be2-f221b71aa74e",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-5cab31891f95b740b380abba02951d34-3dd7336659fd3c40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ffe6da9716317989797626eb4a3d00b1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "ec98adff-ab94-463f-904c-1824a849ad95",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "300",
+        "x-request-id": "ec98adff-ab94-463f-904c-1824a849ad95"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "196536847"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(True).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(True).json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b692436b160b244eb30714378af4b32e-f98464204fd1d142-00",
+        "traceparent": "00-fa38a27c8c49e0429328227e23a858e8-c672a022d3b94e47-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "18a3d941380a038cf555a18dc01b1d16",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "12538b2c-64f0-449c-8d06-69a294e9c28e",
+        "apim-request-id": "97ee45a7-d6d8-4fbe-ba90-cee087ba604d",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:05 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8a079c81-75ee-4882-8be2-f221b71aa74e",
+        "Date": "Wed, 09 Jun 2021 23:03:34 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ebc756ac-28e6-48c2-a2a8-5ae05a54d402",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "647",
-        "x-request-id": "12538b2c-64f0-449c-8d06-69a294e9c28e"
+        "x-envoy-upstream-service-time": "431",
+        "x-request-id": "97ee45a7-d6d8-4fbe-ba90-cee087ba604d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8a079c81-75ee-4882-8be2-f221b71aa74e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ebc756ac-28e6-48c2-a2a8-5ae05a54d402",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b692436b160b244eb30714378af4b32e-1cb47579f7720a4d-00",
+        "traceparent": "00-fa38a27c8c49e0429328227e23a858e8-4761577565860d45-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "faac52bf6e56e4ed880433800aa248b0",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "72fffee6-b960-4936-ae9a-99620f981bc1",
+        "apim-request-id": "a9110aa0-d6d8-4ccd-8ced-7f03c1df3cb6",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:05 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "164",
-        "x-request-id": "72fffee6-b960-4936-ae9a-99620f981bc1"
+        "x-envoy-upstream-service-time": "165",
+        "x-request-id": "a9110aa0-d6d8-4ccd-8ced-7f03c1df3cb6"
       },
       "ResponseBody": {
-        "dataFeedId": "8a079c81-75ee-4882-8be2-f221b71aa74e",
+        "dataFeedId": "ebc756ac-28e6-48c2-a2a8-5ae05a54d402",
         "dataFeedName": "dataFeedvvfJ7FgJ",
         "metrics": [
           {
-            "metricId": "6a4b4f2c-1515-44a9-8433-935a3c0b7524",
+            "metricId": "5f58c8a4-dd46-4c17-9557-0d2d386d73f9",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:05Z",
+        "createdTime": "2021-06-09T23:03:34Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "872",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e7136c70b31a2442b8695cb39d088ffc-4bb1571250fb8943-00",
+        "traceparent": "00-0e9ed9af1473884c877d97b5974044dc-683d74d82e657140-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d7ea94c7664bf36d4d60a5e758de95d2",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "configGwRKjMqC",
-        "metricId": "6a4b4f2c-1515-44a9-8433-935a3c0b7524",
+        "metricId": "5f58c8a4-dd46-4c17-9557-0d2d386d73f9",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -165,7 +165,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -184,7 +184,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -201,24 +201,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "fd037369-9380-4b22-9d77-c253b0cdd647",
+        "apim-request-id": "0bc10ff2-b6ec-4233-9c9f-9394c82879e6",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:05 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/475d1d1b-a9cf-424e-ab29-76e907354e1e",
+        "Date": "Wed, 09 Jun 2021 23:03:34 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/ed243ef8-8ac2-4fc3-be47-4038b290dbd7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "170",
-        "x-request-id": "fd037369-9380-4b22-9d77-c253b0cdd647"
+        "x-envoy-upstream-service-time": "172",
+        "x-request-id": "0bc10ff2-b6ec-4233-9c9f-9394c82879e6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/475d1d1b-a9cf-424e-ab29-76e907354e1e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/ed243ef8-8ac2-4fc3-be47-4038b290dbd7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e7136c70b31a2442b8695cb39d088ffc-f9a326d477970448-00",
+        "traceparent": "00-0e9ed9af1473884c877d97b5974044dc-8c4419dc0fbbcb44-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0590beeb0b0552f80df0448824b137dc",
@@ -227,20 +227,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b420e633-4aa4-43d8-a47f-7a1a755d0247",
+        "apim-request-id": "b12e7e7f-64bf-442a-996b-bd46fe7001d0",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:05 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "104",
-        "x-request-id": "b420e633-4aa4-43d8-a47f-7a1a755d0247"
+        "x-envoy-upstream-service-time": "92",
+        "x-request-id": "b12e7e7f-64bf-442a-996b-bd46fe7001d0"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "475d1d1b-a9cf-424e-ab29-76e907354e1e",
+        "anomalyDetectionConfigurationId": "ed243ef8-8ac2-4fc3-be47-4038b290dbd7",
         "name": "configGwRKjMqC",
         "description": "",
-        "metricId": "6a4b4f2c-1515-44a9-8433-935a3c0b7524",
+        "metricId": "5f58c8a4-dd46-4c17-9557-0d2d386d73f9",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -264,7 +264,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -283,7 +283,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -300,12 +300,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/475d1d1b-a9cf-424e-ab29-76e907354e1e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/ed243ef8-8ac2-4fc3-be47-4038b290dbd7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-63967612ff899f4e8db871f788fb7445-499ae0a1aa2b1744-00",
+        "traceparent": "00-ed3704f5a79e8345a95ea6a04042752b-579aafc08640a64a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c23290e215832298963f32aafc61586a",
@@ -314,20 +314,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fadc0aa8-5bba-4be2-aa8c-da43ab9e6ca1",
+        "apim-request-id": "bb9eb037-b910-44e5-abbc-0d72368ddebe",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:05 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "x-envoy-upstream-service-time": "89",
-        "x-request-id": "fadc0aa8-5bba-4be2-aa8c-da43ab9e6ca1"
+        "x-request-id": "bb9eb037-b910-44e5-abbc-0d72368ddebe"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "475d1d1b-a9cf-424e-ab29-76e907354e1e",
+        "anomalyDetectionConfigurationId": "ed243ef8-8ac2-4fc3-be47-4038b290dbd7",
         "name": "configGwRKjMqC",
         "description": "",
-        "metricId": "6a4b4f2c-1515-44a9-8433-935a3c0b7524",
+        "metricId": "5f58c8a4-dd46-4c17-9557-0d2d386d73f9",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -351,7 +351,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -370,7 +370,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -387,14 +387,14 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/475d1d1b-a9cf-424e-ab29-76e907354e1e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/ed243ef8-8ac2-4fc3-be47-4038b290dbd7",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "839",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4c0b74fdf75fc34497a76ab8a20920ea-301edda96e1a604d-00",
+        "traceparent": "00-a948c1949c219a469e1031a3afdbf7a9-39160592d6d83949-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "208024a26953bc169b97ca5b21e5cf9c",
@@ -426,7 +426,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -445,7 +445,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -462,20 +462,20 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a45cd9c8-abca-4b8c-aa9a-54d19d899628",
+        "apim-request-id": "f463dced-6c51-4bc4-bd91-b419373e7c36",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:07 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "260",
-        "x-request-id": "a45cd9c8-abca-4b8c-aa9a-54d19d899628"
+        "x-envoy-upstream-service-time": "245",
+        "x-request-id": "f463dced-6c51-4bc4-bd91-b419373e7c36"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "475d1d1b-a9cf-424e-ab29-76e907354e1e",
+        "anomalyDetectionConfigurationId": "ed243ef8-8ac2-4fc3-be47-4038b290dbd7",
         "name": "configGwRKjMqC",
         "description": "",
-        "metricId": "6a4b4f2c-1515-44a9-8433-935a3c0b7524",
+        "metricId": "5f58c8a4-dd46-4c17-9557-0d2d386d73f9",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -499,7 +499,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -518,7 +518,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -535,12 +535,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/475d1d1b-a9cf-424e-ab29-76e907354e1e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/ed243ef8-8ac2-4fc3-be47-4038b290dbd7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7e13941b8b5a024da6dffaf9ca085222-68d75a0700d7c648-00",
+        "traceparent": "00-5744223d09970046a817e9ba6ec794f0-880ae65fcf2a1242-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c704c929d3abd64e256d6fc5d84e56ac",
@@ -549,23 +549,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5b6c4ce1-4983-406e-8781-8d59f601e76e",
+        "apim-request-id": "5e3694aa-52bc-4d5b-9585-826321b965bc",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:07 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "105",
-        "x-request-id": "5b6c4ce1-4983-406e-8781-8d59f601e76e"
+        "x-envoy-upstream-service-time": "92",
+        "x-request-id": "5e3694aa-52bc-4d5b-9585-826321b965bc"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8a079c81-75ee-4882-8be2-f221b71aa74e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ebc756ac-28e6-48c2-a2a8-5ae05a54d402",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5cab31891f95b740b380abba02951d34-3dd7336659fd3c40-00",
+        "traceparent": "00-71febfb221c4744a9f9ac4d99391b1dc-d9a566994d4dc346-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ffe6da9716317989797626eb4a3d00b1",
@@ -574,19 +574,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ec98adff-ab94-463f-904c-1824a849ad95",
+        "apim-request-id": "0bfc902a-9b20-48a0-9c0c-1dd43ce0108f",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:07 GMT",
+        "Date": "Wed, 09 Jun 2021 23:03:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "300",
-        "x-request-id": "ec98adff-ab94-463f-904c-1824a849ad95"
+        "x-envoy-upstream-service-time": "289",
+        "x-request-id": "0bfc902a-9b20-48a0-9c0c-1dd43ce0108f"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "196536847"

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(True)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(True)Async.json
@@ -1,21 +1,147 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "858",
+        "Content-Length": "312",
         "Content-Type": "application/json",
-        "traceparent": "00-b6e4d1eea46b114e9c8528e6ffb1a5ca-e05a1d87e7eb184a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-780a2881ab3a354eb51f3ee2de649399-1f8057189e824843-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
         "x-ms-client-request-id": "44d33fe48170c13acd1c9736f8c740a4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configNBUpfLc4",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedNBUpfLc4",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "2d225962-3eab-4106-8de1-bf29eb461bab",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:28 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/67276062-76d2-49a5-b5dd-ba2f64222a15",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "687",
+        "x-request-id": "2d225962-3eab-4106-8de1-bf29eb461bab"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/67276062-76d2-49a5-b5dd-ba2f64222a15",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-780a2881ab3a354eb51f3ee2de649399-f517ad1c853dbe40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d39d34622047a701a03d2883ef74e60c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "82d92b47-62c1-493b-bc4b-51b951b854c0",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "162",
+        "x-request-id": "82d92b47-62c1-493b-bc4b-51b951b854c0"
+      },
+      "ResponseBody": {
+        "dataFeedId": "67276062-76d2-49a5-b5dd-ba2f64222a15",
+        "dataFeedName": "dataFeedNBUpfLc4",
+        "metrics": [
+          {
+            "metricId": "f98d9a98-f74d-47ee-b114-e874e800c4be",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "DimensionA",
+            "dimensionDisplayName": "DimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-09T19:46:28Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "872",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c7b544214c34654eb0300a01e0ccb37d-cfcaede30681d64d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "5ff10b6921e4fe798a13820899891cc3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configsuJALrSB",
+        "metricId": "f98d9a98-f74d-47ee-b114-e874e800c4be",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -39,7 +165,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -58,8 +184,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -75,131 +201,46 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "3a27c84b-674c-46d7-89d0-5e0f39283f77",
+        "apim-request-id": "d6e5961c-191f-4409-8496-377d12f24ea4",
         "Content-Length": "0",
-        "Date": "Wed, 02 Jun 2021 11:51:44 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e706690a-1083-4f64-b2e8-f540a358523d",
+        "Date": "Wed, 09 Jun 2021 19:46:28 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "396",
-        "x-request-id": "3a27c84b-674c-46d7-89d0-5e0f39283f77"
+        "x-envoy-upstream-service-time": "184",
+        "x-request-id": "d6e5961c-191f-4409-8496-377d12f24ea4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e706690a-1083-4f64-b2e8-f540a358523d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-b6e4d1eea46b114e9c8528e6ffb1a5ca-97b9edd7d976cd43-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d39d34622047a701a03d2883ef74e60c",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c7b544214c34654eb0300a01e0ccb37d-ec4375587e7cfa42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "33a42c3db65858d2358bf4716980e93d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7ca9b130-897b-4f2c-a862-5e4d7fa02b98",
-        "Content-Length": "964",
+        "apim-request-id": "4931db25-07ad-4574-ab35-60ac85259923",
+        "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:51:45 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "74",
-        "x-request-id": "7ca9b130-897b-4f2c-a862-5e4d7fa02b98"
-      },
-      "ResponseBody": {
-        "anomalyDetectionConfigurationId": "e706690a-1083-4f64-b2e8-f540a358523d",
-        "name": "configNBUpfLc4",
-        "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-        "wholeMetricConfiguration": {
-          "conditionOperator": "OR",
-          "smartDetectionCondition": {
-            "sensitivity": 60.0,
-            "anomalyDetectorDirection": "Up",
-            "suppressCondition": {
-              "minNumber": 5,
-              "minRatio": 6.0
-            }
-          },
-          "hardThresholdCondition": {
-            "lowerBound": 10.0,
-            "anomalyDetectorDirection": "Down",
-            "suppressCondition": {
-              "minNumber": 1,
-              "minRatio": 2.0
-            }
-          }
-        },
-        "dimensionGroupOverrideConfigurations": [
-          {
-            "group": {
-              "dimension": {
-                "city": "Koltaka"
-              }
-            },
-            "changeThresholdCondition": {
-              "changePercentage": 40.0,
-              "shiftPoint": 12,
-              "anomalyDetectorDirection": "Up",
-              "withinRange": false,
-              "suppressCondition": {
-                "minNumber": 5,
-                "minRatio": 6.0
-              }
-            }
-          }
-        ],
-        "seriesOverrideConfigurations": [
-          {
-            "series": {
-              "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
-              }
-            },
-            "smartDetectionCondition": {
-              "sensitivity": 30.0,
-              "anomalyDetectorDirection": "Both",
-              "suppressCondition": {
-                "minNumber": 3,
-                "minRatio": 4.0
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e706690a-1083-4f64-b2e8-f540a358523d",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-1ed38c6ab0e1db448d6ef8a9f435a9f0-85d39fc7e5bf9447-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c05e864224bb2e35690bf15fe42179fe",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7f6610eb-a683-47c6-81dd-9b3056e3dba6",
-        "Content-Length": "964",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:51:45 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "x-envoy-upstream-service-time": "84",
-        "x-request-id": "7f6610eb-a683-47c6-81dd-9b3056e3dba6"
+        "x-request-id": "4931db25-07ad-4574-ab35-60ac85259923"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "e706690a-1083-4f64-b2e8-f540a358523d",
-        "name": "configNBUpfLc4",
+        "anomalyDetectionConfigurationId": "bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+        "name": "configsuJALrSB",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "f98d9a98-f74d-47ee-b114-e874e800c4be",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -223,7 +264,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -242,8 +283,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -259,20 +300,108 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e706690a-1083-4f64-b2e8-f540a358523d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3c92d330adedfa489670e5a87d897e4a-66a8e57e7f50db41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "3b696fffa12f7ec3c429f8dbf2dd72b9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6973de2f-ce58-4551-b805-b891cc35f336",
+        "Content-Length": "978",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 09 Jun 2021 19:46:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "93",
+        "x-request-id": "6973de2f-ce58-4551-b805-b891cc35f336"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+        "name": "configsuJALrSB",
+        "description": "",
+        "metricId": "f98d9a98-f74d-47ee-b114-e874e800c4be",
+        "wholeMetricConfiguration": {
+          "conditionOperator": "OR",
+          "smartDetectionCondition": {
+            "sensitivity": 60.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 5,
+              "minRatio": 6.0
+            }
+          },
+          "hardThresholdCondition": {
+            "lowerBound": 10.0,
+            "anomalyDetectorDirection": "Down",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 2.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [
+          {
+            "group": {
+              "dimension": {
+                "DimensionA": "Koltaka"
+              }
+            },
+            "changeThresholdCondition": {
+              "changePercentage": 40.0,
+              "shiftPoint": 12,
+              "anomalyDetectorDirection": "Up",
+              "withinRange": false,
+              "suppressCondition": {
+                "minNumber": 5,
+                "minRatio": 6.0
+              }
+            }
+          }
+        ],
+        "seriesOverrideConfigurations": [
+          {
+            "series": {
+              "dimension": {
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
+              }
+            },
+            "smartDetectionCondition": {
+              "sensitivity": 30.0,
+              "anomalyDetectorDirection": "Both",
+              "suppressCondition": {
+                "minNumber": 3,
+                "minRatio": 4.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "825",
+        "Content-Length": "839",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a7751f1978430149b46d4cfa67c5ae0b-d27ccf81eaa2e745-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0882138a8999c31c3d2ca43358b6d258",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-61afd4f7514c97479d1c4b59011e408c-86385695042f5041-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8f829a6a0180b3d539982a582d07950a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configNBUpfLc4",
+        "name": "configsuJALrSB",
         "description": "",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
@@ -297,7 +426,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -316,8 +445,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -333,20 +462,20 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "43109bce-08a0-4074-ac3f-364c7dbe9e7a",
-        "Content-Length": "964",
+        "apim-request-id": "ba5f81a4-b624-4970-b992-ace66ff7cf78",
+        "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:51:45 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "265",
-        "x-request-id": "43109bce-08a0-4074-ac3f-364c7dbe9e7a"
+        "x-envoy-upstream-service-time": "243",
+        "x-request-id": "ba5f81a4-b624-4970-b992-ace66ff7cf78"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "e706690a-1083-4f64-b2e8-f540a358523d",
-        "name": "configNBUpfLc4",
+        "anomalyDetectionConfigurationId": "bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+        "name": "configsuJALrSB",
         "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+        "metricId": "f98d9a98-f74d-47ee-b114-e874e800c4be",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -370,7 +499,7 @@
           {
             "group": {
               "dimension": {
-                "city": "Koltaka"
+                "DimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -389,8 +518,8 @@
           {
             "series": {
               "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
+                "DimensionA": "Delhi",
+                "dimensionB": "Handmade"
               }
             },
             "smartDetectionCondition": {
@@ -406,119 +535,60 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e706690a-1083-4f64-b2e8-f540a358523d",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-605d5f59608fbe439029618f85dd65f8-79ef710755ca0f42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "71f48b3580693de9ff6f693b2fa1c37e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ed08e64c-b162-4165-85d2-7b0641686e82",
-        "Content-Length": "964",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 02 Jun 2021 11:51:45 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "65",
-        "x-request-id": "ed08e64c-b162-4165-85d2-7b0641686e82"
-      },
-      "ResponseBody": {
-        "anomalyDetectionConfigurationId": "e706690a-1083-4f64-b2e8-f540a358523d",
-        "name": "configNBUpfLc4",
-        "description": "",
-        "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-        "wholeMetricConfiguration": {
-          "conditionOperator": "OR",
-          "smartDetectionCondition": {
-            "sensitivity": 60.0,
-            "anomalyDetectorDirection": "Up",
-            "suppressCondition": {
-              "minNumber": 5,
-              "minRatio": 6.0
-            }
-          },
-          "hardThresholdCondition": {
-            "lowerBound": 12.0,
-            "anomalyDetectorDirection": "Down",
-            "suppressCondition": {
-              "minNumber": 1,
-              "minRatio": 2.0
-            }
-          }
-        },
-        "dimensionGroupOverrideConfigurations": [
-          {
-            "group": {
-              "dimension": {
-                "city": "Koltaka"
-              }
-            },
-            "changeThresholdCondition": {
-              "changePercentage": 40.0,
-              "shiftPoint": 12,
-              "anomalyDetectorDirection": "Up",
-              "withinRange": false,
-              "suppressCondition": {
-                "minNumber": 5,
-                "minRatio": 6.0
-              }
-            }
-          }
-        ],
-        "seriesOverrideConfigurations": [
-          {
-            "series": {
-              "dimension": {
-                "city": "Delhi",
-                "category": "Handmade"
-              }
-            },
-            "smartDetectionCondition": {
-              "sensitivity": 30.0,
-              "anomalyDetectorDirection": "Both",
-              "suppressCondition": {
-                "minNumber": 3,
-                "minRatio": 4.0
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e706690a-1083-4f64-b2e8-f540a358523d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-59e12340d8872b4fb94ac601dde34cdf-fef730da3a119e46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210602.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "dbf829c4ddf2b9726a9a828f8001d5b3",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-35a54b9dae39c846a70a98d6f9920b41-99bc08251c4b5f4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2a09442ae0209b9368256f2fbef66658",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7e41834a-6ec4-4312-a6b4-e8a8fd9656b7",
+        "apim-request-id": "b992478a-688a-4d6f-88d1-ae5be75d58bd",
         "Content-Length": "0",
-        "Date": "Wed, 02 Jun 2021 11:51:45 GMT",
+        "Date": "Wed, 09 Jun 2021 19:46:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "140",
-        "x-request-id": "7e41834a-6ec4-4312-a6b4-e8a8fd9656b7"
+        "x-envoy-upstream-service-time": "105",
+        "x-request-id": "b992478a-688a-4d6f-88d1-ae5be75d58bd"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/67276062-76d2-49a5-b5dd-ba2f64222a15",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d500dd431164204e88466c678fc7d8a5-eb047385cae56f4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ce063a195afdfdbd9ab60296776a51bc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "1a1955ba-fa38-48c4-a500-554b48560112",
+        "Content-Length": "0",
+        "Date": "Wed, 09 Jun 2021 19:46:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "351",
+        "x-request-id": "1a1955ba-fa38-48c4-a500-554b48560112"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
-    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "1105372450"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(True)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionConfigurationLiveTests/UpdateDetectionConfigurationWithMinimumSetupAndGetInstance(True)Async.json
@@ -8,7 +8,7 @@
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-780a2881ab3a354eb51f3ee2de649399-1f8057189e824843-00",
+        "traceparent": "00-656abca2c279374891d7bff89ed5e367-60c1fa84c398774d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "44d33fe48170c13acd1c9736f8c740a4",
@@ -29,7 +29,7 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA"
+            "dimensionName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB"
@@ -39,24 +39,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2d225962-3eab-4106-8de1-bf29eb461bab",
+        "apim-request-id": "09c038e1-750b-4c30-b36f-1cc56ad1911c",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:28 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/67276062-76d2-49a5-b5dd-ba2f64222a15",
+        "Date": "Wed, 09 Jun 2021 23:04:06 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1a8c5037-2fad-4a8a-ae40-4fe5bff82f14",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "687",
-        "x-request-id": "2d225962-3eab-4106-8de1-bf29eb461bab"
+        "x-envoy-upstream-service-time": "449",
+        "x-request-id": "09c038e1-750b-4c30-b36f-1cc56ad1911c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/67276062-76d2-49a5-b5dd-ba2f64222a15",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1a8c5037-2fad-4a8a-ae40-4fe5bff82f14",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-780a2881ab3a354eb51f3ee2de649399-f517ad1c853dbe40-00",
+        "traceparent": "00-656abca2c279374891d7bff89ed5e367-46463f5504ba6f4d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d39d34622047a701a03d2883ef74e60c",
@@ -65,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "82d92b47-62c1-493b-bc4b-51b951b854c0",
+        "apim-request-id": "7869406e-5c74-408a-88ef-a6a9ecd6bf42",
         "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:28 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "162",
-        "x-request-id": "82d92b47-62c1-493b-bc4b-51b951b854c0"
+        "x-envoy-upstream-service-time": "165",
+        "x-request-id": "7869406e-5c74-408a-88ef-a6a9ecd6bf42"
       },
       "ResponseBody": {
-        "dataFeedId": "67276062-76d2-49a5-b5dd-ba2f64222a15",
+        "dataFeedId": "1a8c5037-2fad-4a8a-ae40-4fe5bff82f14",
         "dataFeedName": "dataFeedNBUpfLc4",
         "metrics": [
           {
-            "metricId": "f98d9a98-f74d-47ee-b114-e874e800c4be",
+            "metricId": "a02a3e1e-a512-46fa-8d90-39a7d6f0a475",
             "metricName": "metric",
             "metricDisplayName": "metric",
             "metricDescription": ""
@@ -87,8 +87,8 @@
         ],
         "dimension": [
           {
-            "dimensionName": "DimensionA",
-            "dimensionDisplayName": "DimensionA"
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
           },
           {
             "dimensionName": "dimensionB",
@@ -116,7 +116,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-06-09T19:46:28Z",
+        "createdTime": "2021-06-09T23:04:07Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -133,7 +133,7 @@
         "Content-Length": "872",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c7b544214c34654eb0300a01e0ccb37d-cfcaede30681d64d-00",
+        "traceparent": "00-09a045093136064b94ad589c62c891ab-0d58771e3125ed47-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5ff10b6921e4fe798a13820899891cc3",
@@ -141,7 +141,7 @@
       },
       "RequestBody": {
         "name": "configsuJALrSB",
-        "metricId": "f98d9a98-f74d-47ee-b114-e874e800c4be",
+        "metricId": "a02a3e1e-a512-46fa-8d90-39a7d6f0a475",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -165,7 +165,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -184,7 +184,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -201,24 +201,24 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d6e5961c-191f-4409-8496-377d12f24ea4",
+        "apim-request-id": "2b0dc53e-91da-4eca-a1d9-7fba8bbcb908",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:28 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+        "Date": "Wed, 09 Jun 2021 23:04:07 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/23303a63-4357-4fc5-8d77-0e95e20d86dd",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "184",
-        "x-request-id": "d6e5961c-191f-4409-8496-377d12f24ea4"
+        "x-envoy-upstream-service-time": "196",
+        "x-request-id": "2b0dc53e-91da-4eca-a1d9-7fba8bbcb908"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/23303a63-4357-4fc5-8d77-0e95e20d86dd",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c7b544214c34654eb0300a01e0ccb37d-ec4375587e7cfa42-00",
+        "traceparent": "00-09a045093136064b94ad589c62c891ab-cc38e790f63e044b-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "33a42c3db65858d2358bf4716980e93d",
@@ -227,20 +227,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4931db25-07ad-4574-ab35-60ac85259923",
+        "apim-request-id": "1b0fe2b0-19e3-4fe3-93ec-c80ada35d776",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:28 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "84",
-        "x-request-id": "4931db25-07ad-4574-ab35-60ac85259923"
+        "x-envoy-upstream-service-time": "93",
+        "x-request-id": "1b0fe2b0-19e3-4fe3-93ec-c80ada35d776"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+        "anomalyDetectionConfigurationId": "23303a63-4357-4fc5-8d77-0e95e20d86dd",
         "name": "configsuJALrSB",
         "description": "",
-        "metricId": "f98d9a98-f74d-47ee-b114-e874e800c4be",
+        "metricId": "a02a3e1e-a512-46fa-8d90-39a7d6f0a475",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -264,7 +264,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -283,7 +283,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -300,12 +300,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/23303a63-4357-4fc5-8d77-0e95e20d86dd",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3c92d330adedfa489670e5a87d897e4a-66a8e57e7f50db41-00",
+        "traceparent": "00-a9192a0b23cf864384e3bcd52e5e3969-38d794edba656744-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3b696fffa12f7ec3c429f8dbf2dd72b9",
@@ -314,20 +314,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6973de2f-ce58-4551-b805-b891cc35f336",
+        "apim-request-id": "872fff5c-77f9-4b09-a1e2-b3e0ce5e831a",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:28 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "93",
-        "x-request-id": "6973de2f-ce58-4551-b805-b891cc35f336"
+        "x-envoy-upstream-service-time": "89",
+        "x-request-id": "872fff5c-77f9-4b09-a1e2-b3e0ce5e831a"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+        "anomalyDetectionConfigurationId": "23303a63-4357-4fc5-8d77-0e95e20d86dd",
         "name": "configsuJALrSB",
         "description": "",
-        "metricId": "f98d9a98-f74d-47ee-b114-e874e800c4be",
+        "metricId": "a02a3e1e-a512-46fa-8d90-39a7d6f0a475",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -351,7 +351,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -370,7 +370,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -387,14 +387,14 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/23303a63-4357-4fc5-8d77-0e95e20d86dd",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "839",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-61afd4f7514c97479d1c4b59011e408c-86385695042f5041-00",
+        "traceparent": "00-b92b00835f4390489dd83cca5bd0ac2a-affbdc631495674f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8f829a6a0180b3d539982a582d07950a",
@@ -426,7 +426,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -445,7 +445,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -462,20 +462,20 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ba5f81a4-b624-4970-b992-ace66ff7cf78",
+        "apim-request-id": "72cc4b87-dcd9-4f9c-87e8-982b31398681",
         "Content-Length": "978",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 09 Jun 2021 19:46:29 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "243",
-        "x-request-id": "ba5f81a4-b624-4970-b992-ace66ff7cf78"
+        "x-envoy-upstream-service-time": "260",
+        "x-request-id": "72cc4b87-dcd9-4f9c-87e8-982b31398681"
       },
       "ResponseBody": {
-        "anomalyDetectionConfigurationId": "bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+        "anomalyDetectionConfigurationId": "23303a63-4357-4fc5-8d77-0e95e20d86dd",
         "name": "configsuJALrSB",
         "description": "",
-        "metricId": "f98d9a98-f74d-47ee-b114-e874e800c4be",
+        "metricId": "a02a3e1e-a512-46fa-8d90-39a7d6f0a475",
         "wholeMetricConfiguration": {
           "conditionOperator": "OR",
           "smartDetectionCondition": {
@@ -499,7 +499,7 @@
           {
             "group": {
               "dimension": {
-                "DimensionA": "Koltaka"
+                "dimensionA": "Koltaka"
               }
             },
             "changeThresholdCondition": {
@@ -518,7 +518,7 @@
           {
             "series": {
               "dimension": {
-                "DimensionA": "Delhi",
+                "dimensionA": "Delhi",
                 "dimensionB": "Handmade"
               }
             },
@@ -535,12 +535,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bd86df5f-71b2-441d-96e4-4dbf6ad3c29f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/23303a63-4357-4fc5-8d77-0e95e20d86dd",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-35a54b9dae39c846a70a98d6f9920b41-99bc08251c4b5f4d-00",
+        "traceparent": "00-6ad443513fec3b458d6e8d3b1d53d89f-4a96126a10324c4a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2a09442ae0209b9368256f2fbef66658",
@@ -549,23 +549,23 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b992478a-688a-4d6f-88d1-ae5be75d58bd",
+        "apim-request-id": "b4e3a96d-8b76-4676-8b29-83d33e5ee307",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:29 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "105",
-        "x-request-id": "b992478a-688a-4d6f-88d1-ae5be75d58bd"
+        "x-envoy-upstream-service-time": "139",
+        "x-request-id": "b4e3a96d-8b76-4676-8b29-83d33e5ee307"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/67276062-76d2-49a5-b5dd-ba2f64222a15",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1a8c5037-2fad-4a8a-ae40-4fe5bff82f14",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d500dd431164204e88466c678fc7d8a5-eb047385cae56f4a-00",
+        "traceparent": "00-aeed1a0844368644ba4d9bd54257b4f6-48e27d2bbe0eab42-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210609.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ce063a195afdfdbd9ab60296776a51bc",
@@ -574,19 +574,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1a1955ba-fa38-48c4-a500-554b48560112",
+        "apim-request-id": "ff1cdff1-e000-4a12-b2d0-97a0fe01bd50",
         "Content-Length": "0",
-        "Date": "Wed, 09 Jun 2021 19:46:29 GMT",
+        "Date": "Wed, 09 Jun 2021 23:04:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "351",
-        "x-request-id": "1a1955ba-fa38-48c4-a500-554b48560112"
+        "x-envoy-upstream-service-time": "282",
+        "x-request-id": "ff1cdff1-e000-4a12-b2d0-97a0fe01bd50"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
     "RandomSeed": "1105372450"


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-net/issues/21663.

The Metrics Advisor service allows us to create entities called "Data Feeds". And each data feed can have up to 10 "Anomaly Detection Configurations".

In multiple tests, we create => test => delete these detection configurations. However, we're running things in parallel, so we usually end up with many existing configurations at the same time. Sometimes we reach the limit and fail during the creation of a new one:
> {"code":"Bad Request","message":"Invalid parameter. config count should be less than or equal to 10. TraceId: b29a4c4f-3357-4198-91cc-5541507ad822"}

To avoid this problem, now we're creating a mock data feed before every detection configuration test, and create the configuration for this mock data feed only. This way, we'll have only 1 configuration per created data feed. All entities created for these tests are properly deleted after the run.