### PR TITLE
[MetricsAdvisor] Updated alert config tests to use newly created data feeds

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyAlertConfigurationLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyAlertConfigurationLiveTests.cs
@@ -24,9 +24,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task CreateAndGetAlertConfigurationWithWholeSeriesScope(bool useTokenCredential)
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient(useTokenCredential);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
 
+            var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.GetScopeForWholeSeries();
-            var metricAlertConfig = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope);
+            var metricAlertConfig = new MetricAnomalyAlertConfiguration(detectionConfigId, scope);
 
             string configName = Recording.GenerateAlphaNumericId("config");
 
@@ -49,7 +52,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration createdMetricAlertConfig = createdConfig.MetricAlertConfigurations.Single();
 
-            Assert.That(createdMetricAlertConfig.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(createdMetricAlertConfig.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(createdMetricAlertConfig.AlertScope, Is.Not.Null);
             Assert.That(createdMetricAlertConfig.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.WholeSeries));
@@ -68,12 +71,15 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task CreateAndGetAlertConfigurationWithSeriesGroupScope()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
 
             DimensionKey groupKey = new DimensionKey();
             groupKey.AddDimensionColumn("city", "Delhi");
 
+            var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.GetScopeForSeriesGroup(groupKey);
-            var metricAlertConfig = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope);
+            var metricAlertConfig = new MetricAnomalyAlertConfiguration(detectionConfigId, scope);
 
             string configName = Recording.GenerateAlphaNumericId("config");
 
@@ -96,7 +102,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration createdMetricAlertConfig = createdConfig.MetricAlertConfigurations.Single();
 
-            Assert.That(createdMetricAlertConfig.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(createdMetricAlertConfig.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(createdMetricAlertConfig.AlertScope, Is.Not.Null);
             Assert.That(createdMetricAlertConfig.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.SeriesGroup));
@@ -121,10 +127,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task CreateAndGetAlertConfigurationWithTopNScope()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
 
+            var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var topNGroup = new TopNGroupScope(30, 20, 10);
             var scope = MetricAnomalyAlertScope.GetScopeForTopNGroup(topNGroup);
-            var metricAlertConfig = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope);
+            var metricAlertConfig = new MetricAnomalyAlertConfiguration(detectionConfigId, scope);
 
             string configName = Recording.GenerateAlphaNumericId("config");
 
@@ -147,7 +156,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration createdMetricAlertConfig = createdConfig.MetricAlertConfigurations.Single();
 
-            Assert.That(createdMetricAlertConfig.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(createdMetricAlertConfig.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(createdMetricAlertConfig.AlertScope, Is.Not.Null);
             Assert.That(createdMetricAlertConfig.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.TopN));
@@ -170,6 +179,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task CreateAndGetAlertConfigurationWithOptionalSingleMetricConfigurationMembers()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
 
             string hookName0 = Recording.GenerateAlphaNumericId("hook");
             string hookName1 = Recording.GenerateAlphaNumericId("hook");
@@ -183,8 +194,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
             await using var disposableHook0 = await DisposableNotificationHook.CreateHookAsync(adminClient, hookToCreate0);
             await using var disposableHook1 = await DisposableNotificationHook.CreateHookAsync(adminClient, hookToCreate1);
 
+            var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.GetScopeForWholeSeries();
-            var metricAlertConfig = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope)
+            var metricAlertConfig = new MetricAnomalyAlertConfiguration(detectionConfigId, scope)
             {
                 AlertSnoozeCondition = new MetricAnomalyAlertSnoozeCondition(12, SnoozeScope.Series, true),
                 AlertConditions = new MetricAnomalyAlertConditions()
@@ -226,7 +238,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration createdMetricAlertConfig = createdConfig.MetricAlertConfigurations.Single();
 
-            Assert.That(createdMetricAlertConfig.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(createdMetricAlertConfig.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(createdMetricAlertConfig.AlertScope, Is.Not.Null);
             Assert.That(createdMetricAlertConfig.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.WholeSeries));
@@ -256,11 +268,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task CreateAndGetAlertConfigurationWithMultipleMetricConfigurations()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
 
             // Configure the Metric Anomaly Alert Configurations to be used.
 
+            var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.GetScopeForWholeSeries();
-            var metricAlertConfig0 = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope)
+            var metricAlertConfig0 = new MetricAnomalyAlertConfiguration(detectionConfigId, scope)
             {
                 AlertConditions = new MetricAnomalyAlertConditions()
                 {
@@ -268,7 +283,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 },
                 UseDetectionResultToFilterAnomalies = true
             };
-            var metricAlertConfig1 = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope)
+            var metricAlertConfig1 = new MetricAnomalyAlertConfiguration(detectionConfigId, scope)
             {
                 AlertConditions = new MetricAnomalyAlertConditions()
                 {
@@ -305,7 +320,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration createdMetricAlertConfig0 = createdConfig.MetricAlertConfigurations[0];
 
-            Assert.That(createdMetricAlertConfig0.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(createdMetricAlertConfig0.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(createdMetricAlertConfig0.AlertScope, Is.Not.Null);
             Assert.That(createdMetricAlertConfig0.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.WholeSeries));
@@ -328,7 +343,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration createdMetricAlertConfig1 = createdConfig.MetricAlertConfigurations[1];
 
-            Assert.That(createdMetricAlertConfig1.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(createdMetricAlertConfig1.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(createdMetricAlertConfig1.AlertScope, Is.Not.Null);
             Assert.That(createdMetricAlertConfig1.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.WholeSeries));
@@ -354,6 +369,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task UpdateAlertConfigurationWithMinimumSetupAndGetInstance(bool useTokenCrendential)
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient(useTokenCrendential);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
 
             // Configure the Metric Anomaly Alert Configurations to be used.
 
@@ -362,8 +379,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableHook = await DisposableNotificationHook.CreateHookAsync(adminClient, hookToCreate);
 
+            var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.GetScopeForWholeSeries();
-            var metricAlertConfig0 = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope)
+            var metricAlertConfig0 = new MetricAnomalyAlertConfiguration(detectionConfigId, scope)
             {
                 AlertSnoozeCondition = new MetricAnomalyAlertSnoozeCondition(12, SnoozeScope.Series, true),
                 AlertConditions = new MetricAnomalyAlertConditions()
@@ -378,7 +396,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     SeverityCondition = new SeverityCondition(AnomalySeverity.Low, AnomalySeverity.Medium)
                 }
             };
-            var metricAlertConfig1 = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope)
+            var metricAlertConfig1 = new MetricAnomalyAlertConfiguration(detectionConfigId, scope)
             {
                 UseDetectionResultToFilterAnomalies = true
             };
@@ -420,7 +438,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration updatedMetricAlertConfig0 = updatedConfig.MetricAlertConfigurations[0];
 
-            Assert.That(updatedMetricAlertConfig0.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(updatedMetricAlertConfig0.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(updatedMetricAlertConfig0.AlertScope, Is.Not.Null);
             Assert.That(updatedMetricAlertConfig0.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.WholeSeries));
@@ -449,7 +467,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration updatedMetricAlertConfig1 = updatedConfig.MetricAlertConfigurations[1];
 
-            Assert.That(updatedMetricAlertConfig1.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(updatedMetricAlertConfig1.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(updatedMetricAlertConfig1.AlertScope, Is.Not.Null);
             Assert.That(updatedMetricAlertConfig1.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.WholeSeries));
@@ -468,6 +486,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task UpdateAlertConfigurationWithMinimumSetupAndNewInstance()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
 
             // Configure the Metric Anomaly Alert Configurations to be used.
 
@@ -475,8 +495,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var hookToCreate = new WebNotificationHook() { Name = hookName, Endpoint = new Uri("http://contoso.com/") };
             await using var disposableHook = await DisposableNotificationHook.CreateHookAsync(adminClient, hookToCreate);
 
+            var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.GetScopeForWholeSeries();
-            var metricAlertConfig0 = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope)
+            var metricAlertConfig0 = new MetricAnomalyAlertConfiguration(detectionConfigId, scope)
             {
                 AlertSnoozeCondition = new MetricAnomalyAlertSnoozeCondition(12, SnoozeScope.Series, true),
                 AlertConditions = new MetricAnomalyAlertConditions()
@@ -491,7 +512,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     SeverityCondition = new SeverityCondition(AnomalySeverity.Low, AnomalySeverity.Medium)
                 }
             };
-            var metricAlertConfig1 = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope)
+            var metricAlertConfig1 = new MetricAnomalyAlertConfiguration(detectionConfigId, scope)
             {
                 UseDetectionResultToFilterAnomalies = true
             };
@@ -533,7 +554,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration updatedMetricAlertConfig0 = updatedConfig.MetricAlertConfigurations[0];
 
-            Assert.That(updatedMetricAlertConfig0.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(updatedMetricAlertConfig0.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(updatedMetricAlertConfig0.AlertScope, Is.Not.Null);
             Assert.That(updatedMetricAlertConfig0.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.WholeSeries));
@@ -562,7 +583,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration updatedMetricAlertConfig1 = updatedConfig.MetricAlertConfigurations[1];
 
-            Assert.That(updatedMetricAlertConfig1.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(updatedMetricAlertConfig1.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(updatedMetricAlertConfig1.AlertScope, Is.Not.Null);
             Assert.That(updatedMetricAlertConfig1.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.WholeSeries));
@@ -580,6 +601,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task UpdateAlertConfigurationWithEveryMemberAndGetInstance()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
 
             // Configure the Metric Anomaly Alert Configurations to be used.
 
@@ -588,8 +611,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableHook = await DisposableNotificationHook.CreateHookAsync(adminClient, hookToCreate);
 
+            var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.GetScopeForWholeSeries();
-            var metricAlertConfig0 = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope)
+            var metricAlertConfig0 = new MetricAnomalyAlertConfiguration(detectionConfigId, scope)
             {
                 AlertSnoozeCondition = new MetricAnomalyAlertSnoozeCondition(12, SnoozeScope.Series, true),
                 AlertConditions = new MetricAnomalyAlertConditions()
@@ -604,7 +628,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     SeverityCondition = new SeverityCondition(AnomalySeverity.Low, AnomalySeverity.Medium)
                 }
             };
-            var metricAlertConfig1 = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope)
+            var metricAlertConfig1 = new MetricAnomalyAlertConfiguration(detectionConfigId, scope)
             {
                 UseDetectionResultToFilterAnomalies = true
             };
@@ -636,7 +660,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             configToUpdate.MetricAlertConfigurations.RemoveAt(1);
 
             var newScope = MetricAnomalyAlertScope.GetScopeForTopNGroup(new TopNGroupScope(50, 40, 30));
-            var newMetricAlertConfig = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, newScope)
+            var newMetricAlertConfig = new MetricAnomalyAlertConfiguration(detectionConfigId, newScope)
             {
                 AlertSnoozeCondition = new MetricAnomalyAlertSnoozeCondition(4, SnoozeScope.Metric, true),
                 UseDetectionResultToFilterAnomalies = true
@@ -669,7 +693,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration updatedMetricAlertConfig0 = updatedConfig.MetricAlertConfigurations[0];
 
-            Assert.That(updatedMetricAlertConfig0.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(updatedMetricAlertConfig0.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(updatedMetricAlertConfig0.AlertScope, Is.Not.Null);
             Assert.That(updatedMetricAlertConfig0.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.WholeSeries));
@@ -694,7 +718,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration updatedMetricAlertConfig1 = updatedConfig.MetricAlertConfigurations[1];
 
-            Assert.That(updatedMetricAlertConfig1.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(updatedMetricAlertConfig1.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(updatedMetricAlertConfig1.AlertScope, Is.Not.Null);
             Assert.That(updatedMetricAlertConfig1.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.TopN));
@@ -721,6 +745,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task UpdateAlertConfigurationWithEveryMemberAndNewInstance()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
 
             // Configure the Metric Anomaly Alert Configurations to be used.
 
@@ -728,8 +754,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var hookToCreate = new WebNotificationHook() { Name = hookName, Endpoint = new Uri("http://contoso.com/") };
             await using var disposableHook = await DisposableNotificationHook.CreateHookAsync(adminClient, hookToCreate);
 
+            var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.GetScopeForWholeSeries();
-            var metricAlertConfig0 = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope)
+            var metricAlertConfig0 = new MetricAnomalyAlertConfiguration(detectionConfigId, scope)
             {
                 AlertSnoozeCondition = new MetricAnomalyAlertSnoozeCondition(12, SnoozeScope.Series, true),
                 AlertConditions = new MetricAnomalyAlertConditions()
@@ -744,7 +771,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     SeverityCondition = new SeverityCondition(AnomalySeverity.Low, AnomalySeverity.Medium)
                 }
             };
-            var metricAlertConfig1 = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, scope)
+            var metricAlertConfig1 = new MetricAnomalyAlertConfiguration(detectionConfigId, scope)
             {
                 UseDetectionResultToFilterAnomalies = true
             };
@@ -776,7 +803,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             configToUpdate.IdsOfHooksToAlert.Clear();
 
             var newScope = MetricAnomalyAlertScope.GetScopeForTopNGroup(new TopNGroupScope(50, 40, 30));
-            var newMetricAlertConfig = new MetricAnomalyAlertConfiguration(DetectionConfigurationId, newScope)
+            var newMetricAlertConfig = new MetricAnomalyAlertConfiguration(detectionConfigId, newScope)
             {
                 AlertSnoozeCondition = new MetricAnomalyAlertSnoozeCondition(4, SnoozeScope.Metric, true),
                 UseDetectionResultToFilterAnomalies = true
@@ -809,7 +836,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration updatedMetricAlertConfig0 = updatedConfig.MetricAlertConfigurations[0];
 
-            Assert.That(updatedMetricAlertConfig0.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(updatedMetricAlertConfig0.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(updatedMetricAlertConfig0.AlertScope, Is.Not.Null);
             Assert.That(updatedMetricAlertConfig0.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.WholeSeries));
@@ -834,7 +861,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricAnomalyAlertConfiguration updatedMetricAlertConfig1 = updatedConfig.MetricAlertConfigurations[1];
 
-            Assert.That(updatedMetricAlertConfig1.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
+            Assert.That(updatedMetricAlertConfig1.DetectionConfigurationId, Is.EqualTo(detectionConfigId));
 
             Assert.That(updatedMetricAlertConfig1.AlertScope, Is.Not.Null);
             Assert.That(updatedMetricAlertConfig1.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.TopN));
@@ -915,13 +942,16 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task DeleteAlertConfiguration(bool useTokenCredential)
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient(useTokenCredential);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
 
             string configName = Recording.GenerateAlphaNumericId("config");
+            var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.GetScopeForWholeSeries();
             var configToCreate = new AnomalyAlertConfiguration()
             {
                 Name = configName,
-                MetricAlertConfigurations = { new(DetectionConfigurationId, scope) }
+                MetricAlertConfigurations = { new(detectionConfigId, scope) }
             };
 
             string configId = null;
@@ -1017,6 +1047,18 @@ namespace Azure.AI.MetricsAdvisor.Tests
             }
 
             Assert.That(configuration.UseDetectionResultToFilterAnomalies, Is.Not.Null);
+        }
+
+        private async Task<DisposableDetectionConfiguration> CreateTempDetectionConfigurationAsync(MetricsAdvisorAdministrationClient adminClient, DisposableDataFeed disposableDataFeed)
+        {
+            var config = new AnomalyDetectionConfiguration()
+            {
+                Name = Recording.GenerateAlphaNumericId("dataFeed"),
+                MetricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName],
+                WholeSeriesDetectionConditions = new MetricWholeSeriesDetectionCondition()
+            };
+
+            return await DisposableDetectionConfiguration.CreateDetectionConfigurationAsync(adminClient, config);
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyAlertConfigurationLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyAlertConfigurationLiveTests.cs
@@ -25,7 +25,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient(useTokenCredential);
             await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
-            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, metricId);
 
             var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.GetScopeForWholeSeries();
@@ -72,10 +73,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
             await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
-            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, metricId);
 
             DimensionKey groupKey = new DimensionKey();
-            groupKey.AddDimensionColumn("city", "Delhi");
+            groupKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Delhi");
 
             var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.GetScopeForSeriesGroup(groupKey);
@@ -108,12 +110,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(createdMetricAlertConfig.AlertScope.ScopeType, Is.EqualTo(MetricAnomalyAlertScopeType.SeriesGroup));
             Assert.That(createdMetricAlertConfig.AlertScope.TopNGroupInScope, Is.Null);
 
-            ValidateGroupKey(createdMetricAlertConfig.AlertScope.SeriesGroupInScope);
-
-            Dictionary<string, string> dimensionColumns = createdMetricAlertConfig.AlertScope.SeriesGroupInScope.AsDictionary();
-
-            Assert.That(dimensionColumns.Count, Is.EqualTo(1));
-            Assert.That(dimensionColumns["city"], Is.EqualTo("Delhi"));
+            ValidateTempDataFeedDimensionKey(createdMetricAlertConfig.AlertScope.SeriesGroupInScope, "Delhi");
 
             Assert.That(createdMetricAlertConfig.AlertConditions, Is.Not.Null);
             Assert.That(createdMetricAlertConfig.AlertConditions.MetricBoundaryCondition, Is.Null);
@@ -128,7 +125,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
             await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
-            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, metricId);
 
             var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var topNGroup = new TopNGroupScope(30, 20, 10);
@@ -180,7 +178,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
             await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
-            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, metricId);
 
             string hookName0 = Recording.GenerateAlphaNumericId("hook");
             string hookName1 = Recording.GenerateAlphaNumericId("hook");
@@ -205,7 +204,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     {
                         UpperBound = 20.0,
                         LowerBound = 10.0,
-                        CompanionMetricId = MetricId,
+                        CompanionMetricId = metricId,
                         ShouldAlertIfDataPointMissing = true
                     },
                     SeverityCondition = new SeverityCondition(AnomalySeverity.Low, AnomalySeverity.Medium)
@@ -250,7 +249,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(createdMetricAlertConfig.AlertConditions.MetricBoundaryCondition.Direction, Is.EqualTo(BoundaryDirection.Both));
             Assert.That(createdMetricAlertConfig.AlertConditions.MetricBoundaryCondition.UpperBound, Is.EqualTo(20.0));
             Assert.That(createdMetricAlertConfig.AlertConditions.MetricBoundaryCondition.LowerBound, Is.EqualTo(10.0));
-            Assert.That(createdMetricAlertConfig.AlertConditions.MetricBoundaryCondition.CompanionMetricId, Is.EqualTo(MetricId));
+            Assert.That(createdMetricAlertConfig.AlertConditions.MetricBoundaryCondition.CompanionMetricId, Is.EqualTo(metricId));
             Assert.That(createdMetricAlertConfig.AlertConditions.MetricBoundaryCondition.ShouldAlertIfDataPointMissing, Is.True);
             Assert.That(createdMetricAlertConfig.AlertConditions.SeverityCondition, Is.Not.Null);
             Assert.That(createdMetricAlertConfig.AlertConditions.SeverityCondition.MinimumAlertSeverity, Is.EqualTo(AnomalySeverity.Low));
@@ -269,7 +268,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
             await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
-            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, metricId);
 
             // Configure the Metric Anomaly Alert Configurations to be used.
 
@@ -370,7 +370,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient(useTokenCrendential);
             await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
-            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, metricId);
 
             // Configure the Metric Anomaly Alert Configurations to be used.
 
@@ -390,7 +391,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     {
                         UpperBound = 20.0,
                         LowerBound = 10.0,
-                        CompanionMetricId = MetricId,
+                        CompanionMetricId = metricId,
                         ShouldAlertIfDataPointMissing = true
                     },
                     SeverityCondition = new SeverityCondition(AnomalySeverity.Low, AnomalySeverity.Medium)
@@ -450,7 +451,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.Direction, Is.EqualTo(BoundaryDirection.Both));
             Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.UpperBound, Is.EqualTo(20.0));
             Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.LowerBound, Is.EqualTo(10.0));
-            Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.CompanionMetricId, Is.EqualTo(MetricId));
+            Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.CompanionMetricId, Is.EqualTo(metricId));
             Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.ShouldAlertIfDataPointMissing, Is.True);
             Assert.That(updatedMetricAlertConfig0.AlertConditions.SeverityCondition, Is.Not.Null);
             Assert.That(updatedMetricAlertConfig0.AlertConditions.SeverityCondition.MinimumAlertSeverity, Is.EqualTo(AnomalySeverity.Low));
@@ -487,7 +488,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
             await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
-            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, metricId);
 
             // Configure the Metric Anomaly Alert Configurations to be used.
 
@@ -506,7 +508,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     {
                         UpperBound = 20.0,
                         LowerBound = 10.0,
-                        CompanionMetricId = MetricId,
+                        CompanionMetricId = metricId,
                         ShouldAlertIfDataPointMissing = true
                     },
                     SeverityCondition = new SeverityCondition(AnomalySeverity.Low, AnomalySeverity.Medium)
@@ -566,7 +568,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.Direction, Is.EqualTo(BoundaryDirection.Both));
             Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.UpperBound, Is.EqualTo(20.0));
             Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.LowerBound, Is.EqualTo(10.0));
-            Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.CompanionMetricId, Is.EqualTo(MetricId));
+            Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.CompanionMetricId, Is.EqualTo(metricId));
             Assert.That(updatedMetricAlertConfig0.AlertConditions.MetricBoundaryCondition.ShouldAlertIfDataPointMissing, Is.True);
             Assert.That(updatedMetricAlertConfig0.AlertConditions.SeverityCondition, Is.Not.Null);
             Assert.That(updatedMetricAlertConfig0.AlertConditions.SeverityCondition.MinimumAlertSeverity, Is.EqualTo(AnomalySeverity.Low));
@@ -602,7 +604,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
             await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
-            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, metricId);
 
             // Configure the Metric Anomaly Alert Configurations to be used.
 
@@ -622,7 +625,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     {
                         UpperBound = 20.0,
                         LowerBound = 10.0,
-                        CompanionMetricId = MetricId,
+                        CompanionMetricId = metricId,
                         ShouldAlertIfDataPointMissing = true
                     },
                     SeverityCondition = new SeverityCondition(AnomalySeverity.Low, AnomalySeverity.Medium)
@@ -746,7 +749,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
             await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
-            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, metricId);
 
             // Configure the Metric Anomaly Alert Configurations to be used.
 
@@ -765,7 +769,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     {
                         UpperBound = 20.0,
                         LowerBound = 10.0,
-                        CompanionMetricId = MetricId,
+                        CompanionMetricId = metricId,
                         ShouldAlertIfDataPointMissing = true
                     },
                     SeverityCondition = new SeverityCondition(AnomalySeverity.Low, AnomalySeverity.Medium)
@@ -943,7 +947,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient(useTokenCredential);
             await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
-            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, disposableDataFeed);
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
+            await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, metricId);
 
             string configName = Recording.GenerateAlphaNumericId("config");
             var detectionConfigId = disposableDetectionConfig.Configuration.Id;
@@ -1049,13 +1054,19 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(configuration.UseDetectionResultToFilterAnomalies, Is.Not.Null);
         }
 
-        private async Task<DisposableDetectionConfiguration> CreateTempDetectionConfigurationAsync(MetricsAdvisorAdministrationClient adminClient, DisposableDataFeed disposableDataFeed)
+        private async Task<DisposableDetectionConfiguration> CreateTempDetectionConfigurationAsync(MetricsAdvisorAdministrationClient adminClient, string metricId)
         {
             var config = new AnomalyDetectionConfiguration()
             {
                 Name = Recording.GenerateAlphaNumericId("dataFeed"),
-                MetricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName],
+                MetricId = metricId,
                 WholeSeriesDetectionConditions = new MetricWholeSeriesDetectionCondition()
+                {
+                    HardThresholdCondition = new HardThresholdCondition(AnomalyDetectorDirection.Up, new SuppressCondition(1, 1.0))
+                    {
+                        UpperBound = 1.0
+                    }
+                }
             };
 
             return await DisposableDetectionConfiguration.CreateDetectionConfigurationAsync(adminClient, config);

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
@@ -14,10 +14,6 @@ namespace Azure.AI.MetricsAdvisor.Tests
 {
     public class AnomalyDetectionConfigurationLiveTests : MetricsAdvisorLiveTestBase
     {
-        private const string MetricName = "metric";
-        private const string DimensionNameA = "dimensionA";
-        private const string DimensionNameB = "dimensionB";
-
         public AnomalyDetectionConfigurationLiveTests(bool isAsync) : base(isAsync)
         {
         }
@@ -28,10 +24,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task CreateAndGetDetectionConfigurationWithHardCondition(bool useTokenCredential)
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient(useTokenCredential);
-            await using DisposableDataFeed disposableDataFeed = await CreateDisposableDataFeedAsync(adminClient);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
 
             string configName = Recording.GenerateAlphaNumericId("config");
-            string metricId = disposableDataFeed.DataFeed.MetricIds[MetricName];
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
             var description = "This configuration was created to test the .NET client.";
 
             var wholeConditions = new MetricWholeSeriesDetectionCondition()
@@ -76,10 +72,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task CreateAndGetDetectionConfigurationWithChangeAndSmartConditions()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
-            await using DisposableDataFeed disposableDataFeed = await CreateDisposableDataFeedAsync(adminClient);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
 
             string configName = Recording.GenerateAlphaNumericId("config");
-            string metricId = disposableDataFeed.DataFeed.MetricIds[MetricName];
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
 
             var wholeConditions = new MetricWholeSeriesDetectionCondition()
             {
@@ -122,10 +118,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
             // Set required parameters of the configuration to be created.
 
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
-            await using DisposableDataFeed disposableDataFeed = await CreateDisposableDataFeedAsync(adminClient);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
 
             string configName = Recording.GenerateAlphaNumericId("config");
-            string metricId = disposableDataFeed.DataFeed.MetricIds[MetricName];
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
 
             var wholeConditions = new MetricWholeSeriesDetectionCondition()
             {
@@ -149,14 +145,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            groupConditions0.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Delhi");
+            groupConditions0.SeriesGroupKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Delhi");
 
             var groupConditions1 = new MetricSeriesGroupDetectionCondition()
             {
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            groupConditions1.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Koltaka");
+            groupConditions1.SeriesGroupKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Koltaka");
 
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions0);
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions1);
@@ -195,7 +191,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdGroupConditions0, Is.Not.Null);
 
-            ValidateDimensionKey(createdGroupConditions0.SeriesGroupKey, "Delhi");
+            ValidateTempDataFeedDimensionKey(createdGroupConditions0.SeriesGroupKey, "Delhi");
 
             Assert.That(createdGroupConditions0.CrossConditionsOperator, Is.Null);
             Assert.That(createdGroupConditions0.HardThresholdCondition, Is.Null);
@@ -209,7 +205,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdGroupConditions1, Is.Not.Null);
 
-            ValidateDimensionKey(createdGroupConditions1.SeriesGroupKey, "Koltaka");
+            ValidateTempDataFeedDimensionKey(createdGroupConditions1.SeriesGroupKey, "Koltaka");
 
             Assert.That(createdGroupConditions1.CrossConditionsOperator, Is.Null);
             Assert.That(createdGroupConditions1.HardThresholdCondition, Is.Null);
@@ -224,10 +220,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
             // Set required parameters of the configuration to be created.
 
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
-            await using DisposableDataFeed disposableDataFeed = await CreateDisposableDataFeedAsync(adminClient);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
 
             string configName = Recording.GenerateAlphaNumericId("config");
-            string metricId = disposableDataFeed.DataFeed.MetricIds[MetricName];
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
 
             var wholeConditions = new MetricWholeSeriesDetectionCondition()
             {
@@ -252,16 +248,16 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            seriesConditions0.SeriesKey.AddDimensionColumn(DimensionNameA, "Delhi");
-            seriesConditions0.SeriesKey.AddDimensionColumn(DimensionNameB, "Handmade");
+            seriesConditions0.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Delhi");
+            seriesConditions0.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameB, "Handmade");
 
             var seriesConditions1 = new MetricSingleSeriesDetectionCondition()
             {
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            seriesConditions1.SeriesKey.AddDimensionColumn(DimensionNameA, "Koltaka");
-            seriesConditions1.SeriesKey.AddDimensionColumn(DimensionNameB, "Grocery & Gourmet Food");
+            seriesConditions1.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Koltaka");
+            seriesConditions1.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameB, "Grocery & Gourmet Food");
 
             configToCreate.SeriesDetectionConditions.Add(seriesConditions0);
             configToCreate.SeriesDetectionConditions.Add(seriesConditions1);
@@ -300,7 +296,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdSeriesConditions0, Is.Not.Null);
 
-            ValidateDimensionKey(createdSeriesConditions0.SeriesKey, "Delhi", "Handmade");
+            ValidateTempDataFeedDimensionKey(createdSeriesConditions0.SeriesKey, "Delhi", "Handmade");
 
             Assert.That(createdSeriesConditions0.CrossConditionsOperator, Is.Null);
             Assert.That(createdSeriesConditions0.HardThresholdCondition, Is.Null);
@@ -314,7 +310,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdSeriesConditions1, Is.Not.Null);
 
-            ValidateDimensionKey(createdSeriesConditions1.SeriesKey, "Koltaka", "Grocery & Gourmet Food");
+            ValidateTempDataFeedDimensionKey(createdSeriesConditions1.SeriesKey, "Koltaka", "Grocery & Gourmet Food");
 
             Assert.That(createdSeriesConditions1.CrossConditionsOperator, Is.Null);
             Assert.That(createdSeriesConditions1.HardThresholdCondition, Is.Null);
@@ -331,10 +327,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
             // Set required parameters of the configuration to be created.
 
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
-            await using DisposableDataFeed disposableDataFeed = await CreateDisposableDataFeedAsync(adminClient);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
 
             string configName = Recording.GenerateAlphaNumericId("config");
-            string metricId = disposableDataFeed.DataFeed.MetricIds[MetricName];
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
 
             var wholeConditions = new MetricWholeSeriesDetectionCondition()
             {
@@ -360,7 +356,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            groupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Koltaka");
+            groupConditions.SeriesGroupKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Koltaka");
 
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions);
 
@@ -371,8 +367,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameA, "Delhi");
-            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameB, "Handmade");
+            seriesConditions.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Delhi");
+            seriesConditions.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameB, "Handmade");
 
             configToCreate.SeriesDetectionConditions.Add(seriesConditions);
 
@@ -412,7 +408,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions, Is.Not.Null);
 
-            ValidateDimensionKey(updatedGroupConditions.SeriesGroupKey, "Koltaka");
+            ValidateTempDataFeedDimensionKey(updatedGroupConditions.SeriesGroupKey, "Koltaka");
 
             Assert.That(updatedGroupConditions.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions.HardThresholdCondition, Is.Null);
@@ -426,7 +422,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedSeriesConditions = updatedConfig.SeriesDetectionConditions.Single();
 
-            ValidateDimensionKey(updatedSeriesConditions.SeriesKey, "Delhi", "Handmade");
+            ValidateTempDataFeedDimensionKey(updatedSeriesConditions.SeriesKey, "Delhi", "Handmade");
 
             Assert.That(updatedSeriesConditions, Is.Not.Null);
             Assert.That(updatedSeriesConditions.CrossConditionsOperator, Is.Null);
@@ -443,10 +439,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
             // Set required parameters of the configuration to be created.
 
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
-            await using DisposableDataFeed disposableDataFeed = await CreateDisposableDataFeedAsync(adminClient);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
 
             string configName = Recording.GenerateAlphaNumericId("config");
-            string metricId = disposableDataFeed.DataFeed.MetricIds[MetricName];
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
 
             var wholeConditions = new MetricWholeSeriesDetectionCondition()
             {
@@ -472,7 +468,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            groupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Koltaka");
+            groupConditions.SeriesGroupKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Koltaka");
 
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions);
 
@@ -483,8 +479,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameA, "Delhi");
-            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameB, "Handmade");
+            seriesConditions.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Delhi");
+            seriesConditions.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameB, "Handmade");
 
             configToCreate.SeriesDetectionConditions.Add(seriesConditions);
 
@@ -524,7 +520,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions, Is.Not.Null);
 
-            ValidateDimensionKey(updatedGroupConditions.SeriesGroupKey, "Koltaka");
+            ValidateTempDataFeedDimensionKey(updatedGroupConditions.SeriesGroupKey, "Koltaka");
 
             Assert.That(updatedGroupConditions.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions.HardThresholdCondition, Is.Null);
@@ -538,7 +534,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedSeriesConditions = updatedConfig.SeriesDetectionConditions.Single();
 
-            ValidateDimensionKey(updatedSeriesConditions.SeriesKey, "Delhi", "Handmade");
+            ValidateTempDataFeedDimensionKey(updatedSeriesConditions.SeriesKey, "Delhi", "Handmade");
 
             Assert.That(updatedSeriesConditions, Is.Not.Null);
             Assert.That(updatedSeriesConditions.CrossConditionsOperator, Is.Null);
@@ -555,10 +551,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
             // Set parameters of the configuration to be created.
 
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
-            await using DisposableDataFeed disposableDataFeed = await CreateDisposableDataFeedAsync(adminClient);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
 
             string configName = Recording.GenerateAlphaNumericId("config");
-            string metricId = disposableDataFeed.DataFeed.MetricIds[MetricName];
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
             var description = "This configuration was created to test the .NET client.";
 
             var wholeConditions = new MetricWholeSeriesDetectionCondition()
@@ -586,7 +582,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            groupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Koltaka");
+            groupConditions.SeriesGroupKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Koltaka");
 
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions);
 
@@ -597,8 +593,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameA, "Delhi");
-            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameB, "Handmade");
+            seriesConditions.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Delhi");
+            seriesConditions.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameB, "Handmade");
 
             configToCreate.SeriesDetectionConditions.Add(seriesConditions);
 
@@ -620,7 +616,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(95.0, AnomalyDetectorDirection.Both, new(25, 26.0))
             };
 
-            newGroupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Delhi");
+            newGroupConditions.SeriesGroupKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Delhi");
 
             configToUpdate.SeriesGroupDetectionConditions.Add(newGroupConditions);
 
@@ -658,7 +654,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions0, Is.Not.Null);
 
-            ValidateDimensionKey(updatedGroupConditions0.SeriesGroupKey, "Koltaka");
+            ValidateTempDataFeedDimensionKey(updatedGroupConditions0.SeriesGroupKey, "Koltaka");
 
             Assert.That(updatedGroupConditions0.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions0.HardThresholdCondition, Is.Null);
@@ -672,7 +668,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions1, Is.Not.Null);
 
-            ValidateDimensionKey(updatedGroupConditions1.SeriesGroupKey, "Delhi");
+            ValidateTempDataFeedDimensionKey(updatedGroupConditions1.SeriesGroupKey, "Delhi");
 
             Assert.That(updatedGroupConditions1.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions1.HardThresholdCondition, Is.Null);
@@ -688,10 +684,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
             // Set parameters of the configuration to be created.
 
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
-            await using DisposableDataFeed disposableDataFeed = await CreateDisposableDataFeedAsync(adminClient);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
 
             string configName = Recording.GenerateAlphaNumericId("config");
-            string metricId = disposableDataFeed.DataFeed.MetricIds[MetricName];
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
             var description = "This configuration was created to test the .NET client.";
 
             var wholeConditions = new MetricWholeSeriesDetectionCondition()
@@ -719,7 +715,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
 
-            groupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Koltaka");
+            groupConditions.SeriesGroupKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Koltaka");
 
             configToCreate.SeriesGroupDetectionConditions.Add(groupConditions);
 
@@ -730,8 +726,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameA, "Delhi");
-            seriesConditions.SeriesKey.AddDimensionColumn(DimensionNameB, "Handmade");
+            seriesConditions.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Delhi");
+            seriesConditions.SeriesKey.AddDimensionColumn(TempDataFeedDimensionNameB, "Handmade");
 
             configToCreate.SeriesDetectionConditions.Add(seriesConditions);
 
@@ -755,7 +751,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 SmartDetectionCondition = new(95.0, AnomalyDetectorDirection.Both, new(25, 26.0))
             };
 
-            newGroupConditions.SeriesGroupKey.AddDimensionColumn(DimensionNameA, "Delhi");
+            newGroupConditions.SeriesGroupKey.AddDimensionColumn(TempDataFeedDimensionNameA, "Delhi");
 
             configToUpdate.SeriesGroupDetectionConditions.Add(groupConditions);
             configToUpdate.SeriesGroupDetectionConditions.Add(newGroupConditions);
@@ -794,7 +790,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions0, Is.Not.Null);
 
-            ValidateDimensionKey(updatedGroupConditions0.SeriesGroupKey, "Koltaka");
+            ValidateTempDataFeedDimensionKey(updatedGroupConditions0.SeriesGroupKey, "Koltaka");
 
             Assert.That(updatedGroupConditions0.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions0.HardThresholdCondition, Is.Null);
@@ -808,7 +804,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedGroupConditions1, Is.Not.Null);
 
-            ValidateDimensionKey(updatedGroupConditions1.SeriesGroupKey, "Delhi");
+            ValidateTempDataFeedDimensionKey(updatedGroupConditions1.SeriesGroupKey, "Delhi");
 
             Assert.That(updatedGroupConditions1.CrossConditionsOperator, Is.Null);
             Assert.That(updatedGroupConditions1.HardThresholdCondition, Is.Null);
@@ -865,10 +861,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
         public async Task DeleteDetectionConfiguration(bool useTokenCredential)
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
-            await using DisposableDataFeed disposableDataFeed = await CreateDisposableDataFeedAsync(adminClient);
+            await using DisposableDataFeed disposableDataFeed = await CreateTempDataFeedAsync(adminClient);
 
             string configName = Recording.GenerateAlphaNumericId("config");
-            string metricId = disposableDataFeed.DataFeed.MetricIds[MetricName];
+            string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
 
             var wholeConditions = new MetricWholeSeriesDetectionCondition()
             {
@@ -904,30 +900,6 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     Assert.That(async () => await adminClient.GetDetectionConfigurationAsync(configId), Throws.InstanceOf<RequestFailedException>().With.Message.Contains(errorCause));
                 }
             }
-        }
-
-        private void ValidateDimensionKey(DimensionKey dimensionKey, string expectedDimensionA)
-        {
-            Assert.That(dimensionKey, Is.Not.Null);
-
-            Dictionary<string, string> dimensionColumns = dimensionKey.AsDictionary();
-
-            Assert.That(dimensionColumns.Count, Is.EqualTo(1));
-            Assert.That(dimensionColumns.ContainsKey(DimensionNameA));
-            Assert.That(dimensionColumns[DimensionNameA], Is.EqualTo(expectedDimensionA));
-        }
-
-        private void ValidateDimensionKey(DimensionKey dimensionKey, string expectedDimensionA, string expectedDimensionB)
-        {
-            Assert.That(dimensionKey, Is.Not.Null);
-
-            Dictionary<string, string> dimensionDictionary = dimensionKey.AsDictionary();
-
-            Assert.That(dimensionDictionary.Count, Is.EqualTo(2));
-            Assert.That(dimensionDictionary.ContainsKey(DimensionNameA));
-            Assert.That(dimensionDictionary.ContainsKey(DimensionNameB));
-            Assert.That(dimensionDictionary[DimensionNameA], Is.EqualTo(expectedDimensionA));
-            Assert.That(dimensionDictionary[DimensionNameB], Is.EqualTo(expectedDimensionB));
         }
 
         private void ValidateHardThresholdCondition(HardThresholdCondition condition, AnomalyDetectorDirection direction, double? upperBound, double? lowerBound, int minimumNumber, double minimumRatio)
@@ -1025,24 +997,6 @@ namespace Azure.AI.MetricsAdvisor.Tests
             {
                 Assert.That(conditions.CrossConditionsOperator, Is.Null);
             }
-        }
-
-        private async Task<DisposableDataFeed> CreateDisposableDataFeedAsync(MetricsAdvisorAdministrationClient adminClient)
-        {
-            var dataFeed = new DataFeed()
-            {
-                Name = Recording.GenerateAlphaNumericId("dataFeed"),
-                DataSource = new SqlServerDataFeedSource("connString", "query"),
-                Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
-                Schema = new DataFeedSchema()
-                {
-                    MetricColumns = { new DataFeedMetric(MetricName) },
-                    DimensionColumns = { new DataFeedDimension(DimensionNameA), new DataFeedDimension(DimensionNameB) }
-                },
-                IngestionSettings = new DataFeedIngestionSettings() { IngestionStartTime = SamplingStartTime }
-            };
-
-            return await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeed);
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithMultipleMetricConfigurations.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithMultipleMetricConfigurations.json
@@ -1,6 +1,215 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b7936e11531850489b02fce240f97ae9-9a739623d56be24d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0bd7bcf3a83a0bef03cdc015db3f9a65",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedRUbHcTl2",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "d82f2cb1-8df2-4f68-abf4-89b68432d90d",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:36:59 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/04dfa598-1ebd-4fdd-a08c-ec513a3f8d82",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "411",
+        "x-request-id": "d82f2cb1-8df2-4f68-abf4-89b68432d90d"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/04dfa598-1ebd-4fdd-a08c-ec513a3f8d82",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b7936e11531850489b02fce240f97ae9-680f51e7f3c2a047-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1b99e95263bf7c8b16b41db9fef765a1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8029165f-883d-4568-af83-ee956a6e55c2",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:00 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "157",
+        "x-request-id": "8029165f-883d-4568-af83-ee956a6e55c2"
+      },
+      "ResponseBody": {
+        "dataFeedId": "04dfa598-1ebd-4fdd-a08c-ec513a3f8d82",
+        "dataFeedName": "dataFeedRUbHcTl2",
+        "metrics": [
+          {
+            "metricId": "3ddba323-799e-480d-ad4c-26fd41eef1bf",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:37:00Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9abbab16cc942b4ba787c103d9c76a80-c5524fd99ec32a45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "a5222a8f92540a4804598c1f0cf60090",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedjM0Iup5k",
+        "metricId": "3ddba323-799e-480d-ad4c-26fd41eef1bf",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "c93f292a-6cb6-40da-a4ca-d572f9500f9c",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:00 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3a99df58-96b5-4e75-b442-49058fc9a3bb",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "123",
+        "x-request-id": "c93f292a-6cb6-40da-a4ca-d572f9500f9c"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3a99df58-96b5-4e75-b442-49058fc9a3bb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9abbab16cc942b4ba787c103d9c76a80-b962080a11a07242-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "86f45a30368a0c0d681fcfdc12080625",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "21ee06d9-1214-41c0-9947-98d81d9218d2",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:00 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "89",
+        "x-request-id": "21ee06d9-1214-41c0-9947-98d81d9218d2"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "3a99df58-96b5-4e75-b442-49058fc9a3bb",
+        "name": "dataFeedjM0Iup5k",
+        "description": "",
+        "metricId": "3ddba323-799e-480d-ad4c-26fd41eef1bf",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,19 +217,19 @@
         "Content-Length": "415",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cf7982a192dc154ab6e3f82217a9a505-38f7a791cab2934c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-a425fa666fcaf94cafdefad1180dd251-0bde1e4c4763134a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "0bd7bcf3a83a0bef03cdc015db3f9a65",
+        "x-ms-client-request-id": "a5b5126b456b4e95fd9c610337614958",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configRUbHcTl2",
+        "name": "configKKt1cOQp",
         "crossMetricsOperator": "XOR",
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "3a99df58-96b5-4e75-b442-49058fc9a3bb",
             "anomalyScopeType": "All",
             "negationOperation": true,
             "valueFilter": {
@@ -29,7 +238,7 @@
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "3a99df58-96b5-4e75-b442-49058fc9a3bb",
             "anomalyScopeType": "All",
             "valueFilter": {
               "lower": 10,
@@ -40,51 +249,51 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "0ce263aa-e65e-422c-8c58-0b6c912a3b79",
+        "apim-request-id": "fd74c4a7-29b5-4cf7-abd9-9419020583d1",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/e306c0d8-3784-43c6-988c-29bb039f0619",
+        "Date": "Thu, 10 Jun 2021 18:37:00 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/d3fe1ca9-0ad0-447e-b5ab-5105073f27ff",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "180",
-        "x-request-id": "0ce263aa-e65e-422c-8c58-0b6c912a3b79"
+        "x-envoy-upstream-service-time": "140",
+        "x-request-id": "fd74c4a7-29b5-4cf7-abd9-9419020583d1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/e306c0d8-3784-43c6-988c-29bb039f0619",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/d3fe1ca9-0ad0-447e-b5ab-5105073f27ff",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cf7982a192dc154ab6e3f82217a9a505-b34a11a731031a4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-a425fa666fcaf94cafdefad1180dd251-7aa188a0384a214c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1b99e95263bf7c8b16b41db9fef765a1",
+        "x-ms-client-request-id": "353d151d6cc3fbf852661e47696b4e4a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f4ba23d-dfaf-4c20-8341-e6341ca7c8f7",
+        "apim-request-id": "41261f81-048b-49b2-b217-62525584ce01",
         "Content-Length": "644",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:36 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "133",
-        "x-request-id": "6f4ba23d-dfaf-4c20-8341-e6341ca7c8f7"
+        "x-envoy-upstream-service-time": "92",
+        "x-request-id": "41261f81-048b-49b2-b217-62525584ce01"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "e306c0d8-3784-43c6-988c-29bb039f0619",
-        "name": "configRUbHcTl2",
+        "anomalyAlertingConfigurationId": "d3fe1ca9-0ad0-447e-b5ab-5105073f27ff",
+        "name": "configKKt1cOQp",
         "description": "",
         "crossMetricsOperator": "XOR",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "3a99df58-96b5-4e75-b442-49058fc9a3bb",
             "anomalyScopeType": "All",
             "negationOperation": true,
             "valueFilter": {
@@ -95,7 +304,7 @@
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "3a99df58-96b5-4e75-b442-49058fc9a3bb",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "valueFilter": {
@@ -109,84 +318,77 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/e306c0d8-3784-43c6-988c-29bb039f0619",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6a0facda07b4304fb62865fe44fb55bc-02831fa377dcb248-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "922cfe452c5ed4e78f2a22a55492480a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "199f2ee9-e30b-4d3b-a13b-57bd8f1a30b5",
-        "Content-Length": "644",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:36 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "119",
-        "x-request-id": "199f2ee9-e30b-4d3b-a13b-57bd8f1a30b5"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "e306c0d8-3784-43c6-988c-29bb039f0619",
-        "name": "configRUbHcTl2",
-        "description": "",
-        "crossMetricsOperator": "XOR",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true,
-            "valueFilter": {
-              "upper": 20.0,
-              "direction": "Up",
-              "triggerForMissing": false,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "valueFilter": {
-              "lower": 10.0,
-              "direction": "Down",
-              "triggerForMissing": false,
-              "type": "Value"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/e306c0d8-3784-43c6-988c-29bb039f0619",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/d3fe1ca9-0ad0-447e-b5ab-5105073f27ff",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-17247b6dccb63d4d9d20652739452651-e543aa6d8cc14f4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-f3436367823aa24fab9e433ed037e52c-ae66e97d2d8a4543-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1f8c5904f60c9000305af4868a360d0c",
+        "x-ms-client-request-id": "781a7133678122a18a80df75a602ed9f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4f870177-c1d1-44b2-96b8-8a792e62fcdc",
+        "apim-request-id": "7495408d-681f-4ca5-8287-f491a57e93d4",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:37 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "151",
-        "x-request-id": "4f870177-c1d1-44b2-96b8-8a792e62fcdc"
+        "x-envoy-upstream-service-time": "126",
+        "x-request-id": "7495408d-681f-4ca5-8287-f491a57e93d4"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/3a99df58-96b5-4e75-b442-49058fc9a3bb",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4d09d10d72d51d46b71c98776d141a9e-20ce9e840ec7ff44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2b78347bf1a8ffc01ab95204274de492",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "dfce6029-a2c3-4f18-9ee6-14806768713b",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "130",
+        "x-request-id": "dfce6029-a2c3-4f18-9ee6-14806768713b"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/04dfa598-1ebd-4fdd-a08c-ec513a3f8d82",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-76ed675b40fe354f8d3805df038279fd-e3dc68fdfe07f244-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c6d0174dd147b5d7741aab428c82554f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "d9be7113-1ef6-4760-ad77-ac5a733b358f",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "330",
+        "x-request-id": "d9be7113-1ef6-4760-ad77-ac5a733b358f"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithMultipleMetricConfigurationsAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithMultipleMetricConfigurationsAsync.json
@@ -1,6 +1,215 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a79d5b95777b04db1838f84cc96dc57-9f9795f1dbcab84a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "9c53efbbd99947cdf9cbfa628f01f571",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedtP7ePBS1",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "8a38370c-d205-44f4-acbc-4080ce542dd1",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:15 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/af18c18c-b1cf-4469-a061-ebc64317af4a",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "416",
+        "x-request-id": "8a38370c-d205-44f4-acbc-4080ce542dd1"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/af18c18c-b1cf-4469-a061-ebc64317af4a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a79d5b95777b04db1838f84cc96dc57-d123e939791d044f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "4d52fdfaf7a88a9e2977f5270179bf77",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8c355605-e21f-4b71-a37e-b6ad4cc4c8bc",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "173",
+        "x-request-id": "8c355605-e21f-4b71-a37e-b6ad4cc4c8bc"
+      },
+      "ResponseBody": {
+        "dataFeedId": "af18c18c-b1cf-4469-a061-ebc64317af4a",
+        "dataFeedName": "dataFeedtP7ePBS1",
+        "metrics": [
+          {
+            "metricId": "d55c8a1b-540a-4821-97de-13079ca74b19",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:39:15Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-5b89361aacf7df4fbcdb7aaeb6574c1d-8672c25274d9c044-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "233d70f771484a214d4204502e8642c3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedKtvawpVH",
+        "metricId": "d55c8a1b-540a-4821-97de-13079ca74b19",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "d69f9fcf-4ebf-4d34-84f5-1621af1ba20e",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:15 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb907ff4-96e9-477d-97b7-f6a9b93159f6",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "132",
+        "x-request-id": "d69f9fcf-4ebf-4d34-84f5-1621af1ba20e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb907ff4-96e9-477d-97b7-f6a9b93159f6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-5b89361aacf7df4fbcdb7aaeb6574c1d-58c27bde55b96c44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2172c851a5e47f460b828b580dac1a93",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1deae6cf-b097-47b0-920a-bddebf6cb906",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "120",
+        "x-request-id": "1deae6cf-b097-47b0-920a-bddebf6cb906"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "fb907ff4-96e9-477d-97b7-f6a9b93159f6",
+        "name": "dataFeedKtvawpVH",
+        "description": "",
+        "metricId": "d55c8a1b-540a-4821-97de-13079ca74b19",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,19 +217,19 @@
         "Content-Length": "415",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-34dc1301a7304d4580004882392feab7-7d1049fcf48c514a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-33e7648bd1d48b469ebe01506d78b2a5-dcebd47ee8ccbb45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9c53efbbd99947cdf9cbfa628f01f571",
+        "x-ms-client-request-id": "bed9ab566e755049f430f78df3834451",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configtP7ePBS1",
+        "name": "configFhWhq1n7",
         "crossMetricsOperator": "XOR",
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fb907ff4-96e9-477d-97b7-f6a9b93159f6",
             "anomalyScopeType": "All",
             "negationOperation": true,
             "valueFilter": {
@@ -29,7 +238,7 @@
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fb907ff4-96e9-477d-97b7-f6a9b93159f6",
             "anomalyScopeType": "All",
             "valueFilter": {
               "lower": 10,
@@ -40,51 +249,51 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "1583c334-a915-43b2-adbe-4e758dababba",
+        "apim-request-id": "77bebea0-345a-4b5e-ae51-f0a07b3eeaa3",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:44 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/6d05291f-9b40-4adb-b99f-a1e1f5703719",
+        "Date": "Thu, 10 Jun 2021 18:39:15 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/0c86d28b-b971-47fb-8c2d-307dfb351e9f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "150",
-        "x-request-id": "1583c334-a915-43b2-adbe-4e758dababba"
+        "x-envoy-upstream-service-time": "125",
+        "x-request-id": "77bebea0-345a-4b5e-ae51-f0a07b3eeaa3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/6d05291f-9b40-4adb-b99f-a1e1f5703719",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/0c86d28b-b971-47fb-8c2d-307dfb351e9f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-34dc1301a7304d4580004882392feab7-0407b9fa3f070e4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-33e7648bd1d48b469ebe01506d78b2a5-695dec9dbdc54d49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "4d52fdfaf7a88a9e2977f5270179bf77",
+        "x-ms-client-request-id": "c517bd2ac8e6a13c2770f804300a0ad6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b6572d9f-1899-4ff4-983f-a2e3ea6e6e69",
+        "apim-request-id": "69ac173d-41a0-47ab-8003-bbd1c348b7a8",
         "Content-Length": "644",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:44 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "106",
-        "x-request-id": "b6572d9f-1899-4ff4-983f-a2e3ea6e6e69"
+        "x-envoy-upstream-service-time": "88",
+        "x-request-id": "69ac173d-41a0-47ab-8003-bbd1c348b7a8"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "6d05291f-9b40-4adb-b99f-a1e1f5703719",
-        "name": "configtP7ePBS1",
+        "anomalyAlertingConfigurationId": "0c86d28b-b971-47fb-8c2d-307dfb351e9f",
+        "name": "configFhWhq1n7",
         "description": "",
         "crossMetricsOperator": "XOR",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fb907ff4-96e9-477d-97b7-f6a9b93159f6",
             "anomalyScopeType": "All",
             "negationOperation": true,
             "valueFilter": {
@@ -95,7 +304,7 @@
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fb907ff4-96e9-477d-97b7-f6a9b93159f6",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "valueFilter": {
@@ -109,84 +318,77 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/6d05291f-9b40-4adb-b99f-a1e1f5703719",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9c6b93cec94e324abc158c15ee4c8022-de88b16457768747-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "49f336d7665629a5f7703d234871214a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c99e113e-d15c-4f12-9386-3e4a24f5990e",
-        "Content-Length": "644",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:44 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "114",
-        "x-request-id": "c99e113e-d15c-4f12-9386-3e4a24f5990e"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "6d05291f-9b40-4adb-b99f-a1e1f5703719",
-        "name": "configtP7ePBS1",
-        "description": "",
-        "crossMetricsOperator": "XOR",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true,
-            "valueFilter": {
-              "upper": 20.0,
-              "direction": "Up",
-              "triggerForMissing": false,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "valueFilter": {
-              "lower": 10.0,
-              "direction": "Down",
-              "triggerForMissing": false,
-              "type": "Value"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/6d05291f-9b40-4adb-b99f-a1e1f5703719",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/0c86d28b-b971-47fb-8c2d-307dfb351e9f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f3a638cd074d6543a364006e656ecbc4-ea0076da3661ea4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-483014723c8b0f4fb893037b03713397-68ea2c4bc6ca984c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "5004424d862ec34251c87221e4a5467f",
+        "x-ms-client-request-id": "38cbba8688cc9c09393a64ddb48c9fd4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "44e7bbdd-365c-4081-a6c9-6909e21f0533",
+        "apim-request-id": "4d8dac0d-2b83-4301-88c4-577d5a8e01c1",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:44 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "160",
-        "x-request-id": "44e7bbdd-365c-4081-a6c9-6909e21f0533"
+        "x-envoy-upstream-service-time": "205",
+        "x-request-id": "4d8dac0d-2b83-4301-88c4-577d5a8e01c1"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb907ff4-96e9-477d-97b7-f6a9b93159f6",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-30f6e875d72478409128df36aa030640-77a3016d5d0ffe42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "fb0d05e47d628dd16f389705764420e9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "c83f739c-08be-4f5b-b93d-e746475238a4",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:22 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5143",
+        "x-request-id": "c83f739c-08be-4f5b-b93d-e746475238a4"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/af18c18c-b1cf-4469-a061-ebc64317af4a",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-79168c2f368209428af73bc5a39c02b5-70162d690ef8044a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "380721250cb7a185b47b8cab645eed9a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "d7cb5276-b71a-4a08-bc54-7f8e9f8b9cc4",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:22 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "439",
+        "x-request-id": "d7cb5276-b71a-4a08-bc54-7f8e9f8b9cc4"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithOptionalSingleMetricConfigurationMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithOptionalSingleMetricConfigurationMembers.json
@@ -1,6 +1,215 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ef5dbd0f836e1e4e88dd0ef597bc3c0c-4536cc3b6728064b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "a346422b541ab93c3c4c2e6cb149f9f0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedVhcyeEA7",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "81186c40-ae6a-4fef-b2a7-1895b648305a",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:02 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c8d7482a-9800-4c51-b379-1f3420f3beb0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "592",
+        "x-request-id": "81186c40-ae6a-4fef-b2a7-1895b648305a"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c8d7482a-9800-4c51-b379-1f3420f3beb0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ef5dbd0f836e1e4e88dd0ef597bc3c0c-0b7aaa8013d34042-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "081f28f6e83bf1de2910ec032fe08b87",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8cae8c0b-0a39-4d60-bed3-c7b7539447a8",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:02 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "178",
+        "x-request-id": "8cae8c0b-0a39-4d60-bed3-c7b7539447a8"
+      },
+      "ResponseBody": {
+        "dataFeedId": "c8d7482a-9800-4c51-b379-1f3420f3beb0",
+        "dataFeedName": "dataFeedVhcyeEA7",
+        "metrics": [
+          {
+            "metricId": "9c6e12cc-ec8b-4ac1-86a1-01baf97793fd",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:37:02Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d57d575451e18a4aa0b74d1f44b170d1-4ffdfe5ee87a0343-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "15e82801f7d1f0ee5d870e895db36342",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedbZ0ADsUF",
+        "metricId": "9c6e12cc-ec8b-4ac1-86a1-01baf97793fd",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "901a711d-fe7f-4043-a53e-cb6915d14ea8",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:02 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0be7374a-2dc6-427f-affc-0e7accea77cf",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "112",
+        "x-request-id": "901a711d-fe7f-4043-a53e-cb6915d14ea8"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0be7374a-2dc6-427f-affc-0e7accea77cf",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d57d575451e18a4aa0b74d1f44b170d1-91ddcc73fb05114c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "097a556339675b8ac0a6ac426e376972",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6dfe5f5e-8ed7-4b1c-8ca6-cd318b0625de",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:02 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "92",
+        "x-request-id": "6dfe5f5e-8ed7-4b1c-8ca6-cd318b0625de"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "0be7374a-2dc6-427f-affc-0e7accea77cf",
+        "name": "dataFeedbZ0ADsUF",
+        "description": "",
+        "metricId": "9c6e12cc-ec8b-4ac1-86a1-01baf97793fd",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,10 +217,10 @@
         "Content-Length": "92",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-26d204c876d0e744b4ca2faba7ed03e9-4499a29be483124d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b8957285dec4cc4a8cedd35057023007-e511abfa35bad840-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6c2e4c3c49b1f0f9f6281f083be8def1",
+        "x-ms-client-request-id": "315e990b2709c80b9d8d552b4bac8225",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,48 +230,48 @@
           ]
         },
         "hookType": "Email",
-        "hookName": "hookVhcyeEA7"
+        "hookName": "hook3oyTAJJN"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6abf1bc0-2504-4588-b7ea-1a66a4492fea",
+        "apim-request-id": "7fabd449-6d43-46e1-b1bc-b12ae438c37f",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:37 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/98a5557d-c480-4ad0-b726-a1878df900c4",
+        "Date": "Thu, 10 Jun 2021 18:37:03 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/28ed897f-9738-4a21-b9a4-50c511fa76ef",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "702",
-        "x-request-id": "6abf1bc0-2504-4588-b7ea-1a66a4492fea"
+        "x-envoy-upstream-service-time": "267",
+        "x-request-id": "7fabd449-6d43-46e1-b1bc-b12ae438c37f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/98a5557d-c480-4ad0-b726-a1878df900c4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/28ed897f-9738-4a21-b9a4-50c511fa76ef",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-26d204c876d0e744b4ca2faba7ed03e9-f818150a1fc2944f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b8957285dec4cc4a8cedd35057023007-69bbca74ec588b4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "03ec1029e02f878bc06fdbc287833173",
+        "x-ms-client-request-id": "b0929c1e50ad99423649e76b92e28abe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "260fbd95-3fc8-46a2-8c6f-3b06235d6d3d",
+        "apim-request-id": "37b37b3c-7fad-48bb-aa05-5efc3bb5ac05",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:38 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "169",
-        "x-request-id": "260fbd95-3fc8-46a2-8c6f-3b06235d6d3d"
+        "x-envoy-upstream-service-time": "161",
+        "x-request-id": "37b37b3c-7fad-48bb-aa05-5efc3bb5ac05"
       },
       "ResponseBody": {
-        "hookId": "98a5557d-c480-4ad0-b726-a1878df900c4",
-        "hookName": "hookVhcyeEA7",
+        "hookId": "28ed897f-9738-4a21-b9a4-50c511fa76ef",
+        "hookName": "hook3oyTAJJN",
         "hookType": "Email",
         "externalLink": "",
         "description": "",
@@ -84,10 +293,10 @@
         "Content-Length": "92",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9076f54b84d38643abe9413125b28271-c6099d713a0e4f49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-98bf928f6467a04faa27b78566f46bf7-b83a6c5f9952c641-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "15e82801f7d1f0ee5d870e895db36342",
+        "x-ms-client-request-id": "d4369f7c37d8cf69a13e757273f3e575",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -97,48 +306,48 @@
           ]
         },
         "hookType": "Email",
-        "hookName": "hookgCRgOMal"
+        "hookName": "hook01J0pZSk"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "836ab3df-a395-4247-9041-173c4e399da7",
+        "apim-request-id": "de57d2f5-dbba-4ebc-a934-79bb3e564afe",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:38 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/846278d2-665c-4464-8626-5b14696afc12",
+        "Date": "Thu, 10 Jun 2021 18:37:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/eabb6e1a-5c20-4d78-b70f-bb9e7bf7c2ee",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "507",
-        "x-request-id": "836ab3df-a395-4247-9041-173c4e399da7"
+        "x-envoy-upstream-service-time": "483",
+        "x-request-id": "de57d2f5-dbba-4ebc-a934-79bb3e564afe"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/846278d2-665c-4464-8626-5b14696afc12",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/eabb6e1a-5c20-4d78-b70f-bb9e7bf7c2ee",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9076f54b84d38643abe9413125b28271-99327483508e284b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-98bf928f6467a04faa27b78566f46bf7-b9a2f74536585d47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "097a556339675b8ac0a6ac426e376972",
+        "x-ms-client-request-id": "358980797970bb5f56c4fbc0409f35bb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "49fabe54-e445-4fcb-a10e-8c968e90dd7b",
+        "apim-request-id": "3bb5d943-6793-42b5-b7c5-8434f6c550f0",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:38 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "170",
-        "x-request-id": "49fabe54-e445-4fcb-a10e-8c968e90dd7b"
+        "x-envoy-upstream-service-time": "193",
+        "x-request-id": "3bb5d943-6793-42b5-b7c5-8434f6c550f0"
       },
       "ResponseBody": {
-        "hookId": "846278d2-665c-4464-8626-5b14696afc12",
-        "hookName": "hookgCRgOMal",
+        "hookId": "eabb6e1a-5c20-4d78-b70f-bb9e7bf7c2ee",
+        "hookName": "hook01J0pZSk",
         "hookType": "Email",
         "externalLink": "",
         "description": "",
@@ -160,22 +369,22 @@
         "Content-Length": "596",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-90ef1f7c2670754ea9d4d69322a479a5-79605e0916e1394c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-377f7748986d924c99d56c439b763f63-c286d3f3a0f31643-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a7a6fb2102d10c2a0b995e3109270bc8",
+        "x-ms-client-request-id": "6e0fc332cfda42266372f21258544e02",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "config3oyTAJJN",
+        "name": "config1H1enxSA",
         "description": "This hook was created to test the .NET client.",
         "hookIds": [
-          "98a5557d-c480-4ad0-b726-a1878df900c4",
-          "846278d2-665c-4464-8626-5b14696afc12"
+          "28ed897f-9738-4a21-b9a4-50c511fa76ef",
+          "eabb6e1a-5c20-4d78-b70f-bb9e7bf7c2ee"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "0be7374a-2dc6-427f-affc-0e7accea77cf",
             "anomalyScopeType": "All",
             "severityFilter": {
               "minAlertSeverity": "Low",
@@ -190,7 +399,7 @@
               "lower": 10,
               "upper": 20,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "9c6e12cc-ec8b-4ac1-86a1-01baf97793fd",
               "triggerForMissing": true
             }
           }
@@ -198,207 +407,198 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ed09349e-c4db-46fc-b3e3-0c1f6322535c",
+        "apim-request-id": "5f65b84f-5a59-45d6-82cd-63b9d32326da",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/a55aab3e-74b3-4d77-8669-100603e5d0b8",
+        "Date": "Thu, 10 Jun 2021 18:37:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/d527e4b6-6428-4ec3-96b4-0d0de1a346ea",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "184",
+        "x-request-id": "5f65b84f-5a59-45d6-82cd-63b9d32326da"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/d527e4b6-6428-4ec3-96b4-0d0de1a346ea",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-377f7748986d924c99d56c439b763f63-e8d01a53d7712648-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "137d7a40a93b028e09ba70dc453afecb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f3189bd5-ef2b-46a3-9ec6-ba1366613de2",
+        "Content-Length": "741",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "113",
+        "x-request-id": "f3189bd5-ef2b-46a3-9ec6-ba1366613de2"
+      },
+      "ResponseBody": {
+        "anomalyAlertingConfigurationId": "d527e4b6-6428-4ec3-96b4-0d0de1a346ea",
+        "name": "config1H1enxSA",
+        "description": "This hook was created to test the .NET client.",
+        "splitAlertByDimensions": [],
+        "hookIds": [
+          "28ed897f-9738-4a21-b9a4-50c511fa76ef",
+          "eabb6e1a-5c20-4d78-b70f-bb9e7bf7c2ee"
+        ],
+        "metricAlertingConfigurations": [
+          {
+            "anomalyDetectionConfigurationId": "0be7374a-2dc6-427f-affc-0e7accea77cf",
+            "anomalyScopeType": "All",
+            "negationOperation": false,
+            "severityFilter": {
+              "minAlertSeverity": "Low",
+              "maxAlertSeverity": "Medium"
+            },
+            "snoozeFilter": {
+              "autoSnooze": 12,
+              "snoozeScope": "Series",
+              "onlyForSuccessive": true
+            },
+            "valueFilter": {
+              "lower": 10.0,
+              "upper": 20.0,
+              "direction": "Both",
+              "metricId": "9c6e12cc-ec8b-4ac1-86a1-01baf97793fd",
+              "triggerForMissing": true,
+              "type": "Value"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/d527e4b6-6428-4ec3-96b4-0d0de1a346ea",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-68fb7d50d19bee44b4422f0f2f721bea-b17cebbfdf7acf4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ac02a233f16a87e19eb95ccdac2262ae",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "5c223ee8-f675-4079-978d-ae381ce51f80",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "132",
+        "x-request-id": "5c223ee8-f675-4079-978d-ae381ce51f80"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/eabb6e1a-5c20-4d78-b70f-bb9e7bf7c2ee",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1acba9bb7056b74c9b6829a6a5e03d20-2eebe40264291e48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "fb6bac49392f89ab340d651f5f49fd29",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "ed09cb83-84a7-4964-8e47-0f42e5b6b5b9",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "x-envoy-upstream-service-time": "199",
-        "x-request-id": "ed09349e-c4db-46fc-b3e3-0c1f6322535c"
+        "x-request-id": "ed09cb83-84a7-4964-8e47-0f42e5b6b5b9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/a55aab3e-74b3-4d77-8669-100603e5d0b8",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-90ef1f7c2670754ea9d4d69322a479a5-69f356156094b445-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2b558d9dac4b25821e9c92b0ad504299",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7a70743f-84ef-405a-8f52-458181b48f3b",
-        "Content-Length": "741",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:39 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "98",
-        "x-request-id": "7a70743f-84ef-405a-8f52-458181b48f3b"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "a55aab3e-74b3-4d77-8669-100603e5d0b8",
-        "name": "config3oyTAJJN",
-        "description": "This hook was created to test the .NET client.",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "846278d2-665c-4464-8626-5b14696afc12",
-          "98a5557d-c480-4ad0-b726-a1878df900c4"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/a55aab3e-74b3-4d77-8669-100603e5d0b8",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-810f85627e92ab48b5b83375223b8afc-878a1cd4c759e442-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6be74936e292be8a7c9f36d4d83769cf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "df1f5aaf-00d6-4fad-bbe0-b1c8a374e2e6",
-        "Content-Length": "741",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:39 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "100",
-        "x-request-id": "df1f5aaf-00d6-4fad-bbe0-b1c8a374e2e6"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "a55aab3e-74b3-4d77-8669-100603e5d0b8",
-        "name": "config3oyTAJJN",
-        "description": "This hook was created to test the .NET client.",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "846278d2-665c-4464-8626-5b14696afc12",
-          "98a5557d-c480-4ad0-b726-a1878df900c4"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/a55aab3e-74b3-4d77-8669-100603e5d0b8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/28ed897f-9738-4a21-b9a4-50c511fa76ef",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-365019093a0e954a85b532e57af73d80-6c4028c4051a9a48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-23756cd984bffb4ab762dd50f5e3d0f5-5f969ac39de84a48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "72753ea1f37375e57980893570795fbb",
+        "x-ms-client-request-id": "b6df2774a1514f9899f674814cc155e6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5e01baa4-9940-43bb-aef8-ca873e84baa9",
+        "apim-request-id": "84cdb2d2-ec95-4122-a1a8-f624cf96d1ff",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:39 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "144",
-        "x-request-id": "5e01baa4-9940-43bb-aef8-ca873e84baa9"
+        "x-envoy-upstream-service-time": "189",
+        "x-request-id": "84cdb2d2-ec95-4122-a1a8-f624cf96d1ff"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/846278d2-665c-4464-8626-5b14696afc12",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/0be7374a-2dc6-427f-affc-0e7accea77cf",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f5f4dec856f79a46894012db342fc29e-4931e05c01ce0546-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-fad85ad87a37f24ba0524f8c77b6869b-82afb95f1e00b045-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c0fbc4569f40bb350297aeab76ad4de7",
+        "x-ms-client-request-id": "9893c15802cff99bf679785d8bc12755",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "02448a9d-3926-4c25-80c6-823a7ca93ba8",
+        "apim-request-id": "afeaf11d-2870-475c-a0fd-107fa49b6107",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:39 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "202",
-        "x-request-id": "02448a9d-3926-4c25-80c6-823a7ca93ba8"
+        "x-envoy-upstream-service-time": "99",
+        "x-request-id": "afeaf11d-2870-475c-a0fd-107fa49b6107"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/98a5557d-c480-4ad0-b726-a1878df900c4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c8d7482a-9800-4c51-b379-1f3420f3beb0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f782094c8929e442905b46e5d2f958f1-3fb25cfdf865b84f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-af83ec9310d06644b2cef9471a9bf30c-0a1c635fc53fcd4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6e0fc332cfda42266372f21258544e02",
+        "x-ms-client-request-id": "855933bcab43a75c131b6239c42a3d73",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2398b8ea-6a96-45c3-b880-f84586c1bec4",
+        "apim-request-id": "17acbc7c-269e-4791-9111-18651f03fe3c",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:39 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "183",
-        "x-request-id": "2398b8ea-6a96-45c3-b880-f84586c1bec4"
+        "x-envoy-upstream-service-time": "290",
+        "x-request-id": "17acbc7c-269e-4791-9111-18651f03fe3c"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithOptionalSingleMetricConfigurationMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithOptionalSingleMetricConfigurationMembersAsync.json
@@ -1,6 +1,215 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-bf1a249f60038b4a8bbd38f991571faf-02738e5d673b9448-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "a53b1a6259583e92b8045749c48e6b91",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedV8Nrq89J",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "5fb5d492-13e3-4b11-b112-a0c944c34364",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eae5ef3b-c4f2-4043-9039-3c33c1b9d204",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "483",
+        "x-request-id": "5fb5d492-13e3-4b11-b112-a0c944c34364"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eae5ef3b-c4f2-4043-9039-3c33c1b9d204",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-bf1a249f60038b4a8bbd38f991571faf-79580d04b93d3944-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "385ef0d056f069823f2850cdb9f68d34",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6ea46fde-5aa6-41d6-890d-51409b5d880b",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "215",
+        "x-request-id": "6ea46fde-5aa6-41d6-890d-51409b5d880b"
+      },
+      "ResponseBody": {
+        "dataFeedId": "eae5ef3b-c4f2-4043-9039-3c33c1b9d204",
+        "dataFeedName": "dataFeedV8Nrq89J",
+        "metrics": [
+          {
+            "metricId": "2d31db0f-1652-4bd8-b212-1bd45b636e7f",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:39:23Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-62628cbafa92a3468286c29931bfb52e-f6626e1e8953a543-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1cdf98d0872d3345a570091e3279930b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedBhW6lGZ8",
+        "metricId": "2d31db0f-1652-4bd8-b212-1bd45b636e7f",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "ac96f95d-9024-4f90-964d-e80710d97677",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/4988a8c7-be5c-486f-b591-9562812e222c",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "123",
+        "x-request-id": "ac96f95d-9024-4f90-964d-e80710d97677"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/4988a8c7-be5c-486f-b591-9562812e222c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-62628cbafa92a3468286c29931bfb52e-9581ea4d3b2b904b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "3066d198c508c184762203c2f752c8c4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ccc52fab-bd8b-48e1-89af-4ae0aeaa5af9",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5240",
+        "x-request-id": "ccc52fab-bd8b-48e1-89af-4ae0aeaa5af9"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "4988a8c7-be5c-486f-b591-9562812e222c",
+        "name": "dataFeedBhW6lGZ8",
+        "description": "",
+        "metricId": "2d31db0f-1652-4bd8-b212-1bd45b636e7f",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,10 +217,10 @@
         "Content-Length": "92",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cbe7479de4990f46a24ce7b965033040-e911f096ad433e4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6f96d5e0391c444da21c028a67e487d0-82a403cd277bfc48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "495704b88ec4916bd0f05e38f0568269",
+        "x-ms-client-request-id": "f7808a6ed3a50b96131da60b83833b53",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,48 +230,48 @@
           ]
         },
         "hookType": "Email",
-        "hookName": "hookV8Nrq89J"
+        "hookName": "hookkH1QfClp"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ea354e9a-760c-4316-8dd0-4670fecc12f4",
+        "apim-request-id": "01be5d4d-0644-4c39-8647-b97388d3ddfd",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:45 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/2c24a19d-aea2-440c-ad74-3eac5ef89135",
+        "Date": "Thu, 10 Jun 2021 18:39:33 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/52dc9fcd-a8b3-4c8c-b29b-3a36e2012037",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "618",
-        "x-request-id": "ea354e9a-760c-4316-8dd0-4670fecc12f4"
+        "x-envoy-upstream-service-time": "5357",
+        "x-request-id": "01be5d4d-0644-4c39-8647-b97388d3ddfd"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/2c24a19d-aea2-440c-ad74-3eac5ef89135",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/52dc9fcd-a8b3-4c8c-b29b-3a36e2012037",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cbe7479de4990f46a24ce7b965033040-cf27dc5247d29445-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6f96d5e0391c444da21c028a67e487d0-a5c09dd948450a44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "cd50283ff6b9348d46029618c90c039e",
+        "x-ms-client-request-id": "733245a73b11319496ae4deb9d3bd407",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f3b23cde-3e95-43d0-b647-e65ad88fb712",
+        "apim-request-id": "4f1fe32b-bfa0-469a-bd28-f1f757c8a805",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:45 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "177",
-        "x-request-id": "f3b23cde-3e95-43d0-b647-e65ad88fb712"
+        "x-envoy-upstream-service-time": "226",
+        "x-request-id": "4f1fe32b-bfa0-469a-bd28-f1f757c8a805"
       },
       "ResponseBody": {
-        "hookId": "2c24a19d-aea2-440c-ad74-3eac5ef89135",
-        "hookName": "hookV8Nrq89J",
+        "hookId": "52dc9fcd-a8b3-4c8c-b29b-3a36e2012037",
+        "hookName": "hookkH1QfClp",
         "hookType": "Email",
         "externalLink": "",
         "description": "",
@@ -84,10 +293,10 @@
         "Content-Length": "92",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f439b29e2c3560488a1863160d799416-7e6100af210bdc40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-cd1071f60aada241be949709d0b76bd3-360c784578585d49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1cdf98d0872d3345a570091e3279930b",
+        "x-ms-client-request-id": "6d53371fd0d1191e285c4459bf2f345f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -97,48 +306,48 @@
           ]
         },
         "hookType": "Email",
-        "hookName": "hookghHUkSkB"
+        "hookName": "hookDZrF6QGp"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5f0666bd-c15a-42aa-a06e-d28d27af0104",
+        "apim-request-id": "0fbbe3d6-4833-4e3a-b7ee-5e481c9fbb3d",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:46 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/8f2e028d-b340-4949-a02a-37be86588003",
+        "Date": "Thu, 10 Jun 2021 18:39:34 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/d5e290c6-ca35-4997-abb7-efcd2e0cb9a9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "586",
-        "x-request-id": "5f0666bd-c15a-42aa-a06e-d28d27af0104"
+        "x-envoy-upstream-service-time": "577",
+        "x-request-id": "0fbbe3d6-4833-4e3a-b7ee-5e481c9fbb3d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/8f2e028d-b340-4949-a02a-37be86588003",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/d5e290c6-ca35-4997-abb7-efcd2e0cb9a9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f439b29e2c3560488a1863160d799416-82573f7a763eb34d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-cd1071f60aada241be949709d0b76bd3-258d3d1069902a42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "3066d198c508c184762203c2f752c8c4",
+        "x-ms-client-request-id": "a7a1d3e28e3d33bbf64e61f786aa6ed7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "80bed311-4906-40ee-9336-870963eae934",
+        "apim-request-id": "cef11c6a-c5f9-4dd1-9e5d-2ff3b7c1f280",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:46 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "181",
-        "x-request-id": "80bed311-4906-40ee-9336-870963eae934"
+        "x-envoy-upstream-service-time": "212",
+        "x-request-id": "cef11c6a-c5f9-4dd1-9e5d-2ff3b7c1f280"
       },
       "ResponseBody": {
-        "hookId": "8f2e028d-b340-4949-a02a-37be86588003",
-        "hookName": "hookghHUkSkB",
+        "hookId": "d5e290c6-ca35-4997-abb7-efcd2e0cb9a9",
+        "hookName": "hookDZrF6QGp",
         "hookType": "Email",
         "externalLink": "",
         "description": "",
@@ -160,22 +369,22 @@
         "Content-Length": "596",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9aedd9aa77a2d142ad1aae85da0b5119-93c0f517cf7d1a4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6fb3fc3017d5b84985944e1827318a3b-08895bf861d32549-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "49271de36feccc026e8a80f7a5d3960b",
+        "x-ms-client-request-id": "b54a18263af666727aed09c99a2cc991",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configkH1QfClp",
+        "name": "configAMzVDDfc",
         "description": "This hook was created to test the .NET client.",
         "hookIds": [
-          "2c24a19d-aea2-440c-ad74-3eac5ef89135",
-          "8f2e028d-b340-4949-a02a-37be86588003"
+          "52dc9fcd-a8b3-4c8c-b29b-3a36e2012037",
+          "d5e290c6-ca35-4997-abb7-efcd2e0cb9a9"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "4988a8c7-be5c-486f-b591-9562812e222c",
             "anomalyScopeType": "All",
             "severityFilter": {
               "minAlertSeverity": "Low",
@@ -190,7 +399,7 @@
               "lower": 10,
               "upper": 20,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "2d31db0f-1652-4bd8-b212-1bd45b636e7f",
               "triggerForMissing": true
             }
           }
@@ -198,53 +407,53 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "3af4adc4-e4ba-4d99-a2f2-6aad4412e452",
+        "apim-request-id": "dc4a3064-0efd-44a2-8a35-aa03d1b4e5f7",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:46 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/8d13f047-861f-4b40-be9c-cc76e1ce0d31",
+        "Date": "Thu, 10 Jun 2021 18:39:34 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3b8a73fb-da0f-4f83-9dbe-4ef5edff5fce",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "179",
-        "x-request-id": "3af4adc4-e4ba-4d99-a2f2-6aad4412e452"
+        "x-envoy-upstream-service-time": "184",
+        "x-request-id": "dc4a3064-0efd-44a2-8a35-aa03d1b4e5f7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/8d13f047-861f-4b40-be9c-cc76e1ce0d31",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3b8a73fb-da0f-4f83-9dbe-4ef5edff5fce",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9aedd9aa77a2d142ad1aae85da0b5119-f0e86f05667bc143-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6fb3fc3017d5b84985944e1827318a3b-7a5faf10511c1b41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "0ba61d138383533ba7453273113b9431",
+        "x-ms-client-request-id": "82761f7c276e7e93ed6c102044e72f14",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7adb674c-1723-4da1-b731-a85958a5bd7d",
+        "apim-request-id": "3d12bde3-53e4-443b-854f-622137fe75b4",
         "Content-Length": "741",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:46 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "99",
-        "x-request-id": "7adb674c-1723-4da1-b731-a85958a5bd7d"
+        "x-envoy-upstream-service-time": "104",
+        "x-request-id": "3d12bde3-53e4-443b-854f-622137fe75b4"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "8d13f047-861f-4b40-be9c-cc76e1ce0d31",
-        "name": "configkH1QfClp",
+        "anomalyAlertingConfigurationId": "3b8a73fb-da0f-4f83-9dbe-4ef5edff5fce",
+        "name": "configAMzVDDfc",
         "description": "This hook was created to test the .NET client.",
         "splitAlertByDimensions": [],
         "hookIds": [
-          "2c24a19d-aea2-440c-ad74-3eac5ef89135",
-          "8f2e028d-b340-4949-a02a-37be86588003"
+          "52dc9fcd-a8b3-4c8c-b29b-3a36e2012037",
+          "d5e290c6-ca35-4997-abb7-efcd2e0cb9a9"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "4988a8c7-be5c-486f-b591-9562812e222c",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -260,7 +469,7 @@
               "lower": 10.0,
               "upper": 20.0,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "2d31db0f-1652-4bd8-b212-1bd45b636e7f",
               "triggerForMissing": true,
               "type": "Value"
             }
@@ -269,136 +478,127 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/8d13f047-861f-4b40-be9c-cc76e1ce0d31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d04cc5f41aef3342a23e691df46a0627-cf6809c09b92bf41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "eb4dae963b9d07d41f37536dd1d01e19",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f1ffd637-4ed5-4077-b815-2b8da976c726",
-        "Content-Length": "741",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:46 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "128",
-        "x-request-id": "f1ffd637-4ed5-4077-b815-2b8da976c726"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "8d13f047-861f-4b40-be9c-cc76e1ce0d31",
-        "name": "configkH1QfClp",
-        "description": "This hook was created to test the .NET client.",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "2c24a19d-aea2-440c-ad74-3eac5ef89135",
-          "8f2e028d-b340-4949-a02a-37be86588003"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/8d13f047-861f-4b40-be9c-cc76e1ce0d31",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3b8a73fb-da0f-4f83-9dbe-4ef5edff5fce",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c2973d4a10c6d74982982ad050960c11-419e66ec13f3054b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-3adc5d89729e2b4682864cfe5d18d373-884d2ad9eea48d4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "59445c282fbf5f34e2d3a1a73d8ebb33",
+        "x-ms-client-request-id": "2481c9510543bb3cdcfb7c98a1a53d1c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "aa1c1ce4-3bc0-4b59-88eb-7fb443c2336d",
+        "apim-request-id": "ea2545ac-6d59-44a1-9474-a3c86dee143b",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:46 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "117",
-        "x-request-id": "aa1c1ce4-3bc0-4b59-88eb-7fb443c2336d"
+        "x-envoy-upstream-service-time": "134",
+        "x-request-id": "ea2545ac-6d59-44a1-9474-a3c86dee143b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/8f2e028d-b340-4949-a02a-37be86588003",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/d5e290c6-ca35-4997-abb7-efcd2e0cb9a9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d3a0c7963863c84da614714c3b8742d5-c4b897a465a73c46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-f70b5f0ec53ecf419c594c1f104901f1-ab88375cf408a84c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f7614ef6aa86d76e499feb4c30ce82d7",
+        "x-ms-client-request-id": "10d05ad50057fe6885ccc78929512292",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "9e7f3d7b-8e2b-44f9-97a5-37587da50289",
+        "apim-request-id": "334513d2-fc34-44b4-8732-e57ad1508bab",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:47 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "181",
-        "x-request-id": "9e7f3d7b-8e2b-44f9-97a5-37587da50289"
+        "x-envoy-upstream-service-time": "198",
+        "x-request-id": "334513d2-fc34-44b4-8732-e57ad1508bab"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/2c24a19d-aea2-440c-ad74-3eac5ef89135",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/52dc9fcd-a8b3-4c8c-b29b-3a36e2012037",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0bfb038925fbff479e5dc20e49673ca4-a133fac460908343-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-0fe150813095e74ca733017989aca4d2-0ca324f250a83549-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b54a18263af666727aed09c99a2cc991",
+        "x-ms-client-request-id": "d077f5bda5ab764ee2baa572aafadc48",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3c78e69d-07ac-480e-b954-24ec4dc1a799",
+        "apim-request-id": "4709f2b4-25a6-461f-aaf8-11b6d88dd422",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:47 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "195",
-        "x-request-id": "3c78e69d-07ac-480e-b954-24ec4dc1a799"
+        "x-envoy-upstream-service-time": "200",
+        "x-request-id": "4709f2b4-25a6-461f-aaf8-11b6d88dd422"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/4988a8c7-be5c-486f-b591-9562812e222c",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f3564ed3d3d19445aa019a5419606182-794a8bd31d216243-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e94bf42f1f1751bc60829f763eb2928b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "b802ab10-dcfe-4e70-86fd-5c7edb6b43ea",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:35 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "122",
+        "x-request-id": "b802ab10-dcfe-4e70-86fd-5c7edb6b43ea"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eae5ef3b-c4f2-4043-9039-3c33c1b9d204",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c2ad01829c81a0419ef297ca95b16645-9bd2d3ea6892284d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "acdbead96c2d30700c5a2d9c5af5548a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "0294fe87-a492-4ddc-ae76-093a1706a582",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "308",
+        "x-request-id": "0294fe87-a492-4ddc-ae76-093a1706a582"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithSeriesGroupScope.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithSeriesGroupScope.json
@@ -1,55 +1,63 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "232",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-676ddc2922962941abf54c9505faa2e1-0f64675950333a49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-0446671c35e729459daffb0ad8ca4508-8890cdbc867af745-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b445f7e4ac579422b261a2b83c18cefc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configCpHBcSmG",
-        "hookIds": [],
-        "metricAlertingConfigurations": [
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedCpHBcSmG",
+        "granularityName": "Daily",
+        "metrics": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "Dimension",
-            "dimensionAnomalyScope": {
-              "dimension": {
-                "city": "Delhi"
-              }
-            }
+            "metricName": "metric"
           }
-        ]
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b7c4e82b-ccec-4d86-87e1-0b887c81682e",
+        "apim-request-id": "d836b52c-8330-4b3c-9214-9d4b54a9cc4b",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:40 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/0dc5027f-5a1e-42da-a15f-6859adce51bd",
+        "Date": "Thu, 10 Jun 2021 18:37:06 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a05acf76-a559-47c2-967b-43dd0fa991a0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "227",
-        "x-request-id": "b7c4e82b-ccec-4d86-87e1-0b887c81682e"
+        "x-envoy-upstream-service-time": "399",
+        "x-request-id": "d836b52c-8330-4b3c-9214-9d4b54a9cc4b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/0dc5027f-5a1e-42da-a15f-6859adce51bd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a05acf76-a559-47c2-967b-43dd0fa991a0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-676ddc2922962941abf54c9505faa2e1-9df44b6df2a3b546-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-0446671c35e729459daffb0ad8ca4508-ab01dc4c18e46f4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "75420facd7f99819ab512aeb99d432b9",
         "x-ms-return-client-request-id": "true"
@@ -57,73 +65,230 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "624e387f-0958-43d4-aed8-3d6eb08f5f55",
-        "Content-Length": "375",
+        "apim-request-id": "1fca19b2-db64-4568-8de6-aa11fb716fd2",
+        "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:40 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "108",
-        "x-request-id": "624e387f-0958-43d4-aed8-3d6eb08f5f55"
+        "x-envoy-upstream-service-time": "171",
+        "x-request-id": "1fca19b2-db64-4568-8de6-aa11fb716fd2"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "0dc5027f-5a1e-42da-a15f-6859adce51bd",
-        "name": "configCpHBcSmG",
-        "description": "",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
+        "dataFeedId": "a05acf76-a559-47c2-967b-43dd0fa991a0",
+        "dataFeedName": "dataFeedCpHBcSmG",
+        "metrics": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "Dimension",
-            "negationOperation": false,
-            "dimensionAnomalyScope": {
-              "dimension": {
-                "city": "Delhi"
-              }
-            }
+            "metricId": "4377e68b-a0dd-49e5-9358-11db16c48816",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
           }
-        ]
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:37:07Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/0dc5027f-5a1e-42da-a15f-6859adce51bd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-dbe977060d58d34687d4f1c461d5869d-1365ca798ebc6042-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "465ebf0cbe221afbe6b84fb1fc9c790d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedPr0vwHGL",
+        "metricId": "4377e68b-a0dd-49e5-9358-11db16c48816",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "8def4c52-e2a1-46ce-ad70-4e273562b7ac",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:07 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/afcd05f2-634b-4f24-943e-8096793e67ad",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "112",
+        "x-request-id": "8def4c52-e2a1-46ce-ad70-4e273562b7ac"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/afcd05f2-634b-4f24-943e-8096793e67ad",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-76578d3de375c647b5c041acf81d3ead-b0338001b98d0a44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-dbe977060d58d34687d4f1c461d5869d-f28854cc21eb8c49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d942bc757aea71c30cbf5e4622befb1a",
+        "x-ms-client-request-id": "0608acdd3681defa2ee9437fd5f41231",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "92717302-d6b5-491d-a720-5b5aa84c1489",
-        "Content-Length": "375",
+        "apim-request-id": "d6cfb17b-472f-480d-8400-6f912fc9149b",
+        "Content-Length": "399",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:40 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "115",
-        "x-request-id": "92717302-d6b5-491d-a720-5b5aa84c1489"
+        "x-envoy-upstream-service-time": "170",
+        "x-request-id": "d6cfb17b-472f-480d-8400-6f912fc9149b"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "0dc5027f-5a1e-42da-a15f-6859adce51bd",
-        "name": "configCpHBcSmG",
+        "anomalyDetectionConfigurationId": "afcd05f2-634b-4f24-943e-8096793e67ad",
+        "name": "dataFeedPr0vwHGL",
+        "description": "",
+        "metricId": "4377e68b-a0dd-49e5-9358-11db16c48816",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "238",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e87284f597edd247992ab816faba7924-6bf5111b29ca3743-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e10510558085d8bd4334fc3d71bcefd6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configjtcgxF4F",
+        "hookIds": [],
+        "metricAlertingConfigurations": [
+          {
+            "anomalyDetectionConfigurationId": "afcd05f2-634b-4f24-943e-8096793e67ad",
+            "anomalyScopeType": "Dimension",
+            "dimensionAnomalyScope": {
+              "dimension": {
+                "dimensionA": "Delhi"
+              }
+            }
+          }
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "89e2abd7-85ff-4b16-a489-15c2f31e3fc3",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:13 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/838c4a9c-7447-496b-9687-404980f302aa",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5232",
+        "x-request-id": "89e2abd7-85ff-4b16-a489-15c2f31e3fc3"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/838c4a9c-7447-496b-9687-404980f302aa",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e87284f597edd247992ab816faba7924-a3f342cd5805704b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "39177fc47c7bf144a61d652a333e950a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d2f702e1-c234-4212-b66b-84363c098b61",
+        "Content-Length": "381",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "91",
+        "x-request-id": "d2f702e1-c234-4212-b66b-84363c098b61"
+      },
+      "ResponseBody": {
+        "anomalyAlertingConfigurationId": "838c4a9c-7447-496b-9687-404980f302aa",
+        "name": "configjtcgxF4F",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "afcd05f2-634b-4f24-943e-8096793e67ad",
             "anomalyScopeType": "Dimension",
             "negationOperation": false,
             "dimensionAnomalyScope": {
               "dimension": {
-                "city": "Delhi"
+                "dimensionA": "Delhi"
               }
             }
           }
@@ -131,27 +296,77 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/0dc5027f-5a1e-42da-a15f-6859adce51bd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/838c4a9c-7447-496b-9687-404980f302aa",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c323d40ba508654ba9e874863b4321f8-9a297d9cd2f7814e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-23f42dfee3d0a242842330896d71cb05-e75d0be6cc807344-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b14fb8e69cfc0d79ddac08068136fade",
+        "x-ms-client-request-id": "71b01b371931ae582c6a3ba1f8d4c08f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "72be0c2e-5425-4b54-a13f-6294f59f583f",
+        "apim-request-id": "9ad39705-ed5e-4085-a167-3b9f0906d97d",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:40 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "116",
-        "x-request-id": "72be0c2e-5425-4b54-a13f-6294f59f583f"
+        "x-envoy-upstream-service-time": "119",
+        "x-request-id": "9ad39705-ed5e-4085-a167-3b9f0906d97d"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/afcd05f2-634b-4f24-943e-8096793e67ad",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7640fce0878e804caa1cc747ab0f1079-15da8a8993806840-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f87692e23cbbd971cb143b681b92a504",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "fd10ba6a-70e4-4e72-97f3-e269f96a09ab",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "92",
+        "x-request-id": "fd10ba6a-70e4-4e72-97f3-e269f96a09ab"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a05acf76-a559-47c2-967b-43dd0fa991a0",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a66b7b02cdce58488489ea2ac752c80d-0bcc0e9fd2c8f04c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "5606f19f7d0caba427690d1140a3f8d1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "45d72a30-1f2b-453c-88e2-ad2f368333eb",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "321",
+        "x-request-id": "45d72a30-1f2b-453c-88e2-ad2f368333eb"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithSeriesGroupScopeAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithSeriesGroupScopeAsync.json
@@ -1,55 +1,63 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "232",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-201d498da078d241a28fea9e21f93de2-a69ad6941d2cb54f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-48d7ef71ae36244693132ac2fd066269-52001ae092fd4348-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bca4cb4e370f4adce81c5398b92e5b5e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configInSGyQiJ",
-        "hookIds": [],
-        "metricAlertingConfigurations": [
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedInSGyQiJ",
+        "granularityName": "Daily",
+        "metrics": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "Dimension",
-            "dimensionAnomalyScope": {
-              "dimension": {
-                "city": "Delhi"
-              }
-            }
+            "metricName": "metric"
           }
-        ]
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "071f3227-3162-467e-94df-f44b038228fd",
+        "apim-request-id": "520cdb7d-96a5-4569-97e0-6fd2a9303068",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:47 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3dc19448-5390-431f-a1eb-027bcd06de86",
+        "Date": "Thu, 10 Jun 2021 18:39:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73240286-3df6-4b36-a94f-1cc3325420a3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "197",
-        "x-request-id": "071f3227-3162-467e-94df-f44b038228fd"
+        "x-envoy-upstream-service-time": "402",
+        "x-request-id": "520cdb7d-96a5-4569-97e0-6fd2a9303068"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3dc19448-5390-431f-a1eb-027bcd06de86",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73240286-3df6-4b36-a94f-1cc3325420a3",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-201d498da078d241a28fea9e21f93de2-88c6948445afb345-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-48d7ef71ae36244693132ac2fd066269-a38311121b6b9f45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "11aca2138e4a4caac898e4954fa51a60",
         "x-ms-return-client-request-id": "true"
@@ -57,73 +65,230 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5103622a-5fa1-4cb1-97a3-f513bf300b92",
-        "Content-Length": "375",
+        "apim-request-id": "1224a479-91d2-462d-9a4d-85cc00b63869",
+        "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:47 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "105",
-        "x-request-id": "5103622a-5fa1-4cb1-97a3-f513bf300b92"
+        "x-envoy-upstream-service-time": "185",
+        "x-request-id": "1224a479-91d2-462d-9a4d-85cc00b63869"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "3dc19448-5390-431f-a1eb-027bcd06de86",
-        "name": "configInSGyQiJ",
-        "description": "",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
+        "dataFeedId": "73240286-3df6-4b36-a94f-1cc3325420a3",
+        "dataFeedName": "dataFeedInSGyQiJ",
+        "metrics": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "Dimension",
-            "negationOperation": false,
-            "dimensionAnomalyScope": {
-              "dimension": {
-                "city": "Delhi"
-              }
-            }
+            "metricId": "face4346-74a0-4bf2-8804-f21d863735a8",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
           }
-        ]
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:39:37Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3dc19448-5390-431f-a1eb-027bcd06de86",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7b94b58117bff846b59f44e5d819557d-9780a3548209064c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "04a9cc6e84694bfcbc547774e69beabf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedMx82goAh",
+        "metricId": "face4346-74a0-4bf2-8804-f21d863735a8",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "74d00e66-9739-4072-870c-c35432977a1e",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1fc96bab-3d3d-4dc2-99c2-470fbf875f63",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "131",
+        "x-request-id": "74d00e66-9739-4072-870c-c35432977a1e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1fc96bab-3d3d-4dc2-99c2-470fbf875f63",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c02662376308804cbe4b4231a72a05e4-1cdbc89903da994e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-7b94b58117bff846b59f44e5d819557d-7270d6c247fa8248-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d490af8642c63bcb6ecca9046984fc4b",
+        "x-ms-client-request-id": "76f35821465343fa01f3120a9d8697d0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cd810082-5e99-433d-90f8-069f2a2e373c",
-        "Content-Length": "375",
+        "apim-request-id": "30dc185f-8c36-4652-9ed0-abb124ed2412",
+        "Content-Length": "399",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:48 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "117",
-        "x-request-id": "cd810082-5e99-433d-90f8-069f2a2e373c"
+        "x-envoy-upstream-service-time": "86",
+        "x-request-id": "30dc185f-8c36-4652-9ed0-abb124ed2412"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "3dc19448-5390-431f-a1eb-027bcd06de86",
-        "name": "configInSGyQiJ",
+        "anomalyDetectionConfigurationId": "1fc96bab-3d3d-4dc2-99c2-470fbf875f63",
+        "name": "dataFeedMx82goAh",
+        "description": "",
+        "metricId": "face4346-74a0-4bf2-8804-f21d863735a8",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "238",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-036cd4b87e836b45819971f21b6d820e-2ffa5c11da6d204d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "fad9989ca62dea79c5d1b36e4e54e728",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "confighTTaS0z6",
+        "hookIds": [],
+        "metricAlertingConfigurations": [
+          {
+            "anomalyDetectionConfigurationId": "1fc96bab-3d3d-4dc2-99c2-470fbf875f63",
+            "anomalyScopeType": "Dimension",
+            "dimensionAnomalyScope": {
+              "dimension": {
+                "dimensionA": "Delhi"
+              }
+            }
+          }
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "0d09b2dc-2a5f-49b4-bc53-19d4f52246b1",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:37 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/1a3c2f11-1229-4044-98b8-31483be0b07c",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "167",
+        "x-request-id": "0d09b2dc-2a5f-49b4-bc53-19d4f52246b1"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/1a3c2f11-1229-4044-98b8-31483be0b07c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-036cd4b87e836b45819971f21b6d820e-8a1fabca65730d45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "750266d1f27236adbca79c75f86cda7b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9434e5a5-7734-4258-843f-6096b7979fb6",
+        "Content-Length": "381",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "93",
+        "x-request-id": "9434e5a5-7734-4258-843f-6096b7979fb6"
+      },
+      "ResponseBody": {
+        "anomalyAlertingConfigurationId": "1a3c2f11-1229-4044-98b8-31483be0b07c",
+        "name": "confighTTaS0z6",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "1fc96bab-3d3d-4dc2-99c2-470fbf875f63",
             "anomalyScopeType": "Dimension",
             "negationOperation": false,
             "dimensionAnomalyScope": {
               "dimension": {
-                "city": "Delhi"
+                "dimensionA": "Delhi"
               }
             }
           }
@@ -131,27 +296,77 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3dc19448-5390-431f-a1eb-027bcd06de86",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/1a3c2f11-1229-4044-98b8-31483be0b07c",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-06160a9f5484e246ac573af0c54e70c9-11b3db4a65c9c142-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-8b64ea3174d3cc4a952da17cf3a232f0-df34a3af6946264f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "747754bc9be6bfea2158f3765346fa43",
+        "x-ms-client-request-id": "badaaf75006c5b15792744ccd2298183",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c8faf41b-8567-447c-8231-e89676671c65",
+        "apim-request-id": "e95b52a6-bb77-49de-b59f-728bc894a9ae",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:48 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "126",
-        "x-request-id": "c8faf41b-8567-447c-8231-e89676671c65"
+        "x-envoy-upstream-service-time": "111",
+        "x-request-id": "e95b52a6-bb77-49de-b59f-728bc894a9ae"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/1fc96bab-3d3d-4dc2-99c2-470fbf875f63",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a38946a1471ee14eb4c34e27ae30bb7d-1abb616e5a2ec74e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7fad7b896ca3a9d1eba33d860904f259",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "34a677cb-18da-4a9f-8017-302630753270",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "100",
+        "x-request-id": "34a677cb-18da-4a9f-8017-302630753270"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73240286-3df6-4b36-a94f-1cc3325420a3",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a220f602d8e0bf4bb867a1984db147f3-995f821a84724e47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "9ff838f72d7ad0bb50a6fc4aade16393",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "ca3aef4b-d424-4ba0-9f55-0a9e4a62e061",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:38 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "317",
+        "x-request-id": "ca3aef4b-d424-4ba0-9f55-0a9e4a62e061"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithTopNScope.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithTopNScope.json
@@ -1,6 +1,215 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-045a89faa9845f4c9fceb1f290aaa776-ba96071c38c6504f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f73903b0ce09111b4025e817eb4e3e2e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedcUJctDmU",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "d3b17cce-ebc3-42eb-b4a6-367fb94ef280",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:14 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bf460230-318e-456c-a380-219a437668aa",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "462",
+        "x-request-id": "d3b17cce-ebc3-42eb-b4a6-367fb94ef280"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bf460230-318e-456c-a380-219a437668aa",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-045a89faa9845f4c9fceb1f290aaa776-1fc5bcbcd709104a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "032d37b14d7ebbff6a1d927a1e88c82a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "81accf20-f0b2-400c-a6a3-c196d0cb2f44",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "180",
+        "x-request-id": "81accf20-f0b2-400c-a6a3-c196d0cb2f44"
+      },
+      "ResponseBody": {
+        "dataFeedId": "bf460230-318e-456c-a380-219a437668aa",
+        "dataFeedName": "dataFeedcUJctDmU",
+        "metrics": [
+          {
+            "metricId": "27fb68b5-4eec-4c8f-a1e5-09eb1c5062c4",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:37:14Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-fa746bb0664edc4ea08e52ed71f27bb8-6301bcf9f3765b4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0faa5f5cb556a4fe75b5e2cc721ed962",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedeClUYeVF",
+        "metricId": "27fb68b5-4eec-4c8f-a1e5-09eb1c5062c4",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "6694bd37-3d95-435c-9320-eeb898f6eb46",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:14 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/710cb259-11d7-4bb3-86c6-ebbdef27d868",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "157",
+        "x-request-id": "6694bd37-3d95-435c-9320-eeb898f6eb46"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/710cb259-11d7-4bb3-86c6-ebbdef27d868",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-fa746bb0664edc4ea08e52ed71f27bb8-dd65bc3fe35e7341-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ec8c7e03a13bb7f35dbde4453174b9c1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7ed4401e-3be2-4755-9155-6bfa2b44c2ff",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "113",
+        "x-request-id": "7ed4401e-3be2-4755-9155-6bfa2b44c2ff"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "710cb259-11d7-4bb3-86c6-ebbdef27d868",
+        "name": "dataFeedeClUYeVF",
+        "description": "",
+        "metricId": "27fb68b5-4eec-4c8f-a1e5-09eb1c5062c4",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,18 +217,18 @@
         "Content-Length": "231",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3ae60993c761ec4bbc4e21ca95636c7c-ad1688a780fe2046-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-3c9f14d9d9e6b74cbe652e9fc57ca205-a615b6ab989e7944-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f73903b0ce09111b4025e817eb4e3e2e",
+        "x-ms-client-request-id": "6905ee1efba615b8ccbac5f663ba6dbb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configcUJctDmU",
+        "name": "configc0w7kXVP",
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "710cb259-11d7-4bb3-86c6-ebbdef27d868",
             "anomalyScopeType": "TopN",
             "topNAnomalyScope": {
               "top": 30,
@@ -31,50 +240,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a108177b-32ec-4914-8e3b-f69e2d329cb6",
+        "apim-request-id": "22e0571d-f3dc-47dd-b14f-16ddbe29b735",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:40 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/b422e4e3-dad7-4db6-a8db-5043eabc4665",
+        "Date": "Thu, 10 Jun 2021 18:37:15 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/74934bff-2246-4be7-8747-a28af1016838",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "119",
-        "x-request-id": "a108177b-32ec-4914-8e3b-f69e2d329cb6"
+        "x-envoy-upstream-service-time": "146",
+        "x-request-id": "22e0571d-f3dc-47dd-b14f-16ddbe29b735"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/b422e4e3-dad7-4db6-a8db-5043eabc4665",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/74934bff-2246-4be7-8747-a28af1016838",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3ae60993c761ec4bbc4e21ca95636c7c-b1829c7e20c7fb49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-3c9f14d9d9e6b74cbe652e9fc57ca205-13fe7be8c5502e40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "032d37b14d7ebbff6a1d927a1e88c82a",
+        "x-ms-client-request-id": "99b1f26cb9d00072fb203ced77babe13",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "401fd9cf-909e-4ab6-8d6e-f35df4c66906",
+        "apim-request-id": "0ef9ed61-1357-4d99-9b17-b936a7808d89",
         "Content-Length": "374",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:41 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "106",
-        "x-request-id": "401fd9cf-909e-4ab6-8d6e-f35df4c66906"
+        "x-envoy-upstream-service-time": "90",
+        "x-request-id": "0ef9ed61-1357-4d99-9b17-b936a7808d89"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "b422e4e3-dad7-4db6-a8db-5043eabc4665",
-        "name": "configcUJctDmU",
+        "anomalyAlertingConfigurationId": "74934bff-2246-4be7-8747-a28af1016838",
+        "name": "configc0w7kXVP",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "710cb259-11d7-4bb3-86c6-ebbdef27d868",
             "anomalyScopeType": "TopN",
             "negationOperation": false,
             "topNAnomalyScope": {
@@ -87,71 +296,77 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/b422e4e3-dad7-4db6-a8db-5043eabc4665",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2373ed40af98704cb3d7397c8ac688ad-e81664f7a8da0b45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c91ca633ef75a9a75c5faa0f56b5fea4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "5a634fd0-c8fc-417d-b7c6-d6bdbe08f76e",
-        "Content-Length": "374",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:41 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "102",
-        "x-request-id": "5a634fd0-c8fc-417d-b7c6-d6bdbe08f76e"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "b422e4e3-dad7-4db6-a8db-5043eabc4665",
-        "name": "configcUJctDmU",
-        "description": "",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "TopN",
-            "negationOperation": false,
-            "topNAnomalyScope": {
-              "top": 30,
-              "period": 20,
-              "minTopCount": 10
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/b422e4e3-dad7-4db6-a8db-5043eabc4665",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/74934bff-2246-4be7-8747-a28af1016838",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2bc803e71a33bd4b9427237993a92361-2172eb04c116da48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-4531284e0653464e8bea1b7b2ff6cc6a-daf3af11b1d29f4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "cce2b5751e7262d9037e8cec3ba1f3b7",
+        "x-ms-client-request-id": "4ccdd71a899c611104cf7877afc25ed5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7655131d-afa9-46e0-b302-23b4dca7bda9",
+        "apim-request-id": "dbb3bbbf-50c0-41e1-b5ea-8ac780bd0054",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:41 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "117",
-        "x-request-id": "7655131d-afa9-46e0-b302-23b4dca7bda9"
+        "x-envoy-upstream-service-time": "109",
+        "x-request-id": "dbb3bbbf-50c0-41e1-b5ea-8ac780bd0054"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/710cb259-11d7-4bb3-86c6-ebbdef27d868",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-8d27d63d51b3c7458c99d48e18e4e9e1-1fbab771c9813b49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b1b2eb17cb3e65e47c056e85bfcb9d12",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "e62c1485-a566-43f8-906c-e1e58c39da25",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "99",
+        "x-request-id": "e62c1485-a566-43f8-906c-e1e58c39da25"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bf460230-318e-456c-a380-219a437668aa",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e906c736bcdee0449c1c65b7280e8cbf-3c6953afa2f5c844-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8cdcb1fb21ede31fe050940140fa5038",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "f2f85ef0-87fd-4038-99f3-ad6736fa8ea9",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "346",
+        "x-request-id": "f2f85ef0-87fd-4038-99f3-ad6736fa8ea9"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithTopNScopeAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithTopNScopeAsync.json
@@ -1,6 +1,215 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a40139cc7901664fb4cb18761f4cb486-a81bd8c2c24d1041-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c4b4dfc18a3c2ad0b022f2785de7a0f5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedscgv9Oyh",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "51c808c6-928a-4057-bb8f-3edad3a47e5b",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:38 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3ae5add8-f152-4dfe-b4bd-b14ff5c01e45",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "563",
+        "x-request-id": "51c808c6-928a-4057-bb8f-3edad3a47e5b"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3ae5add8-f152-4dfe-b4bd-b14ff5c01e45",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a40139cc7901664fb4cb18761f4cb486-ffb016da02a6d744-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "5392b0d9389b56ca2b410b6336d0bddd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e7232307-340c-49ec-8a03-7596278571d6",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "183",
+        "x-request-id": "e7232307-340c-49ec-8a03-7596278571d6"
+      },
+      "ResponseBody": {
+        "dataFeedId": "3ae5add8-f152-4dfe-b4bd-b14ff5c01e45",
+        "dataFeedName": "dataFeedscgv9Oyh",
+        "metrics": [
+          {
+            "metricId": "54b8acfd-cf72-4d3e-ba02-e3c26ca6a4f8",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:39:39Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-24af83eedb1b9a4ba53e389b103825eb-08329fe087c4954b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "cc53a0c884d44c0961bb212d211ad188",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedxgpucaaO",
+        "metricId": "54b8acfd-cf72-4d3e-ba02-e3c26ca6a4f8",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "34ac76eb-034e-4578-8d11-5c7b88629044",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:39 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bf291178-00b7-4a19-bdb4-df314efa8029",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "109",
+        "x-request-id": "34ac76eb-034e-4578-8d11-5c7b88629044"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bf291178-00b7-4a19-bdb4-df314efa8029",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-24af83eedb1b9a4ba53e389b103825eb-ba0b6e448b79b741-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "fa995e146c7ee0f36515362659c14a19",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "914e4b4f-1b4c-4bb7-9901-eb7cda470220",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "95",
+        "x-request-id": "914e4b4f-1b4c-4bb7-9901-eb7cda470220"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "bf291178-00b7-4a19-bdb4-df314efa8029",
+        "name": "dataFeedxgpucaaO",
+        "description": "",
+        "metricId": "54b8acfd-cf72-4d3e-ba02-e3c26ca6a4f8",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,18 +217,18 @@
         "Content-Length": "231",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9c0765c8e572a34ebb3af6951ba72016-c067bb1e86f41145-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-bad89cc222f8004eb1e285d2b3ce7ad6-342b7a0bed95ca4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c4b4dfc18a3c2ad0b022f2785de7a0f5",
+        "x-ms-client-request-id": "7b01bf3890af26bb6405cb4c2713bc5c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configscgv9Oyh",
+        "name": "config3eE2LiTH",
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "bf291178-00b7-4a19-bdb4-df314efa8029",
             "anomalyScopeType": "TopN",
             "topNAnomalyScope": {
               "top": 30,
@@ -31,50 +240,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "79d7d554-2abc-4e0b-9895-96e6539a9709",
+        "apim-request-id": "f4518695-480a-42c5-948e-b93333e323a0",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:48 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/2eb46d1f-c904-4e4e-89aa-1bf3482fbb59",
+        "Date": "Thu, 10 Jun 2021 18:39:39 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/29eb3d96-81e0-4b87-b572-3cfdec687efc",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "127",
-        "x-request-id": "79d7d554-2abc-4e0b-9895-96e6539a9709"
+        "x-envoy-upstream-service-time": "125",
+        "x-request-id": "f4518695-480a-42c5-948e-b93333e323a0"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/2eb46d1f-c904-4e4e-89aa-1bf3482fbb59",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/29eb3d96-81e0-4b87-b572-3cfdec687efc",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9c0765c8e572a34ebb3af6951ba72016-cffd2be6e250544d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-bad89cc222f8004eb1e285d2b3ce7ad6-08e20a814813014e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "5392b0d9389b56ca2b410b6336d0bddd",
+        "x-ms-client-request-id": "be6773ade24ea0f270078bca90d6a315",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "97af647c-5d1c-4452-8fa2-2acf72baa81d",
+        "apim-request-id": "bbe9d18e-ebd6-4b8e-b762-fb0c02f18540",
         "Content-Length": "374",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:48 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "99",
-        "x-request-id": "97af647c-5d1c-4452-8fa2-2acf72baa81d"
+        "x-envoy-upstream-service-time": "105",
+        "x-request-id": "bbe9d18e-ebd6-4b8e-b762-fb0c02f18540"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "2eb46d1f-c904-4e4e-89aa-1bf3482fbb59",
-        "name": "configscgv9Oyh",
+        "anomalyAlertingConfigurationId": "29eb3d96-81e0-4b87-b572-3cfdec687efc",
+        "name": "config3eE2LiTH",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "bf291178-00b7-4a19-bdb4-df314efa8029",
             "anomalyScopeType": "TopN",
             "negationOperation": false,
             "topNAnomalyScope": {
@@ -87,71 +296,77 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/2eb46d1f-c904-4e4e-89aa-1bf3482fbb59",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2fdcffc2a14b0e458790499ffaba838e-64bebe6138ed0646-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "df8d3641c0aa3b0ec8a053ccd484094c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6519d27f-f2bf-4190-9e58-87363c173385",
-        "Content-Length": "374",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:48 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "95",
-        "x-request-id": "6519d27f-f2bf-4190-9e58-87363c173385"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "2eb46d1f-c904-4e4e-89aa-1bf3482fbb59",
-        "name": "configscgv9Oyh",
-        "description": "",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "TopN",
-            "negationOperation": false,
-            "topNAnomalyScope": {
-              "top": 30,
-              "period": 20,
-              "minTopCount": 10
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/2eb46d1f-c904-4e4e-89aa-1bf3482fbb59",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/29eb3d96-81e0-4b87-b572-3cfdec687efc",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-036b339a71760f44ab9c4263f0cc9dac-fcc50ee3300e694f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-1a59497559fb2f4b884a2fc1fe40151b-484ff8d920cf524a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2d21bb611a2188d1145e99fa7e6cf3e0",
+        "x-ms-client-request-id": "bfc2f3dc786bd430590fc254f5fef18e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8c6484be-4ef8-40a7-9b0a-96aec64df798",
+        "apim-request-id": "9aefa1c2-41e7-4cf0-87b4-005cda767fe2",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:53 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5149",
-        "x-request-id": "8c6484be-4ef8-40a7-9b0a-96aec64df798"
+        "x-envoy-upstream-service-time": "116",
+        "x-request-id": "9aefa1c2-41e7-4cf0-87b4-005cda767fe2"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/bf291178-00b7-4a19-bdb4-df314efa8029",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-691179d309be224a8e507196f24ef037-43cf283fbd3c3841-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "714d2e9ac3975557cd610ba704f1968d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "0c10e709-5326-46e7-9b24-a204cd69a51b",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "104",
+        "x-request-id": "0c10e709-5326-46e7-9b24-a204cd69a51b"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3ae5add8-f152-4dfe-b4bd-b14ff5c01e45",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-09d1b195fcdc124396e051eb05ef1fca-b71df85fa7e05541-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "346fb662fd5034f04292653f209eab71",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "737064b0-2425-4f7d-bc49-e285e22cf685",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:41 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "316",
+        "x-request-id": "737064b0-2425-4f7d-bc49-e285e22cf685"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithWholeSeriesScope(False).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithWholeSeriesScope(False).json
@@ -1,50 +1,63 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "171",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-778fcb3c69da294eadc653c00561ae3a-aeb2d5dba2fa0f4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-5a40b0e60d715844ae7623f9ec42a172-ed857fe66e8c5342-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d28ee219cc50a62d312372ef51ad5912",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configBWFDTI5K",
-        "hookIds": [],
-        "metricAlertingConfigurations": [
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedBWFDTI5K",
+        "granularityName": "Daily",
+        "metrics": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All"
+            "metricName": "metric"
           }
-        ]
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "73112b47-642d-4d59-9ea9-f16ae6a3b85f",
+        "apim-request-id": "1c685bb4-b792-4b79-89e8-ce609e2ab577",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:00 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/4bbb9a69-2495-4f6b-a3a8-bb3b6d5b6e93",
+        "Date": "Thu, 10 Jun 2021 18:37:49 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac7e56f9-f85f-4e2f-adad-0b45e7181ac6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "116",
-        "x-request-id": "73112b47-642d-4d59-9ea9-f16ae6a3b85f"
+        "x-envoy-upstream-service-time": "749",
+        "x-request-id": "1c685bb4-b792-4b79-89e8-ce609e2ab577"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/4bbb9a69-2495-4f6b-a3a8-bb3b6d5b6e93",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac7e56f9-f85f-4e2f-adad-0b45e7181ac6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-778fcb3c69da294eadc653c00561ae3a-8ca51c1493e1db43-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-5a40b0e60d715844ae7623f9ec42a172-70bf034285fa2d43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fb4f2be40eb16f54ed2c411bd5c7add5",
         "x-ms-return-client-request-id": "true"
@@ -52,63 +65,220 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cd4b2505-44b6-47cf-b9bc-29f722f92929",
-        "Content-Length": "314",
+        "apim-request-id": "3872bc4a-3e01-43cf-adef-710f7d10f6b7",
+        "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:00 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "101",
-        "x-request-id": "cd4b2505-44b6-47cf-b9bc-29f722f92929"
+        "x-envoy-upstream-service-time": "203",
+        "x-request-id": "3872bc4a-3e01-43cf-adef-710f7d10f6b7"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "4bbb9a69-2495-4f6b-a3a8-bb3b6d5b6e93",
-        "name": "configBWFDTI5K",
-        "description": "",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
+        "dataFeedId": "ac7e56f9-f85f-4e2f-adad-0b45e7181ac6",
+        "dataFeedName": "dataFeedBWFDTI5K",
+        "metrics": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false
+            "metricId": "be0b617f-acf1-471f-8dfa-c0274bf04620",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
           }
-        ]
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:37:50Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/4bbb9a69-2495-4f6b-a3a8-bb3b6d5b6e93",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4ceb40c10d7e0845b159f802c792771c-d5a0931c9feef340-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "69b5b5f8262f128278fb3e782504000a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedSqmYLMLy",
+        "metricId": "be0b617f-acf1-471f-8dfa-c0274bf04620",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "e3a1323b-f476-4dda-a4c5-067f3a35c945",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:55 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/6e2b0bdb-c774-4b7b-b558-de58f9a02515",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5205",
+        "x-request-id": "e3a1323b-f476-4dda-a4c5-067f3a35c945"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/6e2b0bdb-c774-4b7b-b558-de58f9a02515",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b6024885b88e8041809ffbb132436a62-43936659940e674c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-4ceb40c10d7e0845b159f802c792771c-965ad6026472704c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7c409f3914abdd93f8b5b5692f268212",
+        "x-ms-client-request-id": "24e51f8d118a6ad0759db5b16cdd67d0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ab057f84-4e0b-4ade-ae1e-0ee19e29c7d7",
-        "Content-Length": "314",
+        "apim-request-id": "2ff9a650-b3dc-4318-b736-658a05d603df",
+        "Content-Length": "399",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:06 GMT",
+        "Date": "Thu, 10 Jun 2021 18:38:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5125",
-        "x-request-id": "ab057f84-4e0b-4ade-ae1e-0ee19e29c7d7"
+        "x-envoy-upstream-service-time": "5169",
+        "x-request-id": "2ff9a650-b3dc-4318-b736-658a05d603df"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "4bbb9a69-2495-4f6b-a3a8-bb3b6d5b6e93",
-        "name": "configBWFDTI5K",
+        "anomalyDetectionConfigurationId": "6e2b0bdb-c774-4b7b-b558-de58f9a02515",
+        "name": "dataFeedSqmYLMLy",
+        "description": "",
+        "metricId": "be0b617f-acf1-471f-8dfa-c0274bf04620",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "171",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-59571323fe10d64cad794509396c17ce-28e79f8ce2e13046-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "daa22fa9358835af9e35ee8b2f6f53e6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "config12bH1v4D",
+        "hookIds": [],
+        "metricAlertingConfigurations": [
+          {
+            "anomalyDetectionConfigurationId": "6e2b0bdb-c774-4b7b-b558-de58f9a02515",
+            "anomalyScopeType": "All"
+          }
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "1d4583a3-2949-4846-8efc-d822f995b18e",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:01 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/1cfb78a2-d56e-4ee5-8cd3-3a5dff86220d",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "189",
+        "x-request-id": "1d4583a3-2949-4846-8efc-d822f995b18e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/1cfb78a2-d56e-4ee5-8cd3-3a5dff86220d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-59571323fe10d64cad794509396c17ce-2805189d27e63943-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "91f34ae4d1709ba5936ee0b30004b1a2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "87df2e2b-4b7b-4ab1-bebe-2d16da18f48c",
+        "Content-Length": "314",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:38:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "231",
+        "x-request-id": "87df2e2b-4b7b-4ab1-bebe-2d16da18f48c"
+      },
+      "ResponseBody": {
+        "anomalyAlertingConfigurationId": "1cfb78a2-d56e-4ee5-8cd3-3a5dff86220d",
+        "name": "config12bH1v4D",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "6e2b0bdb-c774-4b7b-b558-de58f9a02515",
             "anomalyScopeType": "All",
             "negationOperation": false
           }
@@ -116,27 +286,77 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/4bbb9a69-2495-4f6b-a3a8-bb3b6d5b6e93",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/1cfb78a2-d56e-4ee5-8cd3-3a5dff86220d",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-914a153b0643754da20edd8eccf7a36d-b7f11f90c3e95b4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-2e61f4422adda14ca60967fbed756836-5f9c6110e1804940-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "783efb7804250a008d1fe5248a11d06a",
+        "x-ms-client-request-id": "5a7a1edff66e40e2ed801237eedba128",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ac8a8046-c994-4ec2-b481-c252289d9197",
+        "apim-request-id": "65a4b56f-1d0c-4488-87e4-fa69f76f6643",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:06 GMT",
+        "Date": "Thu, 10 Jun 2021 18:38:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "113",
-        "x-request-id": "ac8a8046-c994-4ec2-b481-c252289d9197"
+        "x-envoy-upstream-service-time": "201",
+        "x-request-id": "65a4b56f-1d0c-4488-87e4-fa69f76f6643"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/6e2b0bdb-c774-4b7b-b558-de58f9a02515",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-8bea7478c24e7e4c980659d91e119585-1bb311ab36cb5c43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0e171c1eaef7d8568907461a55fc349a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "b097759a-66f6-4b59-8009-f07999ae43c5",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5126",
+        "x-request-id": "b097759a-66f6-4b59-8009-f07999ae43c5"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac7e56f9-f85f-4e2f-adad-0b45e7181ac6",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-aa39489dfaba7540a2ec001fec017165-c16330ed9f198f4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "11ac4b83f8f4ee7768b3a3f0be6eacb7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "b6c48c7d-2790-4667-81f8-08db8bbd0bc9",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5363",
+        "x-request-id": "b6c48c7d-2790-4667-81f8-08db8bbd0bc9"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithWholeSeriesScope(False)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithWholeSeriesScope(False)Async.json
@@ -1,50 +1,63 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "171",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-473ab5e7cbe7b7468e6b83049433bb2e-0f8dbfb46c5c5443-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-5b0b5dde242d6f409cd126e484b2a472-be30870edc1c8b47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6c05e891ad99e3f2aaa010c902014a37",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configVozWhYXK",
-        "hookIds": [],
-        "metricAlertingConfigurations": [
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedVozWhYXK",
+        "granularityName": "Daily",
+        "metrics": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All"
+            "metricName": "metric"
           }
-        ]
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "aa9553ac-1918-495a-8e63-fce5e4a060ff",
+        "apim-request-id": "51da50e5-3445-49e4-b60f-96dbdc79c1c1",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:16 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/10b14914-9049-40cf-838c-80dcfc7ed7f0",
+        "Date": "Thu, 10 Jun 2021 18:39:45 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f341288-93d4-4684-a7e0-1905aa80cd60",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "127",
-        "x-request-id": "aa9553ac-1918-495a-8e63-fce5e4a060ff"
+        "x-envoy-upstream-service-time": "599",
+        "x-request-id": "51da50e5-3445-49e4-b60f-96dbdc79c1c1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/10b14914-9049-40cf-838c-80dcfc7ed7f0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f341288-93d4-4684-a7e0-1905aa80cd60",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-473ab5e7cbe7b7468e6b83049433bb2e-bd918d3bd4731749-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-5b0b5dde242d6f409cd126e484b2a472-bb20722b91138c44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bd9536f24e125a77b73dd10c13c039ce",
         "x-ms-return-client-request-id": "true"
@@ -52,63 +65,220 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "37b8e90a-90ff-41a5-888e-4a10cc55dfec",
-        "Content-Length": "314",
+        "apim-request-id": "bfcc24e9-caf1-4ea6-9734-c00bc20c09a9",
+        "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:16 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "92",
-        "x-request-id": "37b8e90a-90ff-41a5-888e-4a10cc55dfec"
+        "x-envoy-upstream-service-time": "175",
+        "x-request-id": "bfcc24e9-caf1-4ea6-9734-c00bc20c09a9"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "10b14914-9049-40cf-838c-80dcfc7ed7f0",
-        "name": "configVozWhYXK",
-        "description": "",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
+        "dataFeedId": "9f341288-93d4-4684-a7e0-1905aa80cd60",
+        "dataFeedName": "dataFeedVozWhYXK",
+        "metrics": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false
+            "metricId": "17076f7a-bbf5-4d68-8857-82fe3c72efb4",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
           }
-        ]
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:39:46Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/10b14914-9049-40cf-838c-80dcfc7ed7f0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9e9c2a90eec55143b42ad30da1d0f45e-5913a0688dccdc43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8359286bf014da01bf407cfdc5925442",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedivZRCqUX",
+        "metricId": "17076f7a-bbf5-4d68-8857-82fe3c72efb4",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "ef01bc2a-1117-47db-a787-105a87062616",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:46 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9f35e496-0f4e-4a4b-8b82-543c02c7545c",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "157",
+        "x-request-id": "ef01bc2a-1117-47db-a787-105a87062616"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9f35e496-0f4e-4a4b-8b82-543c02c7545c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2382ea46dc3b2c44941d680dc077c993-863d62718f2a5d4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-9e9c2a90eec55143b42ad30da1d0f45e-b2c56869186b8746-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "56f986d4c98e36576b28598314f001da",
+        "x-ms-client-request-id": "5cb4ab70e6dbeacf6741f47b08f4a929",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "93802d25-3006-41cd-b68a-46c648bcc648",
-        "Content-Length": "314",
+        "apim-request-id": "491290d0-771e-484e-b285-c0e74a9cf5bd",
+        "Content-Length": "399",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:17 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "100",
-        "x-request-id": "93802d25-3006-41cd-b68a-46c648bcc648"
+        "x-envoy-upstream-service-time": "109",
+        "x-request-id": "491290d0-771e-484e-b285-c0e74a9cf5bd"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "10b14914-9049-40cf-838c-80dcfc7ed7f0",
-        "name": "configVozWhYXK",
+        "anomalyDetectionConfigurationId": "9f35e496-0f4e-4a4b-8b82-543c02c7545c",
+        "name": "dataFeedivZRCqUX",
+        "description": "",
+        "metricId": "17076f7a-bbf5-4d68-8857-82fe3c72efb4",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "171",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6eb0b1e62f18594d86452871db4e7e6a-8895fc0c90efb449-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d24cf63b3b43410832b6e5e214fa5a85",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configDFBEYext",
+        "hookIds": [],
+        "metricAlertingConfigurations": [
+          {
+            "anomalyDetectionConfigurationId": "9f35e496-0f4e-4a4b-8b82-543c02c7545c",
+            "anomalyScopeType": "All"
+          }
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "a99ef6aa-4fa9-4747-a7e5-dc0b6242698a",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:46 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/894046e6-f2dc-4cd7-9ddf-bd910525c004",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "133",
+        "x-request-id": "a99ef6aa-4fa9-4747-a7e5-dc0b6242698a"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/894046e6-f2dc-4cd7-9ddf-bd910525c004",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6eb0b1e62f18594d86452871db4e7e6a-0a8bdc0c9c30cd45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d21b6f5886fccbd297531e66406a4d7c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "da0fb157-3cab-45d2-ab5c-6dfae6c604c8",
+        "Content-Length": "314",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:47 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "116",
+        "x-request-id": "da0fb157-3cab-45d2-ab5c-6dfae6c604c8"
+      },
+      "ResponseBody": {
+        "anomalyAlertingConfigurationId": "894046e6-f2dc-4cd7-9ddf-bd910525c004",
+        "name": "configDFBEYext",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9f35e496-0f4e-4a4b-8b82-543c02c7545c",
             "anomalyScopeType": "All",
             "negationOperation": false
           }
@@ -116,27 +286,77 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/10b14914-9049-40cf-838c-80dcfc7ed7f0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/894046e6-f2dc-4cd7-9ddf-bd910525c004",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-98443d030813ee40ad0fcea920cdf937-3cd258799b23c54b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6bc78b91adc3a14096db2a77ed2f143a-27c71a2771e92648-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "fd7c40bf92c5425470abb45cdbe6cfea",
+        "x-ms-client-request-id": "e520ee65fd9a2ba638b249510ec614e4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "99bed8f0-5220-4ece-9b71-5e2ce9a7b3bf",
+        "apim-request-id": "f9880a02-3cf2-4c41-b5df-9fe08858bc93",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:17 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "137",
-        "x-request-id": "99bed8f0-5220-4ece-9b71-5e2ce9a7b3bf"
+        "x-envoy-upstream-service-time": "5142",
+        "x-request-id": "f9880a02-3cf2-4c41-b5df-9fe08858bc93"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9f35e496-0f4e-4a4b-8b82-543c02c7545c",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ff8bf3b204e5ba4c95663b78938e3593-70d85d58bebcda40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8691cc0473d8b5ca23803af01da101c7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "40bec37e-4ff9-4ac0-bfdd-bb42c1eef4fd",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "133",
+        "x-request-id": "40bec37e-4ff9-4ac0-bfdd-bb42c1eef4fd"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f341288-93d4-4684-a7e0-1905aa80cd60",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a0a2bf80453b104487802625f08e4b63-3fd3c59ddbf4574a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "267d696975d95bebc8f099493d81bcd1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "9374623d-572f-4ea6-b0a2-a878980fa2f4",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "316",
+        "x-request-id": "9374623d-572f-4ea6-b0a2-a878980fa2f4"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithWholeSeriesScope(True).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithWholeSeriesScope(True).json
@@ -1,6 +1,211 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "traceparent": "00-812a7c3e21f18244b60c6efe7e3aa1d5-2139170c9518b040-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4b50290ef58247e362f5d598bf15eb99",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeed20SWrjvv",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "12bf0ad8-66b9-4c2c-b5ff-ebe2a5cb7bd4",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:31 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/64b1d903-7135-4aeb-9b5c-8e340b38c607",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5728",
+        "x-request-id": "12bf0ad8-66b9-4c2c-b5ff-ebe2a5cb7bd4"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/64b1d903-7135-4aeb-9b5c-8e340b38c607",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-812a7c3e21f18244b60c6efe7e3aa1d5-17034e1ec8d4644d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a4bd9802bdca7679d3645c425ca73982",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d082bcb9-a041-47b4-a35e-a7d2d9dfb322",
+        "Content-Length": "1052",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5248",
+        "x-request-id": "d082bcb9-a041-47b4-a35e-a7d2d9dfb322"
+      },
+      "ResponseBody": {
+        "dataFeedId": "64b1d903-7135-4aeb-9b5c-8e340b38c607",
+        "dataFeedName": "dataFeed20SWrjvv",
+        "metrics": [
+          {
+            "metricId": "2e0693e5-a9f3-4659-847c-2a9d6450c21b",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "94dc466b-52e4-4678-892d-70a0c45c5f42"
+        ],
+        "viewers": [],
+        "creator": "94dc466b-52e4-4678-892d-70a0c45c5f42",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:37:32Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "traceparent": "00-890bfaebb28a124ca33f5f348ef4d3ab-4f899c4ec11ec540-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7810955d9125ec7ecf04bd354319d551",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedkYtNArfc",
+        "metricId": "2e0693e5-a9f3-4659-847c-2a9d6450c21b",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "0248647c-d700-41e5-a16c-e6b846aad40f",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:37 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b6245975-3e77-4042-bfe5-2363b74a064e",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "142",
+        "x-request-id": "0248647c-d700-41e5-a16c-e6b846aad40f"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b6245975-3e77-4042-bfe5-2363b74a064e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-890bfaebb28a124ca33f5f348ef4d3ab-40e41b08017b704a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1d77d9afa099bbebbc5397b2522899fb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b35d2ed5-8545-4afb-b0fd-01f72c666e44",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "111",
+        "x-request-id": "b35d2ed5-8545-4afb-b0fd-01f72c666e44"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "b6245975-3e77-4042-bfe5-2363b74a064e",
+        "name": "dataFeedkYtNArfc",
+        "description": "",
+        "metricId": "2e0693e5-a9f3-4659-847c-2a9d6450c21b",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,66 +213,66 @@
         "Authorization": "Sanitized",
         "Content-Length": "171",
         "Content-Type": "application/json",
-        "traceparent": "00-ae35ef9a429fa14a92e0eb246385eb71-377955ab2969cb42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4b50290ef58247e362f5d598bf15eb99",
+        "traceparent": "00-e1ad5c34a5531745900dfc08e5b3345a-230166bad0e36f4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "58736fe604e9e63f377113268eed09bd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "config20SWrjvv",
+        "name": "configJ92VrONy",
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "b6245975-3e77-4042-bfe5-2363b74a064e",
             "anomalyScopeType": "All"
           }
         ]
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c1a5c348-51b1-49c9-b2ef-fdb41163d369",
+        "apim-request-id": "6d776358-8b57-4302-9c06-b73015a36fd1",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:45 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/900ec4da-7ef5-4022-8a57-47ed43f56b01",
+        "Date": "Thu, 10 Jun 2021 18:37:38 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/bbeb32a9-d9d6-4e41-a781-61fe081cbf4a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "232",
-        "x-request-id": "c1a5c348-51b1-49c9-b2ef-fdb41163d369"
+        "x-envoy-upstream-service-time": "146",
+        "x-request-id": "6d776358-8b57-4302-9c06-b73015a36fd1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/900ec4da-7ef5-4022-8a57-47ed43f56b01",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/bbeb32a9-d9d6-4e41-a781-61fe081cbf4a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ae35ef9a429fa14a92e0eb246385eb71-5202850f3bb1ff47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a4bd9802bdca7679d3645c425ca73982",
+        "traceparent": "00-e1ad5c34a5531745900dfc08e5b3345a-3646504a2e9fb242-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d2bc55aacbfaa6996ac2a729d3a1a4ae",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8821e770-e04b-4799-82a1-36abe287d293",
+        "apim-request-id": "55efa507-20aa-484a-8efb-7a337e714a6e",
         "Content-Length": "314",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:49 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "3613",
-        "x-request-id": "8821e770-e04b-4799-82a1-36abe287d293"
+        "x-envoy-upstream-service-time": "5125",
+        "x-request-id": "55efa507-20aa-484a-8efb-7a337e714a6e"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "900ec4da-7ef5-4022-8a57-47ed43f56b01",
-        "name": "config20SWrjvv",
+        "anomalyAlertingConfigurationId": "bbeb32a9-d9d6-4e41-a781-61fe081cbf4a",
+        "name": "configJ92VrONy",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "b6245975-3e77-4042-bfe5-2363b74a064e",
             "anomalyScopeType": "All",
             "negationOperation": false
           }
@@ -75,64 +280,74 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/900ec4da-7ef5-4022-8a57-47ed43f56b01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-0b0bc04d57254647ba7fb1ade9f80b21-f4bb22490af7ff41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c3c20d000600a30b5d95107825917eec",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "dd3b3b13-0066-42e1-a1c0-e72575b9421e",
-        "Content-Length": "314",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:54 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5130",
-        "x-request-id": "dd3b3b13-0066-42e1-a1c0-e72575b9421e"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "900ec4da-7ef5-4022-8a57-47ed43f56b01",
-        "name": "config20SWrjvv",
-        "description": "",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/900ec4da-7ef5-4022-8a57-47ed43f56b01",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/bbeb32a9-d9d6-4e41-a781-61fe081cbf4a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-11d6fa682ae491428dd1ae85dc728299-f769be60606b624c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "35bd04cf194351d5afd9771d99a0ebbb",
+        "traceparent": "00-cba7fc321ba57445aab920eacfb77b5f-d2a5e15b31645540-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2a363688932db8d213b07ae115726c9f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b5ed0853-b0ce-4942-a2c8-a245ca345cb6",
+        "apim-request-id": "e183c657-1673-4046-a25a-cebc4b41bc04",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:00 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5137",
-        "x-request-id": "b5ed0853-b0ce-4942-a2c8-a245ca345cb6"
+        "x-envoy-upstream-service-time": "233",
+        "x-request-id": "e183c657-1673-4046-a25a-cebc4b41bc04"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/b6245975-3e77-4042-bfe5-2363b74a064e",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ab206cc79338a543940bb5c1bac12d3a-2137528d4046c54b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "578989107e441b47d5cced275c161396",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "5d229eab-00c0-447f-8231-b518bec972e2",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:43 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "179",
+        "x-request-id": "5d229eab-00c0-447f-8231-b518bec972e2"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/64b1d903-7135-4aeb-9b5c-8e340b38c607",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7ccef3961463324a84cae6d89f69fe3c-13f4050bb5cc6242-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "589d64ccdfb6178f8204be4951b891f7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "4f1ca51a-6e42-45bd-93f4-ab7992b76aab",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:48 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5312",
+        "x-request-id": "4f1ca51a-6e42-45bd-93f4-ab7992b76aab"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithWholeSeriesScope(True)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/CreateAndGetAlertConfigurationWithWholeSeriesScope(True)Async.json
@@ -1,6 +1,211 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "traceparent": "00-cbe0c5f51cfaea40b8c7a4e031d523f3-11b3f66a11d02d4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "97236ec6aa5d3611e3b5616329e39190",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedl70tMng4",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "f56f4d42-2db3-436a-aba7-8c43554d4c19",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:52:47 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d40499cf-2306-424a-89ec-c55c290bbc68",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "1049",
+        "x-request-id": "f56f4d42-2db3-436a-aba7-8c43554d4c19"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d40499cf-2306-424a-89ec-c55c290bbc68",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-cbe0c5f51cfaea40b8c7a4e031d523f3-c62895cb7d097041-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "831de2b6ae445c9e08738dc4245fa266",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c42c70bd-8694-4da3-bc7a-2cd2931f40d1",
+        "Content-Length": "1052",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:52:47 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "243",
+        "x-request-id": "c42c70bd-8694-4da3-bc7a-2cd2931f40d1"
+      },
+      "ResponseBody": {
+        "dataFeedId": "d40499cf-2306-424a-89ec-c55c290bbc68",
+        "dataFeedName": "dataFeedl70tMng4",
+        "metrics": [
+          {
+            "metricId": "56c13fc7-c949-48e8-b95e-5aaa8cdddf38",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "94dc466b-52e4-4678-892d-70a0c45c5f42"
+        ],
+        "viewers": [],
+        "creator": "94dc466b-52e4-4678-892d-70a0c45c5f42",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:52:47Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "traceparent": "00-7e6c891649a3bb4db3b6c9202e0efb2e-d79c54db7ab00a4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "252de7f78e975c2eca2bb4505d0ded17",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedsSeXL73N",
+        "metricId": "56c13fc7-c949-48e8-b95e-5aaa8cdddf38",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "c0bd8ed7-b48e-497f-8879-ac0c2b41baca",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:52:52 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/be53ddcf-5550-4897-bbf3-71699d674b58",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5254",
+        "x-request-id": "c0bd8ed7-b48e-497f-8879-ac0c2b41baca"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/be53ddcf-5550-4897-bbf3-71699d674b58",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7e6c891649a3bb4db3b6c9202e0efb2e-0be67cfe6ac66746-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e98ec7d04d1d841112fbb1995178b5a1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "71f38955-be7a-4521-98de-6185a0e1627c",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:52:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5222",
+        "x-request-id": "71f38955-be7a-4521-98de-6185a0e1627c"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "be53ddcf-5550-4897-bbf3-71699d674b58",
+        "name": "dataFeedsSeXL73N",
+        "description": "",
+        "metricId": "56c13fc7-c949-48e8-b95e-5aaa8cdddf38",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,66 +213,66 @@
         "Authorization": "Sanitized",
         "Content-Length": "171",
         "Content-Type": "application/json",
-        "traceparent": "00-0a07e9c90cc83240bb11b82f9c1a1522-2dcc3c31c97acd41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "97236ec6aa5d3611e3b5616329e39190",
+        "traceparent": "00-c57a482bc446bc4bbe6f82acddfe8e07-999872a6ba6f8347-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f9f9314551aaa409a279481386c28ea9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configl70tMng4",
+        "name": "configWP0ZJnF6",
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "be53ddcf-5550-4897-bbf3-71699d674b58",
             "anomalyScopeType": "All"
           }
         ]
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "0150b926-1ea2-48d6-a8e4-1dfa69b38ac5",
+        "apim-request-id": "af4a53a4-4942-4a96-9581-e35797478f30",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:00 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/51f0fe05-04c8-4ea0-adce-866348f1762e",
+        "Date": "Thu, 10 Jun 2021 18:53:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/e48db453-954f-4787-9359-376cac2f5dea",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5141",
-        "x-request-id": "0150b926-1ea2-48d6-a8e4-1dfa69b38ac5"
+        "x-envoy-upstream-service-time": "5174",
+        "x-request-id": "af4a53a4-4942-4a96-9581-e35797478f30"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/51f0fe05-04c8-4ea0-adce-866348f1762e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/e48db453-954f-4787-9359-376cac2f5dea",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0a07e9c90cc83240bb11b82f9c1a1522-4cb5adcfd71c8c45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "831de2b6ae445c9e08738dc4245fa266",
+        "traceparent": "00-c57a482bc446bc4bbe6f82acddfe8e07-796e64cd28cf484e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9b13a8d694dd510a76121aea81919657",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ff00818a-ae29-42de-97d9-a9db36f746ca",
+        "apim-request-id": "87c39cb7-becc-4512-a89c-df4ce7ccd710",
         "Content-Length": "314",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:05 GMT",
+        "Date": "Thu, 10 Jun 2021 18:53:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5117",
-        "x-request-id": "ff00818a-ae29-42de-97d9-a9db36f746ca"
+        "x-envoy-upstream-service-time": "5161",
+        "x-request-id": "87c39cb7-becc-4512-a89c-df4ce7ccd710"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "51f0fe05-04c8-4ea0-adce-866348f1762e",
-        "name": "configl70tMng4",
+        "anomalyAlertingConfigurationId": "e48db453-954f-4787-9359-376cac2f5dea",
+        "name": "configWP0ZJnF6",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "be53ddcf-5550-4897-bbf3-71699d674b58",
             "anomalyScopeType": "All",
             "negationOperation": false
           }
@@ -75,64 +280,74 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/51f0fe05-04c8-4ea0-adce-866348f1762e",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-5f617dff0aa74e489ac0396e58ba5271-2f957474e073f74d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "199190b114dbababf7e72d25978e2e5c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "de5aacab-75b2-4901-974b-386206e5e14a",
-        "Content-Length": "314",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:16 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10221",
-        "x-request-id": "de5aacab-75b2-4901-974b-386206e5e14a"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "51f0fe05-04c8-4ea0-adce-866348f1762e",
-        "name": "configl70tMng4",
-        "description": "",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/51f0fe05-04c8-4ea0-adce-866348f1762e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/e48db453-954f-4787-9359-376cac2f5dea",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0a1011de4d678b45b49455d169bc7b3d-0f64411e0f40724a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "50b42bca0d5d17edd0c78ee91d4d1184",
+        "traceparent": "00-8f5b5c9c46b0ed4497a42bd9110c9f51-ca0db5910f5bae4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "eca414021853c0d9f20df6d82fa11b74",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f79e5769-0a09-48eb-85e4-758f503f12f6",
+        "apim-request-id": "3af954d8-941a-4e54-b6db-500bd91e421e",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:16 GMT",
+        "Date": "Thu, 10 Jun 2021 18:53:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "48",
-        "x-request-id": "f79e5769-0a09-48eb-85e4-758f503f12f6"
+        "x-envoy-upstream-service-time": "5166",
+        "x-request-id": "3af954d8-941a-4e54-b6db-500bd91e421e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/be53ddcf-5550-4897-bbf3-71699d674b58",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-34da034c357d9843a7a20b0c81aa930e-d83fbf75ca7f654d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d886e2e42965b09c26a88398371e2310",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "62178466-d79d-4013-ae4f-b41df2730000",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:53:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "597",
+        "x-request-id": "62178466-d79d-4013-ae4f-b41df2730000"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d40499cf-2306-424a-89ec-c55c290bbc68",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7f83a7e07a8f6046b30d071293de300f-f69b0c34d90bc244-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7111f1e2a11dbe55ce53a9cf9e3222d4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "b003dd3e-6fbb-4121-82cf-28ddc2964a74",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:53:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5675",
+        "x-request-id": "b003dd3e-6fbb-4121-82cf-28ddc2964a74"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/DeleteAlertConfiguration(False).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/DeleteAlertConfiguration(False).json
@@ -1,50 +1,63 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "171",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d19fcc9619147e4e974082e6c798ea0d-bb2bb2c73671614e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-22621eea52ddc844900da59e034cf7c4-dfac35b76d19cc4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e6e3c0caa688d0d75d6ab7e13a2bba6b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configrxUEaA6u",
-        "hookIds": [],
-        "metricAlertingConfigurations": [
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedrxUEaA6u",
+        "granularityName": "Daily",
+        "metrics": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All"
+            "metricName": "metric"
           }
-        ]
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ee8d091a-d524-47e8-a216-777b9b7a00a8",
+        "apim-request-id": "5e7a43cf-14f0-43e1-aa49-cbdddfbf0cec",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:22 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/14f99cc5-9ee8-4306-91ac-4f71ac03687b",
+        "Date": "Thu, 10 Jun 2021 18:38:46 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/093ebe79-243a-4e75-a80b-cd9c1eae79f6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "124",
-        "x-request-id": "ee8d091a-d524-47e8-a216-777b9b7a00a8"
+        "x-envoy-upstream-service-time": "772",
+        "x-request-id": "5e7a43cf-14f0-43e1-aa49-cbdddfbf0cec"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/14f99cc5-9ee8-4306-91ac-4f71ac03687b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/093ebe79-243a-4e75-a80b-cd9c1eae79f6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d19fcc9619147e4e974082e6c798ea0d-ec76ac43813df149-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-22621eea52ddc844900da59e034cf7c4-b4732a702c757749-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7a63e284bbbe335262599329b091c0e5",
         "x-ms-return-client-request-id": "true"
@@ -52,24 +65,220 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7db595e2-20ae-4762-b93b-02e05c839831",
-        "Content-Length": "314",
+        "apim-request-id": "52f5fa4a-afeb-460a-9903-ca5df9931ceb",
+        "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:22 GMT",
+        "Date": "Thu, 10 Jun 2021 18:38:46 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "224",
+        "x-request-id": "52f5fa4a-afeb-460a-9903-ca5df9931ceb"
+      },
+      "ResponseBody": {
+        "dataFeedId": "093ebe79-243a-4e75-a80b-cd9c1eae79f6",
+        "dataFeedName": "dataFeedrxUEaA6u",
+        "metrics": [
+          {
+            "metricId": "0361f094-59e1-4389-956c-e1afc6cb4734",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:38:46Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-592eb474c83ae144aea0a674d37edf0c-d4e2ac2241f22349-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "996867e3305d73870033557891bc9f0e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeeddHYPmNbA",
+        "metricId": "0361f094-59e1-4389-956c-e1afc6cb4734",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "830849c8-3d11-4681-967d-a689620c2e72",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:46 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/19a378d6-0406-4d52-b933-b432a10b76ca",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "122",
+        "x-request-id": "830849c8-3d11-4681-967d-a689620c2e72"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/19a378d6-0406-4d52-b933-b432a10b76ca",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-592eb474c83ae144aea0a674d37edf0c-aadb4c7caa4ae64d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2e84b06dae13cc20aad21721e39a1847",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1197181c-f11d-449a-be52-f40446d06ee9",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:38:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "x-envoy-upstream-service-time": "103",
-        "x-request-id": "7db595e2-20ae-4762-b93b-02e05c839831"
+        "x-request-id": "1197181c-f11d-449a-be52-f40446d06ee9"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "14f99cc5-9ee8-4306-91ac-4f71ac03687b",
-        "name": "configrxUEaA6u",
+        "anomalyDetectionConfigurationId": "19a378d6-0406-4d52-b933-b432a10b76ca",
+        "name": "dataFeeddHYPmNbA",
+        "description": "",
+        "metricId": "0361f094-59e1-4389-956c-e1afc6cb4734",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "171",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-bf139be8366b1c45ba0d33ac5d80a0bc-63e30f7eeacd4448-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7c291fd1473c0c537a39b2a3b8243235",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "config8XBl9SNo",
+        "hookIds": [],
+        "metricAlertingConfigurations": [
+          {
+            "anomalyDetectionConfigurationId": "19a378d6-0406-4d52-b933-b432a10b76ca",
+            "anomalyScopeType": "All"
+          }
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "a9949b36-efa1-40b3-9fc6-5d0343b87147",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:47 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/337b2ab9-0775-48d4-800d-503a9c8ab1e7",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "130",
+        "x-request-id": "a9949b36-efa1-40b3-9fc6-5d0343b87147"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/337b2ab9-0775-48d4-800d-503a9c8ab1e7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-bf139be8366b1c45ba0d33ac5d80a0bc-f1b61be4356bbb4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8bee9c46661865901b0dea742647bbb4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "520bfe28-321e-43ca-9ac8-55d32678e2d6",
+        "Content-Length": "314",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:38:47 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "106",
+        "x-request-id": "520bfe28-321e-43ca-9ac8-55d32678e2d6"
+      },
+      "ResponseBody": {
+        "anomalyAlertingConfigurationId": "337b2ab9-0775-48d4-800d-503a9c8ab1e7",
+        "name": "config8XBl9SNo",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "19a378d6-0406-4d52-b933-b432a10b76ca",
             "anomalyScopeType": "All",
             "negationOperation": false
           }
@@ -77,58 +286,108 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/14f99cc5-9ee8-4306-91ac-4f71ac03687b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/337b2ab9-0775-48d4-800d-503a9c8ab1e7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-31a676ef86194c4a91764645ff22f01a-c86d434c4c201942-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-03d4786d20222d429d9b166a9281b7ae-cf4d0feb9f499248-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "204819c93d534653e36768995d308773",
+        "x-ms-client-request-id": "f35c52d9a484638f7e0ba7a9e7748e6a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "748043ee-6d20-4581-ad0a-69072fc48180",
+        "apim-request-id": "2b78a40d-3e38-4071-b724-db91378c2388",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:22 GMT",
+        "Date": "Thu, 10 Jun 2021 18:38:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "110",
-        "x-request-id": "748043ee-6d20-4581-ad0a-69072fc48180"
+        "x-envoy-upstream-service-time": "117",
+        "x-request-id": "2b78a40d-3e38-4071-b724-db91378c2388"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/14f99cc5-9ee8-4306-91ac-4f71ac03687b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/337b2ab9-0775-48d4-800d-503a9c8ab1e7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-21610a918275d049ad9664783e3d577d-6453d6e06611d14a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-61e704d3cb56c14d8a17d75435c06ca4-310ab3bcee24d64b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "78553300bc910e9f6db0842e13ae20cc",
+        "x-ms-client-request-id": "b61160ea4bca6b188fc3612f5cdfe532",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "0a18f629-3ede-43d1-ba45-618a5e2ead64",
+        "apim-request-id": "5e6750ec-ee08-434d-b209-db4524e74383",
         "Content-Length": "123",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:22 GMT",
+        "Date": "Thu, 10 Jun 2021 18:38:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "72",
-        "x-request-id": "0a18f629-3ede-43d1-ba45-618a5e2ead64"
+        "x-envoy-upstream-service-time": "80",
+        "x-request-id": "5e6750ec-ee08-434d-b209-db4524e74383"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyAlertingConfiguration. TraceId: 9c69297c-3ddf-4934-a878-d829d4dd5ee6"
+        "message": "Not found this AnomalyAlertingConfiguration. TraceId: 5994af83-2d8b-44fb-acc1-9155c828aac1"
       }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/19a378d6-0406-4d52-b933-b432a10b76ca",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-bdebbedc5db8484086838a510eecb105-f4f115a5ca31fc45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "66c9fd7e3fc7a2b10d8a0c0dbfe67da6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "8ddc21f5-23d7-4f66-b2d5-c600e66fa1bd",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:47 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "128",
+        "x-request-id": "8ddc21f5-23d7-4f66-b2d5-c600e66fa1bd"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/093ebe79-243a-4e75-a80b-cd9c1eae79f6",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2a542e0d4cf4f4448fd5231d153a99d1-15c98c196399e34d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c6897f7e05368ee939f163c14260069e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "94393beb-05b2-4494-b28c-c2e7c0fbfbf4",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:48 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "325",
+        "x-request-id": "94393beb-05b2-4494-b28c-c2e7c0fbfbf4"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/DeleteAlertConfiguration(False)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/DeleteAlertConfiguration(False)Async.json
@@ -1,50 +1,63 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "171",
+        "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9db379e5be7ad74b8af2a524e435ee3d-8d3548d9a565b145-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-576c4654608f7c4cb594a4e4e6c7ec14-d089fe7a2797c54a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a7b3e8bb6c9e31aef9c42fef4fe0a079",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configfi5lgmxY",
-        "hookIds": [],
-        "metricAlertingConfigurations": [
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedfi5lgmxY",
+        "granularityName": "Daily",
+        "metrics": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All"
+            "metricName": "metric"
           }
-        ]
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a6812b7c-dc11-47c7-9dfe-e42e12793564",
+        "apim-request-id": "cd0d9c43-c34d-4e84-bc48-a1d66feaa925",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:18 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/967a0afc-d42e-4918-b6e4-d39e6bd3d617",
+        "Date": "Thu, 10 Jun 2021 18:40:31 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51a9a71c-c93e-4efd-a43a-1d0946ea41a7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "116",
-        "x-request-id": "a6812b7c-dc11-47c7-9dfe-e42e12793564"
+        "x-envoy-upstream-service-time": "5702",
+        "x-request-id": "cd0d9c43-c34d-4e84-bc48-a1d66feaa925"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/967a0afc-d42e-4918-b6e4-d39e6bd3d617",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51a9a71c-c93e-4efd-a43a-1d0946ea41a7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9db379e5be7ad74b8af2a524e435ee3d-8057a263d57b684d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-576c4654608f7c4cb594a4e4e6c7ec14-db09c5d1f0874e49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e092e16427401beb0e24314108275949",
         "x-ms-return-client-request-id": "true"
@@ -52,24 +65,220 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8b8478d1-ddc2-44af-b2bb-0ab45d9cbdbc",
-        "Content-Length": "314",
+        "apim-request-id": "e3560abb-659d-43c7-9afa-4bd50d3f826f",
+        "Content-Length": "1010",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:18 GMT",
+        "Date": "Thu, 10 Jun 2021 18:40:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "93",
-        "x-request-id": "8b8478d1-ddc2-44af-b2bb-0ab45d9cbdbc"
+        "x-envoy-upstream-service-time": "5240",
+        "x-request-id": "e3560abb-659d-43c7-9afa-4bd50d3f826f"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "967a0afc-d42e-4918-b6e4-d39e6bd3d617",
-        "name": "configfi5lgmxY",
+        "dataFeedId": "51a9a71c-c93e-4efd-a43a-1d0946ea41a7",
+        "dataFeedName": "dataFeedfi5lgmxY",
+        "metrics": [
+          {
+            "metricId": "ebba9f54-03de-4981-8d43-dc68d121067b",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:40:32Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3f39921165752d4c877757470e9f3546-6c2f7cd11d088846-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7628fac950ba3e7d0b03daaca33c0694",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeednpwrgk9q",
+        "metricId": "ebba9f54-03de-4981-8d43-dc68d121067b",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "1841718c-86ac-4e58-b376-80f6c822157c",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:40:42 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e58a4856-4462-4a8c-9268-7d039bb71157",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5247",
+        "x-request-id": "1841718c-86ac-4e58-b376-80f6c822157c"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e58a4856-4462-4a8c-9268-7d039bb71157",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3f39921165752d4c877757470e9f3546-df032afa23aa844a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7a9997fd6d3bd1296ae6149b00cc6982",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1a3f6e1d-cfae-4cf7-bb01-11112d1655a8",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:40:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "118",
+        "x-request-id": "1a3f6e1d-cfae-4cf7-bb01-11112d1655a8"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "e58a4856-4462-4a8c-9268-7d039bb71157",
+        "name": "dataFeednpwrgk9q",
+        "description": "",
+        "metricId": "ebba9f54-03de-4981-8d43-dc68d121067b",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "171",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f27a667910fcd942bae4d4f19fe729d0-504799b911d4e446-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0436f3a6ac4d9ea5ac4bd67948634b5c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "configsbonFVo9",
+        "hookIds": [],
+        "metricAlertingConfigurations": [
+          {
+            "anomalyDetectionConfigurationId": "e58a4856-4462-4a8c-9268-7d039bb71157",
+            "anomalyScopeType": "All"
+          }
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "feba50f0-ca6e-426a-ac0a-8a50dc8651ed",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:40:42 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/410fb703-d00a-4f76-b95f-161a8da484ac",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "240",
+        "x-request-id": "feba50f0-ca6e-426a-ac0a-8a50dc8651ed"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/410fb703-d00a-4f76-b95f-161a8da484ac",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f27a667910fcd942bae4d4f19fe729d0-e3a0b250dcbf3d43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d40b56d1e23c3f3e9a57a99825c19589",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "31b94aa6-b46f-46a4-bfd9-cd7e11e208ec",
+        "Content-Length": "314",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:40:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "118",
+        "x-request-id": "31b94aa6-b46f-46a4-bfd9-cd7e11e208ec"
+      },
+      "ResponseBody": {
+        "anomalyAlertingConfigurationId": "410fb703-d00a-4f76-b95f-161a8da484ac",
+        "name": "configsbonFVo9",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "e58a4856-4462-4a8c-9268-7d039bb71157",
             "anomalyScopeType": "All",
             "negationOperation": false
           }
@@ -77,58 +286,108 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/967a0afc-d42e-4918-b6e4-d39e6bd3d617",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/410fb703-d00a-4f76-b95f-161a8da484ac",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ffe200ed07f12e49a91141a6bb1154a9-67d945525e69c844-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e4c42b0d574e99469a26a12ab645f58b-f13a88ad36cd0849-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d4dfb3dbe11086ddc9fa2876ba507d3e",
+        "x-ms-client-request-id": "47d3db362436be834175efb4f5f03a9f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "37d84021-905a-4a3f-ab95-db3406e5c821",
+        "apim-request-id": "620afcf6-431f-4954-ba58-589af25d069c",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:18 GMT",
+        "Date": "Thu, 10 Jun 2021 18:40:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "119",
-        "x-request-id": "37d84021-905a-4a3f-ab95-db3406e5c821"
+        "x-envoy-upstream-service-time": "174",
+        "x-request-id": "620afcf6-431f-4954-ba58-589af25d069c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/967a0afc-d42e-4918-b6e4-d39e6bd3d617",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/410fb703-d00a-4f76-b95f-161a8da484ac",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e4e64102ad0f5b49a971d15587f7922d-24887e03a4a3ef47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6e767b58491b2842aa54df16a43cf98e-9d4873d1b6b9824a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "acda030b3ca39406fd97997a3b6d29d1",
+        "x-ms-client-request-id": "a873bbbf8c68c481b4f669f6030d79eb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "7574b1dd-81a0-459d-8671-c241bb9da504",
+        "apim-request-id": "f83a8896-1eb4-44a4-afb1-f0a5c197fdfb",
         "Content-Length": "123",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:18 GMT",
+        "Date": "Thu, 10 Jun 2021 18:40:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "95",
-        "x-request-id": "7574b1dd-81a0-459d-8671-c241bb9da504"
+        "x-envoy-upstream-service-time": "81",
+        "x-request-id": "f83a8896-1eb4-44a4-afb1-f0a5c197fdfb"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyAlertingConfiguration. TraceId: d5ff1857-4b6b-4984-b491-5b74b8f61fe7"
+        "message": "Not found this AnomalyAlertingConfiguration. TraceId: fa56425c-4d33-49a5-b6ff-28e170244e6b"
       }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/e58a4856-4462-4a8c-9268-7d039bb71157",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9f18ac313e4a314692f61b32cbe7d1d7-5d710c1ae503b34d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6d424db6038fad25d24d92c7f3894aaa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "7a401157-974e-4f69-82fc-e49ad6663b1f",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:40:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "109",
+        "x-request-id": "7a401157-974e-4f69-82fc-e49ad6663b1f"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51a9a71c-c93e-4efd-a43a-1d0946ea41a7",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ab3c7fcb091536478936a4052f679290-eaa5a708b85a384a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "69d8091cec4daa21590f933fba8dba33",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "60f99444-58d6-467c-b6f0-f96501e12032",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:40:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "374",
+        "x-request-id": "60f99444-58d6-467c-b6f0-f96501e12032"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/DeleteAlertConfiguration(True).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/DeleteAlertConfiguration(True).json
@@ -1,6 +1,211 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "traceparent": "00-09143d4b7646d241b8ce2ce14f0d352d-67950f99330a814b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7c0eac40c3715a884cf2b66d97ef9292",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedH8ckEiVW",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "5fc64650-1356-48cf-b51e-6fb729875b2c",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd89399a-eb33-4dc6-a8f2-6a38602fbf81",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "10832",
+        "x-request-id": "5fc64650-1356-48cf-b51e-6fb729875b2c"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd89399a-eb33-4dc6-a8f2-6a38602fbf81",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-09143d4b7646d241b8ce2ce14f0d352d-9769bb5c79063d41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e09a8c8258ecb451eb6d130973148bce",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cacff790-1de5-4fc6-8b2a-3c41dff27724",
+        "Content-Length": "1052",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:38:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "295",
+        "x-request-id": "cacff790-1de5-4fc6-8b2a-3c41dff27724"
+      },
+      "ResponseBody": {
+        "dataFeedId": "bd89399a-eb33-4dc6-a8f2-6a38602fbf81",
+        "dataFeedName": "dataFeedH8ckEiVW",
+        "metrics": [
+          {
+            "metricId": "5306485a-5639-42b9-adbd-606ba01d6f3d",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "94dc466b-52e4-4678-892d-70a0c45c5f42"
+        ],
+        "viewers": [],
+        "creator": "94dc466b-52e4-4678-892d-70a0c45c5f42",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:38:23Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "traceparent": "00-db19cfda95975240bb67b124faadc70c-9211b40a67139a4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b434db0ade1e9b205c5716f7c13eb5e8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedktabhsuD",
+        "metricId": "5306485a-5639-42b9-adbd-606ba01d6f3d",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "6dce3d26-ab47-4e2e-9822-c6924fdef767",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d11a724d-5aa8-4d52-91a6-5863574acc93",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "6dce3d26-ab47-4e2e-9822-c6924fdef767"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d11a724d-5aa8-4d52-91a6-5863574acc93",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-db19cfda95975240bb67b124faadc70c-37b4132871bd0a47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0491595a7faf38e666e74b4cfd88d852",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b7208c22-eadd-4912-9a97-929cc70b001a",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:38:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5210",
+        "x-request-id": "b7208c22-eadd-4912-9a97-929cc70b001a"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "d11a724d-5aa8-4d52-91a6-5863574acc93",
+        "name": "dataFeedktabhsuD",
+        "description": "",
+        "metricId": "5306485a-5639-42b9-adbd-606ba01d6f3d",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,66 +213,66 @@
         "Authorization": "Sanitized",
         "Content-Length": "171",
         "Content-Type": "application/json",
-        "traceparent": "00-d0093fa5ffff674aabc6d8746fdf410a-c4ef6a83d70abe49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7c0eac40c3715a884cf2b66d97ef9292",
+        "traceparent": "00-181bc765188d6a4f9aae94fdb72baf38-e9b79430711e5d4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1bad774c94fee40d9508af609ed7478b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configH8ckEiVW",
+        "name": "configPK5Tu81A",
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "d11a724d-5aa8-4d52-91a6-5863574acc93",
             "anomalyScopeType": "All"
           }
         ]
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f044d666-c400-49bc-946d-3535c25e9947",
+        "apim-request-id": "22f45c5b-bbd5-43f7-933b-f71ceb19cb87",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:11 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/c7ab2897-c899-4516-b765-13a50aed6f85",
+        "Date": "Thu, 10 Jun 2021 18:38:34 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/4d5990f3-92d2-491b-ad8a-025905b7369f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5281",
-        "x-request-id": "f044d666-c400-49bc-946d-3535c25e9947"
+        "x-envoy-upstream-service-time": "5185",
+        "x-request-id": "22f45c5b-bbd5-43f7-933b-f71ceb19cb87"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/c7ab2897-c899-4516-b765-13a50aed6f85",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/4d5990f3-92d2-491b-ad8a-025905b7369f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d0093fa5ffff674aabc6d8746fdf410a-2232827300468346-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e09a8c8258ecb451eb6d130973148bce",
+        "traceparent": "00-181bc765188d6a4f9aae94fdb72baf38-6697c13ef3955349-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "364efcf4d493d39e7fc3451e68a4c4bd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ca120720-246d-4253-af47-a235b94190c6",
+        "apim-request-id": "b5093e5e-f5d9-43eb-a2c1-84df6c0ed59e",
         "Content-Length": "314",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:16 GMT",
+        "Date": "Thu, 10 Jun 2021 18:38:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5136",
-        "x-request-id": "ca120720-246d-4253-af47-a235b94190c6"
+        "x-envoy-upstream-service-time": "203",
+        "x-request-id": "b5093e5e-f5d9-43eb-a2c1-84df6c0ed59e"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "c7ab2897-c899-4516-b765-13a50aed6f85",
-        "name": "configH8ckEiVW",
+        "anomalyAlertingConfigurationId": "4d5990f3-92d2-491b-ad8a-025905b7369f",
+        "name": "configPK5Tu81A",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "d11a724d-5aa8-4d52-91a6-5863574acc93",
             "anomalyScopeType": "All",
             "negationOperation": false
           }
@@ -75,56 +280,104 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/c7ab2897-c899-4516-b765-13a50aed6f85",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/4d5990f3-92d2-491b-ad8a-025905b7369f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6dda4651693e4243a6b70ae093ac1dde-15e0c5acb6044e47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0af14a222fbaf7db0adb34b41ede209b",
+        "traceparent": "00-b5edaf1a14fb0d49b86cc48100dfe726-c1c8f349cdc6e64b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "38b784c4cbd1d139d966b7f4d877b4d9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f4d82264-710a-4b6f-8545-2cb417662e36",
+        "apim-request-id": "323e98bd-28dc-47f0-8a06-b458ed33341c",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:17 GMT",
+        "Date": "Thu, 10 Jun 2021 18:38:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "140",
-        "x-request-id": "f4d82264-710a-4b6f-8545-2cb417662e36"
+        "x-envoy-upstream-service-time": "172",
+        "x-request-id": "323e98bd-28dc-47f0-8a06-b458ed33341c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/c7ab2897-c899-4516-b765-13a50aed6f85",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/4d5990f3-92d2-491b-ad8a-025905b7369f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-2497a661ed660641bdde906859998c25-b41190ae9e185f44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f716575c3ec1e8b55a599104af7fe638",
+        "traceparent": "00-8990d8a9b6cb0f43a33e7b310f7bf661-93d834ca7ab59d4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "271b4a5c5f4e7879d9da9c3a4eef7cf0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "1b144ef6-48af-43ea-bbd3-200ea1a2a276",
+        "apim-request-id": "04392136-62c9-47e9-b5ab-7d5011349467",
         "Content-Length": "123",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:21 GMT",
+        "Date": "Thu, 10 Jun 2021 18:38:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5103",
-        "x-request-id": "1b144ef6-48af-43ea-bbd3-200ea1a2a276"
+        "x-envoy-upstream-service-time": "5215",
+        "x-request-id": "04392136-62c9-47e9-b5ab-7d5011349467"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyAlertingConfiguration. TraceId: 5a7b4b65-9afd-4107-8292-ff2e2ec64b29"
+        "message": "Not found this AnomalyAlertingConfiguration. TraceId: 3be60768-a806-4bcf-87ad-b79d010844eb"
       }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/d11a724d-5aa8-4d52-91a6-5863574acc93",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-226070f0e8c6d6458b39bfc3bd2bf225-7ca6a5b427bb7d48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1a9cf2440e2029bac27c5c2c1ca9fa07",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "17e6ed4c-f8d8-4751-8c86-ca4a3de5076b",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5151",
+        "x-request-id": "17e6ed4c-f8d8-4751-8c86-ca4a3de5076b"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd89399a-eb33-4dc6-a8f2-6a38602fbf81",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-10d794ebeb0e97478f6da4f46680744a-04f19e96902e5a4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1dc26c0e9d89646e0a3e5ff72fff82ea",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "8bfbb46d-a45c-478b-891a-13e0379a64fb",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "328",
+        "x-request-id": "8bfbb46d-a45c-478b-891a-13e0379a64fb"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/DeleteAlertConfiguration(True)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/DeleteAlertConfiguration(True)Async.json
@@ -1,6 +1,211 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "traceparent": "00-f621b079d508f9489f06e910c0fa5790-483b338405842940-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "18f0da8d0489c225006f2c8a99189c33",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedR8n3wtAJ",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "eb3a3627-8a9d-4038-84d3-80aeed9f4f12",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:54 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/98f40422-b15d-4d37-8daa-25bd43329c67",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "408",
+        "x-request-id": "eb3a3627-8a9d-4038-84d3-80aeed9f4f12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/98f40422-b15d-4d37-8daa-25bd43329c67",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f621b079d508f9489f06e910c0fa5790-025e9b02ad32cc4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0a6401a0b16683bcdd607e49b5af7228",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "695858f3-ebbe-468c-b874-96b5399bd91f",
+        "Content-Length": "1052",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "86",
+        "x-request-id": "695858f3-ebbe-468c-b874-96b5399bd91f"
+      },
+      "ResponseBody": {
+        "dataFeedId": "98f40422-b15d-4d37-8daa-25bd43329c67",
+        "dataFeedName": "dataFeedR8n3wtAJ",
+        "metrics": [
+          {
+            "metricId": "659b70d5-42d0-4800-921b-fc07e6eb5424",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "94dc466b-52e4-4678-892d-70a0c45c5f42"
+        ],
+        "viewers": [],
+        "creator": "94dc466b-52e4-4678-892d-70a0c45c5f42",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:39:54Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "traceparent": "00-fecd1703cb13564daf889804f0b8ccf7-f263c2a43c9afe4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "eaad603601d6ffb3d2f8f579afff90dc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedK7lyT7VW",
+        "metricId": "659b70d5-42d0-4800-921b-fc07e6eb5424",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "b1b1ee0e-fbc3-4169-9398-cc64e936c8aa",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:59 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/ee38bb49-5039-4323-b86b-9d4016df97d8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5169",
+        "x-request-id": "b1b1ee0e-fbc3-4169-9398-cc64e936c8aa"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/ee38bb49-5039-4323-b86b-9d4016df97d8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fecd1703cb13564daf889804f0b8ccf7-defd0edf55549b43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "283b6c1edc86510cfd04905944120cca",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "43159e46-ecc8-4767-a331-9a677409949e",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:59 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "147",
+        "x-request-id": "43159e46-ecc8-4767-a331-9a677409949e"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "ee38bb49-5039-4323-b86b-9d4016df97d8",
+        "name": "dataFeedK7lyT7VW",
+        "description": "",
+        "metricId": "659b70d5-42d0-4800-921b-fc07e6eb5424",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,66 +213,66 @@
         "Authorization": "Sanitized",
         "Content-Length": "171",
         "Content-Type": "application/json",
-        "traceparent": "00-88eef49908e5674d943c57db39d3bfcc-3dab69fd3a190e49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "18f0da8d0489c225006f2c8a99189c33",
+        "traceparent": "00-7a25a5423249b345b600c316ba10be7e-ffba79759c29ae4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bc767eadf8b9fa78aff76bb99a593b59",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configR8n3wtAJ",
+        "name": "confignMuFYJHR",
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "ee38bb49-5039-4323-b86b-9d4016df97d8",
             "anomalyScopeType": "All"
           }
         ]
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ee260870-febb-42a5-8d5d-0e4845e57722",
+        "apim-request-id": "a382c52d-66aa-464e-84ad-54e1efb878d8",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:17 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/666ad061-05b2-4a52-9fa0-e5d45117ddd6",
+        "Date": "Thu, 10 Jun 2021 18:40:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/00136a09-9599-4b0c-892f-d740cfef20d2",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "81",
-        "x-request-id": "ee260870-febb-42a5-8d5d-0e4845e57722"
+        "x-envoy-upstream-service-time": "5222",
+        "x-request-id": "a382c52d-66aa-464e-84ad-54e1efb878d8"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/666ad061-05b2-4a52-9fa0-e5d45117ddd6",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/00136a09-9599-4b0c-892f-d740cfef20d2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-88eef49908e5674d943c57db39d3bfcc-5779ac5c59cdbc49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0a6401a0b16683bcdd607e49b5af7228",
+        "traceparent": "00-7a25a5423249b345b600c316ba10be7e-8f19a2653fabe849-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d2ed5c535970c0baeb2af90c2a8ad84d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7242b1fb-275f-4d7f-8e77-0aac9dfafab4",
+        "apim-request-id": "2c0a4197-4417-4524-8587-85ae4ca60aee",
         "Content-Length": "314",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:17 GMT",
+        "Date": "Thu, 10 Jun 2021 18:40:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "74",
-        "x-request-id": "7242b1fb-275f-4d7f-8e77-0aac9dfafab4"
+        "x-envoy-upstream-service-time": "5182",
+        "x-request-id": "2c0a4197-4417-4524-8587-85ae4ca60aee"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "666ad061-05b2-4a52-9fa0-e5d45117ddd6",
-        "name": "configR8n3wtAJ",
+        "anomalyAlertingConfigurationId": "00136a09-9599-4b0c-892f-d740cfef20d2",
+        "name": "confignMuFYJHR",
         "description": "",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "ee38bb49-5039-4323-b86b-9d4016df97d8",
             "anomalyScopeType": "All",
             "negationOperation": false
           }
@@ -75,56 +280,104 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/666ad061-05b2-4a52-9fa0-e5d45117ddd6",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/00136a09-9599-4b0c-892f-d740cfef20d2",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6be2eeac53dad148bdb654e6d4b48453-0ac39c9c2b1ccf4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "89d33ffad526c2813660adead601b3ff",
+        "traceparent": "00-00b4bc47a69712439bb20dfe00e27817-bb2459c18ed2e040-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "087b60bf4f6504978b95aa4da6533027",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ff70b2f8-3474-4355-8be5-66b7a240ef86",
+        "apim-request-id": "71733419-b62b-40d1-83fb-741aa06b202c",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:17 GMT",
+        "Date": "Thu, 10 Jun 2021 18:40:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "49",
-        "x-request-id": "ff70b2f8-3474-4355-8be5-66b7a240ef86"
+        "x-envoy-upstream-service-time": "5136",
+        "x-request-id": "71733419-b62b-40d1-83fb-741aa06b202c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/666ad061-05b2-4a52-9fa0-e5d45117ddd6",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/00136a09-9599-4b0c-892f-d740cfef20d2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7ac5e2db5b914042b2b8600752053cd8-010b85ec2c434b41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "79f5f8d2ffafdc901e6c3b2886dc0c51",
+        "traceparent": "00-7d927610d671674d9c382da5bcd5f61e-d26f3452a2c8674d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a6b27a66dae3536ac3b6d18fff6bd024",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "8cc68e20-b7fe-4b1d-919e-a834edbe7054",
+        "apim-request-id": "9b22b19c-f975-425d-8a46-d69b5608043f",
         "Content-Length": "123",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:17 GMT",
+        "Date": "Thu, 10 Jun 2021 18:40:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "53",
-        "x-request-id": "8cc68e20-b7fe-4b1d-919e-a834edbe7054"
+        "x-envoy-upstream-service-time": "86",
+        "x-request-id": "9b22b19c-f975-425d-8a46-d69b5608043f"
       },
       "ResponseBody": {
         "code": "Not Found",
-        "message": "Not found this AnomalyAlertingConfiguration. TraceId: d426703d-4831-43b9-a49c-08b0f662ac6f"
+        "message": "Not found this AnomalyAlertingConfiguration. TraceId: d8ab0488-ac5a-4cf1-b8a6-fb159e7efb4d"
       }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/ee38bb49-5039-4323-b86b-9d4016df97d8",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fdcdf3480841eb4eb55a1b9409b70816-7108189e2f23a241-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "39fa1e1e33dd03f3c4e947dbaf6d1998",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "670f0f82-a4b8-4c7c-b732-6e6e0c838ba9",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:40:20 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5163",
+        "x-request-id": "670f0f82-a4b8-4c7c-b732-6e6e0c838ba9"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/98f40422-b15d-4d37-8daa-25bd43329c67",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-da83f45a04186847b7c845858fb46514-e88d0ba72aa5854f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "afa6d1fa31d8e569f62844af7e08051f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "499ddd33-6e59-4f2a-80b1-9bb9fd710e5b",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:40:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5376",
+        "x-request-id": "499ddd33-6e59-4f2a-80b1-9bb9fd710e5b"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithEveryMemberAndGetInstance.json
@@ -1,6 +1,215 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-48c7657ea0cda541818545cce94b364c-c523d201043c854a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "71cb7994c6b66edb15b6c05fb26f5f00",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedXsKZvjKB",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "f1db1641-4865-400b-b6e3-9ecf314af04a",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:16 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1e7c4c01-1f17-456f-8e0e-e7bc141b0614",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "384",
+        "x-request-id": "f1db1641-4865-400b-b6e3-9ecf314af04a"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1e7c4c01-1f17-456f-8e0e-e7bc141b0614",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-48c7657ea0cda541818545cce94b364c-6db789191486a74b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f83099cd0736aec9c97e424d6b55d724",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "25fab720-baa0-484a-8391-56fe4c10f9f4",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "174",
+        "x-request-id": "25fab720-baa0-484a-8391-56fe4c10f9f4"
+      },
+      "ResponseBody": {
+        "dataFeedId": "1e7c4c01-1f17-456f-8e0e-e7bc141b0614",
+        "dataFeedName": "dataFeedXsKZvjKB",
+        "metrics": [
+          {
+            "metricId": "98c0b1e3-1e80-40e3-8c73-75254eb4abc8",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:37:16Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-45af2f650222384b81240ff15a395239-4eb09e5a6d7ce74c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "dbe4b46228cf782afa4579da951b668d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedb28BWxSJ",
+        "metricId": "98c0b1e3-1e80-40e3-8c73-75254eb4abc8",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "247f3f20-7fce-4034-bbb9-f8767670e94e",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:16 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9331cf72-d06e-4a89-895f-bb52e7df1d66",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "121",
+        "x-request-id": "247f3f20-7fce-4034-bbb9-f8767670e94e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9331cf72-d06e-4a89-895f-bb52e7df1d66",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-45af2f650222384b81240ff15a395239-065ed09e7cd2dc4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "38a71db08d84c003df9cdcc5a1cc6025",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "184bf232-d3b6-4ba7-9c31-e8200fd676bd",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:37:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "114",
+        "x-request-id": "184bf232-d3b6-4ba7-9c31-e8200fd676bd"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "9331cf72-d06e-4a89-895f-bb52e7df1d66",
+        "name": "dataFeedb28BWxSJ",
+        "description": "",
+        "metricId": "98c0b1e3-1e80-40e3-8c73-75254eb4abc8",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,10 +217,10 @@
         "Content-Length": "92",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-59808755c85f8746afb1f3851128faf3-7b89a2096fdec940-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-868e1d3c8865db469f656f5a5a854a4f-bf48f8f07bb86940-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "71cb7994c6b66edb15b6c05fb26f5f00",
+        "x-ms-client-request-id": "2552ca53fddb688f8640e28300d656d5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,48 +230,48 @@
           ]
         },
         "hookType": "Email",
-        "hookName": "hookXsKZvjKB"
+        "hookName": "hookaY4szEQN"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "3fb59d70-c470-41ed-88fb-034ccabba265",
+        "apim-request-id": "e736d825-5ba7-409f-bfb2-5e3135020824",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:42 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/a40638a7-836c-44dd-b1ff-b145efa97195",
+        "Date": "Thu, 10 Jun 2021 18:37:17 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/d6ee83b2-9767-4433-86e7-c8d8da3fa856",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "664",
-        "x-request-id": "3fb59d70-c470-41ed-88fb-034ccabba265"
+        "x-envoy-upstream-service-time": "319",
+        "x-request-id": "e736d825-5ba7-409f-bfb2-5e3135020824"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/a40638a7-836c-44dd-b1ff-b145efa97195",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/d6ee83b2-9767-4433-86e7-c8d8da3fa856",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-59808755c85f8746afb1f3851128faf3-ad51e76741383e43-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-868e1d3c8865db469f656f5a5a854a4f-adf4ac76e275c14d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f83099cd0736aec9c97e424d6b55d724",
+        "x-ms-client-request-id": "33fb23b1654c2ed7e4544f3e85e46ac2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3282cc98-acf7-424d-91f3-7458f958a5c3",
+        "apim-request-id": "50cb707b-8c38-4ead-a12f-ab5a07aa1046",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:42 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "170",
-        "x-request-id": "3282cc98-acf7-424d-91f3-7458f958a5c3"
+        "x-envoy-upstream-service-time": "196",
+        "x-request-id": "50cb707b-8c38-4ead-a12f-ab5a07aa1046"
       },
       "ResponseBody": {
-        "hookId": "a40638a7-836c-44dd-b1ff-b145efa97195",
-        "hookName": "hookXsKZvjKB",
+        "hookId": "d6ee83b2-9767-4433-86e7-c8d8da3fa856",
+        "hookName": "hookaY4szEQN",
         "hookType": "Email",
         "externalLink": "",
         "description": "",
@@ -84,21 +293,21 @@
         "Content-Length": "648",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-afb80849eef1ea4f9d344020f20f026f-37e5249303c5c143-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-51fa9ff065abcb46b3b6d11288d15ecd-8b4abbc64ee3cb46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "dbe4b46228cf782afa4579da951b668d",
+        "x-ms-client-request-id": "603e740ddde9b32400c0d0fef2ab55ed",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configb28BWxSJ",
+        "name": "config8Qpxblb0",
         "crossMetricsOperator": "XOR",
         "hookIds": [
-          "a40638a7-836c-44dd-b1ff-b145efa97195"
+          "d6ee83b2-9767-4433-86e7-c8d8da3fa856"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9331cf72-d06e-4a89-895f-bb52e7df1d66",
             "anomalyScopeType": "All",
             "severityFilter": {
               "minAlertSeverity": "Low",
@@ -113,12 +322,12 @@
               "lower": 10,
               "upper": 20,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "98c0b1e3-1e80-40e3-8c73-75254eb4abc8",
               "triggerForMissing": true
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9331cf72-d06e-4a89-895f-bb52e7df1d66",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -126,53 +335,53 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "198e8af6-fb1a-4cc8-88b2-2938128c2538",
+        "apim-request-id": "141c52bf-08fc-4b89-ac58-5dde702dd92a",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:42 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/da0f559a-4fd2-498f-9375-a51876288602",
+        "Date": "Thu, 10 Jun 2021 18:37:17 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/85bb0146-0f43-422b-a45e-7a0034dfbd68",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "191",
-        "x-request-id": "198e8af6-fb1a-4cc8-88b2-2938128c2538"
+        "x-envoy-upstream-service-time": "156",
+        "x-request-id": "141c52bf-08fc-4b89-ac58-5dde702dd92a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/da0f559a-4fd2-498f-9375-a51876288602",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/85bb0146-0f43-422b-a45e-7a0034dfbd68",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-afb80849eef1ea4f9d344020f20f026f-353ce1218ff2be4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-51fa9ff065abcb46b3b6d11288d15ecd-8b085d661a6d5141-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "38a71db08d84c003df9cdcc5a1cc6025",
+        "x-ms-client-request-id": "874124f250ada1e2d62044faf09c99d3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3688c9e4-5c3c-4645-bd3b-fe0054e12946",
+        "apim-request-id": "4024caf8-be02-47e1-98d9-83280da02fa6",
         "Content-Length": "810",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:42 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "163",
-        "x-request-id": "3688c9e4-5c3c-4645-bd3b-fe0054e12946"
+        "x-envoy-upstream-service-time": "96",
+        "x-request-id": "4024caf8-be02-47e1-98d9-83280da02fa6"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "da0f559a-4fd2-498f-9375-a51876288602",
-        "name": "configb28BWxSJ",
+        "anomalyAlertingConfigurationId": "85bb0146-0f43-422b-a45e-7a0034dfbd68",
+        "name": "config8Qpxblb0",
         "description": "",
         "crossMetricsOperator": "XOR",
         "splitAlertByDimensions": [],
         "hookIds": [
-          "a40638a7-836c-44dd-b1ff-b145efa97195"
+          "d6ee83b2-9767-4433-86e7-c8d8da3fa856"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9331cf72-d06e-4a89-895f-bb52e7df1d66",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -188,13 +397,13 @@
               "lower": 10.0,
               "upper": 20.0,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "98c0b1e3-1e80-40e3-8c73-75254eb4abc8",
               "triggerForMissing": true,
               "type": "Value"
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9331cf72-d06e-4a89-895f-bb52e7df1d66",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -202,91 +411,27 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/da0f559a-4fd2-498f-9375-a51876288602",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bab2301d6b9ef544be4604bf304c04bb-26e22e598c70cd4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8195568aee22a1de53ca5225dbfd8f68",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4acdbdd8-182e-4d86-a3ed-c910c6cd9033",
-        "Content-Length": "810",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:43 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "166",
-        "x-request-id": "4acdbdd8-182e-4d86-a3ed-c910c6cd9033"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "da0f559a-4fd2-498f-9375-a51876288602",
-        "name": "configb28BWxSJ",
-        "description": "",
-        "crossMetricsOperator": "XOR",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "a40638a7-836c-44dd-b1ff-b145efa97195"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/da0f559a-4fd2-498f-9375-a51876288602",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/85bb0146-0f43-422b-a45e-7a0034dfbd68",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "724",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7b098a424e8de7498adc88b5ac72f67a-4440d630e089ca43-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-2c279f95a2d1e447a8bf4c9c00d3a6f0-131ad2fb81587849-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "83e24086d600d556b123fb334c65d72e",
+        "x-ms-client-request-id": "d825183f762607442f9b3ec4146bcf93",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configb28BWxSJ",
+        "name": "config8Qpxblb0",
         "description": "This hook was created to test the .NET client.",
         "crossMetricsOperator": "AND",
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9331cf72-d06e-4a89-895f-bb52e7df1d66",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -302,7 +447,7 @@
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9331cf72-d06e-4a89-895f-bb52e7df1d66",
             "anomalyScopeType": "TopN",
             "negationOperation": true,
             "topNAnomalyScope": {
@@ -320,25 +465,25 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e0d51435-3c1d-4f3c-b0ee-a4fa521289cd",
+        "apim-request-id": "fd85ee8f-5e32-4775-9aa1-3150d935fa55",
         "Content-Length": "828",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:43 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "191",
-        "x-request-id": "e0d51435-3c1d-4f3c-b0ee-a4fa521289cd"
+        "x-envoy-upstream-service-time": "171",
+        "x-request-id": "fd85ee8f-5e32-4775-9aa1-3150d935fa55"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "da0f559a-4fd2-498f-9375-a51876288602",
-        "name": "configb28BWxSJ",
+        "anomalyAlertingConfigurationId": "85bb0146-0f43-422b-a45e-7a0034dfbd68",
+        "name": "config8Qpxblb0",
         "description": "This hook was created to test the .NET client.",
         "crossMetricsOperator": "AND",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9331cf72-d06e-4a89-895f-bb52e7df1d66",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -354,7 +499,7 @@
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9331cf72-d06e-4a89-895f-bb52e7df1d66",
             "anomalyScopeType": "TopN",
             "negationOperation": true,
             "topNAnomalyScope": {
@@ -372,118 +517,102 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/da0f559a-4fd2-498f-9375-a51876288602",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f985d80faf5fdb4a819b4d9835c1e10c-49cf2eaced78c449-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "3e4f54e4e485c26a3e06e5b93bdde4e2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9c8660ce-ea04-4d05-90ce-88a1ae76ee1a",
-        "Content-Length": "828",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:25:43 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "102",
-        "x-request-id": "9c8660ce-ea04-4d05-90ce-88a1ae76ee1a"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "da0f559a-4fd2-498f-9375-a51876288602",
-        "name": "configb28BWxSJ",
-        "description": "This hook was created to test the .NET client.",
-        "crossMetricsOperator": "AND",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Medium",
-              "maxAlertSeverity": "High"
-            },
-            "valueFilter": {
-              "lower": 5.0,
-              "upper": 15.0,
-              "direction": "Both",
-              "triggerForMissing": false,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "TopN",
-            "negationOperation": true,
-            "topNAnomalyScope": {
-              "top": 50,
-              "period": 40,
-              "minTopCount": 30
-            },
-            "snoozeFilter": {
-              "autoSnooze": 4,
-              "snoozeScope": "Metric",
-              "onlyForSuccessive": true
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/da0f559a-4fd2-498f-9375-a51876288602",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/85bb0146-0f43-422b-a45e-7a0034dfbd68",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cb0ba7f8cbab5c488fb690a7fecabca7-a908b7ca565ccc42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-63225629519e6d45becae7e0744ceb31-471d802e8392de43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "603e740ddde9b32400c0d0fef2ab55ed",
+        "x-ms-client-request-id": "17c6f8b15c9cbd35919c8ac9992ac364",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "426862c7-16f4-425e-b6c4-bc5d3ce3fac9",
+        "apim-request-id": "63c336bd-1d60-426c-826b-23bf9e910155",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:43 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "155",
-        "x-request-id": "426862c7-16f4-425e-b6c4-bc5d3ce3fac9"
+        "x-envoy-upstream-service-time": "5197",
+        "x-request-id": "63c336bd-1d60-426c-826b-23bf9e910155"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/a40638a7-836c-44dd-b1ff-b145efa97195",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/d6ee83b2-9767-4433-86e7-c8d8da3fa856",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7f7d1026f973b2428a942b69dc431f6a-98453c7179742f46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-8cf0d2ea0c51894fb48466bc0c064539-d3a12885efb04e4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "874124f250ada1e2d62044faf09c99d3",
+        "x-ms-client-request-id": "dabffc277c857cc6e0395811121e8d6a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "17700270-e7c6-4ff0-a9ce-9666901b4bec",
+        "apim-request-id": "401d5574-02fd-4021-8e2d-150840d1bebf",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:25:43 GMT",
+        "Date": "Thu, 10 Jun 2021 18:37:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "242",
-        "x-request-id": "17700270-e7c6-4ff0-a9ce-9666901b4bec"
+        "x-envoy-upstream-service-time": "210",
+        "x-request-id": "401d5574-02fd-4021-8e2d-150840d1bebf"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9331cf72-d06e-4a89-895f-bb52e7df1d66",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0ab766b25ddc944384b7539df0a38105-efdea3f56872f042-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f848b05182d5e237e3684689ec7a6d04",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "2fc559c4-5e77-4ad5-aff4-94e102c2def4",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "97",
+        "x-request-id": "2fc559c4-5e77-4ad5-aff4-94e102c2def4"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1e7c4c01-1f17-456f-8e0e-e7bc141b0614",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e51b6c9f487db04aa2b68c3c008ca3b7-276b5ef7bbfb8941-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "189ddad8f4ab340e314a36620323ab73",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "98f52fa4-0357-4dba-9cf4-bf35c1d707ce",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:37:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "364",
+        "x-request-id": "98f52fa4-0357-4dba-9cf4-bf35c1d707ce"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithEveryMemberAndGetInstanceAsync.json
@@ -1,6 +1,215 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0eca4462541c824dbcf5946c8c38d75c-415949258ced8b45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1c8a0c386da02e79c403cc2b5065d1a8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedw4cgJZAG",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "d8cfc30c-0056-4b81-bdb9-a5573c7684b2",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:41 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f621b1db-4d15-4da7-be5e-062be56ba91d",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "670",
+        "x-request-id": "d8cfc30c-0056-4b81-bdb9-a5573c7684b2"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f621b1db-4d15-4da7-be5e-062be56ba91d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0eca4462541c824dbcf5946c8c38d75c-4aad26df298acf42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "46c0b5d63b98f772c156eb529877c8be",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b7c002f3-83b0-46ee-aab1-13a8a5a2c48f",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:41 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "162",
+        "x-request-id": "b7c002f3-83b0-46ee-aab1-13a8a5a2c48f"
+      },
+      "ResponseBody": {
+        "dataFeedId": "f621b1db-4d15-4da7-be5e-062be56ba91d",
+        "dataFeedName": "dataFeedw4cgJZAG",
+        "metrics": [
+          {
+            "metricId": "57984bad-5d18-42c7-a64b-40019a8f52e1",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:39:41Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6a15211b8aa93c47bee043a09b8977db-1583d4ceab92a346-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0fd4e100f899b70bbd58eb388638fffc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedfKQJczgV",
+        "metricId": "57984bad-5d18-42c7-a64b-40019a8f52e1",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "b5094638-e053-4161-be00-25e4ea5fda63",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:42 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/dacde955-46d2-4f9a-91f0-d91724b4ee35",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "106",
+        "x-request-id": "b5094638-e053-4161-be00-25e4ea5fda63"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/dacde955-46d2-4f9a-91f0-d91724b4ee35",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6a15211b8aa93c47bee043a09b8977db-0fd1316bf4529441-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "495a929927814c963a0d1b8d6ee08ff6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "31396dea-6339-4163-b2a0-1d57f9985186",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "92",
+        "x-request-id": "31396dea-6339-4163-b2a0-1d57f9985186"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "dacde955-46d2-4f9a-91f0-d91724b4ee35",
+        "name": "dataFeedfKQJczgV",
+        "description": "",
+        "metricId": "57984bad-5d18-42c7-a64b-40019a8f52e1",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,10 +217,10 @@
         "Content-Length": "92",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e851fea005533b47821e849aa19e76a4-81840d4341df2047-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-92d8753f1447b64384a48177111e97dc-2bf50d4cd14e1e45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1c8a0c386da02e79c403cc2b5065d1a8",
+        "x-ms-client-request-id": "4094334b908bd738c4fa568685d4d1d9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,48 +230,48 @@
           ]
         },
         "hookType": "Email",
-        "hookName": "hookw4cgJZAG"
+        "hookName": "hookPOeAhem9"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f77024e8-3e67-4c02-8dc7-3aa143507900",
+        "apim-request-id": "2a4a88ab-a54c-4610-86bf-76ef4a5db223",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:53 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/f761c7b1-0173-4a22-ae20-28c62e9b8050",
+        "Date": "Thu, 10 Jun 2021 18:39:42 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/e910eee0-288a-4808-ba1d-2388104400a0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "571",
-        "x-request-id": "f77024e8-3e67-4c02-8dc7-3aa143507900"
+        "x-envoy-upstream-service-time": "296",
+        "x-request-id": "2a4a88ab-a54c-4610-86bf-76ef4a5db223"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/f761c7b1-0173-4a22-ae20-28c62e9b8050",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/e910eee0-288a-4808-ba1d-2388104400a0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e851fea005533b47821e849aa19e76a4-a2bf37ed62739945-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-92d8753f1447b64384a48177111e97dc-2fcbe39801674740-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "46c0b5d63b98f772c156eb529877c8be",
+        "x-ms-client-request-id": "8cd4874b7ddddc49c9f4a019f3489436",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "703e9349-b404-4d0a-97af-4277fcbba2e5",
+        "apim-request-id": "df3fc639-d4d4-4869-97b6-3d21d6d6b9b2",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:54 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "168",
-        "x-request-id": "703e9349-b404-4d0a-97af-4277fcbba2e5"
+        "x-envoy-upstream-service-time": "163",
+        "x-request-id": "df3fc639-d4d4-4869-97b6-3d21d6d6b9b2"
       },
       "ResponseBody": {
-        "hookId": "f761c7b1-0173-4a22-ae20-28c62e9b8050",
-        "hookName": "hookw4cgJZAG",
+        "hookId": "e910eee0-288a-4808-ba1d-2388104400a0",
+        "hookName": "hookPOeAhem9",
         "hookType": "Email",
         "externalLink": "",
         "description": "",
@@ -84,21 +293,21 @@
         "Content-Length": "648",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ee1848394edaf14d933a4b603351696d-8162e9843cbc4a4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-7ae8728bc6f4ca4aa427f99d460f4629-c968d8e75f8e8447-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "0fd4e100f899b70bbd58eb388638fffc",
+        "x-ms-client-request-id": "73c943d5088ac4719b6c6bdf8fd2ebcd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configfKQJczgV",
+        "name": "configPtj9T6kb",
         "crossMetricsOperator": "XOR",
         "hookIds": [
-          "f761c7b1-0173-4a22-ae20-28c62e9b8050"
+          "e910eee0-288a-4808-ba1d-2388104400a0"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "dacde955-46d2-4f9a-91f0-d91724b4ee35",
             "anomalyScopeType": "All",
             "severityFilter": {
               "minAlertSeverity": "Low",
@@ -113,12 +322,12 @@
               "lower": 10,
               "upper": 20,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "57984bad-5d18-42c7-a64b-40019a8f52e1",
               "triggerForMissing": true
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "dacde955-46d2-4f9a-91f0-d91724b4ee35",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -126,53 +335,53 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e9b26b56-d6e4-449e-a7d1-1afa86a33a41",
+        "apim-request-id": "94671dfd-5127-43cd-9590-d88605ec9992",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:54 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/519b1538-7db2-4724-95df-fb13fb662abf",
+        "Date": "Thu, 10 Jun 2021 18:39:43 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/a6f5f932-639f-4869-b148-f9187db922ac",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "160",
-        "x-request-id": "e9b26b56-d6e4-449e-a7d1-1afa86a33a41"
+        "x-envoy-upstream-service-time": "144",
+        "x-request-id": "94671dfd-5127-43cd-9590-d88605ec9992"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/519b1538-7db2-4724-95df-fb13fb662abf",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/a6f5f932-639f-4869-b148-f9187db922ac",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ee1848394edaf14d933a4b603351696d-3f81fd3daa25fd4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-7ae8728bc6f4ca4aa427f99d460f4629-1085e11eaccee94b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "495a929927814c963a0d1b8d6ee08ff6",
+        "x-ms-client-request-id": "9676b7ea1ef07ce4652052f3d68346f5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "66f1b205-d47b-4d10-bb5c-8ce2deb63110",
+        "apim-request-id": "1740e411-859c-4e84-bcba-273f460006a5",
         "Content-Length": "810",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:54 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "114",
-        "x-request-id": "66f1b205-d47b-4d10-bb5c-8ce2deb63110"
+        "x-envoy-upstream-service-time": "90",
+        "x-request-id": "1740e411-859c-4e84-bcba-273f460006a5"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "519b1538-7db2-4724-95df-fb13fb662abf",
-        "name": "configfKQJczgV",
+        "anomalyAlertingConfigurationId": "a6f5f932-639f-4869-b148-f9187db922ac",
+        "name": "configPtj9T6kb",
         "description": "",
         "crossMetricsOperator": "XOR",
         "splitAlertByDimensions": [],
         "hookIds": [
-          "f761c7b1-0173-4a22-ae20-28c62e9b8050"
+          "e910eee0-288a-4808-ba1d-2388104400a0"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "dacde955-46d2-4f9a-91f0-d91724b4ee35",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -188,13 +397,13 @@
               "lower": 10.0,
               "upper": 20.0,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "57984bad-5d18-42c7-a64b-40019a8f52e1",
               "triggerForMissing": true,
               "type": "Value"
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "dacde955-46d2-4f9a-91f0-d91724b4ee35",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -202,91 +411,27 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/519b1538-7db2-4724-95df-fb13fb662abf",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1f034037b2744445aeb9f8a33f47672a-297849b13ccf5946-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b7456d986367c85e4b3394408b9038d7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "462350fa-dff2-4706-8c07-6e0e47085a89",
-        "Content-Length": "810",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:54 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "115",
-        "x-request-id": "462350fa-dff2-4706-8c07-6e0e47085a89"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "519b1538-7db2-4724-95df-fb13fb662abf",
-        "name": "configfKQJczgV",
-        "description": "",
-        "crossMetricsOperator": "XOR",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "f761c7b1-0173-4a22-ae20-28c62e9b8050"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/519b1538-7db2-4724-95df-fb13fb662abf",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/a6f5f932-639f-4869-b148-f9187db922ac",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "724",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6d6ecaa29d68024ebb075c16af5a0188-c23729368c8d1e44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-09e0ec840a76164d98a49800ef11f6cc-1950a04b92ed9e48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8656fac4d485d9d14b87d48cdd7d49dc",
+        "x-ms-client-request-id": "99b629c7d5b4c05283db7d86dcb5a761",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configfKQJczgV",
+        "name": "configPtj9T6kb",
         "description": "This hook was created to test the .NET client.",
         "crossMetricsOperator": "AND",
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "dacde955-46d2-4f9a-91f0-d91724b4ee35",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -302,7 +447,7 @@
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "dacde955-46d2-4f9a-91f0-d91724b4ee35",
             "anomalyScopeType": "TopN",
             "negationOperation": true,
             "topNAnomalyScope": {
@@ -320,25 +465,25 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d52204e9-399c-4ef1-99fb-1efa4f530e85",
+        "apim-request-id": "d574ecbc-9480-4fd6-b3c6-02528010087e",
         "Content-Length": "828",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:54 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "175",
-        "x-request-id": "d52204e9-399c-4ef1-99fb-1efa4f530e85"
+        "x-envoy-upstream-service-time": "167",
+        "x-request-id": "d574ecbc-9480-4fd6-b3c6-02528010087e"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "519b1538-7db2-4724-95df-fb13fb662abf",
-        "name": "configfKQJczgV",
+        "anomalyAlertingConfigurationId": "a6f5f932-639f-4869-b148-f9187db922ac",
+        "name": "configPtj9T6kb",
         "description": "This hook was created to test the .NET client.",
         "crossMetricsOperator": "AND",
         "splitAlertByDimensions": [],
         "hookIds": [],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "dacde955-46d2-4f9a-91f0-d91724b4ee35",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -354,7 +499,7 @@
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "dacde955-46d2-4f9a-91f0-d91724b4ee35",
             "anomalyScopeType": "TopN",
             "negationOperation": true,
             "topNAnomalyScope": {
@@ -372,118 +517,102 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/519b1538-7db2-4724-95df-fb13fb662abf",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c41415f3677a4d459a96fb7ef5c4b71e-c223577d25b1d946-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "19a0f4c948f336943491fd4d9355c0aa",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "eee38ec8-ace6-4c55-9bd0-980fe26fdb4d",
-        "Content-Length": "828",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:55 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "98",
-        "x-request-id": "eee38ec8-ace6-4c55-9bd0-980fe26fdb4d"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "519b1538-7db2-4724-95df-fb13fb662abf",
-        "name": "configfKQJczgV",
-        "description": "This hook was created to test the .NET client.",
-        "crossMetricsOperator": "AND",
-        "splitAlertByDimensions": [],
-        "hookIds": [],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Medium",
-              "maxAlertSeverity": "High"
-            },
-            "valueFilter": {
-              "lower": 5.0,
-              "upper": 15.0,
-              "direction": "Both",
-              "triggerForMissing": false,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "TopN",
-            "negationOperation": true,
-            "topNAnomalyScope": {
-              "top": 50,
-              "period": 40,
-              "minTopCount": 30
-            },
-            "snoozeFilter": {
-              "autoSnooze": 4,
-              "snoozeScope": "Metric",
-              "onlyForSuccessive": true
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/519b1538-7db2-4724-95df-fb13fb662abf",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/a6f5f932-639f-4869-b148-f9187db922ac",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-04f4bd7c51418841bd14d2fa5384de6d-1cec92dc13a7be4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b931a55cda12d846a271b3fafe6d1926-14a8de8218b7194a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "73c943d5088ac4719b6c6bdf8fd2ebcd",
+        "x-ms-client-request-id": "db632fa529dfb6ba5e4c0d6ab67eed18",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e08c99a5-fd6a-4d0d-83da-fbfc58fce915",
+        "apim-request-id": "bb521eda-69cd-49fe-a276-1f0ba940ba9a",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:55 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "133",
-        "x-request-id": "e08c99a5-fd6a-4d0d-83da-fbfc58fce915"
+        "x-envoy-upstream-service-time": "123",
+        "x-request-id": "bb521eda-69cd-49fe-a276-1f0ba940ba9a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/f761c7b1-0173-4a22-ae20-28c62e9b8050",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/e910eee0-288a-4808-ba1d-2388104400a0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f272cff789105e4cb08a4b49cb48a020-52402e4f545aa64b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-bebe976f98f15449b001d6b5eabdde09-d3717a35ccde3f4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9676b7ea1ef07ce4652052f3d68346f5",
+        "x-ms-client-request-id": "65187625521b151964b61314a05ea0b0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f1335b9d-d863-498f-ae14-f3fe17a3627a",
+        "apim-request-id": "a0d75385-8bb7-4013-8a43-d189f3719ce7",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:55 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "185",
-        "x-request-id": "f1335b9d-d863-498f-ae14-f3fe17a3627a"
+        "x-envoy-upstream-service-time": "212",
+        "x-request-id": "a0d75385-8bb7-4013-8a43-d189f3719ce7"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/dacde955-46d2-4f9a-91f0-d91724b4ee35",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-8e5ad706b767d945b44d7ac9f2ddfad6-6bfb3230b098824a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "a64df0796a209d156f003b67c7e80a04",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "63d5d6df-b668-41a6-a59c-28ed2990040e",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:43 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "93",
+        "x-request-id": "63d5d6df-b668-41a6-a59c-28ed2990040e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f621b1db-4d15-4da7-be5e-062be56ba91d",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2320662425969c409cc1244e8d49677e-fa7ddee990086f40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "656065ee419c5346164d772815a61600",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "8eb11ab2-9af3-4daf-a789-73361cd20fdd",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "358",
+        "x-request-id": "8eb11ab2-9af3-4daf-a789-73361cd20fdd"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithMinimumSetupAndGetInstance(False).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithMinimumSetupAndGetInstance(False).json
@@ -1,6 +1,215 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-20247ac8dd983d4e8ce8971bc2272e54-45c2aa28e8c7154d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ed58a064843411fc2f29240b32955245",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedXFxl3hI3",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "7ef64971-9186-4997-8a0b-fb7cd479669e",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:12 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2273fe32-5759-48d3-99e3-fe17b3f20c2e",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "477",
+        "x-request-id": "7ef64971-9186-4997-8a0b-fb7cd479669e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2273fe32-5759-48d3-99e3-fe17b3f20c2e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-20247ac8dd983d4e8ce8971bc2272e54-d4e86f1cc7717b4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1204d670485457bf040eaa103b04b0fb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "dad7cefe-1548-4e84-baa5-ccb35f15ce64",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "181",
+        "x-request-id": "dad7cefe-1548-4e84-baa5-ccb35f15ce64"
+      },
+      "ResponseBody": {
+        "dataFeedId": "2273fe32-5759-48d3-99e3-fe17b3f20c2e",
+        "dataFeedName": "dataFeedXFxl3hI3",
+        "metrics": [
+          {
+            "metricId": "d280895a-7c31-450a-b9cc-81606cac9887",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:39:12Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b10a567434a63c4a865bc0a8736ac7d2-681d93073f282648-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "bb8dbcf45244123be9eef4d7581ad41c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedIEfwmZCt",
+        "metricId": "d280895a-7c31-450a-b9cc-81606cac9887",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "53996f88-81b9-4f14-8c71-ecab135000d8",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:12 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fd52b5de-983e-4dfa-92cb-81e26671039d",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "130",
+        "x-request-id": "53996f88-81b9-4f14-8c71-ecab135000d8"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fd52b5de-983e-4dfa-92cb-81e26671039d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b10a567434a63c4a865bc0a8736ac7d2-448bb854cc2edc40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "25e901e1ebd92bd578281c2ec903c1cc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2423c162-76bb-4834-ad3a-0680fc9acb18",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:39:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "106",
+        "x-request-id": "2423c162-76bb-4834-ad3a-0680fc9acb18"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "fd52b5de-983e-4dfa-92cb-81e26671039d",
+        "name": "dataFeedIEfwmZCt",
+        "description": "",
+        "metricId": "d280895a-7c31-450a-b9cc-81606cac9887",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,10 +217,10 @@
         "Content-Length": "92",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-376996afacf7ef4d98c19c0afc7109a9-302c3922fce3a14a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-17713995fe61fb4fa669496d40ace6fa-84503a85cf2eba4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ed58a064843411fc2f29240b32955245",
+        "x-ms-client-request-id": "4c2797d2d90fd4a32eb06d82ba9b1808",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,48 +230,48 @@
           ]
         },
         "hookType": "Email",
-        "hookName": "hookXFxl3hI3"
+        "hookName": "hooktstpGuzG"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "9e747693-e8ef-401e-96d6-ff099e654296",
+        "apim-request-id": "018084da-aa44-43aa-a324-4c52c6ad270d",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/f067760c-9186-405f-8e50-c8a7367f2ddc",
+        "Date": "Thu, 10 Jun 2021 18:39:13 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/0534876b-7114-463b-a01d-72521effc35e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "650",
-        "x-request-id": "9e747693-e8ef-401e-96d6-ff099e654296"
+        "x-envoy-upstream-service-time": "296",
+        "x-request-id": "018084da-aa44-43aa-a324-4c52c6ad270d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/f067760c-9186-405f-8e50-c8a7367f2ddc",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/0534876b-7114-463b-a01d-72521effc35e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-376996afacf7ef4d98c19c0afc7109a9-5177cea9b8c5a64a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-17713995fe61fb4fa669496d40ace6fa-8c0ea325f58cd44b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1204d670485457bf040eaa103b04b0fb",
+        "x-ms-client-request-id": "1b4262e60c35e5492d27c146fb3d62dd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6ba4908b-b75b-4787-b24e-d141f7af7462",
+        "apim-request-id": "cb5e4384-37f9-49d3-860c-0f9a184f15da",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:36 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "167",
-        "x-request-id": "6ba4908b-b75b-4787-b24e-d141f7af7462"
+        "x-envoy-upstream-service-time": "175",
+        "x-request-id": "cb5e4384-37f9-49d3-860c-0f9a184f15da"
       },
       "ResponseBody": {
-        "hookId": "f067760c-9186-405f-8e50-c8a7367f2ddc",
-        "hookName": "hookXFxl3hI3",
+        "hookId": "0534876b-7114-463b-a01d-72521effc35e",
+        "hookName": "hooktstpGuzG",
         "hookType": "Email",
         "externalLink": "",
         "description": "",
@@ -84,21 +293,21 @@
         "Content-Length": "648",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fb192f4dcc9c0947941aa5bf48741536-370feda7f8758d46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-1521d53a68733144b57fb0dfb480a38a-dd53aafbfacab14a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "bb8dbcf45244123be9eef4d7581ad41c",
+        "x-ms-client-request-id": "190047853e957a12f816b157c1f67cc5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configIEfwmZCt",
+        "name": "configNQTz3HHH",
         "crossMetricsOperator": "XOR",
         "hookIds": [
-          "f067760c-9186-405f-8e50-c8a7367f2ddc"
+          "0534876b-7114-463b-a01d-72521effc35e"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fd52b5de-983e-4dfa-92cb-81e26671039d",
             "anomalyScopeType": "All",
             "severityFilter": {
               "minAlertSeverity": "Low",
@@ -113,12 +322,12 @@
               "lower": 10,
               "upper": 20,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "d280895a-7c31-450a-b9cc-81606cac9887",
               "triggerForMissing": true
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fd52b5de-983e-4dfa-92cb-81e26671039d",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -126,53 +335,53 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "01e1c00e-2215-49c7-af45-e322f99f8544",
+        "apim-request-id": "84cc8074-f020-4216-b6d0-d0a2a217a248",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3e0a4939-732f-43b7-a117-ac6267675aca",
+        "Date": "Thu, 10 Jun 2021 18:39:13 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/ff34a14f-94fc-498c-99ff-7b3282826fa0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "172",
-        "x-request-id": "01e1c00e-2215-49c7-af45-e322f99f8544"
+        "x-envoy-upstream-service-time": "148",
+        "x-request-id": "84cc8074-f020-4216-b6d0-d0a2a217a248"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3e0a4939-732f-43b7-a117-ac6267675aca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/ff34a14f-94fc-498c-99ff-7b3282826fa0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fb192f4dcc9c0947941aa5bf48741536-74034736d584cb47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-1521d53a68733144b57fb0dfb480a38a-a64f18acf2feeb42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "25e901e1ebd92bd578281c2ec903c1cc",
+        "x-ms-client-request-id": "e81f424e5c18f1d94d90948247d7445d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "72e85692-bf96-4266-85c4-a6f4c6982407",
+        "apim-request-id": "bbb2552e-6796-41e4-a9c2-0c634d1030cd",
         "Content-Length": "810",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:42 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5227",
-        "x-request-id": "72e85692-bf96-4266-85c4-a6f4c6982407"
+        "x-envoy-upstream-service-time": "105",
+        "x-request-id": "bbb2552e-6796-41e4-a9c2-0c634d1030cd"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "3e0a4939-732f-43b7-a117-ac6267675aca",
-        "name": "configIEfwmZCt",
+        "anomalyAlertingConfigurationId": "ff34a14f-94fc-498c-99ff-7b3282826fa0",
+        "name": "configNQTz3HHH",
         "description": "",
         "crossMetricsOperator": "XOR",
         "splitAlertByDimensions": [],
         "hookIds": [
-          "f067760c-9186-405f-8e50-c8a7367f2ddc"
+          "0534876b-7114-463b-a01d-72521effc35e"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fd52b5de-983e-4dfa-92cb-81e26671039d",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -188,13 +397,13 @@
               "lower": 10.0,
               "upper": 20.0,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "d280895a-7c31-450a-b9cc-81606cac9887",
               "triggerForMissing": true,
               "type": "Value"
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fd52b5de-983e-4dfa-92cb-81e26671039d",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -202,93 +411,29 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3e0a4939-732f-43b7-a117-ac6267675aca",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-54d0b607cc1f834a83c551a937854d12-630fdff23e883441-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "971e111503bab212d297274c0fd9a3d4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f5d78884-110b-40ca-8834-70298525c706",
-        "Content-Length": "810",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:43 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "103",
-        "x-request-id": "f5d78884-110b-40ca-8834-70298525c706"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "3e0a4939-732f-43b7-a117-ac6267675aca",
-        "name": "configIEfwmZCt",
-        "description": "",
-        "crossMetricsOperator": "XOR",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "f067760c-9186-405f-8e50-c8a7367f2ddc"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3e0a4939-732f-43b7-a117-ac6267675aca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/ff34a14f-94fc-498c-99ff-7b3282826fa0",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "705",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-50421b3fa6920d43849f8f45553a398d-3535ceedeab1774f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-2b490df67a119945a8c48043fb51dbdd-b62198a60a65e940-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "826db02e9bba0818e662421b350c49e5",
+        "x-ms-client-request-id": "ee95a347300cee5015464de58c0b1cf7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configIEfwmZCt",
+        "name": "configNQTz3HHH",
         "description": "",
         "crossMetricsOperator": "OR",
         "hookIds": [
-          "f067760c-9186-405f-8e50-c8a7367f2ddc"
+          "0534876b-7114-463b-a01d-72521effc35e"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fd52b5de-983e-4dfa-92cb-81e26671039d",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -305,12 +450,12 @@
               "upper": 20,
               "direction": "Both",
               "type": "Value",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "d280895a-7c31-450a-b9cc-81606cac9887",
               "triggerForMissing": true
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fd52b5de-983e-4dfa-92cb-81e26671039d",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -318,27 +463,27 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0b54a2a4-eb13-4a06-8f9a-57dfa4dd8258",
+        "apim-request-id": "a7109ddc-4dd5-4ca0-a25c-50ec52e0d274",
         "Content-Length": "809",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:43 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "196",
-        "x-request-id": "0b54a2a4-eb13-4a06-8f9a-57dfa4dd8258"
+        "x-envoy-upstream-service-time": "217",
+        "x-request-id": "a7109ddc-4dd5-4ca0-a25c-50ec52e0d274"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "3e0a4939-732f-43b7-a117-ac6267675aca",
-        "name": "configIEfwmZCt",
+        "anomalyAlertingConfigurationId": "ff34a14f-94fc-498c-99ff-7b3282826fa0",
+        "name": "configNQTz3HHH",
         "description": "",
         "crossMetricsOperator": "OR",
         "splitAlertByDimensions": [],
         "hookIds": [
-          "f067760c-9186-405f-8e50-c8a7367f2ddc"
+          "0534876b-7114-463b-a01d-72521effc35e"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fd52b5de-983e-4dfa-92cb-81e26671039d",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -354,13 +499,13 @@
               "lower": 10.0,
               "upper": 20.0,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "d280895a-7c31-450a-b9cc-81606cac9887",
               "triggerForMissing": true,
               "type": "Value"
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "fd52b5de-983e-4dfa-92cb-81e26671039d",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -368,116 +513,102 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3e0a4939-732f-43b7-a117-ac6267675aca",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d9702c94007c3746a9d82c6de7e5c49c-53ebfc1c5a9cba48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "46c1272d3dfbdd62ee375341c3891b9f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "06eb713b-0ca3-4802-9ee0-6521c7735169",
-        "Content-Length": "809",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:43 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "101",
-        "x-request-id": "06eb713b-0ca3-4802-9ee0-6521c7735169"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "3e0a4939-732f-43b7-a117-ac6267675aca",
-        "name": "configIEfwmZCt",
-        "description": "",
-        "crossMetricsOperator": "OR",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "f067760c-9186-405f-8e50-c8a7367f2ddc"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/3e0a4939-732f-43b7-a117-ac6267675aca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/ff34a14f-94fc-498c-99ff-7b3282826fa0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-26993c297dfbca4a83565ba1814fbdd9-0cb545091be26342-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-f061ca6d583a234a9c2ed1c535b3ef4b-0d10dccf2b548241-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "190047853e957a12f816b157c1f67cc5",
+        "x-ms-client-request-id": "81f38dbb326929866e0fcb04aa8f3221",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "790167ec-2ba9-4a51-98db-09c05240df3c",
+        "apim-request-id": "6e440082-c382-484c-8f12-9fb49ca4424d",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:43 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "218",
-        "x-request-id": "790167ec-2ba9-4a51-98db-09c05240df3c"
+        "x-envoy-upstream-service-time": "158",
+        "x-request-id": "6e440082-c382-484c-8f12-9fb49ca4424d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/f067760c-9186-405f-8e50-c8a7367f2ddc",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/0534876b-7114-463b-a01d-72521effc35e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2ffe5dc07d38b4469eda2b586c5b43aa-969b29fee4a9f243-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-879ed70fbc1ecd4681bed527ef212996-27acfb89c0c42b4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e81f424e5c18f1d94d90948247d7445d",
+        "x-ms-client-request-id": "1d0f53d18d601eb9f131d3d10ff46442",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e6b4b6c0-2194-4c8d-b5c8-1d388bdd2115",
+        "apim-request-id": "a6dd5c47-da2b-4eca-81d0-cdf655b21db7",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:43 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "187",
-        "x-request-id": "e6b4b6c0-2194-4c8d-b5c8-1d388bdd2115"
+        "x-envoy-upstream-service-time": "192",
+        "x-request-id": "a6dd5c47-da2b-4eca-81d0-cdf655b21db7"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fd52b5de-983e-4dfa-92cb-81e26671039d",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a90c4b9d1444324681289887961f0bc1-b1461e3010fd6544-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "bac79d74c2e314f31c6c80fc644b4385",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "d25d8178-c39b-4faa-bb8f-61ccf1a302ad",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "113",
+        "x-request-id": "d25d8178-c39b-4faa-bb8f-61ccf1a302ad"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2273fe32-5759-48d3-99e3-fe17b3f20c2e",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a253e3e18257c43bb25c34f056ed971-55be32452bb54c41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "38132b13fefb2d96d4d58f385fb51a79",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "769bf6f2-4f96-4189-9152-09e17ca575a5",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "323",
+        "x-request-id": "769bf6f2-4f96-4189-9152-09e17ca575a5"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithMinimumSetupAndGetInstance(False)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithMinimumSetupAndGetInstance(False)Async.json
@@ -1,6 +1,215 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0a490317c73f744f89e59c3d1ca85e29-1a9e809559998144-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f51a7fba05098112da4dbfd7f425efa5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedHQAKEf0B",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "cdfa2eee-6f7d-46e8-8138-8116d85d0ed6",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:41:25 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cfe18603-61b6-424a-9d04-03d8889ce818",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "780",
+        "x-request-id": "cdfa2eee-6f7d-46e8-8138-8116d85d0ed6"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cfe18603-61b6-424a-9d04-03d8889ce818",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0a490317c73f744f89e59c3d1ca85e29-5afa69ba24272b42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1fda89c1584222658b1dab6b806f3f83",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9f862306-da19-439b-990d-c38e6f69cbe4",
+        "Content-Length": "1010",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:41:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "163",
+        "x-request-id": "9f862306-da19-439b-990d-c38e6f69cbe4"
+      },
+      "ResponseBody": {
+        "dataFeedId": "cfe18603-61b6-424a-9d04-03d8889ce818",
+        "dataFeedName": "dataFeedHQAKEf0B",
+        "metrics": [
+          {
+            "metricId": "841a156b-5791-4183-b1eb-d33d523070bc",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:41:25Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2785801d8ff12042961723afcd978bc5-77102ae468fa304a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "5347b952b5943204e35937e195d89d61",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedbpm8WawA",
+        "metricId": "841a156b-5791-4183-b1eb-d33d523070bc",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "55ed8b4e-e29a-4138-9738-288bc9cc0c45",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:41:25 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/6ac784d6-04be-49bb-934b-aa9206d81853",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "120",
+        "x-request-id": "55ed8b4e-e29a-4138-9738-288bc9cc0c45"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/6ac784d6-04be-49bb-934b-aa9206d81853",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2785801d8ff12042961723afcd978bc5-6c977f35b5401344-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ec6af819a65a6a000e3c1980440157e8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2b71add2-d8b5-4426-88dc-b69f14556fe4",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:41:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "116",
+        "x-request-id": "2b71add2-d8b5-4426-88dc-b69f14556fe4"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "6ac784d6-04be-49bb-934b-aa9206d81853",
+        "name": "dataFeedbpm8WawA",
+        "description": "",
+        "metricId": "841a156b-5791-4183-b1eb-d33d523070bc",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,10 +217,10 @@
         "Content-Length": "92",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-09f0d14e8715cb44a86171a8c3267b90-8f38a1507f327345-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-97d4342acabace40a9a8a5b9ab3974ff-36d00e41e3a66243-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f51a7fba05098112da4dbfd7f425efa5",
+        "x-ms-client-request-id": "278879185d38e6eed67ed4546dbf10ab",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,48 +230,48 @@
           ]
         },
         "hookType": "Email",
-        "hookName": "hookHQAKEf0B"
+        "hookName": "hookWGNV2CGJ"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f781332e-b828-4de0-b029-c25729fe6b80",
+        "apim-request-id": "ca679409-9dd8-409a-a6b3-2792ea465063",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/85e3e0cb-26a1-4cbf-bc0e-ff340c5aeabc",
+        "Date": "Thu, 10 Jun 2021 18:41:25 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/fd70dd13-0363-4726-a69e-8f781657f70b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "323",
-        "x-request-id": "f781332e-b828-4de0-b029-c25729fe6b80"
+        "x-envoy-upstream-service-time": "386",
+        "x-request-id": "ca679409-9dd8-409a-a6b3-2792ea465063"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/85e3e0cb-26a1-4cbf-bc0e-ff340c5aeabc",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/fd70dd13-0363-4726-a69e-8f781657f70b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-09f0d14e8715cb44a86171a8c3267b90-1d3b3f0a2f9c7642-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-97d4342acabace40a9a8a5b9ab3974ff-b8aecf6f9506dd41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1fda89c1584222658b1dab6b806f3f83",
+        "x-ms-client-request-id": "5845ddb8839ce1ed024e04260b145007",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a8dec093-1c28-40c0-a55b-130cd35460d2",
+        "apim-request-id": "cc589ee1-b573-467a-bcb8-ad47c1ef0476",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:36 GMT",
+        "Date": "Thu, 10 Jun 2021 18:41:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "161",
-        "x-request-id": "a8dec093-1c28-40c0-a55b-130cd35460d2"
+        "x-envoy-upstream-service-time": "186",
+        "x-request-id": "cc589ee1-b573-467a-bcb8-ad47c1ef0476"
       },
       "ResponseBody": {
-        "hookId": "85e3e0cb-26a1-4cbf-bc0e-ff340c5aeabc",
-        "hookName": "hookHQAKEf0B",
+        "hookId": "fd70dd13-0363-4726-a69e-8f781657f70b",
+        "hookName": "hookWGNV2CGJ",
         "hookType": "Email",
         "externalLink": "",
         "description": "",
@@ -84,21 +293,21 @@
         "Content-Length": "648",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6519117dd0f7e7469d2123ee3213450f-62eaf33e76c1b042-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-0fb3008042daba41b95a967d96d0515a-ebd76d7abd9ad341-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "5347b952b5943204e35937e195d89d61",
+        "x-ms-client-request-id": "c5aa324d022d1d7b5e21d033cc353894",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configbpm8WawA",
+        "name": "configSufBbiox",
         "crossMetricsOperator": "XOR",
         "hookIds": [
-          "85e3e0cb-26a1-4cbf-bc0e-ff340c5aeabc"
+          "fd70dd13-0363-4726-a69e-8f781657f70b"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "6ac784d6-04be-49bb-934b-aa9206d81853",
             "anomalyScopeType": "All",
             "severityFilter": {
               "minAlertSeverity": "Low",
@@ -113,12 +322,12 @@
               "lower": 10,
               "upper": 20,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "841a156b-5791-4183-b1eb-d33d523070bc",
               "triggerForMissing": true
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "6ac784d6-04be-49bb-934b-aa9206d81853",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -126,53 +335,53 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2029b294-4641-4c40-8a0c-37528ffb9c09",
+        "apim-request-id": "eb2d0e2d-385b-4106-a2b2-a01257dcda19",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/07376230-1191-40fe-9b88-ef4e86bafe40",
+        "Date": "Thu, 10 Jun 2021 18:41:26 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/ebe9330d-5808-4ecf-8fad-da0a4094d5a5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "152",
-        "x-request-id": "2029b294-4641-4c40-8a0c-37528ffb9c09"
+        "x-envoy-upstream-service-time": "179",
+        "x-request-id": "eb2d0e2d-385b-4106-a2b2-a01257dcda19"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/07376230-1191-40fe-9b88-ef4e86bafe40",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/ebe9330d-5808-4ecf-8fad-da0a4094d5a5",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6519117dd0f7e7469d2123ee3213450f-b021db4ede989b48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-0fb3008042daba41b95a967d96d0515a-20af17dafc5ff74c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ec6af819a65a6a000e3c1980440157e8",
+        "x-ms-client-request-id": "ea24a68bc858c1db2dccead7eb2f8dde",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "13443ae9-417e-41cd-8b28-225c4fc8cecc",
+        "apim-request-id": "026a1bef-b950-49ce-88cc-ba98e693d8c1",
         "Content-Length": "810",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:36 GMT",
+        "Date": "Thu, 10 Jun 2021 18:41:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "93",
-        "x-request-id": "13443ae9-417e-41cd-8b28-225c4fc8cecc"
+        "x-envoy-upstream-service-time": "98",
+        "x-request-id": "026a1bef-b950-49ce-88cc-ba98e693d8c1"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "07376230-1191-40fe-9b88-ef4e86bafe40",
-        "name": "configbpm8WawA",
+        "anomalyAlertingConfigurationId": "ebe9330d-5808-4ecf-8fad-da0a4094d5a5",
+        "name": "configSufBbiox",
         "description": "",
         "crossMetricsOperator": "XOR",
         "splitAlertByDimensions": [],
         "hookIds": [
-          "85e3e0cb-26a1-4cbf-bc0e-ff340c5aeabc"
+          "fd70dd13-0363-4726-a69e-8f781657f70b"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "6ac784d6-04be-49bb-934b-aa9206d81853",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -188,13 +397,13 @@
               "lower": 10.0,
               "upper": 20.0,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "841a156b-5791-4183-b1eb-d33d523070bc",
               "triggerForMissing": true,
               "type": "Value"
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "6ac784d6-04be-49bb-934b-aa9206d81853",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -202,93 +411,29 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/07376230-1191-40fe-9b88-ef4e86bafe40",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-852158de8ffd83459c382d27862a8af7-f195c98a83357242-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "89cd6fdd1210d58e18798827385deee6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7f8c63bc-e2ea-4181-94f6-9611e812a585",
-        "Content-Length": "810",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:36 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "93",
-        "x-request-id": "7f8c63bc-e2ea-4181-94f6-9611e812a585"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "07376230-1191-40fe-9b88-ef4e86bafe40",
-        "name": "configbpm8WawA",
-        "description": "",
-        "crossMetricsOperator": "XOR",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "85e3e0cb-26a1-4cbf-bc0e-ff340c5aeabc"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/07376230-1191-40fe-9b88-ef4e86bafe40",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/ebe9330d-5808-4ecf-8fad-da0a4094d5a5",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "705",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-90f1361e8061604589d5b6ff524a368e-ae0c0e56d0cfcc46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-565cbf884b22f24bb2fd6491fb433818-d0be38b02694914c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "54d47ed6bf6dab10b8dd45589c83ede1",
+        "x-ms-client-request-id": "690a94ab27d9ffb4d3e6c7e9431d3b34",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configbpm8WawA",
+        "name": "configSufBbiox",
         "description": "",
         "crossMetricsOperator": "OR",
         "hookIds": [
-          "85e3e0cb-26a1-4cbf-bc0e-ff340c5aeabc"
+          "fd70dd13-0363-4726-a69e-8f781657f70b"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "6ac784d6-04be-49bb-934b-aa9206d81853",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -305,12 +450,12 @@
               "upper": 20,
               "direction": "Both",
               "type": "Value",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "841a156b-5791-4183-b1eb-d33d523070bc",
               "triggerForMissing": true
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "6ac784d6-04be-49bb-934b-aa9206d81853",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -318,27 +463,27 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "168ee692-8fc2-4247-b379-bffe05246e7f",
+        "apim-request-id": "a03c6400-3461-4218-bc4d-3f693fe43ae5",
         "Content-Length": "809",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:36 GMT",
+        "Date": "Thu, 10 Jun 2021 18:41:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "169",
-        "x-request-id": "168ee692-8fc2-4247-b379-bffe05246e7f"
+        "x-envoy-upstream-service-time": "210",
+        "x-request-id": "a03c6400-3461-4218-bc4d-3f693fe43ae5"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "07376230-1191-40fe-9b88-ef4e86bafe40",
-        "name": "configbpm8WawA",
+        "anomalyAlertingConfigurationId": "ebe9330d-5808-4ecf-8fad-da0a4094d5a5",
+        "name": "configSufBbiox",
         "description": "",
         "crossMetricsOperator": "OR",
         "splitAlertByDimensions": [],
         "hookIds": [
-          "85e3e0cb-26a1-4cbf-bc0e-ff340c5aeabc"
+          "fd70dd13-0363-4726-a69e-8f781657f70b"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "6ac784d6-04be-49bb-934b-aa9206d81853",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -354,13 +499,13 @@
               "lower": 10.0,
               "upper": 20.0,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "841a156b-5791-4183-b1eb-d33d523070bc",
               "triggerForMissing": true,
               "type": "Value"
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "6ac784d6-04be-49bb-934b-aa9206d81853",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -368,116 +513,102 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/07376230-1191-40fe-9b88-ef4e86bafe40",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-737eeae3fd4eb14282d6a47166fc84d3-0477f2088f6b634a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "26044e02140b07506a95d3e11ed931b0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ac9e3690-5c67-465b-87fc-20e5d255e440",
-        "Content-Length": "809",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:37 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "106",
-        "x-request-id": "ac9e3690-5c67-465b-87fc-20e5d255e440"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "07376230-1191-40fe-9b88-ef4e86bafe40",
-        "name": "configbpm8WawA",
-        "description": "",
-        "crossMetricsOperator": "OR",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "85e3e0cb-26a1-4cbf-bc0e-ff340c5aeabc"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/07376230-1191-40fe-9b88-ef4e86bafe40",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/ebe9330d-5808-4ecf-8fad-da0a4094d5a5",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ca7bf33239cac84ea7ca28551e0a8a8b-f29f2169bfbd3046-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-62f554a771d8dd49bbc2b4f0006bd657-8b055abf288e4843-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c5aa324d022d1d7b5e21d033cc353894",
+        "x-ms-client-request-id": "78553e5d47b4855857e8976018a3312e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6538f6ed-7b96-4426-9c51-d4ae0b6e2f07",
+        "apim-request-id": "39ab82cd-6797-468a-b83f-18a91cdb3162",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:37 GMT",
+        "Date": "Thu, 10 Jun 2021 18:41:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "138",
-        "x-request-id": "6538f6ed-7b96-4426-9c51-d4ae0b6e2f07"
+        "x-envoy-upstream-service-time": "144",
+        "x-request-id": "39ab82cd-6797-468a-b83f-18a91cdb3162"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/85e3e0cb-26a1-4cbf-bc0e-ff340c5aeabc",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/fd70dd13-0363-4726-a69e-8f781657f70b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-47a4122e44ad8247bec54a8c30c8a1c6-efed9783553a544c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e87ae1007675304a8fe06897e682c178-c3ec55dcb03ef348-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ea24a68bc858c1db2dccead7eb2f8dde",
+        "x-ms-client-request-id": "3887f194ce2b64bbf125167200f17e10",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5320f8b2-96b0-45d0-822f-e49847bfebd6",
+        "apim-request-id": "ca88d7d8-f2cd-47a0-9c5d-77b22f907cbc",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:37 GMT",
+        "Date": "Thu, 10 Jun 2021 18:41:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "207",
-        "x-request-id": "5320f8b2-96b0-45d0-822f-e49847bfebd6"
+        "x-envoy-upstream-service-time": "199",
+        "x-request-id": "ca88d7d8-f2cd-47a0-9c5d-77b22f907cbc"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/6ac784d6-04be-49bb-934b-aa9206d81853",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7caa4da19527194996859622b2aa3ef7-812b8072c480d748-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ad7ab69115da642a3c8411f18f53e730",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "24a6b0d1-6f97-4ba2-b085-2d37d32d5316",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:41:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "120",
+        "x-request-id": "24a6b0d1-6f97-4ba2-b085-2d37d32d5316"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cfe18603-61b6-424a-9d04-03d8889ce818",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-364ad6f138819c4b9d48fbe4424ce3cd-4b04b7aa673e7e4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "515598b402958e0983f1868f30e58566",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "c2a6807f-cc02-4f67-9712-71ec221dce9b",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:41:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "336",
+        "x-request-id": "c2a6807f-cc02-4f67-9712-71ec221dce9b"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithMinimumSetupAndGetInstance(True).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithMinimumSetupAndGetInstance(True).json
@@ -1,6 +1,211 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "traceparent": "00-472d2814610356479d9d7ebe72840977-fedab152933a1a46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a2ef29f511b604b7d6f3ec843189718b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeed2iLEvC5I",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "1676b0f1-2940-40f3-b675-2afa1f1056b4",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:54 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c90b9d35-d3b5-4928-b726-4c90898486a7",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5372",
+        "x-request-id": "1676b0f1-2940-40f3-b675-2afa1f1056b4"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c90b9d35-d3b5-4928-b726-4c90898486a7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-472d2814610356479d9d7ebe72840977-c836787821da8747-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d122fe4fcb666564c3f6840468f0b7a3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bb17a33e-a221-48a4-acac-b8fe2da58acb",
+        "Content-Length": "1052",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:38:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "197",
+        "x-request-id": "bb17a33e-a221-48a4-acac-b8fe2da58acb"
+      },
+      "ResponseBody": {
+        "dataFeedId": "c90b9d35-d3b5-4928-b726-4c90898486a7",
+        "dataFeedName": "dataFeed2iLEvC5I",
+        "metrics": [
+          {
+            "metricId": "863fc25e-4119-4001-a0a6-b52f6c1b0630",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "94dc466b-52e4-4678-892d-70a0c45c5f42"
+        ],
+        "viewers": [],
+        "creator": "94dc466b-52e4-4678-892d-70a0c45c5f42",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:38:54Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "traceparent": "00-be96bf12b6853d42bd2be6fa2ac5ba12-1534e6f1c6d86446-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a2a78ff8e60a8becf722ece4c5971f2a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedfQrvhxDm",
+        "metricId": "863fc25e-4119-4001-a0a6-b52f6c1b0630",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "d470f72f-4638-4f43-8def-b91bb250998d",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:38:54 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/5832e1fb-d573-4916-94ff-9fb673f4db6d",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "78",
+        "x-request-id": "d470f72f-4638-4f43-8def-b91bb250998d"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/5832e1fb-d573-4916-94ff-9fb673f4db6d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-be96bf12b6853d42bd2be6fa2ac5ba12-da4d8a94aa6b6d44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bfde8ac5b28de59c3c49b570c9962c22",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a8be9de2-852d-4f79-ad87-30e69191243b",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:38:59 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5137",
+        "x-request-id": "a8be9de2-852d-4f79-ad87-30e69191243b"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "5832e1fb-d573-4916-94ff-9fb673f4db6d",
+        "name": "dataFeedfQrvhxDm",
+        "description": "",
+        "metricId": "863fc25e-4119-4001-a0a6-b52f6c1b0630",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,9 +213,9 @@
         "Authorization": "Sanitized",
         "Content-Length": "92",
         "Content-Type": "application/json",
-        "traceparent": "00-3897d3f817ab2540aa8e6eb0dca52e27-05354b1328ef9d4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a2ef29f511b604b7d6f3ec843189718b",
+        "traceparent": "00-ffb5f96c94736d458b0977b8f0c191a7-f02a35d6be37bc42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "450cf90ad30438dda29615d44e6eac45",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -20,47 +225,47 @@
           ]
         },
         "hookType": "Email",
-        "hookName": "hook2iLEvC5I"
+        "hookName": "hookWqGdAMuD"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "76ec090a-4ea9-4192-9950-bd133f49d4dd",
+        "apim-request-id": "047e8c20-0537-4310-810f-a9d14f0c16f9",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:24 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/c475c953-1c71-49b4-8844-79f6937438c8",
+        "Date": "Thu, 10 Jun 2021 18:39:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/bf984380-c5cd-48c9-9ead-91e14788ba8b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "629",
-        "x-request-id": "76ec090a-4ea9-4192-9950-bd133f49d4dd"
+        "x-envoy-upstream-service-time": "5373",
+        "x-request-id": "047e8c20-0537-4310-810f-a9d14f0c16f9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/c475c953-1c71-49b4-8844-79f6937438c8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/bf984380-c5cd-48c9-9ead-91e14788ba8b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-3897d3f817ab2540aa8e6eb0dca52e27-9079e71c25535940-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d122fe4fcb666564c3f6840468f0b7a3",
+        "traceparent": "00-ffb5f96c94736d458b0977b8f0c191a7-ad5210eda76b334a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c166c2f37b3161c2f6c913ddbe470603",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "456322e9-9643-473c-96f7-d8eabe2002b8",
+        "apim-request-id": "9f372a2e-6557-42d7-b5db-645eb2a890d8",
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:29 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5183",
-        "x-request-id": "456322e9-9643-473c-96f7-d8eabe2002b8"
+        "x-envoy-upstream-service-time": "199",
+        "x-request-id": "9f372a2e-6557-42d7-b5db-645eb2a890d8"
       },
       "ResponseBody": {
-        "hookId": "c475c953-1c71-49b4-8844-79f6937438c8",
-        "hookName": "hook2iLEvC5I",
+        "hookId": "bf984380-c5cd-48c9-9ead-91e14788ba8b",
+        "hookName": "hookWqGdAMuD",
         "hookType": "Email",
         "externalLink": "",
         "description": "",
@@ -82,20 +287,20 @@
         "Authorization": "Sanitized",
         "Content-Length": "648",
         "Content-Type": "application/json",
-        "traceparent": "00-0a3ce0c14d1ba748a0046615a006b9ea-16a278e55a9f6c4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a2a78ff8e60a8becf722ece4c5971f2a",
+        "traceparent": "00-eb7b7c4688473a428e87cacbc6cb1d15-757b3c50645ecb48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "32ce7c6b588162d33c93e4615a99ab8f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configfQrvhxDm",
+        "name": "confighZ2fc2Np",
         "crossMetricsOperator": "XOR",
         "hookIds": [
-          "c475c953-1c71-49b4-8844-79f6937438c8"
+          "bf984380-c5cd-48c9-9ead-91e14788ba8b"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "5832e1fb-d573-4916-94ff-9fb673f4db6d",
             "anomalyScopeType": "All",
             "severityFilter": {
               "minAlertSeverity": "Low",
@@ -110,12 +315,12 @@
               "lower": 10,
               "upper": 20,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "863fc25e-4119-4001-a0a6-b52f6c1b0630",
               "triggerForMissing": true
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "5832e1fb-d573-4916-94ff-9fb673f4db6d",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -123,52 +328,52 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "46bc9c32-5ca6-43a2-afb0-b91a29bb7d7b",
+        "apim-request-id": "1582ec03-6de9-41e5-8c18-dce0cc38ceaf",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:29 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/f392d7d0-f2ba-4681-a139-3c5a53c41a63",
+        "Date": "Thu, 10 Jun 2021 18:39:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/0118e9ce-de7d-4974-b743-f37ef807ffa7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "107",
-        "x-request-id": "46bc9c32-5ca6-43a2-afb0-b91a29bb7d7b"
+        "x-envoy-upstream-service-time": "167",
+        "x-request-id": "1582ec03-6de9-41e5-8c18-dce0cc38ceaf"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/f392d7d0-f2ba-4681-a139-3c5a53c41a63",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/0118e9ce-de7d-4974-b743-f37ef807ffa7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0a3ce0c14d1ba748a0046615a006b9ea-d9bbb7154e399d4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bfde8ac5b28de59c3c49b570c9962c22",
+        "traceparent": "00-eb7b7c4688473a428e87cacbc6cb1d15-d7601c27b735cf45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "3a4fab3700bf5a7a9011a44cb9199f9c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d7ce8b6a-6921-4282-89c2-0ba89c972868",
+        "apim-request-id": "69979c8a-3325-4f17-aa21-78866d3161f8",
         "Content-Length": "810",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:29 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "34",
-        "x-request-id": "d7ce8b6a-6921-4282-89c2-0ba89c972868"
+        "x-envoy-upstream-service-time": "76",
+        "x-request-id": "69979c8a-3325-4f17-aa21-78866d3161f8"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "f392d7d0-f2ba-4681-a139-3c5a53c41a63",
-        "name": "configfQrvhxDm",
+        "anomalyAlertingConfigurationId": "0118e9ce-de7d-4974-b743-f37ef807ffa7",
+        "name": "confighZ2fc2Np",
         "description": "",
         "crossMetricsOperator": "XOR",
         "splitAlertByDimensions": [],
         "hookIds": [
-          "c475c953-1c71-49b4-8844-79f6937438c8"
+          "bf984380-c5cd-48c9-9ead-91e14788ba8b"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "5832e1fb-d573-4916-94ff-9fb673f4db6d",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -184,13 +389,13 @@
               "lower": 10.0,
               "upper": 20.0,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "863fc25e-4119-4001-a0a6-b52f6c1b0630",
               "triggerForMissing": true,
               "type": "Value"
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "5832e1fb-d573-4916-94ff-9fb673f4db6d",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -198,91 +403,28 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/f392d7d0-f2ba-4681-a139-3c5a53c41a63",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-225bf5a9fbe59e4b83214530d9882312-47eeb851c49d0744-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d7d9e8d0c124dd5a0af90c4504d3dd38",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "dfa9602e-0ef3-4a20-9d64-b71d2a7282d7",
-        "Content-Length": "810",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:34 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5095",
-        "x-request-id": "dfa9602e-0ef3-4a20-9d64-b71d2a7282d7"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "f392d7d0-f2ba-4681-a139-3c5a53c41a63",
-        "name": "configfQrvhxDm",
-        "description": "",
-        "crossMetricsOperator": "XOR",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "c475c953-1c71-49b4-8844-79f6937438c8"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/f392d7d0-f2ba-4681-a139-3c5a53c41a63",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/0118e9ce-de7d-4974-b743-f37ef807ffa7",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "705",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a744d40fc38b3d4ab7780e83591efff6-33996f8f35817446-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d41596a26e4e45acf3c266c1317bc261",
+        "traceparent": "00-17862cd408da41468c447a36198f484a-7c37da025650a846-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b455fee18fac9de0f5b1a02a63a4a996",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configfQrvhxDm",
+        "name": "confighZ2fc2Np",
         "description": "",
         "crossMetricsOperator": "OR",
         "hookIds": [
-          "c475c953-1c71-49b4-8844-79f6937438c8"
+          "bf984380-c5cd-48c9-9ead-91e14788ba8b"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "5832e1fb-d573-4916-94ff-9fb673f4db6d",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -299,12 +441,12 @@
               "upper": 20,
               "direction": "Both",
               "type": "Value",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "863fc25e-4119-4001-a0a6-b52f6c1b0630",
               "triggerForMissing": true
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "5832e1fb-d573-4916-94ff-9fb673f4db6d",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -312,90 +454,27 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "330dead9-b6c8-47d4-b7c8-eba4dd65329b",
+        "apim-request-id": "e0681da0-633f-4715-a144-fa1c7626c40c",
         "Content-Length": "809",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:35 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "381",
-        "x-request-id": "330dead9-b6c8-47d4-b7c8-eba4dd65329b"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "f392d7d0-f2ba-4681-a139-3c5a53c41a63",
-        "name": "configfQrvhxDm",
-        "description": "",
-        "crossMetricsOperator": "OR",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "c475c953-1c71-49b4-8844-79f6937438c8"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/f392d7d0-f2ba-4681-a139-3c5a53c41a63",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-0e1f94fe0df5bc43b08dadaa06f0087f-0815125a6e1f9748-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "dd13c9f647be03062f01b493a656e168",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "a2a49b85-5f16-4ea3-8858-3f9c6ee2c60a",
-        "Content-Length": "809",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:26:35 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "x-envoy-upstream-service-time": "149",
-        "x-request-id": "a2a49b85-5f16-4ea3-8858-3f9c6ee2c60a"
+        "x-request-id": "e0681da0-633f-4715-a144-fa1c7626c40c"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "f392d7d0-f2ba-4681-a139-3c5a53c41a63",
-        "name": "configfQrvhxDm",
+        "anomalyAlertingConfigurationId": "0118e9ce-de7d-4974-b743-f37ef807ffa7",
+        "name": "confighZ2fc2Np",
         "description": "",
         "crossMetricsOperator": "OR",
         "splitAlertByDimensions": [],
         "hookIds": [
-          "c475c953-1c71-49b4-8844-79f6937438c8"
+          "bf984380-c5cd-48c9-9ead-91e14788ba8b"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "5832e1fb-d573-4916-94ff-9fb673f4db6d",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -411,13 +490,13 @@
               "lower": 10.0,
               "upper": 20.0,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "863fc25e-4119-4001-a0a6-b52f6c1b0630",
               "triggerForMissing": true,
               "type": "Value"
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "5832e1fb-d573-4916-94ff-9fb673f4db6d",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -425,50 +504,98 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/f392d7d0-f2ba-4681-a139-3c5a53c41a63",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/0118e9ce-de7d-4974-b743-f37ef807ffa7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-018db3a7943d4a40b073126ddd6deb2c-f2d67c1aa977fe48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "32ce7c6b588162d33c93e4615a99ab8f",
+        "traceparent": "00-26b7b228bf1dc64d947c0ca15a6e6de0-d33ef2c8fcb40a45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fb5c2556a6076ba90274a16fb386a823",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "9b7a928e-da07-4b50-b057-848a37760a3e",
+        "apim-request-id": "94ff0e0c-2199-496c-ad6f-efab436c0311",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:35 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "134",
-        "x-request-id": "9b7a928e-da07-4b50-b057-848a37760a3e"
+        "x-envoy-upstream-service-time": "87",
+        "x-request-id": "94ff0e0c-2199-496c-ad6f-efab436c0311"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/c475c953-1c71-49b4-8844-79f6937438c8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/bf984380-c5cd-48c9-9ead-91e14788ba8b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-09120e07eb1a0945afc35ec43b6cc524-efbd7e8379360641-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3a4fab3700bf5a7a9011a44cb9199f9c",
+        "traceparent": "00-1bc32e983cf1dd48b3c83ae739351d12-a14edd11d8aadf4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5c8047f4f643a7e2cbb1440d5f4ff6ec",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5b7667e1-d4ac-4496-afb3-a55d9424dbd6",
+        "apim-request-id": "084c2a71-fa00-4fc1-bfa8-d8826ea0e4a0",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:26:35 GMT",
+        "Date": "Thu, 10 Jun 2021 18:39:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "183",
-        "x-request-id": "5b7667e1-d4ac-4496-afb3-a55d9424dbd6"
+        "x-envoy-upstream-service-time": "174",
+        "x-request-id": "084c2a71-fa00-4fc1-bfa8-d8826ea0e4a0"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/5832e1fb-d573-4916-94ff-9fb673f4db6d",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ea9ffc61e7599043b5bbafc635db7039-6ecb24a590e4ed4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "94f60e68a4bd3a9454eab238ee70e96f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "12cf9650-9e4a-4d55-9875-9376f499fda0",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "90",
+        "x-request-id": "12cf9650-9e4a-4d55-9875-9376f499fda0"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c90b9d35-d3b5-4928-b726-4c90898486a7",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-08689931b9825d499f0d2d4693785fbe-f9b20af245446b43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1b367d094d235f5342b42f56629b0cb2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "fd39b55d-f3db-46ff-967b-c1681dc8c927",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:39:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5286",
+        "x-request-id": "fd39b55d-f3db-46ff-967b-c1681dc8c927"
       },
       "ResponseBody": []
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithMinimumSetupAndGetInstance(True)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyAlertConfigurationLiveTests/UpdateAlertConfigurationWithMinimumSetupAndGetInstance(True)Async.json
@@ -1,6 +1,211 @@
 {
   "Entries": [
     {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "312",
+        "Content-Type": "application/json",
+        "traceparent": "00-9d080a867f424b4180d923e0300d5f84-0fa9412567c84b4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "beae3b5cd1b3fc5ab7a2bffa77563a4f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedBbtJKdza",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "metric"
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "634a7968-0700-4d73-801a-cd1b0cc92a61",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:40:50 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/676adf3f-ba80-46cb-a5f4-8ccbf7bfcbff",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5759",
+        "x-request-id": "634a7968-0700-4d73-801a-cd1b0cc92a61"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/676adf3f-ba80-46cb-a5f4-8ccbf7bfcbff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9d080a867f424b4180d923e0300d5f84-f487272eded5ef42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9c2de96a169a3ab39d59f9950cd6f62f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fbea455d-2754-46ce-8a4c-1b7374094516",
+        "Content-Length": "1052",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:40:55 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5143",
+        "x-request-id": "fbea455d-2754-46ce-8a4c-1b7374094516"
+      },
+      "ResponseBody": {
+        "dataFeedId": "676adf3f-ba80-46cb-a5f4-8ccbf7bfcbff",
+        "dataFeedName": "dataFeedBbtJKdza",
+        "metrics": [
+          {
+            "metricId": "850fcdc3-676d-4113-8b9d-8d87790f9802",
+            "metricName": "metric",
+            "metricDisplayName": "metric",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [
+          {
+            "dimensionName": "dimensionA",
+            "dimensionDisplayName": "dimensionA"
+          },
+          {
+            "dimensionName": "dimensionB",
+            "dimensionDisplayName": "dimensionB"
+          }
+        ],
+        "dataStartFrom": "2020-10-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "94dc466b-52e4-4678-892d-70a0c45c5f42"
+        ],
+        "viewers": [],
+        "creator": "94dc466b-52e4-4678-892d-70a0c45c5f42",
+        "status": "Active",
+        "createdTime": "2021-06-10T18:40:51Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "query": "query"
+        },
+        "authenticationType": "Basic"
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "traceparent": "00-3ac498f38e98234191e80869a0ccc023-540ef1e01a305d42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2aee85738a3f453e57773cd299bded45",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "dataFeedS2lunFoI",
+        "metricId": "850fcdc3-676d-4113-8b9d-8d87790f9802",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1
+            }
+          }
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "5cc56fc3-7bef-46b5-a2be-57d475a91317",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:41:01 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5113",
+        "x-request-id": "5cc56fc3-7bef-46b5-a2be-57d475a91317"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3ac498f38e98234191e80869a0ccc023-aa8dc2de46146c48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "59207487c5d7e0f0ac907c64f0d372b1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1d9ec4ec-81e7-422c-8c52-b6176dc549ac",
+        "Content-Length": "399",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 10 Jun 2021 18:41:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "81",
+        "x-request-id": "1d9ec4ec-81e7-422c-8c52-b6176dc549ac"
+      },
+      "ResponseBody": {
+        "anomalyDetectionConfigurationId": "9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
+        "name": "dataFeedS2lunFoI",
+        "description": "",
+        "metricId": "850fcdc3-676d-4113-8b9d-8d87790f9802",
+        "wholeMetricConfiguration": {
+          "hardThresholdCondition": {
+            "upperBound": 1.0,
+            "anomalyDetectorDirection": "Up",
+            "suppressCondition": {
+              "minNumber": 1,
+              "minRatio": 1.0
+            }
+          }
+        },
+        "dimensionGroupOverrideConfigurations": [],
+        "seriesOverrideConfigurations": []
+      }
+    },
+    {
       "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -8,9 +213,9 @@
         "Authorization": "Sanitized",
         "Content-Length": "92",
         "Content-Type": "application/json",
-        "traceparent": "00-de6a5ab14c37c041bb2bba6db029f4db-838f6d088e9b7d44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "beae3b5cd1b3fc5ab7a2bffa77563a4f",
+        "traceparent": "00-223440c8173ff74e94a1df8829fd1a68-03136a352b6f064d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "943db31b239ac196261fdf68972451ad",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -20,47 +225,47 @@
           ]
         },
         "hookType": "Email",
-        "hookName": "hookBbtJKdza"
+        "hookName": "hookvMXONjM2"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b418ac94-774b-4b93-b940-66fd30dd394a",
+        "apim-request-id": "cf260682-395c-49ec-9cd5-2be3124f6fd2",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:19 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/68dcaba3-ee19-4488-9546-32606b243938",
+        "Date": "Thu, 10 Jun 2021 18:41:07 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/9653c15d-4aca-4d76-a3d1-b880a56aeda5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "387",
-        "x-request-id": "b418ac94-774b-4b93-b940-66fd30dd394a"
+        "x-envoy-upstream-service-time": "5409",
+        "x-request-id": "cf260682-395c-49ec-9cd5-2be3124f6fd2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/68dcaba3-ee19-4488-9546-32606b243938",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/9653c15d-4aca-4d76-a3d1-b880a56aeda5",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-de6a5ab14c37c041bb2bba6db029f4db-f9f554e4b09e5441-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9c2de96a169a3ab39d59f9950cd6f62f",
+        "traceparent": "00-223440c8173ff74e94a1df8829fd1a68-725523fca131c542-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "af7e0d95da0e8455058a669493d81dfd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2e4d6d7f-ad5c-4267-8b37-3fc44391568c",
+        "apim-request-id": "e2ed50e1-202d-4467-b1c4-19758f12fd91",
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:19 GMT",
+        "Date": "Thu, 10 Jun 2021 18:41:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "232",
-        "x-request-id": "2e4d6d7f-ad5c-4267-8b37-3fc44391568c"
+        "x-envoy-upstream-service-time": "5159",
+        "x-request-id": "e2ed50e1-202d-4467-b1c4-19758f12fd91"
       },
       "ResponseBody": {
-        "hookId": "68dcaba3-ee19-4488-9546-32606b243938",
-        "hookName": "hookBbtJKdza",
+        "hookId": "9653c15d-4aca-4d76-a3d1-b880a56aeda5",
+        "hookName": "hookvMXONjM2",
         "hookType": "Email",
         "externalLink": "",
         "description": "",
@@ -82,20 +287,20 @@
         "Authorization": "Sanitized",
         "Content-Length": "648",
         "Content-Type": "application/json",
-        "traceparent": "00-064416d35f8b7145b9ab38c81e7202bb-38d8cd4aaae57d4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2aee85738a3f453e57773cd299bded45",
+        "traceparent": "00-e8c975326846b94a8f95f40a7a967f73-295597dadca1f74f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d03ebbf909f3471ab27b801a0b4a0441",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configS2lunFoI",
+        "name": "configl2vlqIvd",
         "crossMetricsOperator": "XOR",
         "hookIds": [
-          "68dcaba3-ee19-4488-9546-32606b243938"
+          "9653c15d-4aca-4d76-a3d1-b880a56aeda5"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
             "anomalyScopeType": "All",
             "severityFilter": {
               "minAlertSeverity": "Low",
@@ -110,12 +315,12 @@
               "lower": 10,
               "upper": 20,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "850fcdc3-676d-4113-8b9d-8d87790f9802",
               "triggerForMissing": true
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -123,52 +328,52 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d9180466-7650-4bcd-b9a5-fc8ef52810f4",
+        "apim-request-id": "46cf9c9d-d9ee-490a-95b4-6ae45f4313c4",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:19 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/c9eeed4d-90d9-4c7d-af94-f8e87eeb77d7",
+        "Date": "Thu, 10 Jun 2021 18:41:12 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/6546c3bb-83f1-42d9-b097-a762b3c26667",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "190",
-        "x-request-id": "d9180466-7650-4bcd-b9a5-fc8ef52810f4"
+        "x-envoy-upstream-service-time": "161",
+        "x-request-id": "46cf9c9d-d9ee-490a-95b4-6ae45f4313c4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/c9eeed4d-90d9-4c7d-af94-f8e87eeb77d7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/6546c3bb-83f1-42d9-b097-a762b3c26667",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-064416d35f8b7145b9ab38c81e7202bb-a02befb368fecb4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "59207487c5d7e0f0ac907c64f0d372b1",
+        "traceparent": "00-e8c975326846b94a8f95f40a7a967f73-b87a09dbc606e64a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "108eb95e01bc4d2d02e1ee89e62d2638",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e24de25a-bd8b-45ea-99e1-60393c61e284",
+        "apim-request-id": "9567623d-b24e-4182-a038-ce27d136b38e",
         "Content-Length": "810",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:24 GMT",
+        "Date": "Thu, 10 Jun 2021 18:41:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5057",
-        "x-request-id": "e24de25a-bd8b-45ea-99e1-60393c61e284"
+        "x-envoy-upstream-service-time": "5267",
+        "x-request-id": "9567623d-b24e-4182-a038-ce27d136b38e"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "c9eeed4d-90d9-4c7d-af94-f8e87eeb77d7",
-        "name": "configS2lunFoI",
+        "anomalyAlertingConfigurationId": "6546c3bb-83f1-42d9-b097-a762b3c26667",
+        "name": "configl2vlqIvd",
         "description": "",
         "crossMetricsOperator": "XOR",
         "splitAlertByDimensions": [],
         "hookIds": [
-          "68dcaba3-ee19-4488-9546-32606b243938"
+          "9653c15d-4aca-4d76-a3d1-b880a56aeda5"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -184,13 +389,13 @@
               "lower": 10.0,
               "upper": 20.0,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "850fcdc3-676d-4113-8b9d-8d87790f9802",
               "triggerForMissing": true,
               "type": "Value"
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -198,91 +403,28 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/c9eeed4d-90d9-4c7d-af94-f8e87eeb77d7",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-e01ac685611c82499b4e2d99920ccc48-c7868830bb420b4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1529046b892812fa1bb33d949a2396c1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "874fdcb6-1d50-47e6-add1-2c94c85ccf36",
-        "Content-Length": "810",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:30 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5108",
-        "x-request-id": "874fdcb6-1d50-47e6-add1-2c94c85ccf36"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "c9eeed4d-90d9-4c7d-af94-f8e87eeb77d7",
-        "name": "configS2lunFoI",
-        "description": "",
-        "crossMetricsOperator": "XOR",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "68dcaba3-ee19-4488-9546-32606b243938"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/c9eeed4d-90d9-4c7d-af94-f8e87eeb77d7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/6546c3bb-83f1-42d9-b097-a762b3c26667",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "705",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2af950f817c29e4daf1cf9b63950a7b1-4a572fe783495344-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "68df1f262497ad51950d7eaf0eda5584",
+        "traceparent": "00-83f3be9886f390409cf1d12bf8a11748-f46ea25b819f2242-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "52b5f5c7849cfc906f1fe2185803f230",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "configS2lunFoI",
+        "name": "configl2vlqIvd",
         "description": "",
         "crossMetricsOperator": "OR",
         "hookIds": [
-          "68dcaba3-ee19-4488-9546-32606b243938"
+          "9653c15d-4aca-4d76-a3d1-b880a56aeda5"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -299,12 +441,12 @@
               "upper": 20,
               "direction": "Both",
               "type": "Value",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "850fcdc3-676d-4113-8b9d-8d87790f9802",
               "triggerForMissing": true
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -312,27 +454,27 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f4254952-b5e4-46ee-be8a-9d1e8a6715e0",
+        "apim-request-id": "2fe7926b-4a8d-4a5f-a476-1c5ca6b1f6b3",
         "Content-Length": "809",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:35 GMT",
+        "Date": "Thu, 10 Jun 2021 18:41:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5228",
-        "x-request-id": "f4254952-b5e4-46ee-be8a-9d1e8a6715e0"
+        "x-envoy-upstream-service-time": "220",
+        "x-request-id": "2fe7926b-4a8d-4a5f-a476-1c5ca6b1f6b3"
       },
       "ResponseBody": {
-        "anomalyAlertingConfigurationId": "c9eeed4d-90d9-4c7d-af94-f8e87eeb77d7",
-        "name": "configS2lunFoI",
+        "anomalyAlertingConfigurationId": "6546c3bb-83f1-42d9-b097-a762b3c26667",
+        "name": "configl2vlqIvd",
         "description": "",
         "crossMetricsOperator": "OR",
         "splitAlertByDimensions": [],
         "hookIds": [
-          "68dcaba3-ee19-4488-9546-32606b243938"
+          "9653c15d-4aca-4d76-a3d1-b880a56aeda5"
         ],
         "metricAlertingConfigurations": [
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
             "anomalyScopeType": "All",
             "negationOperation": false,
             "severityFilter": {
@@ -348,13 +490,13 @@
               "lower": 10.0,
               "upper": 20.0,
               "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+              "metricId": "850fcdc3-676d-4113-8b9d-8d87790f9802",
               "triggerForMissing": true,
               "type": "Value"
             }
           },
           {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "anomalyDetectionConfigurationId": "9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
             "anomalyScopeType": "All",
             "negationOperation": true
           }
@@ -362,113 +504,98 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/c9eeed4d-90d9-4c7d-af94-f8e87eeb77d7",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-f40edf36940c5b4f9d0bce8182e8a42a-a353668015593642-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "94668a05d893fd1d7a0d3d23875c4588",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "927d23d6-8418-42aa-ab34-6abaa31b144c",
-        "Content-Length": "809",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 04 Jun 2021 10:27:35 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "44",
-        "x-request-id": "927d23d6-8418-42aa-ab34-6abaa31b144c"
-      },
-      "ResponseBody": {
-        "anomalyAlertingConfigurationId": "c9eeed4d-90d9-4c7d-af94-f8e87eeb77d7",
-        "name": "configS2lunFoI",
-        "description": "",
-        "crossMetricsOperator": "OR",
-        "splitAlertByDimensions": [],
-        "hookIds": [
-          "68dcaba3-ee19-4488-9546-32606b243938"
-        ],
-        "metricAlertingConfigurations": [
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": false,
-            "severityFilter": {
-              "minAlertSeverity": "Low",
-              "maxAlertSeverity": "Medium"
-            },
-            "snoozeFilter": {
-              "autoSnooze": 12,
-              "snoozeScope": "Series",
-              "onlyForSuccessive": true
-            },
-            "valueFilter": {
-              "lower": 10.0,
-              "upper": 20.0,
-              "direction": "Both",
-              "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
-              "triggerForMissing": true,
-              "type": "Value"
-            }
-          },
-          {
-            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
-            "anomalyScopeType": "All",
-            "negationOperation": true
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/c9eeed4d-90d9-4c7d-af94-f8e87eeb77d7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/6546c3bb-83f1-42d9-b097-a762b3c26667",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f6d30a24594b5747860244827d39b517-49560237cf768745-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d03ebbf909f3471ab27b801a0b4a0441",
+        "traceparent": "00-36580d8334e76d41bf98bcd9702a25ea-de9fc8f452145a4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "cec5fc0935cdf8cb8ef0ce121b916084",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8a23c3f3-1da9-4a7a-bb66-e9f9c81897f4",
+        "apim-request-id": "07809688-c73e-4123-865f-409035089c05",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:35 GMT",
+        "Date": "Thu, 10 Jun 2021 18:41:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "90",
-        "x-request-id": "8a23c3f3-1da9-4a7a-bb66-e9f9c81897f4"
+        "x-envoy-upstream-service-time": "206",
+        "x-request-id": "07809688-c73e-4123-865f-409035089c05"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/68dcaba3-ee19-4488-9546-32606b243938",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/hooks/9653c15d-4aca-4d76-a3d1-b880a56aeda5",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-b48170436ed7f142928a90db4c400498-06f043756700fb4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210604.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "108eb95e01bc4d2d02e1ee89e62d2638",
+        "traceparent": "00-e9b3b93d75fc1e429ac676d031d0fad1-e47e656110732440-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "15524755b194daa52992a09d1e15f5fe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "846b067a-763d-46f5-be64-de57bc04bb3d",
+        "apim-request-id": "95af97e9-b766-4df3-97e8-7096e0e046b5",
         "Content-Length": "0",
-        "Date": "Fri, 04 Jun 2021 10:27:35 GMT",
+        "Date": "Thu, 10 Jun 2021 18:41:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "158",
-        "x-request-id": "846b067a-763d-46f5-be64-de57bc04bb3d"
+        "x-envoy-upstream-service-time": "174",
+        "x-request-id": "95af97e9-b766-4df3-97e8-7096e0e046b5"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/9a0459d9-b29a-4fff-a7ec-d7c2afe629af",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-acb88cff5a088549970db3313c2f8dbe-89628a58de66a44a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ea80bdef5868926b29bcc4abb57ee0de",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "8cd28377-890f-42d3-bb8c-6efda0ff88e1",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:41:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "85",
+        "x-request-id": "8cd28377-890f-42d3-bb8c-6efda0ff88e1"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/676adf3f-ba80-46cb-a5f4-8ccbf7bfcbff",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a5bf94453a256448a20c9e7f1e56dc5-bae60becd78ed14a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210610.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "11c35dbeddb0579b57eaa43b942eda79",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "d61ef719-451b-4af9-9c0e-3288b2b3845e",
+        "Content-Length": "0",
+        "Date": "Thu, 10 Jun 2021 18:41:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "5297",
+        "x-request-id": "d61ef719-451b-4af9-9c0e-3288b2b3845e"
       },
       "ResponseBody": []
     }


### PR DESCRIPTION
Part of https://github.com/azure/azure-sdk-for-net/issues/21663.

Same as we did in https://github.com/Azure/azure-sdk-for-net/pull/21748. The service doesn't seem to have a limit of how many alert configurations we can create per data feed, but it's still a good idea to stop polluting the static data feed we use for other tests.