### PR TITLE
Add main trigger to new-ish pipelines.

### DIFF
--- a/sdk/modelsrepository/ci.yml
+++ b/sdk/modelsrepository/ci.yml
@@ -4,6 +4,7 @@ trigger:
   branches:
     include:
     - master
+    - main
     - hotfix/*
     - release/*
   paths:
@@ -14,6 +15,7 @@ pr:
   branches:
     include:
     - master
+    - main
     - feature/*
     - hotfix/*
     - release/*

--- a/sdk/objectanchors/ci.yml
+++ b/sdk/objectanchors/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
     - master
+    - main
     - hotfix/*
     - release/*
   paths:
@@ -13,6 +14,7 @@ pr:
   branches:
     include:
     - master
+    - main
     - feature/*
     - hotfix/*
     - release/*

--- a/sdk/remoterendering/ci.yml
+++ b/sdk/remoterendering/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
     - master
+    - main
     - hotfix/*
     - release/*
   paths:
@@ -13,6 +14,7 @@ pr:
   branches:
     include:
     - master
+    - main
     - feature/*
     - hotfix/*
     - release/*

--- a/sdk/translation/ci.yml
+++ b/sdk/translation/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
     - master
+    - main
     - hotfix/*
     - release/*
   paths:
@@ -13,6 +14,7 @@ pr:
   branches:
     include:
     - master
+    - main
     - feature/*
     - hotfix/*
     - release/*


### PR DESCRIPTION
This PR adds the ```main``` branch to some pipelines that were added after the first sweep through. Probably branches that had already been cloned off template and merged in after the first pass.