### PR TITLE
Use sparse checkout for Create Release Tag release job

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -56,7 +56,10 @@ stages:
               runOnce:
                 deploy:
                   steps:
-                    - checkout: self
+                    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+                      parameters:
+                        Paths:
+                          - '${{ parameters.ServiceDirectory }}'
                     - template: /eng/common/pipelines/templates/steps/retain-run.yml
                     - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
                       parameters:


### PR DESCRIPTION
This should be a relatively easy (i.e. likely no file dependencies to debug) perf improvement on release times. A similar update was made for java: https://github.com/Azure/azure-sdk-for-java/blob/master/eng/pipelines/templates/stages/archetype-java-release.yml#L135

Resolves https://github.com/Azure/azure-sdk-tools/issues/1686

Template release test: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=942099&view=results