### PR TITLE
[MetricsAdvisor] Moved options and abstract types to different namespaces

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0-beta.5 (Unreleased)
 
+### Breaking Changes
+- Moved `GetAlertConfigurationsOptions`, `GetDatasourceCredentialsOptions`, and `GetDetectionConfigurationsOptions` to the `Azure.AI.MetricsAdvisor.Administration` namespace.
+- Moved `DatasourceCredential`, `DataFeedSource`, `NotificationHook`, and all of their concrete child types to the `Azure.AI.MetricsAdvisor.Administration` namespace.
+- Moved `MetricFeedback` and all of its concrete child types to the `Azure.AI.MetricsAdvisor` namespace. 
 
 ## 1.0.0-beta.4 (2021-06-07)
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -37,12 +37,6 @@ namespace Azure.AI.MetricsAdvisor
         public static bool operator !=(Azure.AI.MetricsAdvisor.FeedbackQueryTimeMode left, Azure.AI.MetricsAdvisor.FeedbackQueryTimeMode right) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class GetAlertConfigurationsOptions
-    {
-        public GetAlertConfigurationsOptions() { }
-        public int? MaxPageSize { get { throw null; } set { } }
-        public int? Skip { get { throw null; } set { } }
-    }
     public partial class GetAlertsOptions
     {
         public GetAlertsOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime, Azure.AI.MetricsAdvisor.AlertQueryTimeMode timeMode) { }
@@ -95,18 +89,6 @@ namespace Azure.AI.MetricsAdvisor
         public int? Skip { get { throw null; } set { } }
         public System.DateTimeOffset StartTime { get { throw null; } }
     }
-    public partial class GetDatasourceCredentialsOptions
-    {
-        public GetDatasourceCredentialsOptions() { }
-        public int? MaxPageSize { get { throw null; } set { } }
-        public int? Skip { get { throw null; } set { } }
-    }
-    public partial class GetDetectionConfigurationsOptions
-    {
-        public GetDetectionConfigurationsOptions() { }
-        public int? MaxPageSize { get { throw null; } set { } }
-        public int? Skip { get { throw null; } set { } }
-    }
     public partial class GetIncidentsForAlertOptions
     {
         public GetIncidentsForAlertOptions() { }
@@ -151,6 +133,45 @@ namespace Azure.AI.MetricsAdvisor
         public int? MaxPageSize { get { throw null; } set { } }
         public int? Skip { get { throw null; } set { } }
     }
+    public partial class MetricAnomalyFeedback : Azure.AI.MetricsAdvisor.MetricFeedback
+    {
+        public MetricAnomalyFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.FeedbackDimensionFilter dimensionFilter, System.DateTimeOffset startTime, System.DateTimeOffset endTime, Azure.AI.MetricsAdvisor.Models.AnomalyValue value) { }
+        public string AnomalyDetectionConfigurationId { get { throw null; } set { } }
+        public Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration AnomalyDetectionConfigurationSnapshot { get { throw null; } }
+        public Azure.AI.MetricsAdvisor.Models.AnomalyValue AnomalyValue { get { throw null; } }
+        public System.DateTimeOffset EndTime { get { throw null; } set { } }
+        public System.DateTimeOffset StartTime { get { throw null; } set { } }
+    }
+    public partial class MetricChangePointFeedback : Azure.AI.MetricsAdvisor.MetricFeedback
+    {
+        public MetricChangePointFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.FeedbackDimensionFilter dimensionFilter, System.DateTimeOffset startTime, System.DateTimeOffset endTime, Azure.AI.MetricsAdvisor.Models.ChangePointValue value) { }
+        public Azure.AI.MetricsAdvisor.Models.ChangePointValue ChangePointValue { get { throw null; } }
+        public System.DateTimeOffset EndTime { get { throw null; } set { } }
+        public System.DateTimeOffset StartTime { get { throw null; } set { } }
+    }
+    public partial class MetricCommentFeedback : Azure.AI.MetricsAdvisor.MetricFeedback
+    {
+        public MetricCommentFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.FeedbackDimensionFilter dimensionFilter, string comment) { }
+        public string Comment { get { throw null; } }
+        public System.DateTimeOffset? EndTime { get { throw null; } set { } }
+        public System.DateTimeOffset? StartTime { get { throw null; } set { } }
+    }
+    public abstract partial class MetricFeedback
+    {
+        internal MetricFeedback() { }
+        public System.DateTimeOffset? CreatedTime { get { throw null; } }
+        public Azure.AI.MetricsAdvisor.Models.FeedbackDimensionFilter DimensionFilter { get { throw null; } }
+        public string Id { get { throw null; } }
+        public string MetricId { get { throw null; } }
+        public Azure.AI.MetricsAdvisor.Models.FeedbackType Type { get { throw null; } }
+        public string UserPrincipal { get { throw null; } }
+    }
+    public partial class MetricPeriodFeedback : Azure.AI.MetricsAdvisor.MetricFeedback
+    {
+        public MetricPeriodFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.FeedbackDimensionFilter dimensionFilter, Azure.AI.MetricsAdvisor.Models.PeriodType periodType, int periodValue) { }
+        public Azure.AI.MetricsAdvisor.Models.PeriodType PeriodType { get { throw null; } }
+        public int PeriodValue { get { throw null; } }
+    }
     public partial class MetricsAdvisorClient
     {
         protected MetricsAdvisorClient() { }
@@ -158,20 +179,20 @@ namespace Azure.AI.MetricsAdvisor
         public MetricsAdvisorClient(System.Uri endpoint, Azure.AI.MetricsAdvisor.MetricsAdvisorKeyCredential credential, Azure.AI.MetricsAdvisor.MetricsAdvisorClientsOptions options) { }
         public MetricsAdvisorClient(System.Uri endpoint, Azure.Core.TokenCredential credential) { }
         public MetricsAdvisorClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.AI.MetricsAdvisor.MetricsAdvisorClientsOptions options) { }
-        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.MetricFeedback> AddFeedback(Azure.AI.MetricsAdvisor.Models.MetricFeedback feedback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.MetricFeedback>> AddFeedbackAsync(Azure.AI.MetricsAdvisor.Models.MetricFeedback feedback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.MetricsAdvisor.MetricFeedback> AddFeedback(Azure.AI.MetricsAdvisor.MetricFeedback feedback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.MetricFeedback>> AddFeedbackAsync(Azure.AI.MetricsAdvisor.MetricFeedback feedback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.AnomalyAlert> GetAlerts(string alertConfigurationId, Azure.AI.MetricsAdvisor.GetAlertsOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.AnomalyAlert> GetAlertsAsync(string alertConfigurationId, Azure.AI.MetricsAdvisor.GetAlertsOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.MetricFeedback> GetAllFeedback(string metricId, Azure.AI.MetricsAdvisor.GetAllFeedbackOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.MetricFeedback> GetAllFeedbackAsync(string metricId, Azure.AI.MetricsAdvisor.GetAllFeedbackOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.MetricFeedback> GetAllFeedback(string metricId, Azure.AI.MetricsAdvisor.GetAllFeedbackOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.MetricFeedback> GetAllFeedbackAsync(string metricId, Azure.AI.MetricsAdvisor.GetAllFeedbackOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.DataPointAnomaly> GetAnomalies(string detectionConfigurationId, Azure.AI.MetricsAdvisor.GetAnomaliesForDetectionConfigurationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.DataPointAnomaly> GetAnomalies(string alertConfigurationId, string alertId, Azure.AI.MetricsAdvisor.GetAnomaliesForAlertOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.DataPointAnomaly> GetAnomaliesAsync(string detectionConfigurationId, Azure.AI.MetricsAdvisor.GetAnomaliesForDetectionConfigurationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.DataPointAnomaly> GetAnomaliesAsync(string alertConfigurationId, string alertId, Azure.AI.MetricsAdvisor.GetAnomaliesForAlertOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<string> GetAnomalyDimensionValues(string detectionConfigurationId, string dimensionName, Azure.AI.MetricsAdvisor.GetAnomalyDimensionValuesOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<string> GetAnomalyDimensionValuesAsync(string detectionConfigurationId, string dimensionName, Azure.AI.MetricsAdvisor.GetAnomalyDimensionValuesOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.MetricFeedback> GetFeedback(string feedbackId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.MetricFeedback>> GetFeedbackAsync(string feedbackId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.MetricsAdvisor.MetricFeedback> GetFeedback(string feedbackId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.MetricFeedback>> GetFeedbackAsync(string feedbackId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.IncidentRootCause> GetIncidentRootCauses(Azure.AI.MetricsAdvisor.Models.AnomalyIncident incident, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.IncidentRootCause> GetIncidentRootCauses(string detectionConfigurationId, string incidentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.IncidentRootCause> GetIncidentRootCausesAsync(Azure.AI.MetricsAdvisor.Models.AnomalyIncident incident, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -209,6 +230,108 @@ namespace Azure.AI.MetricsAdvisor
 }
 namespace Azure.AI.MetricsAdvisor.Administration
 {
+    public partial class AzureApplicationInsightsDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public AzureApplicationInsightsDataFeedSource(string applicationId, string apiKey, string azureCloud, string query) { }
+        public string ApplicationId { get { throw null; } set { } }
+        public string AzureCloud { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        public void UpdateApiKey(string apiKey) { }
+    }
+    public partial class AzureBlobDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public AzureBlobDataFeedSource(string connectionString, string container, string blobTemplate) { }
+        public Azure.AI.MetricsAdvisor.Administration.AzureBlobDataFeedSource.AuthenticationType? Authentication { get { throw null; } set { } }
+        public string BlobTemplate { get { throw null; } set { } }
+        public string Container { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
+        public enum AuthenticationType
+        {
+            Basic = 0,
+            ManagedIdentity = 1,
+        }
+    }
+    public partial class AzureCosmosDbDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public AzureCosmosDbDataFeedSource(string connectionString, string sqlQuery, string database, string collectionId) { }
+        public string CollectionId { get { throw null; } set { } }
+        public string Database { get { throw null; } set { } }
+        public string SqlQuery { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
+    }
+    public partial class AzureDataExplorerDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public AzureDataExplorerDataFeedSource(string connectionString, string query) { }
+        public Azure.AI.MetricsAdvisor.Administration.AzureDataExplorerDataFeedSource.AuthenticationType? Authentication { get { throw null; } set { } }
+        public string DatasourceCredentialId { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
+        public enum AuthenticationType
+        {
+            Basic = 0,
+            ManagedIdentity = 1,
+            ServicePrincipal = 2,
+            ServicePrincipalInKeyVault = 3,
+        }
+    }
+    public partial class AzureDataLakeStorageGen2DataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public AzureDataLakeStorageGen2DataFeedSource(string accountName, string accountKey, string fileSystemName, string directoryTemplate, string fileTemplate) { }
+        public string AccountName { get { throw null; } set { } }
+        public Azure.AI.MetricsAdvisor.Administration.AzureDataLakeStorageGen2DataFeedSource.AuthenticationType? Authentication { get { throw null; } set { } }
+        public string DatasourceCredentialId { get { throw null; } set { } }
+        public string DirectoryTemplate { get { throw null; } set { } }
+        public string FileSystemName { get { throw null; } set { } }
+        public string FileTemplate { get { throw null; } set { } }
+        public void UpdateAccountKey(string accountKey) { }
+        public enum AuthenticationType
+        {
+            Basic = 0,
+            SharedKey = 1,
+            ServicePrincipal = 2,
+            ServicePrincipalInKeyVault = 3,
+        }
+    }
+    public partial class AzureEventHubsDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public AzureEventHubsDataFeedSource(string connectionString, string consumerGroup) { }
+        public string ConsumerGroup { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
+    }
+    public partial class AzureTableDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public AzureTableDataFeedSource(string connectionString, string table, string query) { }
+        public string Query { get { throw null; } set { } }
+        public string Table { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
+    }
+    public abstract partial class DataFeedSource
+    {
+        internal DataFeedSource() { }
+    }
+    public partial class DataLakeGen2SharedKeyDatasourceCredential : Azure.AI.MetricsAdvisor.Administration.DatasourceCredential
+    {
+        public DataLakeGen2SharedKeyDatasourceCredential(string name, string accountKey) { }
+        public void UpdateAccountKey(string accountKey) { }
+    }
+    public partial class DatasourceCredential
+    {
+        internal DatasourceCredential() { }
+        public string Description { get { throw null; } set { } }
+        public string Id { get { throw null; } }
+        public string Name { get { throw null; } set { } }
+    }
+    public partial class EmailNotificationHook : Azure.AI.MetricsAdvisor.Administration.NotificationHook
+    {
+        public EmailNotificationHook() { }
+        public System.Collections.Generic.IList<string> EmailsToAlert { get { throw null; } }
+    }
+    public partial class GetAlertConfigurationsOptions
+    {
+        public GetAlertConfigurationsOptions() { }
+        public int? MaxPageSize { get { throw null; } set { } }
+        public int? Skip { get { throw null; } set { } }
+    }
     public partial class GetDataFeedIngestionStatusesOptions
     {
         public GetDataFeedIngestionStatusesOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
@@ -233,12 +356,43 @@ namespace Azure.AI.MetricsAdvisor.Administration
         public int? MaxPageSize { get { throw null; } set { } }
         public int? Skip { get { throw null; } set { } }
     }
+    public partial class GetDatasourceCredentialsOptions
+    {
+        public GetDatasourceCredentialsOptions() { }
+        public int? MaxPageSize { get { throw null; } set { } }
+        public int? Skip { get { throw null; } set { } }
+    }
+    public partial class GetDetectionConfigurationsOptions
+    {
+        public GetDetectionConfigurationsOptions() { }
+        public int? MaxPageSize { get { throw null; } set { } }
+        public int? Skip { get { throw null; } set { } }
+    }
     public partial class GetHooksOptions
     {
         public GetHooksOptions() { }
         public string HookNameFilter { get { throw null; } set { } }
         public int? MaxPageSize { get { throw null; } set { } }
         public int? Skip { get { throw null; } set { } }
+    }
+    public partial class InfluxDbDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public InfluxDbDataFeedSource(string connectionString, string database, string username, string password, string query) { }
+        public string Database { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        public string Username { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
+        public void UpdatePassword(string password) { }
+    }
+    public partial class LogAnalyticsDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public LogAnalyticsDataFeedSource(string workspaceId, string query) { }
+        public LogAnalyticsDataFeedSource(string workspaceId, string query, string clientId, string clientSecret, string tenantId) { }
+        public string ClientId { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        public string TenantId { get { throw null; } set { } }
+        public string WorkspaceId { get { throw null; } set { } }
+        public void UpdateClientSecret(string clientSecret) { }
     }
     public partial class MetricsAdvisorAdministrationClient
     {
@@ -251,12 +405,12 @@ namespace Azure.AI.MetricsAdvisor.Administration
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration>> CreateAlertConfigurationAsync(Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration alertConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeed> CreateDataFeed(Azure.AI.MetricsAdvisor.Models.DataFeed dataFeed, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeed>> CreateDataFeedAsync(Azure.AI.MetricsAdvisor.Models.DataFeed dataFeed, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.DatasourceCredential> CreateDatasourceCredential(Azure.AI.MetricsAdvisor.Models.DatasourceCredential datasourceCredential, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.DatasourceCredential>> CreateDatasourceCredentialAsync(Azure.AI.MetricsAdvisor.Models.DatasourceCredential datasourceCredential, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Administration.DatasourceCredential> CreateDatasourceCredential(Azure.AI.MetricsAdvisor.Administration.DatasourceCredential datasourceCredential, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Administration.DatasourceCredential>> CreateDatasourceCredentialAsync(Azure.AI.MetricsAdvisor.Administration.DatasourceCredential datasourceCredential, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration> CreateDetectionConfiguration(Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration detectionConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration>> CreateDetectionConfigurationAsync(Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration detectionConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.NotificationHook> CreateHook(Azure.AI.MetricsAdvisor.Models.NotificationHook hook, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.NotificationHook>> CreateHookAsync(Azure.AI.MetricsAdvisor.Models.NotificationHook hook, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Administration.NotificationHook> CreateHook(Azure.AI.MetricsAdvisor.Administration.NotificationHook hook, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Administration.NotificationHook>> CreateHookAsync(Azure.AI.MetricsAdvisor.Administration.NotificationHook hook, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response DeleteAlertConfiguration(string alertConfigurationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> DeleteAlertConfigurationAsync(string alertConfigurationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response DeleteDataFeed(string dataFeedId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -269,8 +423,8 @@ namespace Azure.AI.MetricsAdvisor.Administration
         public virtual System.Threading.Tasks.Task<Azure.Response> DeleteHookAsync(string hookId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration> GetAlertConfiguration(string alertConfigurationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration>> GetAlertConfigurationAsync(string alertConfigurationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration> GetAlertConfigurations(string detectionConfigurationId, Azure.AI.MetricsAdvisor.GetAlertConfigurationsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration> GetAlertConfigurationsAsync(string detectionConfigurationId, Azure.AI.MetricsAdvisor.GetAlertConfigurationsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration> GetAlertConfigurations(string detectionConfigurationId, Azure.AI.MetricsAdvisor.Administration.GetAlertConfigurationsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration> GetAlertConfigurationsAsync(string detectionConfigurationId, Azure.AI.MetricsAdvisor.Administration.GetAlertConfigurationsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeed> GetDataFeed(string dataFeedId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeed>> GetDataFeedAsync(string dataFeedId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeedIngestionProgress> GetDataFeedIngestionProgress(string dataFeedId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -279,30 +433,106 @@ namespace Azure.AI.MetricsAdvisor.Administration
         public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.DataFeedIngestionStatus> GetDataFeedIngestionStatusesAsync(string dataFeedId, Azure.AI.MetricsAdvisor.Administration.GetDataFeedIngestionStatusesOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.DataFeed> GetDataFeeds(Azure.AI.MetricsAdvisor.Administration.GetDataFeedsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.DataFeed> GetDataFeedsAsync(Azure.AI.MetricsAdvisor.Administration.GetDataFeedsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.DatasourceCredential> GetDatasourceCredential(string datasourceCredentialId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.DatasourceCredential>> GetDatasourceCredentialAsync(string datasourceCredentialId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.DatasourceCredential> GetDatasourceCredentials(Azure.AI.MetricsAdvisor.GetDatasourceCredentialsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.DatasourceCredential> GetDatasourceCredentialsAsync(Azure.AI.MetricsAdvisor.GetDatasourceCredentialsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Administration.DatasourceCredential> GetDatasourceCredential(string datasourceCredentialId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Administration.DatasourceCredential>> GetDatasourceCredentialAsync(string datasourceCredentialId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Administration.DatasourceCredential> GetDatasourceCredentials(Azure.AI.MetricsAdvisor.Administration.GetDatasourceCredentialsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Administration.DatasourceCredential> GetDatasourceCredentialsAsync(Azure.AI.MetricsAdvisor.Administration.GetDatasourceCredentialsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration> GetDetectionConfiguration(string detectionConfigurationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration>> GetDetectionConfigurationAsync(string detectionConfigurationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration> GetDetectionConfigurations(string metricId, Azure.AI.MetricsAdvisor.GetDetectionConfigurationsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration> GetDetectionConfigurationsAsync(string metricId, Azure.AI.MetricsAdvisor.GetDetectionConfigurationsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.NotificationHook> GetHook(string hookId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.NotificationHook>> GetHookAsync(string hookId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.NotificationHook> GetHooks(Azure.AI.MetricsAdvisor.Administration.GetHooksOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.NotificationHook> GetHooksAsync(Azure.AI.MetricsAdvisor.Administration.GetHooksOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration> GetDetectionConfigurations(string metricId, Azure.AI.MetricsAdvisor.Administration.GetDetectionConfigurationsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration> GetDetectionConfigurationsAsync(string metricId, Azure.AI.MetricsAdvisor.Administration.GetDetectionConfigurationsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Administration.NotificationHook> GetHook(string hookId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Administration.NotificationHook>> GetHookAsync(string hookId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Administration.NotificationHook> GetHooks(Azure.AI.MetricsAdvisor.Administration.GetHooksOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Administration.NotificationHook> GetHooksAsync(Azure.AI.MetricsAdvisor.Administration.GetHooksOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response RefreshDataFeedIngestion(string dataFeedId, System.DateTimeOffset startTime, System.DateTimeOffset endTime, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> RefreshDataFeedIngestionAsync(string dataFeedId, System.DateTimeOffset startTime, System.DateTimeOffset endTime, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration> UpdateAlertConfiguration(Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration alertConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration>> UpdateAlertConfigurationAsync(Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration alertConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeed> UpdateDataFeed(Azure.AI.MetricsAdvisor.Models.DataFeed dataFeed, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeed>> UpdateDataFeedAsync(Azure.AI.MetricsAdvisor.Models.DataFeed dataFeed, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.DatasourceCredential> UpdateDatasourceCredential(Azure.AI.MetricsAdvisor.Models.DatasourceCredential datasourceCredential, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.DatasourceCredential>> UpdateDatasourceCredentialAsync(Azure.AI.MetricsAdvisor.Models.DatasourceCredential datasourceCredential, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Administration.DatasourceCredential> UpdateDatasourceCredential(Azure.AI.MetricsAdvisor.Administration.DatasourceCredential datasourceCredential, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Administration.DatasourceCredential>> UpdateDatasourceCredentialAsync(Azure.AI.MetricsAdvisor.Administration.DatasourceCredential datasourceCredential, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration> UpdateDetectionConfiguration(Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration detectionConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration>> UpdateDetectionConfigurationAsync(Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration detectionConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.NotificationHook> UpdateHook(Azure.AI.MetricsAdvisor.Models.NotificationHook hook, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.NotificationHook>> UpdateHookAsync(Azure.AI.MetricsAdvisor.Models.NotificationHook hook, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Administration.NotificationHook> UpdateHook(Azure.AI.MetricsAdvisor.Administration.NotificationHook hook, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Administration.NotificationHook>> UpdateHookAsync(Azure.AI.MetricsAdvisor.Administration.NotificationHook hook, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public partial class MongoDbDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public MongoDbDataFeedSource(string connectionString, string database, string command) { }
+        public string Command { get { throw null; } set { } }
+        public string Database { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
+    }
+    public partial class MySqlDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public MySqlDataFeedSource(string connectionString, string query) { }
+        public string Query { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
+    }
+    public partial class NotificationHook
+    {
+        internal NotificationHook() { }
+        public System.Collections.Generic.IReadOnlyList<string> AdministratorsEmails { get { throw null; } }
+        public string Description { get { throw null; } set { } }
+        public System.Uri ExternalLink { get { throw null; } set { } }
+        public string Id { get { throw null; } }
+        public string Name { get { throw null; } set { } }
+    }
+    public partial class PostgreSqlDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public PostgreSqlDataFeedSource(string connectionString, string query) { }
+        public string Query { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
+    }
+    public partial class ServicePrincipalDatasourceCredential : Azure.AI.MetricsAdvisor.Administration.DatasourceCredential
+    {
+        public ServicePrincipalDatasourceCredential(string name, string clientId, string clientSecret, string tenantId) { }
+        public string ClientId { get { throw null; } set { } }
+        public string TenantId { get { throw null; } set { } }
+        public void UpdateClientSecret(string clientSecret) { }
+    }
+    public partial class ServicePrincipalInKeyVaultDatasourceCredential : Azure.AI.MetricsAdvisor.Administration.DatasourceCredential
+    {
+        public ServicePrincipalInKeyVaultDatasourceCredential(string name, System.Uri endpoint, string keyVaultClientId, string keyVaultClientSecret, string tenantId, string secretNameForClientId, string secretNameForClientSecret) { }
+        public System.Uri Endpoint { get { throw null; } set { } }
+        public string KeyVaultClientId { get { throw null; } set { } }
+        public string SecretNameForClientId { get { throw null; } set { } }
+        public string SecretNameForClientSecret { get { throw null; } set { } }
+        public string TenantId { get { throw null; } set { } }
+        public void UpdateKeyVaultClientSecret(string keyVaultClientSecret) { }
+    }
+    public partial class SqlConnectionStringDatasourceCredential : Azure.AI.MetricsAdvisor.Administration.DatasourceCredential
+    {
+        public SqlConnectionStringDatasourceCredential(string name, string connectionString) { }
+        public void UpdateConnectionString(string connectionString) { }
+    }
+    public partial class SqlServerDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
+    {
+        public SqlServerDataFeedSource(string connectionString, string query) { }
+        public Azure.AI.MetricsAdvisor.Administration.SqlServerDataFeedSource.AuthenticationType? Authentication { get { throw null; } set { } }
+        public string DatasourceCredentialId { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        public void UpdateConnectionString(string connectionString) { }
+        public enum AuthenticationType
+        {
+            Basic = 0,
+            ManagedIdentity = 1,
+            SqlConnectionString = 2,
+            ServicePrincipal = 3,
+            ServicePrincipalInKeyVault = 4,
+        }
+    }
+    public partial class WebNotificationHook : Azure.AI.MetricsAdvisor.Administration.NotificationHook
+    {
+        public WebNotificationHook() { }
+        public string CertificateKey { get { throw null; } set { } }
+        public string CertificatePassword { get { throw null; } set { } }
+        public System.Uri Endpoint { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Headers { get { throw null; } }
+        public string Password { get { throw null; } set { } }
+        public string Username { get { throw null; } set { } }
     }
 }
 namespace Azure.AI.MetricsAdvisor.Models
@@ -444,81 +674,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public static bool operator !=(Azure.AI.MetricsAdvisor.Models.AnomalyValue left, Azure.AI.MetricsAdvisor.Models.AnomalyValue right) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class AzureApplicationInsightsDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public AzureApplicationInsightsDataFeedSource(string applicationId, string apiKey, string azureCloud, string query) { }
-        public string ApplicationId { get { throw null; } set { } }
-        public string AzureCloud { get { throw null; } set { } }
-        public string Query { get { throw null; } set { } }
-        public void UpdateApiKey(string apiKey) { }
-    }
-    public partial class AzureBlobDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public AzureBlobDataFeedSource(string connectionString, string container, string blobTemplate) { }
-        public Azure.AI.MetricsAdvisor.Models.AzureBlobDataFeedSource.AuthenticationType? Authentication { get { throw null; } set { } }
-        public string BlobTemplate { get { throw null; } set { } }
-        public string Container { get { throw null; } set { } }
-        public void UpdateConnectionString(string connectionString) { }
-        public enum AuthenticationType
-        {
-            Basic = 0,
-            ManagedIdentity = 1,
-        }
-    }
-    public partial class AzureCosmosDbDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public AzureCosmosDbDataFeedSource(string connectionString, string sqlQuery, string database, string collectionId) { }
-        public string CollectionId { get { throw null; } set { } }
-        public string Database { get { throw null; } set { } }
-        public string SqlQuery { get { throw null; } set { } }
-        public void UpdateConnectionString(string connectionString) { }
-    }
-    public partial class AzureDataExplorerDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public AzureDataExplorerDataFeedSource(string connectionString, string query) { }
-        public Azure.AI.MetricsAdvisor.Models.AzureDataExplorerDataFeedSource.AuthenticationType? Authentication { get { throw null; } set { } }
-        public string DatasourceCredentialId { get { throw null; } set { } }
-        public string Query { get { throw null; } set { } }
-        public void UpdateConnectionString(string connectionString) { }
-        public enum AuthenticationType
-        {
-            Basic = 0,
-            ManagedIdentity = 1,
-            ServicePrincipal = 2,
-            ServicePrincipalInKeyVault = 3,
-        }
-    }
-    public partial class AzureDataLakeStorageGen2DataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public AzureDataLakeStorageGen2DataFeedSource(string accountName, string accountKey, string fileSystemName, string directoryTemplate, string fileTemplate) { }
-        public string AccountName { get { throw null; } set { } }
-        public Azure.AI.MetricsAdvisor.Models.AzureDataLakeStorageGen2DataFeedSource.AuthenticationType? Authentication { get { throw null; } set { } }
-        public string DatasourceCredentialId { get { throw null; } set { } }
-        public string DirectoryTemplate { get { throw null; } set { } }
-        public string FileSystemName { get { throw null; } set { } }
-        public string FileTemplate { get { throw null; } set { } }
-        public void UpdateAccountKey(string accountKey) { }
-        public enum AuthenticationType
-        {
-            Basic = 0,
-            SharedKey = 1,
-            ServicePrincipal = 2,
-            ServicePrincipalInKeyVault = 3,
-        }
-    }
-    public partial class AzureEventHubsDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public AzureEventHubsDataFeedSource(string connectionString, string consumerGroup) { }
-        public string ConsumerGroup { get { throw null; } set { } }
-        public void UpdateConnectionString(string connectionString) { }
-    }
-    public partial class AzureTableDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public AzureTableDataFeedSource(string connectionString, string table, string query) { }
-        public string Query { get { throw null; } set { } }
-        public string Table { get { throw null; } set { } }
-        public void UpdateConnectionString(string connectionString) { }
-    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct BoundaryDirection : System.IEquatable<Azure.AI.MetricsAdvisor.Models.BoundaryDirection>
     {
@@ -574,7 +729,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         public System.Collections.Generic.IList<string> AdministratorsEmails { get { throw null; } }
         public System.DateTimeOffset? CreatedTime { get { throw null; } }
         public string CreatorEmail { get { throw null; } }
-        public Azure.AI.MetricsAdvisor.Models.DataFeedSource DataSource { get { throw null; } set { } }
+        public Azure.AI.MetricsAdvisor.Administration.DataFeedSource DataSource { get { throw null; } set { } }
         public string Description { get { throw null; } set { } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedGranularity Granularity { get { throw null; } set { } }
         public string Id { get { throw null; } }
@@ -754,10 +909,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DataFeedMetric> MetricColumns { get { throw null; } }
         public string TimestampColumn { get { throw null; } set { } }
     }
-    public abstract partial class DataFeedSource
-    {
-        internal DataFeedSource() { }
-    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DataFeedSourceType : System.IEquatable<Azure.AI.MetricsAdvisor.Models.DataFeedSourceType>
     {
@@ -805,11 +956,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public static bool operator !=(Azure.AI.MetricsAdvisor.Models.DataFeedStatus left, Azure.AI.MetricsAdvisor.Models.DataFeedStatus right) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class DataLakeGen2SharedKeyDatasourceCredential : Azure.AI.MetricsAdvisor.Models.DatasourceCredential
-    {
-        public DataLakeGen2SharedKeyDatasourceCredential(string name, string accountKey) { }
-        public void UpdateAccountKey(string accountKey) { }
-    }
     public partial class DataPointAnomaly
     {
         internal DataPointAnomaly() { }
@@ -824,13 +970,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public Azure.AI.MetricsAdvisor.Models.AnomalyStatus? Status { get { throw null; } }
         public System.DateTimeOffset Timestamp { get { throw null; } }
         public double Value { get { throw null; } }
-    }
-    public partial class DatasourceCredential
-    {
-        internal DatasourceCredential() { }
-        public string Description { get { throw null; } set { } }
-        public string Id { get { throw null; } }
-        public string Name { get { throw null; } set { } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DetectionConditionsOperator : System.IEquatable<Azure.AI.MetricsAdvisor.Models.DetectionConditionsOperator>
@@ -863,11 +1002,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public static bool operator ==(Azure.AI.MetricsAdvisor.Models.DimensionKey left, Azure.AI.MetricsAdvisor.Models.DimensionKey right) { throw null; }
         public static bool operator !=(Azure.AI.MetricsAdvisor.Models.DimensionKey left, Azure.AI.MetricsAdvisor.Models.DimensionKey right) { throw null; }
         public void RemoveDimensionColumn(string dimensionColumnName) { }
-    }
-    public partial class EmailNotificationHook : Azure.AI.MetricsAdvisor.Models.NotificationHook
-    {
-        public EmailNotificationHook() { }
-        public System.Collections.Generic.IList<string> EmailsToAlert { get { throw null; } }
     }
     public partial class EnrichmentStatus
     {
@@ -917,15 +1051,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public System.Collections.Generic.IReadOnlyList<string> Paths { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.DimensionKey SeriesKey { get { throw null; } }
     }
-    public partial class InfluxDbDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public InfluxDbDataFeedSource(string connectionString, string database, string username, string password, string query) { }
-        public string Database { get { throw null; } set { } }
-        public string Query { get { throw null; } set { } }
-        public string Username { get { throw null; } set { } }
-        public void UpdateConnectionString(string connectionString) { }
-        public void UpdatePassword(string password) { }
-    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct IngestionStatusType : System.IEquatable<Azure.AI.MetricsAdvisor.Models.IngestionStatusType>
     {
@@ -949,16 +1074,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public static implicit operator Azure.AI.MetricsAdvisor.Models.IngestionStatusType (string value) { throw null; }
         public static bool operator !=(Azure.AI.MetricsAdvisor.Models.IngestionStatusType left, Azure.AI.MetricsAdvisor.Models.IngestionStatusType right) { throw null; }
         public override string ToString() { throw null; }
-    }
-    public partial class LogAnalyticsDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public LogAnalyticsDataFeedSource(string workspaceId, string query) { }
-        public LogAnalyticsDataFeedSource(string workspaceId, string query, string clientId, string clientSecret, string tenantId) { }
-        public string ClientId { get { throw null; } set { } }
-        public string Query { get { throw null; } set { } }
-        public string TenantId { get { throw null; } set { } }
-        public string WorkspaceId { get { throw null; } set { } }
-        public void UpdateClientSecret(string clientSecret) { }
     }
     public partial class MetricAnomalyAlertConditions
     {
@@ -1030,15 +1145,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public bool IsOnlyForSuccessive { get { throw null; } set { } }
         public Azure.AI.MetricsAdvisor.Models.SnoozeScope SnoozeScope { get { throw null; } set { } }
     }
-    public partial class MetricAnomalyFeedback : Azure.AI.MetricsAdvisor.Models.MetricFeedback
-    {
-        public MetricAnomalyFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.FeedbackDimensionFilter dimensionFilter, System.DateTimeOffset startTime, System.DateTimeOffset endTime, Azure.AI.MetricsAdvisor.Models.AnomalyValue value) { }
-        public string AnomalyDetectionConfigurationId { get { throw null; } set { } }
-        public Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration AnomalyDetectionConfigurationSnapshot { get { throw null; } }
-        public Azure.AI.MetricsAdvisor.Models.AnomalyValue AnomalyValue { get { throw null; } }
-        public System.DateTimeOffset EndTime { get { throw null; } set { } }
-        public System.DateTimeOffset StartTime { get { throw null; } set { } }
-    }
     public partial class MetricBoundaryCondition
     {
         public MetricBoundaryCondition(Azure.AI.MetricsAdvisor.Models.BoundaryDirection direction) { }
@@ -1047,20 +1153,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public double? LowerBound { get { throw null; } set { } }
         public bool? ShouldAlertIfDataPointMissing { get { throw null; } set { } }
         public double? UpperBound { get { throw null; } set { } }
-    }
-    public partial class MetricChangePointFeedback : Azure.AI.MetricsAdvisor.Models.MetricFeedback
-    {
-        public MetricChangePointFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.FeedbackDimensionFilter dimensionFilter, System.DateTimeOffset startTime, System.DateTimeOffset endTime, Azure.AI.MetricsAdvisor.Models.ChangePointValue value) { }
-        public Azure.AI.MetricsAdvisor.Models.ChangePointValue ChangePointValue { get { throw null; } }
-        public System.DateTimeOffset EndTime { get { throw null; } set { } }
-        public System.DateTimeOffset StartTime { get { throw null; } set { } }
-    }
-    public partial class MetricCommentFeedback : Azure.AI.MetricsAdvisor.Models.MetricFeedback
-    {
-        public MetricCommentFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.FeedbackDimensionFilter dimensionFilter, string comment) { }
-        public string Comment { get { throw null; } }
-        public System.DateTimeOffset? EndTime { get { throw null; } set { } }
-        public System.DateTimeOffset? StartTime { get { throw null; } set { } }
     }
     public partial class MetricEnrichedSeriesData
     {
@@ -1073,22 +1165,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public Azure.AI.MetricsAdvisor.Models.DimensionKey SeriesKey { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<System.DateTimeOffset> Timestamps { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<double?> UpperBoundaryValues { get { throw null; } }
-    }
-    public abstract partial class MetricFeedback
-    {
-        internal MetricFeedback() { }
-        public System.DateTimeOffset? CreatedTime { get { throw null; } }
-        public Azure.AI.MetricsAdvisor.Models.FeedbackDimensionFilter DimensionFilter { get { throw null; } }
-        public string Id { get { throw null; } }
-        public string MetricId { get { throw null; } }
-        public Azure.AI.MetricsAdvisor.Models.FeedbackType Type { get { throw null; } }
-        public string UserPrincipal { get { throw null; } }
-    }
-    public partial class MetricPeriodFeedback : Azure.AI.MetricsAdvisor.Models.MetricFeedback
-    {
-        public MetricPeriodFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.FeedbackDimensionFilter dimensionFilter, Azure.AI.MetricsAdvisor.Models.PeriodType periodType, int periodValue) { }
-        public Azure.AI.MetricsAdvisor.Models.PeriodType PeriodType { get { throw null; } }
-        public int PeriodValue { get { throw null; } }
     }
     public partial class MetricSeriesData
     {
@@ -1121,28 +1197,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public Azure.AI.MetricsAdvisor.Models.HardThresholdCondition HardThresholdCondition { get { throw null; } set { } }
         public Azure.AI.MetricsAdvisor.Models.SmartDetectionCondition SmartDetectionCondition { get { throw null; } set { } }
     }
-    public partial class MongoDbDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public MongoDbDataFeedSource(string connectionString, string database, string command) { }
-        public string Command { get { throw null; } set { } }
-        public string Database { get { throw null; } set { } }
-        public void UpdateConnectionString(string connectionString) { }
-    }
-    public partial class MySqlDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public MySqlDataFeedSource(string connectionString, string query) { }
-        public string Query { get { throw null; } set { } }
-        public void UpdateConnectionString(string connectionString) { }
-    }
-    public partial class NotificationHook
-    {
-        internal NotificationHook() { }
-        public System.Collections.Generic.IReadOnlyList<string> AdministratorsEmails { get { throw null; } }
-        public string Description { get { throw null; } set { } }
-        public System.Uri ExternalLink { get { throw null; } set { } }
-        public string Id { get { throw null; } }
-        public string Name { get { throw null; } set { } }
-    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct PeriodType : System.IEquatable<Azure.AI.MetricsAdvisor.Models.PeriodType>
     {
@@ -1160,29 +1214,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public static implicit operator Azure.AI.MetricsAdvisor.Models.PeriodType (string value) { throw null; }
         public static bool operator !=(Azure.AI.MetricsAdvisor.Models.PeriodType left, Azure.AI.MetricsAdvisor.Models.PeriodType right) { throw null; }
         public override string ToString() { throw null; }
-    }
-    public partial class PostgreSqlDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public PostgreSqlDataFeedSource(string connectionString, string query) { }
-        public string Query { get { throw null; } set { } }
-        public void UpdateConnectionString(string connectionString) { }
-    }
-    public partial class ServicePrincipalDatasourceCredential : Azure.AI.MetricsAdvisor.Models.DatasourceCredential
-    {
-        public ServicePrincipalDatasourceCredential(string name, string clientId, string clientSecret, string tenantId) { }
-        public string ClientId { get { throw null; } set { } }
-        public string TenantId { get { throw null; } set { } }
-        public void UpdateClientSecret(string clientSecret) { }
-    }
-    public partial class ServicePrincipalInKeyVaultDatasourceCredential : Azure.AI.MetricsAdvisor.Models.DatasourceCredential
-    {
-        public ServicePrincipalInKeyVaultDatasourceCredential(string name, System.Uri endpoint, string keyVaultClientId, string keyVaultClientSecret, string tenantId, string secretNameForClientId, string secretNameForClientSecret) { }
-        public System.Uri Endpoint { get { throw null; } set { } }
-        public string KeyVaultClientId { get { throw null; } set { } }
-        public string SecretNameForClientId { get { throw null; } set { } }
-        public string SecretNameForClientSecret { get { throw null; } set { } }
-        public string TenantId { get { throw null; } set { } }
-        public void UpdateKeyVaultClientSecret(string keyVaultClientSecret) { }
     }
     public partial class SeverityCondition
     {
@@ -1215,27 +1246,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         public static bool operator !=(Azure.AI.MetricsAdvisor.Models.SnoozeScope left, Azure.AI.MetricsAdvisor.Models.SnoozeScope right) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class SqlConnectionStringDatasourceCredential : Azure.AI.MetricsAdvisor.Models.DatasourceCredential
-    {
-        public SqlConnectionStringDatasourceCredential(string name, string connectionString) { }
-        public void UpdateConnectionString(string connectionString) { }
-    }
-    public partial class SqlServerDataFeedSource : Azure.AI.MetricsAdvisor.Models.DataFeedSource
-    {
-        public SqlServerDataFeedSource(string connectionString, string query) { }
-        public Azure.AI.MetricsAdvisor.Models.SqlServerDataFeedSource.AuthenticationType? Authentication { get { throw null; } set { } }
-        public string DatasourceCredentialId { get { throw null; } set { } }
-        public string Query { get { throw null; } set { } }
-        public void UpdateConnectionString(string connectionString) { }
-        public enum AuthenticationType
-        {
-            Basic = 0,
-            ManagedIdentity = 1,
-            SqlConnectionString = 2,
-            ServicePrincipal = 3,
-            ServicePrincipalInKeyVault = 4,
-        }
-    }
     public partial class SuppressCondition
     {
         public SuppressCondition(int minimumNumber, double minimumRatio) { }
@@ -1248,15 +1258,5 @@ namespace Azure.AI.MetricsAdvisor.Models
         public int MinimumTopCount { get { throw null; } set { } }
         public int Period { get { throw null; } set { } }
         public int Top { get { throw null; } set { } }
-    }
-    public partial class WebNotificationHook : Azure.AI.MetricsAdvisor.Models.NotificationHook
-    {
-        public WebNotificationHook() { }
-        public string CertificateKey { get { throw null; } set { } }
-        public string CertificatePassword { get { throw null; } set { } }
-        public System.Uri Endpoint { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Headers { get { throw null; } }
-        public string Password { get { throw null; } set { } }
-        public string Username { get { throw null; } set { } }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/MicrosoftAzureMetricsAdvisorRestAPIOpenAPIV2RestClient.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
+using Azure.AI.MetricsAdvisor.Administration;
 using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 using Azure.Core.Pipeline;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataLakeGen2SharedKeyDatasourceCredential.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataLakeGen2SharedKeyDatasourceCredential.Serialization.cs
@@ -6,9 +6,10 @@
 #nullable disable
 
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     public partial class DataLakeGen2SharedKeyDatasourceCredential : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataLakeGen2SharedKeyDatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataLakeGen2SharedKeyDatasourceCredential.cs
@@ -6,8 +6,9 @@
 #nullable disable
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary> The DataLakeGen2SharedKeyCredential. </summary>
     public partial class DataLakeGen2SharedKeyDatasourceCredential : DatasourceCredential

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataSourceCredentialList.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataSourceCredentialList.Serialization.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Administration;
 using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Models

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataSourceCredentialList.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataSourceCredentialList.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using Azure.AI.MetricsAdvisor.Administration;
 using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Models

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DatasourceCredential.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DatasourceCredential.Serialization.cs
@@ -6,9 +6,10 @@
 #nullable disable
 
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     public partial class DatasourceCredential : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DatasourceCredential.cs
@@ -6,8 +6,9 @@
 #nullable disable
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary> The DataSourceCredential. </summary>
     public partial class DatasourceCredential

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.Serialization.cs
@@ -7,9 +7,10 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     public partial class EmailNotificationHook : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/EmailNotificationHook.cs
@@ -7,8 +7,9 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary> The EmailHookInfo. </summary>
     public partial class EmailNotificationHook : NotificationHook

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/HookList.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/HookList.Serialization.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Administration;
 using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Models

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/HookList.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/HookList.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using Azure.AI.MetricsAdvisor.Administration;
 using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Models

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricAnomalyFeedback.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricAnomalyFeedback.Serialization.cs
@@ -7,9 +7,10 @@
 
 using System;
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     public partial class MetricAnomalyFeedback : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricAnomalyFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricAnomalyFeedback.cs
@@ -6,8 +6,9 @@
 #nullable disable
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     /// <summary> The AnomalyFeedback. </summary>
     public partial class MetricAnomalyFeedback : MetricFeedback

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricChangePointFeedback.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricChangePointFeedback.Serialization.cs
@@ -7,9 +7,10 @@
 
 using System;
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     public partial class MetricChangePointFeedback : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricChangePointFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricChangePointFeedback.cs
@@ -6,8 +6,9 @@
 #nullable disable
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     /// <summary> The ChangePointFeedback. </summary>
     public partial class MetricChangePointFeedback : MetricFeedback

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricCommentFeedback.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricCommentFeedback.Serialization.cs
@@ -7,9 +7,10 @@
 
 using System;
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     public partial class MetricCommentFeedback : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricCommentFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricCommentFeedback.cs
@@ -6,8 +6,9 @@
 #nullable disable
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     /// <summary> The CommentFeedback. </summary>
     public partial class MetricCommentFeedback : MetricFeedback

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricFeedback.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricFeedback.Serialization.cs
@@ -9,7 +9,7 @@ using System;
 using System.Text.Json;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     public partial class MetricFeedback : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricFeedback.cs
@@ -6,8 +6,9 @@
 #nullable disable
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     /// <summary> The MetricFeedback. </summary>
     public partial class MetricFeedback

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricFeedbackList.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricFeedbackList.Serialization.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor;
 using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Models

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricFeedbackList.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricFeedbackList.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using Azure.AI.MetricsAdvisor;
 using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Models

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricPeriodFeedback.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricPeriodFeedback.Serialization.cs
@@ -7,9 +7,10 @@
 
 using System;
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     public partial class MetricPeriodFeedback : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricPeriodFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricPeriodFeedback.cs
@@ -6,8 +6,9 @@
 #nullable disable
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     /// <summary> The PeriodFeedback. </summary>
     public partial class MetricPeriodFeedback : MetricFeedback

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.Serialization.cs
@@ -7,9 +7,10 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     public partial class NotificationHook : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.cs
@@ -7,9 +7,10 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary> The HookInfo. </summary>
     public partial class NotificationHook

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalDatasourceCredential.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalDatasourceCredential.Serialization.cs
@@ -6,9 +6,10 @@
 #nullable disable
 
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     public partial class ServicePrincipalDatasourceCredential : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalDatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalDatasourceCredential.cs
@@ -6,8 +6,9 @@
 #nullable disable
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary> The ServicePrincipalCredential. </summary>
     public partial class ServicePrincipalDatasourceCredential : DatasourceCredential

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalInKeyVaultDatasourceCredential.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalInKeyVaultDatasourceCredential.Serialization.cs
@@ -6,9 +6,10 @@
 #nullable disable
 
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     public partial class ServicePrincipalInKeyVaultDatasourceCredential : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalInKeyVaultDatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ServicePrincipalInKeyVaultDatasourceCredential.cs
@@ -6,8 +6,9 @@
 #nullable disable
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary> The ServicePrincipalInKVCredential. </summary>
     public partial class ServicePrincipalInKeyVaultDatasourceCredential : DatasourceCredential

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/SqlConnectionStringDatasourceCredential.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/SqlConnectionStringDatasourceCredential.Serialization.cs
@@ -6,9 +6,10 @@
 #nullable disable
 
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     public partial class SqlConnectionStringDatasourceCredential : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/SqlConnectionStringDatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/SqlConnectionStringDatasourceCredential.cs
@@ -6,8 +6,9 @@
 #nullable disable
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary> The AzureSQLConnectionStringCredential. </summary>
     public partial class SqlConnectionStringDatasourceCredential : DatasourceCredential

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebNotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebNotificationHook.Serialization.cs
@@ -7,9 +7,10 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     public partial class WebNotificationHook : IUtf8JsonSerializable
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebNotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/WebNotificationHook.cs
@@ -7,8 +7,9 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary> The WebhookHookInfo. </summary>
     public partial class WebNotificationHook : NotificationHook

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAlertConfigurationsOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAlertConfigurationsOptions.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.AI.MetricsAdvisor.Administration;
-
-namespace Azure.AI.MetricsAdvisor
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// The set of options that can be specified when calling <see cref="MetricsAdvisorAdministrationClient.GetAlertConfigurations"/>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetDatasourceCredentialsOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetDatasourceCredentialsOptions.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.AI.MetricsAdvisor.Administration;
-
-namespace Azure.AI.MetricsAdvisor
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// The set of options that can be specified when calling <see cref="MetricsAdvisorAdministrationClient.GetDatasourceCredentialsAsync"/>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetDetectionConfigurationsOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetDetectionConfigurationsOptions.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.AI.MetricsAdvisor.Administration;
-
-namespace Azure.AI.MetricsAdvisor
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// The set of options that can be specified when calling <see cref="MetricsAdvisorAdministrationClient.GetDetectionConfigurations"/>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AlertTriggering/AnomalyAlertConfiguration.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AlertTriggering/AnomalyAlertConfiguration.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Azure.AI.MetricsAdvisor.Administration;
 using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Models

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/DataLakeGen2SharedKeyDatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/DataLakeGen2SharedKeyDatasourceCredential.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Authenticates to a Data Lake Storage Gen2 resource via shared key.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/DatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/DatasourceCredential.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.AI.MetricsAdvisor.Administration;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Provides different ways of authenticating to a <see cref="DataFeedSource"/> for data ingestion when the

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/DatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/DatasourceCredential.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Azure.AI.MetricsAdvisor.Administration;
 using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Models

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/ServicePrincipalDatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/ServicePrincipalDatasourceCredential.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Authenticates to an Azure service via service principal.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/ServicePrincipalInKeyVaultDatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/ServicePrincipalInKeyVaultDatasourceCredential.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Authenticates to an Azure service via service principal. The client ID and the client secret used for datasource

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/SqlConnectionStringDatasourceCredential.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/SqlConnectionStringDatasourceCredential.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Authenticates to an SQL server via connection string.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Azure.AI.MetricsAdvisor.Administration;
 using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Models

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSource.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureApplicationInsightsDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureApplicationInsightsDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes an Azure Application Insights data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureBlobDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureBlobDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes an Azure Blob data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureCosmosDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureCosmosDbDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes an Azure Cosmos DB data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataExplorerDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataExplorerDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes an Azure Data Explorer data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataLakeStorageGen2DataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataLakeStorageGen2DataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes an Azure Data Lake Storage Gen2 data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureEventHubsDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureEventHubsDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes an Azure Event Hubs data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureTableDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureTableDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes an Azure Table data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/InfluxDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/InfluxDbDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes an InfluxDB data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/LogAnalyticsDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/LogAnalyticsDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes a Log Analytics data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MongoDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MongoDbDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes a MongoDB data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MySqlDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/MySqlDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes a MySQL data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/PostgreSqlDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/PostgreSqlDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes a PostgreSQL data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/SqlServerDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/SqlServerDataFeedSource.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Threading;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// Describes an SQL Server data source which ingests data into a <see cref="DataFeed"/> for anomaly detection.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricAnomalyFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricAnomalyFeedback.cs
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     /// <summary>
     /// Feedback indicating that the point was incorrectly labeled by the service.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricChangePointFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricChangePointFeedback.cs
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     /// <summary>
     /// Feedback indicating that this is the start of a trend change.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricCommentFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricCommentFeedback.cs
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     /// <summary> The CommentFeedback. </summary>
     [CodeGenModel("CommentFeedback")]

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricFeedback.cs
@@ -3,13 +3,15 @@
 
 using System;
 using System.Text.Json;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     /// <summary> <see cref="MetricFeedback"/>s are used to describe feedback on unsatisfactory anomaly detection results.
     /// When feedback is created for a given metric, it is applied to future anomaly detection processing of the same series.
     /// The processed points will not be re-calculated. </summary>
+    [CodeGenModel("MetricFeedback")]
     public abstract partial class MetricFeedback : IUtf8JsonSerializable
     {
         /// <summary> Initializes a new instance of the <see cref="MetricFeedback"/> class. </summary>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricPeriodFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricPeriodFeedback.cs
@@ -3,8 +3,9 @@
 
 using System;
 using Azure.Core;
+using Azure.AI.MetricsAdvisor.Models;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor
 {
     /// <summary>
     /// Feedback indicating that this is an interval of seasonality.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/EmailNotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/EmailNotificationHook.cs
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// An email hook is the channel for anomaly alerts to be sent to email addresses specified in the Email to section.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/NotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/NotificationHook.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// An alert notification to be triggered after an anomaly is detected by Metrics Advisor.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/WebNotificationHook.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/NotificationHook/WebNotificationHook.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
-namespace Azure.AI.MetricsAdvisor.Models
+namespace Azure.AI.MetricsAdvisor.Administration
 {
     /// <summary>
     /// A web hook is the entry point for all the information available from the Metrics Advisor service, and calls a user-provided API when an alert is triggered.


### PR DESCRIPTION
Three options types have been moved to the `Administration` namespace, where they belong, since they're part of the admin APIs. Other "Options" types already follow this pattern.

After discussing with .NET architects, we decided to move abstract types (`NotificationHook`, `DataFeedSource`, `DatasourceCredential`, `MetricFeedback`) and their concrete subtypes to the main namespaces, so the concrete implementations are more discoverable. It would be harder to find them amidst too many model types.