### PR TITLE
[MetricsAdvisor] Updated disposable test types to return whole created model

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/DisposableAlertConfiguration.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/DisposableAlertConfiguration.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.MetricsAdvisor.Administration;
 using Azure.AI.MetricsAdvisor.Models;
-using NUnit.Framework;
 
 namespace Azure.AI.MetricsAdvisor.Tests
 {
@@ -25,39 +24,35 @@ namespace Azure.AI.MetricsAdvisor.Tests
         /// Initializes a new instance of the <see cref="DisposableAlertConfiguration"/> class.
         /// </summary>
         /// <param name="adminClient">The client to use for deleting the configuration upon disposal.</param>
-        /// <param name="id">The identifier of the alert configuration this instance is associated with.</param>
-        private DisposableAlertConfiguration(MetricsAdvisorAdministrationClient adminClient, string id)
+        /// <param name="configuration">The alert configuration this instance is associated with.</param>
+        private DisposableAlertConfiguration(MetricsAdvisorAdministrationClient adminClient, AnomalyAlertConfiguration configuration)
         {
             _adminClient = adminClient;
-            Id = id;
+            Configuration = configuration;
         }
 
         /// <summary>
-        /// The identifier of the alert configuration this instance is associated with.
+        /// The alert configuration this instance is associated with.
         /// </summary>
-        public string Id { get; }
+        public AnomalyAlertConfiguration Configuration { get; }
 
         /// <summary>
         /// Creates an alert configuration using the specified <see cref="MetricsAdvisorAdministrationClient"/>.
-        /// A <see cref="DisposableAlertConfiguration"/> instance is returned, from which the ID of the created
-        /// configuration can be obtained. Upon disposal, the associated configuration will be deleted.
+        /// A <see cref="DisposableAlertConfiguration"/> instance is returned, from which the created configuration
+        /// can be obtained. Upon disposal, the associated configuration will be deleted.
         /// </summary>
         /// <param name="adminClient">The client to use for creating and for deleting the configuration.</param>
-        /// <param name="hook">Specifies how the created <see cref="AnomalyAlertConfiguration"/> should be configured.</param>
-        /// <returns>A <see cref="DisposableAlertConfiguration"/> instance from which the ID of the created configuration can be obtained.</returns>
+        /// <param name="configuration">Specifies how the created <see cref="AnomalyAlertConfiguration"/> should be configured.</param>
+        /// <returns>A <see cref="DisposableAlertConfiguration"/> instance from which the created configuration can be obtained.</returns>
         public static async Task<DisposableAlertConfiguration> CreateAlertConfigurationAsync(MetricsAdvisorAdministrationClient adminClient, AnomalyAlertConfiguration alertConfiguration)
         {
             AnomalyAlertConfiguration createdConfig = await adminClient.CreateAlertConfigurationAsync(alertConfiguration);
-
-            Assert.That(createdConfig, Is.Not.Null);
-            Assert.That(createdConfig.Id, Is.Not.Null.And.Not.Empty);
-
-            return new DisposableAlertConfiguration(adminClient, createdConfig.Id);
+            return new DisposableAlertConfiguration(adminClient, createdConfig);
         }
 
         /// <summary>
         /// Deletes the configuration this instance is associated with.
         /// </summary>
-        public async ValueTask DisposeAsync() => await _adminClient.DeleteAlertConfigurationAsync(Id);
+        public async ValueTask DisposeAsync() => await _adminClient.DeleteAlertConfigurationAsync(Configuration.Id);
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/DisposableDataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/DisposableDataFeed.cs
@@ -5,12 +5,11 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.MetricsAdvisor.Administration;
 using Azure.AI.MetricsAdvisor.Models;
-using NUnit.Framework;
 
 namespace Azure.AI.MetricsAdvisor.Tests
 {
     /// <summary>
-    /// Represents a <see cref="DataFeed"/> that has been created for testing purposes. In order to
+    /// Represents a <see cref="Models.DataFeed"/> that has been created for testing purposes. In order to
     /// create a new instance of this class, the <see cref="CreateDataFeedAsync"/> static method must
     /// be invoked. The created data feed will be deleted upon disposal.
     /// </summary>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/DisposableDatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/DisposableDatasourceCredential.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.MetricsAdvisor.Administration;
 using Azure.AI.MetricsAdvisor.Models;
-using NUnit.Framework;
 
 namespace Azure.AI.MetricsAdvisor.Tests
 {
@@ -48,10 +47,6 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public static async Task<DisposableDatasourceCredential> CreateDatasourceCredentialAsync(MetricsAdvisorAdministrationClient adminClient, DatasourceCredential credential)
         {
             DatasourceCredential createdCredential = await adminClient.CreateDatasourceCredentialAsync(credential);
-
-            Assert.That(createdCredential, Is.Not.Null);
-            Assert.That(createdCredential.Id, Is.Not.Null.And.Not.Empty);
-
             return new DisposableDatasourceCredential(adminClient, createdCredential);
         }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/DisposableDetectionConfiguration.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/DisposableDetectionConfiguration.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.MetricsAdvisor.Administration;
 using Azure.AI.MetricsAdvisor.Models;
-using NUnit.Framework;
 
 namespace Azure.AI.MetricsAdvisor.Tests
 {
@@ -25,39 +24,35 @@ namespace Azure.AI.MetricsAdvisor.Tests
         /// Initializes a new instance of the <see cref="DisposableDetectionConfiguration"/> class.
         /// </summary>
         /// <param name="adminClient">The client to use for deleting the configuration upon disposal.</param>
-        /// <param name="id">The identifier of the detection configuration this instance is associated with.</param>
-        private DisposableDetectionConfiguration(MetricsAdvisorAdministrationClient adminClient, string id)
+        /// <param name="configuration">The detection configuration this instance is associated with.</param>
+        private DisposableDetectionConfiguration(MetricsAdvisorAdministrationClient adminClient, AnomalyDetectionConfiguration configuration)
         {
             _adminClient = adminClient;
-            Id = id;
+            Configuration = configuration;
         }
 
         /// <summary>
-        /// The identifier of the detection configuration this instance is associated with.
+        /// The detection configuration this instance is associated with.
         /// </summary>
-        public string Id { get; }
+        public AnomalyDetectionConfiguration Configuration { get; }
 
         /// <summary>
         /// Creates a detection configuration using the specified <see cref="MetricsAdvisorAdministrationClient"/>.
-        /// A <see cref="DisposableDetectionConfiguration"/> instance is returned, from which the ID of the created
-        /// configuration can be obtained. Upon disposal, the associated configuration will be deleted.
+        /// A <see cref="DisposableDetectionConfiguration"/> instance is returned, from which the created configuration
+        /// can be obtained. Upon disposal, the associated configuration will be deleted.
         /// </summary>
         /// <param name="adminClient">The client to use for creating and for deleting the configuration.</param>
-        /// <param name="hook">Specifies how the created <see cref="AnomalyDetectionConfiguration"/> should be configured.</param>
-        /// <returns>A <see cref="DisposableDetectionConfiguration"/> instance from which the ID of the created configuration can be obtained.</returns>
-        public static async Task<DisposableDetectionConfiguration> CreateDetectionConfigurationAsync(MetricsAdvisorAdministrationClient adminClient, AnomalyDetectionConfiguration detectionConfiguration)
+        /// <param name="configuration">Specifies how the created <see cref="AnomalyDetectionConfiguration"/> should be configured.</param>
+        /// <returns>A <see cref="DisposableDetectionConfiguration"/> instance from which the created configuration can be obtained.</returns>
+        public static async Task<DisposableDetectionConfiguration> CreateDetectionConfigurationAsync(MetricsAdvisorAdministrationClient adminClient, AnomalyDetectionConfiguration configuration)
         {
-            AnomalyDetectionConfiguration createdConfig = await adminClient.CreateDetectionConfigurationAsync(detectionConfiguration);
-
-            Assert.That(createdConfig, Is.Not.Null);
-            Assert.That(createdConfig.Id, Is.Not.Null.And.Not.Empty);
-
-            return new DisposableDetectionConfiguration(adminClient, createdConfig.Id);
+            AnomalyDetectionConfiguration createdConfig = await adminClient.CreateDetectionConfigurationAsync(configuration);
+            return new DisposableDetectionConfiguration(adminClient, createdConfig);
         }
 
         /// <summary>
         /// Deletes the configuration this instance is associated with.
         /// </summary>
-        public async ValueTask DisposeAsync() => await _adminClient.DeleteDetectionConfigurationAsync(Id);
+        public async ValueTask DisposeAsync() => await _adminClient.DeleteDetectionConfigurationAsync(Configuration.Id);
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/DisposableNotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/DisposableNotificationHook.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.MetricsAdvisor.Administration;
 using Azure.AI.MetricsAdvisor.Models;
-using NUnit.Framework;
 
 namespace Azure.AI.MetricsAdvisor.Tests
 {
@@ -25,39 +24,35 @@ namespace Azure.AI.MetricsAdvisor.Tests
         /// Initializes a new instance of the <see cref="DisposableNotificationHook"/> class.
         /// </summary>
         /// <param name="adminClient">The client to use for deleting the hook upon disposal.</param>
-        /// <param name="id">The identifier of the hook this instance is associated with.</param>
-        private DisposableNotificationHook(MetricsAdvisorAdministrationClient adminClient, string id)
+        /// <param name="hook">The hook this instance is associated with.</param>
+        private DisposableNotificationHook(MetricsAdvisorAdministrationClient adminClient, NotificationHook hook)
         {
             _adminClient = adminClient;
-            Id = id;
+            Hook = hook;
         }
 
         /// <summary>
-        /// The identifier of the hook this instance is associated with.
+        /// The hook this instance is associated with.
         /// </summary>
-        public string Id { get; }
+        public NotificationHook Hook { get; }
 
         /// <summary>
         /// Creates a hook using the specified <see cref="MetricsAdvisorAdministrationClient"/>. A
-        /// <see cref="DisposableNotificationHook"/> instance is returned, from which the ID of the
-        /// created hook can be obtained. Upon disposal, the associated hook will be deleted.
+        /// <see cref="DisposableNotificationHook"/> instance is returned, from which the created
+        /// hook can be obtained. Upon disposal, the associated hook will be deleted.
         /// </summary>
         /// <param name="adminClient">The client to use for creating and for deleting the hook.</param>
         /// <param name="hook">Specifies how the created <see cref="NotificationHook"/> should be configured.</param>
-        /// <returns>A <see cref="DisposableNotificationHook"/> instance from which the ID of the created hook can be obtained.</returns>
+        /// <returns>A <see cref="DisposableNotificationHook"/> instance from which the created hook can be obtained.</returns>
         public static async Task<DisposableNotificationHook> CreateHookAsync(MetricsAdvisorAdministrationClient adminClient, NotificationHook hook)
         {
             NotificationHook createdHook = await adminClient.CreateHookAsync(hook);
-
-            Assert.That(createdHook, Is.Not.Null);
-            Assert.That(createdHook.Id, Is.Not.Null.And.Not.Empty);
-
-            return new DisposableNotificationHook(adminClient, createdHook.Id);
+            return new DisposableNotificationHook(adminClient, createdHook);
         }
 
         /// <summary>
         /// Deletes the hook this instance is associated with.
         /// </summary>
-        public async ValueTask DisposeAsync() => await _adminClient.DeleteHookAsync(Id);
+        public async ValueTask DisposeAsync() => await _adminClient.DeleteHookAsync(Hook.Id);
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyAlertConfigurationLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyAlertConfigurationLiveTests.cs
@@ -38,9 +38,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableConfig = await DisposableAlertConfiguration.CreateAlertConfigurationAsync(adminClient, configToCreate);
 
-            AnomalyAlertConfiguration createdConfig = await adminClient.GetAlertConfigurationAsync(disposableConfig.Id);
+            AnomalyAlertConfiguration createdConfig = disposableConfig.Configuration;
 
-            Assert.That(createdConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(createdConfig.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdConfig.Name, Is.EqualTo(configName));
             Assert.That(createdConfig.Description, Is.Empty);
             Assert.That(createdConfig.CrossMetricsOperator, Is.Null);
@@ -85,9 +85,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableConfig = await DisposableAlertConfiguration.CreateAlertConfigurationAsync(adminClient, configToCreate);
 
-            AnomalyAlertConfiguration createdConfig = await adminClient.GetAlertConfigurationAsync(disposableConfig.Id);
+            AnomalyAlertConfiguration createdConfig = disposableConfig.Configuration;
 
-            Assert.That(createdConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(createdConfig.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdConfig.Name, Is.EqualTo(configName));
             Assert.That(createdConfig.Description, Is.Empty);
             Assert.That(createdConfig.CrossMetricsOperator, Is.Null);
@@ -136,9 +136,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableConfig = await DisposableAlertConfiguration.CreateAlertConfigurationAsync(adminClient, configToCreate);
 
-            AnomalyAlertConfiguration createdConfig = await adminClient.GetAlertConfigurationAsync(disposableConfig.Id);
+            AnomalyAlertConfiguration createdConfig = disposableConfig.Configuration;
 
-            Assert.That(createdConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(createdConfig.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdConfig.Name, Is.EqualTo(configName));
             Assert.That(createdConfig.Description, Is.Empty);
             Assert.That(createdConfig.CrossMetricsOperator, Is.Null);
@@ -206,22 +206,22 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var configToCreate = new AnomalyAlertConfiguration()
             {
                 Name = configName,
-                IdsOfHooksToAlert = { disposableHook0.Id, disposableHook1.Id },
+                IdsOfHooksToAlert = { disposableHook0.Hook.Id, disposableHook1.Hook.Id },
                 MetricAlertConfigurations = { metricAlertConfig },
                 Description = description
             };
 
             await using var disposableConfig = await DisposableAlertConfiguration.CreateAlertConfigurationAsync(adminClient, configToCreate);
 
-            AnomalyAlertConfiguration createdConfig = await adminClient.GetAlertConfigurationAsync(disposableConfig.Id);
+            AnomalyAlertConfiguration createdConfig = disposableConfig.Configuration;
 
-            Assert.That(createdConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(createdConfig.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdConfig.Name, Is.EqualTo(configName));
             Assert.That(createdConfig.Description, Is.EqualTo(description));
             Assert.That(createdConfig.CrossMetricsOperator, Is.Null);
             Assert.That(createdConfig.IdsOfHooksToAlert.Count, Is.EqualTo(2));
-            Assert.That(createdConfig.IdsOfHooksToAlert.Contains(disposableHook0.Id));
-            Assert.That(createdConfig.IdsOfHooksToAlert.Contains(disposableHook1.Id));
+            Assert.That(createdConfig.IdsOfHooksToAlert.Contains(disposableHook0.Hook.Id));
+            Assert.That(createdConfig.IdsOfHooksToAlert.Contains(disposableHook1.Hook.Id));
             Assert.That(createdConfig.MetricAlertConfigurations, Is.Not.Null);
 
             MetricAnomalyAlertConfiguration createdMetricAlertConfig = createdConfig.MetricAlertConfigurations.Single();
@@ -291,9 +291,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Get the created configuration and validate top-level members.
 
-            AnomalyAlertConfiguration createdConfig = await adminClient.GetAlertConfigurationAsync(disposableConfig.Id);
+            AnomalyAlertConfiguration createdConfig = disposableConfig.Configuration;
 
-            Assert.That(createdConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(createdConfig.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdConfig.Name, Is.EqualTo(configName));
             Assert.That(createdConfig.Description, Is.Empty);
             Assert.That(createdConfig.CrossMetricsOperator, Is.EqualTo(MetricAnomalyAlertConfigurationsOperator.Xor));
@@ -386,12 +386,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
             // Create the Anomaly Alert Configuration.
 
             string configName = Recording.GenerateAlphaNumericId("config");
-            var hookIds = new List<string>() { disposableHook.Id };
+            var hookIds = new List<string>() { disposableHook.Hook.Id };
 
             var configToCreate = new AnomalyAlertConfiguration()
             {
                 Name = configName,
-                IdsOfHooksToAlert = { disposableHook.Id },
+                IdsOfHooksToAlert = { disposableHook.Hook.Id },
                 MetricAlertConfigurations = { metricAlertConfig0, metricAlertConfig1 },
                 CrossMetricsOperator = MetricAnomalyAlertConfigurationsOperator.Xor
             };
@@ -400,7 +400,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Update the created configuration.
 
-            AnomalyAlertConfiguration configToUpdate = await adminClient.GetAlertConfigurationAsync(disposableConfig.Id);
+            AnomalyAlertConfiguration configToUpdate = disposableConfig.Configuration;
 
             configToUpdate.CrossMetricsOperator = MetricAnomalyAlertConfigurationsOperator.Or;
 
@@ -408,7 +408,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Validate top-level members.
 
-            Assert.That(updatedConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(updatedConfig.Id, Is.EqualTo(configToUpdate.Id));
             Assert.That(updatedConfig.Name, Is.EqualTo(configName));
             Assert.That(updatedConfig.Description, Is.Empty);
             Assert.That(updatedConfig.CrossMetricsOperator, Is.EqualTo(MetricAnomalyAlertConfigurationsOperator.Or));
@@ -503,7 +503,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var configToCreate = new AnomalyAlertConfiguration()
             {
                 Name = configName,
-                IdsOfHooksToAlert = { disposableHook.Id },
+                IdsOfHooksToAlert = { disposableHook.Hook.Id },
                 MetricAlertConfigurations = { metricAlertConfig0, metricAlertConfig1 },
                 CrossMetricsOperator = MetricAnomalyAlertConfigurationsOperator.Xor
             };
@@ -521,11 +521,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Validate top-level members.
 
-            Assert.That(updatedConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(updatedConfig.Id, Is.EqualTo(configToUpdate.Id));
             Assert.That(updatedConfig.Name, Is.EqualTo(configName));
             Assert.That(updatedConfig.Description, Is.Empty);
             Assert.That(updatedConfig.CrossMetricsOperator, Is.EqualTo(MetricAnomalyAlertConfigurationsOperator.Or));
-            Assert.That(updatedConfig.IdsOfHooksToAlert.Single(), Is.EqualTo(disposableHook.Id));
+            Assert.That(updatedConfig.IdsOfHooksToAlert.Single(), Is.EqualTo(disposableHook.Hook.Id));
             Assert.That(updatedConfig.MetricAlertConfigurations, Is.Not.Null);
             Assert.That(updatedConfig.MetricAlertConfigurations.Count, Is.EqualTo(2));
 
@@ -613,13 +613,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             string configName = Recording.GenerateAlphaNumericId("config");
             var description = "This hook was created to test the .NET client.";
-            var hookIds = new List<string>() { disposableHook.Id };
+            var hookIds = new List<string>() { disposableHook.Hook.Id };
             var metricAlertConfigs = new List<MetricAnomalyAlertConfiguration>() { metricAlertConfig0, metricAlertConfig1 };
 
             var configToCreate = new AnomalyAlertConfiguration()
             {
                 Name = configName,
-                IdsOfHooksToAlert = { disposableHook.Id },
+                IdsOfHooksToAlert = { disposableHook.Hook.Id },
                 MetricAlertConfigurations = { metricAlertConfig0, metricAlertConfig1 },
                 CrossMetricsOperator = MetricAnomalyAlertConfigurationsOperator.Xor
             };
@@ -628,7 +628,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Update the created configuration.
 
-            AnomalyAlertConfiguration configToUpdate = await adminClient.GetAlertConfigurationAsync(disposableConfig.Id);
+            AnomalyAlertConfiguration configToUpdate = disposableConfig.Configuration;
 
             configToUpdate.Description = description;
             configToUpdate.IdsOfHooksToAlert.Clear();
@@ -658,7 +658,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Validate top-level members.
 
-            Assert.That(updatedConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(updatedConfig.Id, Is.EqualTo(configToUpdate.Id));
             Assert.That(updatedConfig.Name, Is.EqualTo(configName));
             Assert.That(updatedConfig.Description, Is.EqualTo(description));
             Assert.That(updatedConfig.CrossMetricsOperator, Is.EqualTo(MetricAnomalyAlertConfigurationsOperator.And));
@@ -757,7 +757,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var configToCreate = new AnomalyAlertConfiguration()
             {
                 Name = configName,
-                IdsOfHooksToAlert = { disposableHook.Id },
+                IdsOfHooksToAlert = { disposableHook.Hook.Id },
                 MetricAlertConfigurations = { metricAlertConfig0, metricAlertConfig1 },
                 CrossMetricsOperator = MetricAnomalyAlertConfigurationsOperator.Xor
             };
@@ -798,7 +798,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Validate top-level members.
 
-            Assert.That(updatedConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(updatedConfig.Id, Is.EqualTo(configToUpdate.Id));
             Assert.That(updatedConfig.Name, Is.EqualTo(configName));
             Assert.That(updatedConfig.Description, Is.EqualTo(description));
             Assert.That(updatedConfig.CrossMetricsOperator, Is.EqualTo(MetricAnomalyAlertConfigurationsOperator.And));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
@@ -53,9 +53,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableConfig = await DisposableDetectionConfiguration.CreateDetectionConfigurationAsync(adminClient, configToCreate);
 
-            AnomalyDetectionConfiguration createdConfig = await adminClient.GetDetectionConfigurationAsync(disposableConfig.Id);
+            AnomalyDetectionConfiguration createdConfig = disposableConfig.Configuration;
 
-            Assert.That(createdConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(createdConfig.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdConfig.MetricId, Is.EqualTo(metricId));
             Assert.That(createdConfig.Name, Is.EqualTo(configName));
             Assert.That(createdConfig.Description, Is.EqualTo(description));
@@ -97,9 +97,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableConfig = await DisposableDetectionConfiguration.CreateDetectionConfigurationAsync(adminClient, configToCreate);
 
-            AnomalyDetectionConfiguration createdConfig = await adminClient.GetDetectionConfigurationAsync(disposableConfig.Id);
+            AnomalyDetectionConfiguration createdConfig = disposableConfig.Configuration;
 
-            Assert.That(createdConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(createdConfig.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdConfig.MetricId, Is.EqualTo(metricId));
             Assert.That(createdConfig.Name, Is.EqualTo(configName));
             Assert.That(createdConfig.Description, Is.Empty);
@@ -165,9 +165,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Get the created configuration and validate top-level members.
 
-            AnomalyDetectionConfiguration createdConfig = await adminClient.GetDetectionConfigurationAsync(disposableConfig.Id);
+            AnomalyDetectionConfiguration createdConfig = disposableConfig.Configuration;
 
-            Assert.That(createdConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(createdConfig.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdConfig.MetricId, Is.EqualTo(metricId));
             Assert.That(createdConfig.Name, Is.EqualTo(configName));
             Assert.That(createdConfig.Description, Is.Empty);
@@ -270,9 +270,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Get the created configuration and validate top-level members.
 
-            AnomalyDetectionConfiguration createdConfig = await adminClient.GetDetectionConfigurationAsync(disposableConfig.Id);
+            AnomalyDetectionConfiguration createdConfig = disposableConfig.Configuration;
 
-            Assert.That(createdConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(createdConfig.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdConfig.MetricId, Is.EqualTo(metricId));
             Assert.That(createdConfig.Name, Is.EqualTo(configName));
             Assert.That(createdConfig.Description, Is.Empty);
@@ -380,7 +380,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Update the created configuration.
 
-            AnomalyDetectionConfiguration configToUpdate = await adminClient.GetDetectionConfigurationAsync(disposableConfig.Id);
+            AnomalyDetectionConfiguration configToUpdate = disposableConfig.Configuration;
 
             configToUpdate.WholeSeriesDetectionConditions.HardThresholdCondition.LowerBound = 12.0;
 
@@ -388,7 +388,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Validate top-level members.
 
-            Assert.That(updatedConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(updatedConfig.Id, Is.EqualTo(configToUpdate.Id));
             Assert.That(updatedConfig.MetricId, Is.EqualTo(metricId));
             Assert.That(updatedConfig.Name, Is.EqualTo(configName));
             Assert.That(updatedConfig.Description, Is.Empty);
@@ -500,7 +500,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Validate top-level members.
 
-            Assert.That(updatedConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(updatedConfig.Id, Is.EqualTo(configToUpdate.Id));
             Assert.That(updatedConfig.MetricId, Is.EqualTo(metricId));
             Assert.That(updatedConfig.Name, Is.EqualTo(configName));
             Assert.That(updatedConfig.Description, Is.Empty);
@@ -606,7 +606,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Update the created configuration.
 
-            AnomalyDetectionConfiguration configToUpdate = await adminClient.GetDetectionConfigurationAsync(disposableConfig.Id);
+            AnomalyDetectionConfiguration configToUpdate = disposableConfig.Configuration;
 
             configToUpdate.Description = description;
 
@@ -630,7 +630,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Validate top-level members.
 
-            Assert.That(updatedConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(updatedConfig.Id, Is.EqualTo(configToUpdate.Id));
             Assert.That(updatedConfig.MetricId, Is.EqualTo(metricId));
             Assert.That(updatedConfig.Name, Is.EqualTo(configName));
             Assert.That(updatedConfig.Description, Is.EqualTo(description));
@@ -766,7 +766,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Validate top-level members.
 
-            Assert.That(updatedConfig.Id, Is.EqualTo(disposableConfig.Id));
+            Assert.That(updatedConfig.Id, Is.EqualTo(configToUpdate.Id));
             Assert.That(updatedConfig.MetricId, Is.EqualTo(metricId));
             Assert.That(updatedConfig.Name, Is.EqualTo(configName));
             Assert.That(updatedConfig.Description, Is.EqualTo(description));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DatasourceCredentialLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DatasourceCredentialLiveTests.cs
@@ -90,6 +90,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DatasourceCredential updatedCredential = await adminClient.UpdateDatasourceCredentialAsync(credentialToUpdate);
 
+            Assert.That(updatedCredential.Id, Is.EqualTo(credentialToUpdate.Id));
             Assert.That(updatedCredential.Name, Is.EqualTo(expectedName));
             Assert.That(updatedCredential.Description, Is.EqualTo(expectedDescription));
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/NotificationHookLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/NotificationHookLiveTests.cs
@@ -35,9 +35,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableHook = await DisposableNotificationHook.CreateHookAsync(adminClient, hookToCreate);
 
-            NotificationHook createdHook = await adminClient.GetHookAsync(disposableHook.Id);
+            NotificationHook createdHook = disposableHook.Hook;
 
-            Assert.That(createdHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(createdHook.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdHook.Name, Is.EqualTo(hookName));
             Assert.That(createdHook.Description, Is.Empty);
             Assert.That(createdHook.ExternalLink, Is.Null);
@@ -70,9 +70,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableHook = await DisposableNotificationHook.CreateHookAsync(adminClient, hookToCreate);
 
-            NotificationHook createdHook = await adminClient.GetHookAsync(disposableHook.Id);
+            NotificationHook createdHook = disposableHook.Hook;
 
-            Assert.That(createdHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(createdHook.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdHook.Name, Is.EqualTo(hookName));
             Assert.That(createdHook.Description, Is.EqualTo(description));
             Assert.That(createdHook.ExternalLink.AbsoluteUri, Is.EqualTo("http://fake.endpoint.com/"));
@@ -99,9 +99,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableHook = await DisposableNotificationHook.CreateHookAsync(adminClient, hookToCreate);
 
-            NotificationHook createdHook = await adminClient.GetHookAsync(disposableHook.Id);
+            NotificationHook createdHook = disposableHook.Hook;
 
-            Assert.That(createdHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(createdHook.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdHook.Name, Is.EqualTo(hookName));
             Assert.That(createdHook.Description, Is.Empty);
             Assert.That(createdHook.ExternalLink, Is.Null);
@@ -153,9 +153,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableHook = await DisposableNotificationHook.CreateHookAsync(adminClient, hookToCreate);
 
-            NotificationHook createdHook = await adminClient.GetHookAsync(disposableHook.Id);
+            NotificationHook createdHook = disposableHook.Hook;
 
-            Assert.That(createdHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(createdHook.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(createdHook.Name, Is.EqualTo(hookName));
             Assert.That(createdHook.Description, Is.EqualTo(description));
             Assert.That(createdHook.ExternalLink.AbsoluteUri, Is.EqualTo("http://fake.endpoint.com/"));
@@ -194,7 +194,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Update the created hook.
 
-            var hookToUpdate = (await adminClient.GetHookAsync(disposableHook.Id)).Value as EmailNotificationHook;
+            var hookToUpdate = disposableHook.Hook as EmailNotificationHook;
 
             hookToUpdate.EmailsToAlert.Add("fake3@email.com");
 
@@ -202,7 +202,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Check if updates are in place.
 
-            Assert.That(updatedEmailHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(updatedEmailHook.Id, Is.EqualTo(hookToUpdate.Id));
             Assert.That(updatedEmailHook.Name, Is.EqualTo(hookName));
             Assert.That(updatedEmailHook.Description, Is.Empty);
             Assert.That(updatedEmailHook.ExternalLink, Is.Null);
@@ -241,7 +241,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Check if updates are in place.
 
-            Assert.That(updatedEmailHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(updatedEmailHook.Id, Is.EqualTo(hookToUpdate.Id));
             Assert.That(updatedEmailHook.Name, Is.EqualTo(hookName));
             Assert.That(updatedEmailHook.Description, Is.Empty);
             Assert.That(updatedEmailHook.ExternalLink, Is.Null);
@@ -270,7 +270,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Update the created hook.
 
-            var hookToUpdate = (await adminClient.GetHookAsync(disposableHook.Id)).Value as EmailNotificationHook;
+            var hookToUpdate = disposableHook.Hook as EmailNotificationHook;
 
             hookToUpdate.Description = description;
             hookToUpdate.ExternalLink = new Uri("http://fake.endpoint.com/");
@@ -280,7 +280,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Check if updates are in place.
 
-            Assert.That(updatedEmailHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(updatedEmailHook.Id, Is.EqualTo(hookToUpdate.Id));
             Assert.That(updatedEmailHook.Name, Is.EqualTo(hookName));
             Assert.That(updatedEmailHook.Description, Is.EqualTo(description));
             Assert.That(updatedEmailHook.ExternalLink.AbsoluteUri, Is.EqualTo("http://fake.endpoint.com/"));
@@ -324,7 +324,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Check if updates are in place.
 
-            Assert.That(updatedEmailHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(updatedEmailHook.Id, Is.EqualTo(hookToUpdate.Id));
             Assert.That(updatedEmailHook.Name, Is.EqualTo(hookName));
             Assert.That(updatedEmailHook.Description, Is.EqualTo(description));
             Assert.That(updatedEmailHook.ExternalLink.AbsoluteUri, Is.EqualTo("http://fake.endpoint.com/"));
@@ -349,7 +349,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Update the created hook.
 
-            var hookToUpdate = (await adminClient.GetHookAsync(disposableHook.Id)).Value as WebNotificationHook;
+            var hookToUpdate = disposableHook.Hook as WebNotificationHook;
 
             hookToUpdate.Username = "fakeUsername";
 
@@ -357,7 +357,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Check if updates are in place.
 
-            Assert.That(updatedWebHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(updatedWebHook.Id, Is.EqualTo(hookToUpdate.Id));
             Assert.That(updatedWebHook.Name, Is.EqualTo(hookName));
             Assert.That(updatedWebHook.Description, Is.Empty);
             Assert.That(updatedWebHook.ExternalLink, Is.Null);
@@ -395,7 +395,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Check if updates are in place.
 
-            Assert.That(updatedWebHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(updatedWebHook.Id, Is.EqualTo(hookToUpdate.Id));
             Assert.That(updatedWebHook.Name, Is.EqualTo(hookName));
             Assert.That(updatedWebHook.Description, Is.Empty);
             Assert.That(updatedWebHook.ExternalLink, Is.Null);
@@ -433,7 +433,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Update the created hook.
 
-            var hookToUpdate = (await adminClient.GetHookAsync(disposableHook.Id)).Value as WebNotificationHook;
+            var hookToUpdate = disposableHook.Hook as WebNotificationHook;
 
             hookToUpdate.Description = description;
             hookToUpdate.ExternalLink = new Uri("http://fake.endpoint.com/");
@@ -451,7 +451,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Check if updates are in place.
 
-            Assert.That(updatedWebHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(updatedWebHook.Id, Is.EqualTo(hookToUpdate.Id));
             Assert.That(updatedWebHook.Name, Is.EqualTo(hookName));
             Assert.That(updatedWebHook.Description, Is.EqualTo(description));
             Assert.That(updatedWebHook.ExternalLink.AbsoluteUri, Is.EqualTo("http://fake.endpoint.com/"));
@@ -509,7 +509,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Check if updates are in place.
 
-            Assert.That(updatedWebHook.Id, Is.EqualTo(disposableHook.Id));
+            Assert.That(updatedWebHook.Id, Is.EqualTo(hookToUpdate.Id));
             Assert.That(updatedWebHook.Name, Is.EqualTo(hookName));
             Assert.That(updatedWebHook.Description, Is.EqualTo(description));
             Assert.That(updatedWebHook.ExternalLink.AbsoluteUri, Is.EqualTo("http://fake.endpoint.com/"));


### PR DESCRIPTION
Fixes https://github.com/azure/azure-sdk-for-net/issues/21583.

`DisposableDataFeed` and `DisposableDatasourceCredential` have already been fixed in other PRs. This PR addresses the "Disposable" type issue for `DisposableDetectionConfiguration`, `DisposableAlertConfiguration`, and `DisposableHook`.