### PR TITLE
Use sparse checkout for Publish to Docs.MS release job

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -150,7 +150,10 @@ stages:
                 runOnce:
                   deploy:
                     steps:
-                      - checkout: self
+                      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+                        parameters:
+                          paths:
+                            - .github/CODEOWNERS
                       - template: /eng/common/pipelines/templates/steps/get-pr-owners.yml
                         parameters:
                           TargetVariable: "OwningGHUser"
@@ -172,6 +175,9 @@ stages:
                           CIConfigs: $(CIConfigs)
                           OnboardingBranch: 'onboarding'
                           CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
+                          SparseCheckoutPaths:
+                            - api
+
 
           - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
             - deployment: PublishDocs


### PR DESCRIPTION
This PR updates the docs publishing job in the release pipeline to opt-in to sparse checkout. This should shave another few minutes off the total release time.

Template release test: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=942244&view=results
Docs commit still working: https://github.com/Azure/azure-docs-sdk-dotnet/commit/764d1ac0723e65092768f45731765047af04443d