### PR TITLE
Fix CanCancelContentUploadHttps flakiness

### DIFF
--- a/sdk/core/Azure.Core/src/RequestContent.cs
+++ b/sdk/core/Azure.Core/src/RequestContent.cs
@@ -142,10 +142,10 @@ namespace Azure.Core
                 {
                     while (true)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
+                        CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
                         var read = _stream.Read(buffer, 0, buffer.Length);
                         if (read == 0) { break; }
-                        cancellationToken.ThrowIfCancellationRequested();
+                        CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
                         stream.Write(buffer, 0, read);
                     }
                 }

--- a/sdk/core/Azure.Core/tests/HttpPipelineRequestContentTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineRequestContentTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
@@ -21,7 +22,7 @@ namespace Azure.Core.Tests
             var content = RequestContent.Create(source);
             var cancellation = new CancellationTokenSource();
             cancellation.Cancel();
-            Assert.Throws<OperationCanceledException>(() => { content.WriteTo(destination, cancellation.Token); });
+            Assert.Throws<TaskCanceledException>(() => { content.WriteTo(destination, cancellation.Token); });
         }
 
         [Test]


### PR DESCRIPTION
By normalizing the exception type. 

A typical failure looks like this:

```
Expected: instance of <System.Threading.Tasks.TaskCanceledException>
But was:  <System.OperationCanceledException: The operation was canceled.
at System.Threading.CancellationToken.ThrowOperationCanceledException()
at System.Threading.CancellationToken.ThrowIfCancellationRequested()
at Azure.Core.RequestContent.StreamContent.WriteTo(Stream stream, CancellationToken cancellationToken) in //sdk/core/Azure.Core/src/RequestContent.cs:line 145
at Azure.Core.Pipeline.HttpClientTransport.PipelineRequest.PipelineContentAdapter.SerializeToStream(Stream stream, TransportContext context, CancellationToken cancellationToken) in //sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs:line 481
at System.Net.Http.HttpContent.CopyTo(Stream stream, TransportContext context, CancellationToken cancellationToken)
at System.Net.Http.HttpConnection.SendRequestContentAsync(HttpRequestMessage request, HttpContentWriteStream stream, Boolean async, CancellationToken cancellationToken)
at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
at System.Net.Http.HttpConnectionPool.SendWithRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
at System.Net.Http.HttpMessageHandlerStage.Send(HttpRequestMessage request, CancellationToken cancellationToken)
at System.Net.Http.SocketsHttpHandler.Send(HttpRequestMessage request, CancellationToken cancellationToken)
at System.Net.Http.HttpClientHandler.Send(HttpRequestMessage request, CancellationToken cancellationToken)

```