### PR TITLE
Change Parent in ContainerBase to OperationsBase type

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/ContainerBase.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/ContainerBase.cs
@@ -54,7 +54,7 @@ namespace Azure.ResourceManager.Core
         /// Initializes a new instance of the <see cref="ContainerBase"/> class.
         /// </summary>
         /// <param name="parent"> The resource representing the parent resource. </param>
-        protected ContainerBase(ResourceOperationsBase parent)
+        protected ContainerBase(OperationsBase parent)
             : base(new ClientContext(parent.ClientOptions, parent.Credential, parent.BaseUri, parent.Pipeline), parent.Id)
         {
             Parent = parent;
@@ -63,6 +63,6 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Gets the parent resource of this resource.
         /// </summary>
-        protected ResourceOperationsBase Parent { get; }
+        protected OperationsBase Parent { get; }
     }
 }

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/OperationsBase.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/OperationsBase.cs
@@ -23,6 +23,16 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="OperationsBase"/> class.
         /// </summary>
+        /// <param name="parentOperations"> The resource representing the parent resource. </param>
+        /// <param name="id"> The identifier of the resource that is the target of operations. </param>
+        protected OperationsBase(OperationsBase parentOperations, ResourceIdentifier id)
+            : this(new ClientContext(parentOperations.ClientOptions, parentOperations.Credential, parentOperations.BaseUri, parentOperations.Pipeline), id)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationsBase"/> class.
+        /// </summary>
         /// <param name="clientContext"></param>
         /// <param name="id"> The identifier of the resource that is the target of operations. </param>
         internal OperationsBase(ClientContext clientContext, ResourceIdentifier id)

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceContainerBase.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceContainerBase.cs
@@ -49,6 +49,11 @@ namespace Azure.ResourceManager.Core
         }
 
         /// <summary>
+        /// Gets the parent resource of this resource.
+        /// </summary>
+        protected new ResourceOperationsBase Parent { get {return base.Parent as ResourceOperationsBase;} }
+
+        /// <summary>
         /// Verify that the input resource Id is a valid container for this type.
         /// </summary>
         /// <param name="identifier"> The input resource Id to check. </param>


### PR DESCRIPTION
In order to support operations in a TenantContainer and TennantOperations, this PR makes the following changes: 
1. Change `Parent` in `ContainerBase` to `OperationsBase` type.
2. Keep `Parent` in `ResourceContainerBase` as `ResourceOperationsBase` type by hiding `Parent` from the base class `ContainerBase` with the `new` keyword.
3. Add a constructor: `protected OperationsBase(OperationsBase parentOperations, ResourceIdentifier id)`

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
