### PR TITLE
[Azure.Core.Amqp] Lazy Allocation for All Sections

### DIFF
--- a/sdk/core/Azure.Core.Amqp/Azure.Core.Amqp.sln
+++ b/sdk/core/Azure.Core.Amqp/Azure.Core.Amqp.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Amqp", "src\Azure.Core.Amqp.csproj", "{B5AD38C8-DAB6-40E6-AB79-41A8ED9D297B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Amqp.Tests", "tests\Azure.Core.Amqp.Tests.csproj", "{61ABA08F-FA50-4DEA-8C97-00B7B057BDEF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B5AD38C8-DAB6-40E6-AB79-41A8ED9D297B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5AD38C8-DAB6-40E6-AB79-41A8ED9D297B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5AD38C8-DAB6-40E6-AB79-41A8ED9D297B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5AD38C8-DAB6-40E6-AB79-41A8ED9D297B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61ABA08F-FA50-4DEA-8C97-00B7B057BDEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61ABA08F-FA50-4DEA-8C97-00B7B057BDEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61ABA08F-FA50-4DEA-8C97-00B7B057BDEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61ABA08F-FA50-4DEA-8C97-00B7B057BDEF}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1DC074C7-A8F0-4778-B791-323040BDF4C5}
+	EndGlobalSection
+EndGlobal

--- a/sdk/core/Azure.Core.Amqp/CHANGELOG.md
+++ b/sdk/core/Azure.Core.Amqp/CHANGELOG.md
@@ -2,14 +2,10 @@
 
 ## 1.2.0-beta.1 (Unreleased)
 
-### Features Added
-
-### Breaking Changes
-
-### Key Bugs Fixed
-
-### Fixed
-
+### Added
+- All section properties of the `AmqpAnnotatedMessage` are now lazily allocated to reflect that they are defined as optional in the AMQP specification, section 3.2.
+  
+- The `HasSection` method has been added to `AmqpAnnotatedMessage` to allow inspecting the property for a section to determine if it is populated without triggering an allocation.
 
 ## 1.1.0 (2021-06-16)
 

--- a/sdk/core/Azure.Core.Amqp/api/Azure.Core.Amqp.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Amqp/api/Azure.Core.Amqp.netstandard2.0.cs
@@ -26,6 +26,7 @@ namespace Azure.Core.Amqp
         public Azure.Core.Amqp.AmqpMessageHeader Header { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, object> MessageAnnotations { get { throw null; } }
         public Azure.Core.Amqp.AmqpMessageProperties Properties { get { throw null; } }
+        public bool HasSection(Azure.Core.Amqp.AmqpMessageSection section) { throw null; }
     }
     public partial class AmqpMessageBody
     {
@@ -86,5 +87,15 @@ namespace Azure.Core.Amqp
         public string? Subject { get { throw null; } set { } }
         public Azure.Core.Amqp.AmqpAddress? To { get { throw null; } set { } }
         public System.ReadOnlyMemory<byte>? UserId { get { throw null; } set { } }
+    }
+    public enum AmqpMessageSection
+    {
+        Header = 0,
+        DeliveryAnnotations = 1,
+        MessageAnnotations = 2,
+        Properties = 3,
+        ApplicationProperties = 4,
+        Body = 5,
+        Footer = 6,
     }
 }

--- a/sdk/core/Azure.Core.Amqp/src/AmqpAnnotatedMessage.cs
+++ b/sdk/core/Azure.Core.Amqp/src/AmqpAnnotatedMessage.cs
@@ -27,7 +27,19 @@ namespace Azure.Core.Amqp
         /// Gets the header of the AMQP message.
         /// <seealso href="http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-header" />
         /// </summary>
-        public AmqpMessageHeader Header { get; } = new AmqpMessageHeader();
+        public AmqpMessageHeader Header
+        {
+            get
+            {
+                if (_header == null)
+                {
+                    _header = new AmqpMessageHeader();
+                }
+                return _header;
+            }
+        }
+
+        private AmqpMessageHeader? _header;
 
         /// <summary>
         /// Gets the footer of the AMQP message.
@@ -86,7 +98,19 @@ namespace Azure.Core.Amqp
         /// <summary>
         /// Gets the properties of the AMQP message.
         /// </summary>
-        public AmqpMessageProperties Properties { get; } = new AmqpMessageProperties();
+        public AmqpMessageProperties Properties
+        {
+            get
+            {
+                if (_properties == null)
+                {
+                    _properties = new AmqpMessageProperties();
+                }
+                return _properties;
+            }
+        }
+
+        private AmqpMessageProperties? _properties;
 
         /// <summary>
         /// Gets the application properties of the AMQP message.
@@ -111,5 +135,23 @@ namespace Azure.Core.Amqp
         /// <seealso href="http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-data"/>
         /// </summary>
         public AmqpMessageBody Body { get; set; }
+
+        /// <summary>
+        /// Determines whether the specified section is present for the AMQP message.
+        /// </summary>
+        /// <param name="section">The section to consider.</param>
+        /// <returns><c>true</c> if the specified <paramref name="section"/> is populated for the AMQP message; otherwise, <c>false</c>.</returns>
+        public bool HasSection(AmqpMessageSection section) =>
+            section switch
+            {
+                AmqpMessageSection.Header => (_header != null),
+                AmqpMessageSection.DeliveryAnnotations => (_deliveryAnnotations != null),
+                AmqpMessageSection.MessageAnnotations => (_messageAnnotations != null),
+                AmqpMessageSection.Properties => (_properties != null),
+                AmqpMessageSection.ApplicationProperties => (_applicationProperties != null),
+                AmqpMessageSection.Body => (Body != null),
+                AmqpMessageSection.Footer => (_footer != null),
+                _ => throw new ArgumentException($"Unknown AMQP message section: { section }.", nameof(section))
+            };
     }
 }

--- a/sdk/core/Azure.Core.Amqp/src/AmqpMessageSection.cs
+++ b/sdk/core/Azure.Core.Amqp/src/AmqpMessageSection.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Core.Amqp
+{
+    /// <summary>
+    /// Represents the sections of an AMQP message.
+    /// <seealso href="http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format"/>
+    /// </summary>
+    public enum AmqpMessageSection
+    {
+        /// <summary>
+        /// The header section of the message.
+        /// <seealso href="http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-header"/>
+        /// <seealso cref="AmqpMessageHeader" />
+        /// </summary>
+        Header,
+
+        /// <summary>
+        /// The delivery annotations section of the message.
+        /// <seealso href="http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-delivery-annotations"/>
+        /// </summary>
+        DeliveryAnnotations,
+
+        /// <summary>
+        /// The message annotations section of the message.
+        /// <seealso href="http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-message-annotations"/>
+        /// </summary>
+        MessageAnnotations,
+
+        /// <summary>
+        /// The properties section of the message.
+        /// <seealso href="http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-properties"/>
+        /// <seealso cref="AmqpMessageProperties"/>
+        /// </summary>
+        Properties,
+
+        /// <summary>
+        /// The application properties section of the message.
+        /// <seealso href="http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties"/>
+        /// </summary>
+        ApplicationProperties,
+
+        /// <summary>
+        /// The body of the message, representing one specific <see cref="AmqpMessageBodyType" /> sections.
+        /// <seealso cref="AmqpMessageBody"/>
+        /// </summary>
+        Body,
+
+        /// <summary>
+        /// The footer section of the message.
+        /// <seealso href="http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-footer"/>
+        /// </summary>
+        Footer
+    }
+}


### PR DESCRIPTION
# Summary 

The focus of these changes is to enable lazy allocation for all sections of the `AmqpAnnotatedMessage` type, to align with them being defined as optional by the AMQP specification.  In order to allow downstream consumers to test if a section is populated without triggering allocation for the property, the `HasSection` member has been added.

# References and Resources

- [API View](https://apiview.dev/Assemblies/Review/5a14d647aace486ab410e431508120d5?diffRevisionId=082c4005411b45bf87c3b5ee3ca695cf&doc=False&diffOnly=False)
- [AMQP Specification, section 3.2](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format)