### PR TITLE
[TA] Implement actionName

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### New features
 - Added support for service version `3.0`. This can be specified in the `TextAnalyticsClientOptions` object under the `ServiceVersion` enum. By default the SDK targets latest supported service version.
 - Added value `None` to enum `PiiEntityDomainType` to allow user to specify no domain.
+- Added property `ActionName` to all `xxActions` input types so user can specify a name per action. If not provided, service will generate a name.
+- Added property `ActionName` to all `xxActionResult` output types that displays the name of each action. 
 
 ### Breaking changes
 - Renamed `StartAnalyzeBatchActions` to `StartAnalyzeActions`.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -612,6 +612,7 @@ This functionality allows running multiple actions in one or more documents. Act
         int docNumber = 1;
         foreach (RecognizeEntitiesActionResult entitiesActionResults in entitiesResults)
         {
+            Console.WriteLine($" Action name: {entitiesActionResults.ActionName}");
             foreach (RecognizeEntitiesResult documentResults in entitiesActionResults.DocumentsResults)
             {
                 Console.WriteLine($" Document #{docNumber++}");
@@ -634,6 +635,7 @@ This functionality allows running multiple actions in one or more documents. Act
         docNumber = 1;
         foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
         {
+            Console.WriteLine($" Action name: {piiActionResults.ActionName}");
             foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
             {
                 Console.WriteLine($" Document #{docNumber++}");
@@ -656,6 +658,7 @@ This functionality allows running multiple actions in one or more documents. Act
         docNumber = 1;
         foreach (ExtractKeyPhrasesActionResult keyPhrasesActionResult in keyPhrasesResults)
         {
+            Console.WriteLine($" Action name: {keyPhrasesActionResult.ActionName}");
             foreach (ExtractKeyPhrasesResult documentResults in keyPhrasesActionResult.DocumentsResults)
             {
                 Console.WriteLine($" Document #{docNumber++}");
@@ -704,6 +707,7 @@ This functionality allows running multiple actions in one or more documents. Act
         docNumber = 1;
         foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
         {
+            Console.WriteLine($" Action name: {analyzeSentimentActionsResult.ActionName}");
             foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
             {
                 Console.WriteLine($" Document #{docNumber++}");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -83,6 +83,7 @@ namespace Azure.AI.TextAnalytics
     public partial class AnalyzeSentimentAction
     {
         public AnalyzeSentimentAction() { }
+        public string ActionName { get { throw null; } set { } }
         public bool? DisableServiceLogs { get { throw null; } set { } }
         public bool? IncludeOpinionMining { get { throw null; } set { } }
         public string ModelVersion { get { throw null; } set { } }
@@ -90,6 +91,7 @@ namespace Azure.AI.TextAnalytics
     public partial class AnalyzeSentimentActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal AnalyzeSentimentActionResult() { }
+        public string ActionName { get { throw null; } }
         public Azure.AI.TextAnalytics.AnalyzeSentimentResultCollection DocumentsResults { get { throw null; } }
     }
     public partial class AnalyzeSentimentOptions : Azure.AI.TextAnalytics.TextAnalyticsRequestOptions
@@ -229,12 +231,14 @@ namespace Azure.AI.TextAnalytics
     public partial class ExtractKeyPhrasesAction
     {
         public ExtractKeyPhrasesAction() { }
+        public string ActionName { get { throw null; } set { } }
         public bool? DisableServiceLogs { get { throw null; } set { } }
         public string ModelVersion { get { throw null; } set { } }
     }
     public partial class ExtractKeyPhrasesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal ExtractKeyPhrasesActionResult() { }
+        public string ActionName { get { throw null; } }
         public Azure.AI.TextAnalytics.ExtractKeyPhrasesResultCollection DocumentsResults { get { throw null; } }
     }
     public partial class ExtractKeyPhrasesResult : Azure.AI.TextAnalytics.TextAnalyticsResult
@@ -608,12 +612,14 @@ namespace Azure.AI.TextAnalytics
     public partial class RecognizeEntitiesAction
     {
         public RecognizeEntitiesAction() { }
+        public string ActionName { get { throw null; } set { } }
         public bool? DisableServiceLogs { get { throw null; } set { } }
         public string ModelVersion { get { throw null; } set { } }
     }
     public partial class RecognizeEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal RecognizeEntitiesActionResult() { }
+        public string ActionName { get { throw null; } }
         public Azure.AI.TextAnalytics.RecognizeEntitiesResultCollection DocumentsResults { get { throw null; } }
     }
     public partial class RecognizeEntitiesResult : Azure.AI.TextAnalytics.TextAnalyticsResult
@@ -630,12 +636,14 @@ namespace Azure.AI.TextAnalytics
     public partial class RecognizeLinkedEntitiesAction
     {
         public RecognizeLinkedEntitiesAction() { }
+        public string ActionName { get { throw null; } set { } }
         public bool? DisableServiceLogs { get { throw null; } set { } }
         public string ModelVersion { get { throw null; } set { } }
     }
     public partial class RecognizeLinkedEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal RecognizeLinkedEntitiesActionResult() { }
+        public string ActionName { get { throw null; } }
         public Azure.AI.TextAnalytics.RecognizeLinkedEntitiesResultCollection DocumentsResults { get { throw null; } }
     }
     public partial class RecognizeLinkedEntitiesResult : Azure.AI.TextAnalytics.TextAnalyticsResult
@@ -652,6 +660,7 @@ namespace Azure.AI.TextAnalytics
     public partial class RecognizePiiEntitiesAction
     {
         public RecognizePiiEntitiesAction() { }
+        public string ActionName { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.AI.TextAnalytics.PiiEntityCategory> CategoriesFilter { get { throw null; } }
         public bool? DisableServiceLogs { get { throw null; } set { } }
         public Azure.AI.TextAnalytics.PiiEntityDomain DomainFilter { get { throw null; } set { } }
@@ -660,6 +669,7 @@ namespace Azure.AI.TextAnalytics
     public partial class RecognizePiiEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal RecognizePiiEntitiesActionResult() { }
+        public string ActionName { get { throw null; } }
         public Azure.AI.TextAnalytics.RecognizePiiEntitiesResultCollection DocumentsResults { get { throw null; } }
     }
     public partial class RecognizePiiEntitiesOptions : Azure.AI.TextAnalytics.TextAnalyticsRequestOptions
@@ -866,8 +876,8 @@ namespace Azure.AI.TextAnalytics
         public static Azure.AI.TextAnalytics.AnalyzeHealthcareEntitiesResult AnalyzeHealthcareEntitiesResult(string id, Azure.AI.TextAnalytics.TextDocumentStatistics statistics, System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.HealthcareEntity> healthcareEntities, System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.HealthcareEntityRelation> entityRelations, System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.TextAnalyticsWarning> warnings) { throw null; }
         public static Azure.AI.TextAnalytics.AnalyzeHealthcareEntitiesResult AnalyzeHealthcareEntitiesResult(string id, string code, string message) { throw null; }
         public static Azure.AI.TextAnalytics.AnalyzeHealthcareEntitiesResultCollection AnalyzeHealthcareEntitiesResultCollection(System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.AnalyzeHealthcareEntitiesResult> list, Azure.AI.TextAnalytics.TextDocumentBatchStatistics statistics, string modelVersion) { throw null; }
-        public static Azure.AI.TextAnalytics.AnalyzeSentimentActionResult AnalyzeSentimentActionResult(Azure.AI.TextAnalytics.AnalyzeSentimentResultCollection result, System.DateTimeOffset completedOn) { throw null; }
-        public static Azure.AI.TextAnalytics.AnalyzeSentimentActionResult AnalyzeSentimentActionResult(string code, string message) { throw null; }
+        public static Azure.AI.TextAnalytics.AnalyzeSentimentActionResult AnalyzeSentimentActionResult(Azure.AI.TextAnalytics.AnalyzeSentimentResultCollection result, string actionName, System.DateTimeOffset completedOn) { throw null; }
+        public static Azure.AI.TextAnalytics.AnalyzeSentimentActionResult AnalyzeSentimentActionResult(string actionName, System.DateTimeOffset completedOn, string code, string message) { throw null; }
         public static Azure.AI.TextAnalytics.AnalyzeSentimentResult AnalyzeSentimentResult(string id, Azure.AI.TextAnalytics.TextAnalyticsError error) { throw null; }
         public static Azure.AI.TextAnalytics.AnalyzeSentimentResult AnalyzeSentimentResult(string id, Azure.AI.TextAnalytics.TextDocumentStatistics statistics, Azure.AI.TextAnalytics.DocumentSentiment documentSentiment) { throw null; }
         public static Azure.AI.TextAnalytics.AnalyzeSentimentResultCollection AnalyzeSentimentResultCollection(System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.AnalyzeSentimentResult> list, Azure.AI.TextAnalytics.TextDocumentBatchStatistics statistics, string modelVersion) { throw null; }
@@ -882,8 +892,8 @@ namespace Azure.AI.TextAnalytics
         public static Azure.AI.TextAnalytics.DetectLanguageResultCollection DetectLanguageResultCollection(System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.DetectLanguageResult> list, Azure.AI.TextAnalytics.TextDocumentBatchStatistics statistics, string modelVersion) { throw null; }
         public static Azure.AI.TextAnalytics.DocumentSentiment DocumentSentiment(Azure.AI.TextAnalytics.TextSentiment sentiment, double positiveScore, double neutralScore, double negativeScore, System.Collections.Generic.List<Azure.AI.TextAnalytics.SentenceSentiment> sentenceSentiments, System.Collections.Generic.IList<Azure.AI.TextAnalytics.TextAnalyticsWarning> warnings = null) { throw null; }
         public static Azure.AI.TextAnalytics.EntityDataSource EntityDataSource(string name = null, string entityId = null) { throw null; }
-        public static Azure.AI.TextAnalytics.ExtractKeyPhrasesActionResult ExtractKeyPhrasesActionResult(Azure.AI.TextAnalytics.ExtractKeyPhrasesResultCollection result, System.DateTimeOffset completedOn) { throw null; }
-        public static Azure.AI.TextAnalytics.ExtractKeyPhrasesActionResult ExtractKeyPhrasesActionResult(string code, string message) { throw null; }
+        public static Azure.AI.TextAnalytics.ExtractKeyPhrasesActionResult ExtractKeyPhrasesActionResult(Azure.AI.TextAnalytics.ExtractKeyPhrasesResultCollection result, string actionName, System.DateTimeOffset completedOn) { throw null; }
+        public static Azure.AI.TextAnalytics.ExtractKeyPhrasesActionResult ExtractKeyPhrasesActionResult(string actionName, System.DateTimeOffset completedOn, string code, string message) { throw null; }
         public static Azure.AI.TextAnalytics.ExtractKeyPhrasesResult ExtractKeyPhrasesResult(string id, Azure.AI.TextAnalytics.TextAnalyticsError error) { throw null; }
         public static Azure.AI.TextAnalytics.ExtractKeyPhrasesResult ExtractKeyPhrasesResult(string id, Azure.AI.TextAnalytics.TextDocumentStatistics statistics, Azure.AI.TextAnalytics.KeyPhraseCollection keyPhrases) { throw null; }
         public static Azure.AI.TextAnalytics.ExtractKeyPhrasesResultCollection ExtractKeyPhrasesResultCollection(System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.ExtractKeyPhrasesResult> list, Azure.AI.TextAnalytics.TextDocumentBatchStatistics statistics, string modelVersion) { throw null; }
@@ -903,16 +913,18 @@ namespace Azure.AI.TextAnalytics
         public static Azure.AI.TextAnalytics.LinkedEntityMatch LinkedEntityMatch(string text, double score, int offset, int length) { throw null; }
         public static Azure.AI.TextAnalytics.PiiEntity PiiEntity(string text, string category, string subCategory, double score, int offset, int length) { throw null; }
         public static Azure.AI.TextAnalytics.PiiEntityCollection PiiEntityCollection(System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.PiiEntity> entities, string redactedText, System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.TextAnalyticsWarning> warnings = null) { throw null; }
-        public static Azure.AI.TextAnalytics.RecognizeEntitiesActionResult RecognizeEntitiesActionResult(Azure.AI.TextAnalytics.RecognizeEntitiesResultCollection result, System.DateTimeOffset completedOn) { throw null; }
-        public static Azure.AI.TextAnalytics.RecognizeEntitiesActionResult RecognizeEntitiesActionResult(string code, string message) { throw null; }
+        public static Azure.AI.TextAnalytics.RecognizeEntitiesActionResult RecognizeEntitiesActionResult(Azure.AI.TextAnalytics.RecognizeEntitiesResultCollection result, string actionName, System.DateTimeOffset completedOn) { throw null; }
+        public static Azure.AI.TextAnalytics.RecognizeEntitiesActionResult RecognizeEntitiesActionResult(string actionName, System.DateTimeOffset completedOn, string code, string message) { throw null; }
         public static Azure.AI.TextAnalytics.RecognizeEntitiesResult RecognizeEntitiesResult(string id, Azure.AI.TextAnalytics.TextAnalyticsError error) { throw null; }
         public static Azure.AI.TextAnalytics.RecognizeEntitiesResult RecognizeEntitiesResult(string id, Azure.AI.TextAnalytics.TextDocumentStatistics statistics, Azure.AI.TextAnalytics.CategorizedEntityCollection entities) { throw null; }
         public static Azure.AI.TextAnalytics.RecognizeEntitiesResultCollection RecognizeEntitiesResultCollection(System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.RecognizeEntitiesResult> list, Azure.AI.TextAnalytics.TextDocumentBatchStatistics statistics, string modelVersion) { throw null; }
-        public static Azure.AI.TextAnalytics.RecognizeLinkedEntitiesActionResult RecognizeLinkedEntitiesActionResult(Azure.AI.TextAnalytics.RecognizeLinkedEntitiesResultCollection result, System.DateTimeOffset completedOn) { throw null; }
-        public static Azure.AI.TextAnalytics.RecognizeLinkedEntitiesActionResult RecognizeLinkedEntitiesActionResult(string code, string message) { throw null; }
+        public static Azure.AI.TextAnalytics.RecognizeLinkedEntitiesActionResult RecognizeLinkedEntitiesActionResult(Azure.AI.TextAnalytics.RecognizeLinkedEntitiesResultCollection result, string actionName, System.DateTimeOffset completedOn) { throw null; }
+        public static Azure.AI.TextAnalytics.RecognizeLinkedEntitiesActionResult RecognizeLinkedEntitiesActionResult(string actionName, System.DateTimeOffset completedOn, string code, string message) { throw null; }
         public static Azure.AI.TextAnalytics.RecognizeLinkedEntitiesResult RecognizeLinkedEntitiesResult(string id, Azure.AI.TextAnalytics.TextAnalyticsError error) { throw null; }
         public static Azure.AI.TextAnalytics.RecognizeLinkedEntitiesResult RecognizeLinkedEntitiesResult(string id, Azure.AI.TextAnalytics.TextDocumentStatistics statistics, Azure.AI.TextAnalytics.LinkedEntityCollection linkedEntities) { throw null; }
         public static Azure.AI.TextAnalytics.RecognizeLinkedEntitiesResultCollection RecognizeLinkedEntitiesResultCollection(System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.RecognizeLinkedEntitiesResult> list, Azure.AI.TextAnalytics.TextDocumentBatchStatistics statistics, string modelVersion) { throw null; }
+        public static Azure.AI.TextAnalytics.RecognizePiiEntitiesActionResult RecognizePiiEntitiesActionResult(Azure.AI.TextAnalytics.RecognizePiiEntitiesResultCollection result, string actionName, System.DateTimeOffset completedOn) { throw null; }
+        public static Azure.AI.TextAnalytics.RecognizePiiEntitiesActionResult RecognizePiiEntitiesActionResult(string actionName, System.DateTimeOffset completedOn, string code, string message) { throw null; }
         public static Azure.AI.TextAnalytics.RecognizePiiEntitiesResult RecognizePiiEntitiesResult(string id, Azure.AI.TextAnalytics.TextAnalyticsError error) { throw null; }
         public static Azure.AI.TextAnalytics.RecognizePiiEntitiesResult RecognizePiiEntitiesResult(string id, Azure.AI.TextAnalytics.TextDocumentStatistics statistics, Azure.AI.TextAnalytics.PiiEntityCollection entities) { throw null; }
         public static Azure.AI.TextAnalytics.RecognizePiiEntitiesResultCollection RecognizePiiEntitiesResultCollection(System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.RecognizePiiEntitiesResult> list, Azure.AI.TextAnalytics.TextDocumentBatchStatistics statistics, string modelVersion) { throw null; }
@@ -923,7 +935,7 @@ namespace Azure.AI.TextAnalytics
         public static Azure.AI.TextAnalytics.SentimentConfidenceScores SentimentConfidenceScores(double positiveScore, double neutralScore, double negativeScore) { throw null; }
         public static Azure.AI.TextAnalytics.TargetSentiment TargetSentiment(Azure.AI.TextAnalytics.TextSentiment sentiment, string text, double positiveScore, double negativeScore, int offset, int length) { throw null; }
         public static Azure.AI.TextAnalytics.TextAnalyticsActionResult TextAnalyticsActionResult(System.DateTimeOffset completedOn) { throw null; }
-        public static Azure.AI.TextAnalytics.TextAnalyticsActionResult TextAnalyticsActionResult(string code, string message) { throw null; }
+        public static Azure.AI.TextAnalytics.TextAnalyticsActionResult TextAnalyticsActionResult(System.DateTimeOffset completedOn, string code, string message) { throw null; }
         public static Azure.AI.TextAnalytics.TextAnalyticsError TextAnalyticsError(string code, string message, string target = null) { throw null; }
         public static Azure.AI.TextAnalytics.TextAnalyticsWarning TextAnalyticsWarning(string code, string message) { throw null; }
         public static Azure.AI.TextAnalytics.TextDocumentBatchStatistics TextDocumentBatchStatistics(int documentCount, int validDocumentCount, int invalidDocumentCount, long transactionCount) { throw null; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_AnalyzeActions.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_AnalyzeActions.md
@@ -70,6 +70,7 @@ To run multiple actions in multiple documents, call `StartAnalyzeActionsAsync` o
         int docNumber = 1;
         foreach (RecognizeEntitiesActionResult entitiesActionResults in entitiesResults)
         {
+            Console.WriteLine($" Action name: {entitiesActionResults.ActionName}");
             foreach (RecognizeEntitiesResult documentResults in entitiesActionResults.DocumentsResults)
             {
                 Console.WriteLine($" Document #{docNumber++}");
@@ -92,6 +93,7 @@ To run multiple actions in multiple documents, call `StartAnalyzeActionsAsync` o
         docNumber = 1;
         foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
         {
+            Console.WriteLine($" Action name: {piiActionResults.ActionName}");
             foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
             {
                 Console.WriteLine($" Document #{docNumber++}");
@@ -114,6 +116,7 @@ To run multiple actions in multiple documents, call `StartAnalyzeActionsAsync` o
         docNumber = 1;
         foreach (ExtractKeyPhrasesActionResult keyPhrasesActionResult in keyPhrasesResults)
         {
+            Console.WriteLine($" Action name: {keyPhrasesActionResult.ActionName}");
             foreach (ExtractKeyPhrasesResult documentResults in keyPhrasesActionResult.DocumentsResults)
             {
                 Console.WriteLine($" Document #{docNumber++}");
@@ -162,6 +165,7 @@ To run multiple actions in multiple documents, call `StartAnalyzeActionsAsync` o
         docNumber = 1;
         foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
         {
+            Console.WriteLine($" Action name: {analyzeSentimentActionsResult.ActionName}");
             foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
             {
                 Console.WriteLine($" Document #{docNumber++}");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentAction.cs
@@ -49,5 +49,10 @@ namespace Azure.AI.TextAnalytics
         /// This property only has value for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
         /// </remarks>
         public bool? IncludeOpinionMining { get; set; }
+
+        /// <summary>
+        /// Gets or sets a name for this action. If not provided, the service will generate one.
+        /// </summary>
+        public string ActionName { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentActionResult.cs
@@ -13,27 +13,23 @@ namespace Azure.AI.TextAnalytics
     {
         private readonly AnalyzeSentimentResultCollection _documentsResults;
 
-        internal AnalyzeSentimentActionResult(AnalyzeSentimentResultCollection result, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
+        /// <summary>
+        /// Successful action.
+        /// </summary>
+        internal AnalyzeSentimentActionResult(AnalyzeSentimentResultCollection result, string actionName, DateTimeOffset completedOn)
+            : base(completedOn)
+        {
+            _documentsResults = result;
+            ActionName = actionName;
+        }
+
+        /// <summary>
+        /// Action with an error.
+        /// </summary>
+        internal AnalyzeSentimentActionResult(string actionName, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
             : base(completedOn, error)
         {
-            _documentsResults = result;
-        }
-
-        /// <summary>
-        /// Intended for mocking purposes only.
-        /// </summary>
-        internal AnalyzeSentimentActionResult(
-            AnalyzeSentimentResultCollection result,
-            DateTimeOffset completedOn) : base(completedOn)
-        {
-            _documentsResults = result;
-        }
-
-        /// <summary>
-        /// Intended for mocking purposes only.
-        /// </summary>
-        internal AnalyzeSentimentActionResult(TextAnalyticsErrorInternal error) : base(error)
-        {
+            ActionName = actionName;
         }
 
         /// <summary>
@@ -50,5 +46,10 @@ namespace Azure.AI.TextAnalytics
                 return _documentsResults;
             }
         }
+
+        /// <summary>
+        /// Gets the name for this action.
+        /// </summary>
+        public string ActionName { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesAction.cs
@@ -37,5 +37,10 @@ namespace Azure.AI.TextAnalytics
         /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
         /// </remarks>
         public bool? DisableServiceLogs { get; set; }
+
+        /// <summary>
+        /// Gets or sets a name for this action. If not provided, the service will generate one.
+        /// </summary>
+        public string ActionName { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesActionResult.cs
@@ -13,27 +13,23 @@ namespace Azure.AI.TextAnalytics
     {
         private readonly ExtractKeyPhrasesResultCollection _documentsResults;
 
-        internal ExtractKeyPhrasesActionResult(ExtractKeyPhrasesResultCollection result, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
+        /// <summary>
+        /// Successful action.
+        /// </summary>
+        internal ExtractKeyPhrasesActionResult(ExtractKeyPhrasesResultCollection result, string actionName, DateTimeOffset completedOn)
+            : base(completedOn)
+        {
+            _documentsResults = result;
+            ActionName = actionName;
+        }
+
+        /// <summary>
+        /// Action with an error.
+        /// </summary>
+        internal ExtractKeyPhrasesActionResult(string actionName, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
             : base(completedOn, error)
         {
-            _documentsResults = result;
-        }
-
-        /// <summary>
-        /// Intended for mocking purposes only.
-        /// </summary>
-        internal ExtractKeyPhrasesActionResult(
-            ExtractKeyPhrasesResultCollection result,
-            DateTimeOffset completedOn) : base(completedOn)
-        {
-            _documentsResults = result;
-        }
-
-        /// <summary>
-        /// Intended for mocking purposes only.
-        /// </summary>
-        internal ExtractKeyPhrasesActionResult(TextAnalyticsErrorInternal error) : base(error)
-        {
+            ActionName = actionName;
         }
 
         /// <summary>
@@ -52,5 +48,10 @@ namespace Azure.AI.TextAnalytics
                 return _documentsResults;
             }
         }
+
+        /// <summary>
+        /// Gets the name for this action.
+        /// </summary>
+        public string ActionName { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesAction.cs
@@ -37,5 +37,10 @@ namespace Azure.AI.TextAnalytics
         /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
         /// </remarks>
         public bool? DisableServiceLogs { get; set; }
+
+        /// <summary>
+        /// Gets or sets a name for this action. If not provided, the service will generate one.
+        /// </summary>
+        public string ActionName { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesActionResult.cs
@@ -13,28 +13,23 @@ namespace Azure.AI.TextAnalytics
     {
         private readonly RecognizeEntitiesResultCollection _documentsResults;
 
-        internal RecognizeEntitiesActionResult(RecognizeEntitiesResultCollection result, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
+        /// <summary>
+        /// Successful action.
+        /// </summary>
+        internal RecognizeEntitiesActionResult(RecognizeEntitiesResultCollection result, string actionName, DateTimeOffset completedOn)
+            : base(completedOn)
+        {
+            _documentsResults = result;
+            ActionName = actionName;
+        }
+
+        /// <summary>
+        /// Action with an error.
+        /// </summary>
+        internal RecognizeEntitiesActionResult(string actionName, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
             : base(completedOn, error)
         {
-            _documentsResults = result;
-        }
-
-        /// <summary>
-        /// Intended for mocking purposes only.
-        /// </summary>
-        internal RecognizeEntitiesActionResult(
-            RecognizeEntitiesResultCollection result,
-            DateTimeOffset completedOn) : base(completedOn)
-        {
-            _documentsResults = result;
-        }
-
-        /// <summary>
-        /// Intended for mocking purposes only.
-        /// </summary>
-        internal RecognizeEntitiesActionResult(
-            TextAnalyticsErrorInternal error) : base(error)
-        {
+            ActionName = actionName;
         }
 
         /// <summary>
@@ -53,5 +48,10 @@ namespace Azure.AI.TextAnalytics
                 return _documentsResults;
             }
         }
+
+        /// <summary>
+        /// Gets the name for this action.
+        /// </summary>
+        public string ActionName { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesAction.cs
@@ -37,5 +37,10 @@ namespace Azure.AI.TextAnalytics
         /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
         /// </remarks>
         public bool? DisableServiceLogs { get; set; }
+
+        /// <summary>
+        /// Gets or sets a name for this action. If not provided, the service will generate one.
+        /// </summary>
+        public string ActionName { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesActionResult.cs
@@ -13,28 +13,23 @@ namespace Azure.AI.TextAnalytics
     {
         private readonly RecognizeLinkedEntitiesResultCollection _documentsResults;
 
-        internal RecognizeLinkedEntitiesActionResult(RecognizeLinkedEntitiesResultCollection result, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
+        /// <summary>
+        /// Successful action.
+        /// </summary>
+        internal RecognizeLinkedEntitiesActionResult(RecognizeLinkedEntitiesResultCollection result, string actionName, DateTimeOffset completedOn)
+            : base(completedOn)
+        {
+            _documentsResults = result;
+            ActionName = actionName;
+        }
+
+        /// <summary>
+        /// Action with an error.
+        /// </summary>
+        internal RecognizeLinkedEntitiesActionResult(string actionName, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
             : base(completedOn, error)
         {
-            _documentsResults = result;
-        }
-
-        /// <summary>
-        /// Intended for mocking purposes only.
-        /// </summary>
-        internal RecognizeLinkedEntitiesActionResult(
-            RecognizeLinkedEntitiesResultCollection result,
-            DateTimeOffset completedOn) : base(completedOn)
-        {
-            _documentsResults = result;
-        }
-
-        /// <summary>
-        /// Intended for mocking purposes only.
-        /// </summary>
-        internal RecognizeLinkedEntitiesActionResult(
-            TextAnalyticsErrorInternal error) : base(error)
-        {
+            ActionName = actionName;
         }
 
         /// <summary>
@@ -53,5 +48,10 @@ namespace Azure.AI.TextAnalytics
                 return _documentsResults;
             }
         }
+
+        /// <summary>
+        /// Gets the name for this action.
+        /// </summary>
+        public string ActionName { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesAction.cs
@@ -51,5 +51,10 @@ namespace Azure.AI.TextAnalytics
         /// Filters the response entities to entities that match the <see cref="PiiEntityCategory"/> specified.
         /// </summary>
         public IList<PiiEntityCategory> CategoriesFilter { get; internal set; } = new List<PiiEntityCategory>();
+
+        /// <summary>
+        /// Gets or sets a name for this action. If not provided, the service will generate one.
+        /// </summary>
+        public string ActionName { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesActionResult.cs
@@ -13,10 +13,23 @@ namespace Azure.AI.TextAnalytics
     {
         private readonly RecognizePiiEntitiesResultCollection _documentsResults;
 
-        internal RecognizePiiEntitiesActionResult(RecognizePiiEntitiesResultCollection result, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
-            : base(completedOn, error)
+        /// <summary>
+        /// Successful action.
+        /// </summary>
+        internal RecognizePiiEntitiesActionResult(RecognizePiiEntitiesResultCollection result, string actionName, DateTimeOffset completedOn)
+            : base(completedOn)
         {
             _documentsResults = result;
+            ActionName = actionName;
+        }
+
+        /// <summary>
+        /// Action with an error.
+        /// </summary>
+        internal RecognizePiiEntitiesActionResult(string actionName, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
+            : base(completedOn, error)
+        {
+            ActionName = actionName;
         }
 
         /// <summary>
@@ -35,5 +48,10 @@ namespace Azure.AI.TextAnalytics
                 return _documentsResults;
             }
         }
+
+        /// <summary>
+        /// Gets the name for this action.
+        /// </summary>
+        public string ActionName { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActionResult.cs
@@ -17,20 +17,9 @@ namespace Azure.AI.TextAnalytics
             Error = error != null ? Transforms.ConvertToError(error) : default;
         }
 
-        /// <summary>
-        /// Intended for mocking purposes only.
-        /// </summary>
         internal TextAnalyticsActionResult(DateTimeOffset completedOn)
         {
             CompletedOn = completedOn;
-        }
-
-        /// <summary>
-        /// Intended for mocking purposes only.
-        /// </summary>
-        internal TextAnalyticsActionResult(TextAnalyticsErrorInternal error)
-        {
-            Error = Transforms.ConvertToError(error);
         }
 
         /// <summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActions.cs
@@ -9,6 +9,15 @@ namespace Azure.AI.TextAnalytics
     public class TextAnalyticsActions
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="TextAnalyticsActions"/>
+        /// class which determines the set of actions that will get executed on the input documents.
+        /// For example, execute extract key phrases, recognize entities, and more.
+        /// </summary>
+        public TextAnalyticsActions()
+        {
+        }
+
+        /// <summary>
         /// Optional display name for the operation.
         /// </summary>
         public string DisplayName { get; set; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
@@ -566,7 +566,7 @@ namespace Azure.AI.TextAnalytics
         /// </summary>
         /// <param name="extractKeyPhrasesActionResult">Sets the collection of <see cref="TextAnalytics.ExtractKeyPhrasesActionResult"/>.</param>
         /// <param name="recognizeEntitiesActionResults">Sets the collection of <see cref="TextAnalytics.RecognizeEntitiesActionResult"/>.</param>
-        /// <param name="recognizePiiEntitiesActionResults">Sets the collection of <see cref="RecognizePiiEntitiesActionResult"/>.</param>
+        /// <param name="recognizePiiEntitiesActionResults">Sets the collection of <see cref="TextAnalytics.RecognizePiiEntitiesActionResult"/>.</param>
         /// <param name="recognizeLinkedEntitiesActionsResults">Sets the collection of <see cref="TextAnalytics.RecognizeLinkedEntitiesActionResult"/>.</param>
         /// <param name="analyzeSentimentActionsResults">Sets the collection of <see cref="TextAnalytics.AnalyzeSentimentActionResult"/>.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.AnalyzeActionsResult"/> for mocking purposes.</returns>
@@ -589,52 +589,64 @@ namespace Azure.AI.TextAnalytics
         /// Initializes a new instance of <see cref="TextAnalytics.ExtractKeyPhrasesActionResult"/> for mocking purposes.
         /// </summary>
         /// <param name="result">Sets the <see cref="ExtractKeyPhrasesActionResult.DocumentsResults"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="ExtractKeyPhrasesActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.ExtractKeyPhrasesActionResult"/> for mocking purposes.</returns>
         public static ExtractKeyPhrasesActionResult ExtractKeyPhrasesActionResult(
             ExtractKeyPhrasesResultCollection result,
+            string actionName,
             DateTimeOffset completedOn)
         {
-            return new ExtractKeyPhrasesActionResult(result, completedOn);
+            return new ExtractKeyPhrasesActionResult(result, actionName, completedOn);
         }
 
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.ExtractKeyPhrasesActionResult"/> for mocking purposes.
         /// </summary>
+        /// <param name="actionName">Sets the <see cref="ExtractKeyPhrasesActionResult.ActionName"/> property.</param>
+        /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
         /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.ExtractKeyPhrasesActionResult"/> for mocking purposes.</returns>
         public static ExtractKeyPhrasesActionResult ExtractKeyPhrasesActionResult(
+            string actionName,
+            DateTimeOffset completedOn,
             string code,
             string message)
         {
-            return new ExtractKeyPhrasesActionResult(new TextAnalyticsErrorInternal(code, message));
+            return new ExtractKeyPhrasesActionResult(actionName, completedOn, new TextAnalyticsErrorInternal(code, message));
         }
 
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.AnalyzeSentimentActionResult"/> for mocking purposes.
         /// </summary>
         /// <param name="result">Sets the <see cref="AnalyzeSentimentActionResult.DocumentsResults"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="AnalyzeSentimentActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.AnalyzeSentimentActionResult"/> for mocking purposes.</returns>
         public static AnalyzeSentimentActionResult AnalyzeSentimentActionResult(
             AnalyzeSentimentResultCollection result,
+            string actionName,
             DateTimeOffset completedOn)
         {
-            return new AnalyzeSentimentActionResult(result, completedOn);
+            return new AnalyzeSentimentActionResult(result, actionName, completedOn);
         }
 
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.AnalyzeSentimentActionResult"/> for mocking purposes.
         /// </summary>
+        /// <param name="actionName">Sets the <see cref="AnalyzeSentimentActionResult.ActionName"/> property.</param>
+        /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
         /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.AnalyzeSentimentActionResult"/> for mocking purposes.</returns>
         public static AnalyzeSentimentActionResult AnalyzeSentimentActionResult(
+            string actionName,
+            DateTimeOffset completedOn,
             string code,
             string message)
         {
-            return new AnalyzeSentimentActionResult(new TextAnalyticsErrorInternal(code, message));
+            return new AnalyzeSentimentActionResult(actionName, completedOn, new TextAnalyticsErrorInternal(code, message));
         }
 
         /// <summary>
@@ -651,66 +663,112 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.TextAnalyticsActionResult"/> for mocking purposes.
         /// </summary>
+        /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
         /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.TextAnalyticsActionResult"/> for mocking purposes.</returns>
         public static TextAnalyticsActionResult TextAnalyticsActionResult(
+            DateTimeOffset completedOn,
             string code,
             string message)
         {
-            return new TextAnalyticsActionResult(new TextAnalyticsErrorInternal(code, message));
+            return new TextAnalyticsActionResult(completedOn, new TextAnalyticsErrorInternal(code, message));
         }
 
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesActionResult"/> for mocking purposes.
         /// </summary>
         /// <param name="result">Sets the <see cref="RecognizeLinkedEntitiesActionResult.DocumentsResults"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="RecognizeLinkedEntitiesActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesActionResult"/> for mocking purposes.</returns>
         public static RecognizeLinkedEntitiesActionResult RecognizeLinkedEntitiesActionResult(
             RecognizeLinkedEntitiesResultCollection result,
+            string actionName,
             DateTimeOffset completedOn)
         {
-            return new RecognizeLinkedEntitiesActionResult(result, completedOn);
+            return new RecognizeLinkedEntitiesActionResult(result, actionName, completedOn);
         }
 
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesActionResult"/> for mocking purposes.
         /// </summary>
+        /// <param name="actionName">Sets the <see cref="RecognizeLinkedEntitiesActionResult.ActionName"/> property.</param>
+        /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
         /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesActionResult"/> for mocking purposes.</returns>
         public static RecognizeLinkedEntitiesActionResult RecognizeLinkedEntitiesActionResult(
+            string actionName,
+            DateTimeOffset completedOn,
             string code,
             string message)
         {
-            return new RecognizeLinkedEntitiesActionResult(new TextAnalyticsErrorInternal(code, message));
+            return new RecognizeLinkedEntitiesActionResult(actionName, completedOn, new TextAnalyticsErrorInternal(code, message));
         }
 
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizeEntitiesActionResult"/> for mocking purposes.
         /// </summary>
         /// <param name="result">Sets the <see cref="RecognizeEntitiesActionResult.DocumentsResults"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="RecognizePiiEntitiesActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.RecognizeEntitiesActionResult"/> for mocking purposes.</returns>
         public static RecognizeEntitiesActionResult RecognizeEntitiesActionResult(
             RecognizeEntitiesResultCollection result,
+            string actionName,
             DateTimeOffset completedOn)
         {
-            return new RecognizeEntitiesActionResult(result, completedOn);
+            return new RecognizeEntitiesActionResult(result, actionName, completedOn);
         }
 
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizeEntitiesActionResult"/> for mocking purposes.
         /// </summary>
+        /// <param name="actionName">Sets the <see cref="RecognizeEntitiesActionResult.ActionName"/> property.</param>
+        /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
         /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.RecognizeEntitiesActionResult"/> for mocking purposes.</returns>
         public static RecognizeEntitiesActionResult RecognizeEntitiesActionResult(
+            string actionName,
+            DateTimeOffset completedOn,
             string code,
             string message)
         {
-            return new RecognizeEntitiesActionResult(new TextAnalyticsErrorInternal(code, message));
+            return new RecognizeEntitiesActionResult(actionName, completedOn, new TextAnalyticsErrorInternal(code, message));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.RecognizePiiEntitiesActionResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="result">Sets the <see cref="RecognizePiiEntitiesActionResult.DocumentsResults"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="RecognizePiiEntitiesActionResult.ActionName"/> property.</param>
+        /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.RecognizePiiEntitiesActionResult"/> for mocking purposes.</returns>
+        public static RecognizePiiEntitiesActionResult RecognizePiiEntitiesActionResult(
+            RecognizePiiEntitiesResultCollection result,
+            string actionName,
+            DateTimeOffset completedOn)
+        {
+            return new RecognizePiiEntitiesActionResult(result, actionName, completedOn);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.RecognizePiiEntitiesActionResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="actionName">Sets the <see cref="RecognizePiiEntitiesActionResult.ActionName"/> property.</param>
+        /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
+        /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
+        /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.RecognizePiiEntitiesActionResult"/> for mocking purposes.</returns>
+        public static RecognizePiiEntitiesActionResult RecognizePiiEntitiesActionResult(
+            string actionName,
+            DateTimeOffset completedOn,
+            string code,
+            string message)
+        {
+            return new RecognizePiiEntitiesActionResult(actionName, completedOn, new TextAnalyticsErrorInternal(code, message));
         }
 
         #endregion Action Result Models

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
@@ -331,7 +331,8 @@ namespace Azure.AI.TextAnalytics
                     StringIndexType = Constants.DefaultStringIndexType,
                     LoggingOptOut = action.DisableServiceLogs
                     // Categories are not enabled because of https://github.com/Azure/azure-sdk-for-net/issues/19237
-                }
+                },
+                TaskName = action.ActionName
             };
         }
 
@@ -345,6 +346,8 @@ namespace Azure.AI.TextAnalytics
                     StringIndexType = Constants.DefaultStringIndexType,
                     LoggingOptOut = action.DisableServiceLogs
                 }
+                ,
+                TaskName = action.ActionName
             };
         }
 
@@ -357,7 +360,8 @@ namespace Azure.AI.TextAnalytics
                     ModelVersion = action.ModelVersion,
                     StringIndexType = Constants.DefaultStringIndexType,
                     LoggingOptOut = action.DisableServiceLogs
-                }
+                },
+                TaskName = action.ActionName
             };
         }
 
@@ -369,7 +373,8 @@ namespace Azure.AI.TextAnalytics
                 {
                     ModelVersion = action.ModelVersion,
                     LoggingOptOut = action.DisableServiceLogs
-                }
+                },
+                TaskName = action.ActionName
             };
         }
 
@@ -383,7 +388,8 @@ namespace Azure.AI.TextAnalytics
                     StringIndexType = Constants.DefaultStringIndexType,
                     LoggingOptOut = action.DisableServiceLogs,
                     OpinionMining = action.IncludeOpinionMining
-                }
+                },
+                TaskName = action.ActionName
             };
         }
 
@@ -532,11 +538,11 @@ namespace Azure.AI.TextAnalytics
 
                 if (taskError != null)
                 {
-                    collection.Add(new AnalyzeSentimentActionResult(null, task.LastUpdateDateTime, taskError));
+                    collection.Add(new AnalyzeSentimentActionResult(task.TaskName, task.LastUpdateDateTime, taskError));
                 }
                 else
                 {
-                    collection.Add(new AnalyzeSentimentActionResult(ConvertToAnalyzeSentimentResultCollection(task.Results, idToIndexMap), task.LastUpdateDateTime, null));
+                    collection.Add(new AnalyzeSentimentActionResult(ConvertToAnalyzeSentimentResultCollection(task.Results, idToIndexMap), task.TaskName, task.LastUpdateDateTime));
                 }
                 index++;
             }
@@ -554,11 +560,11 @@ namespace Azure.AI.TextAnalytics
 
                 if (taskError != null)
                 {
-                    collection.Add(new RecognizeLinkedEntitiesActionResult(null, task.LastUpdateDateTime, taskError));
+                    collection.Add(new RecognizeLinkedEntitiesActionResult(task.TaskName, task.LastUpdateDateTime, taskError));
                 }
                 else
                 {
-                    collection.Add(new RecognizeLinkedEntitiesActionResult(ConvertToRecognizeLinkedEntitiesResultCollection(task.Results, idToIndexMap), task.LastUpdateDateTime, null));
+                    collection.Add(new RecognizeLinkedEntitiesActionResult(ConvertToRecognizeLinkedEntitiesResultCollection(task.Results, idToIndexMap), task.TaskName, task.LastUpdateDateTime));
                 }
                 index++;
             }
@@ -576,11 +582,11 @@ namespace Azure.AI.TextAnalytics
 
                 if (taskError != null)
                 {
-                    collection.Add(new ExtractKeyPhrasesActionResult(null, task.LastUpdateDateTime, taskError));
+                    collection.Add(new ExtractKeyPhrasesActionResult(task.TaskName, task.LastUpdateDateTime, taskError));
                 }
                 else
                 {
-                    collection.Add(new ExtractKeyPhrasesActionResult(ConvertToExtractKeyPhrasesResultCollection(task.Results, idToIndexMap), task.LastUpdateDateTime, null));
+                    collection.Add(new ExtractKeyPhrasesActionResult(ConvertToExtractKeyPhrasesResultCollection(task.Results, idToIndexMap), task.TaskName, task.LastUpdateDateTime));
                 }
                 index++;
             }
@@ -598,11 +604,11 @@ namespace Azure.AI.TextAnalytics
 
                 if (taskError != null)
                 {
-                    collection.Add(new RecognizePiiEntitiesActionResult(null, task.LastUpdateDateTime, taskError));
+                    collection.Add(new RecognizePiiEntitiesActionResult(task.TaskName, task.LastUpdateDateTime, taskError));
                 }
                 else
                 {
-                    collection.Add(new RecognizePiiEntitiesActionResult(ConvertToRecognizePiiEntitiesResultCollection(task.Results, idToIndexMap), task.LastUpdateDateTime, taskError));
+                    collection.Add(new RecognizePiiEntitiesActionResult(ConvertToRecognizePiiEntitiesResultCollection(task.Results, idToIndexMap), task.TaskName, task.LastUpdateDateTime));
                 }
                 index++;
             }
@@ -622,11 +628,11 @@ namespace Azure.AI.TextAnalytics
 
                 if (taskError != null)
                 {
-                    collection.Add(new RecognizeEntitiesActionResult(null, task.LastUpdateDateTime, taskError));
+                    collection.Add(new RecognizeEntitiesActionResult(task.TaskName, task.LastUpdateDateTime, taskError));
                 }
                 else
                 {
-                    collection.Add(new RecognizeEntitiesActionResult(ConvertToRecognizeEntitiesResultCollection(task.Results, idToIndexMap), task.LastUpdateDateTime, taskError));
+                    collection.Add(new RecognizeEntitiesActionResult(ConvertToRecognizeEntitiesResultCollection(task.Results, idToIndexMap), task.TaskName, task.LastUpdateDateTime));
                 }
                 index++;
             }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperation.cs
@@ -91,6 +91,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 int docNumber = 1;
                 foreach (RecognizeEntitiesActionResult entitiesActionResults in entitiesResults)
                 {
+                    Console.WriteLine($" Action name: {entitiesActionResults.ActionName}");
                     foreach (RecognizeEntitiesResult documentResults in entitiesActionResults.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -113,6 +114,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
                 {
+                    Console.WriteLine($" Action name: {piiActionResults.ActionName}");
                     foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -135,6 +137,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (ExtractKeyPhrasesActionResult keyPhrasesActionResult in keyPhrasesResults)
                 {
+                    Console.WriteLine($" Action name: {keyPhrasesActionResult.ActionName}");
                     foreach (ExtractKeyPhrasesResult documentResults in keyPhrasesActionResult.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -183,6 +186,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
                 {
+                    Console.WriteLine($" Action name: {analyzeSentimentActionsResult.ActionName}");
                     foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationAsync.cs
@@ -82,6 +82,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 int docNumber = 1;
                 foreach (RecognizeEntitiesActionResult entitiesActionResults in entitiesResults)
                 {
+                    Console.WriteLine($" Action name: {entitiesActionResults.ActionName}");
                     foreach (RecognizeEntitiesResult documentResults in entitiesActionResults.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -104,6 +105,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
                 {
+                    Console.WriteLine($" Action name: {piiActionResults.ActionName}");
                     foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -126,6 +128,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (ExtractKeyPhrasesActionResult keyPhrasesActionResult in keyPhrasesResults)
                 {
+                    Console.WriteLine($" Action name: {keyPhrasesActionResult.ActionName}");
                     foreach (ExtractKeyPhrasesResult documentResults in keyPhrasesActionResult.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -174,6 +177,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
                 {
+                    Console.WriteLine($" Action name: {analyzeSentimentActionsResult.ActionName}");
                     foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenience.cs
@@ -84,6 +84,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 int docNumber = 1;
                 foreach (RecognizeEntitiesActionResult entitiesActionResults in entitiesResults)
                 {
+                    Console.WriteLine($" Action name: {entitiesActionResults.ActionName}");
                     foreach (RecognizeEntitiesResult documentResults in entitiesActionResults.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -106,6 +107,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
                 {
+                    Console.WriteLine($" Action name: {piiActionResults.ActionName}");
                     foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -128,6 +130,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (ExtractKeyPhrasesActionResult keyPhrasesActionResult in keyPhrasesResults)
                 {
+                    Console.WriteLine($" Action name: {keyPhrasesActionResult.ActionName}");
                     foreach (ExtractKeyPhrasesResult documentResults in keyPhrasesActionResult.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -176,6 +179,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
                 {
+                    Console.WriteLine($" Action name: {analyzeSentimentActionsResult.ActionName}");
                     foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenienceAsync.cs
@@ -76,6 +76,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 int docNumber = 1;
                 foreach (RecognizeEntitiesActionResult entitiesActionResults in entitiesResults)
                 {
+                    Console.WriteLine($" Action name: {entitiesActionResults.ActionName}");
                     foreach (RecognizeEntitiesResult documentResults in entitiesActionResults.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -98,6 +99,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
                 {
+                    Console.WriteLine($" Action name: {piiActionResults.ActionName}");
                     foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -120,6 +122,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (ExtractKeyPhrasesActionResult keyPhrasesActionResult in keyPhrasesResults)
                 {
+                    Console.WriteLine($" Action name: {keyPhrasesActionResult.ActionName}");
                     foreach (ExtractKeyPhrasesResult documentResults in keyPhrasesActionResult.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");
@@ -168,6 +171,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 docNumber = 1;
                 foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
                 {
+                    Console.WriteLine($" Action name: {analyzeSentimentActionsResult.ActionName}");
                     foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
                     {
                         Console.WriteLine($" Document #{docNumber++}");


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/21804

It also simplifies the internal constructors of our `xxActionResult` types so we have one for an error action and one for successful action.