### PR TITLE
Remove Get/GetAsync from ResourceContainerBase

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Generated/GenericResourceContainer.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Generated/GenericResourceContainer.cs
@@ -57,8 +57,14 @@ namespace Azure.ResourceManager.Core
             }
         }
 
-        /// <inheritdoc/>
-        public override Response<GenericResource> Get(string resourceId, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Gets details for this resource from the service.
+        /// </summary>
+        /// <param name="resourceId"> The ID of the resource to get. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A response with the <see cref="Response{GenericResource}"/> operation for this resource. </returns>
+        /// <exception cref="ArgumentException"> resourceId cannot be null or a whitespace. </exception>
+        public Response<GenericResource> Get(string resourceId, CancellationToken cancellationToken = default)
         {
             using var scope = Diagnostics.CreateScope("GenericResourceContainer.Get");
             scope.Start();
@@ -75,8 +81,14 @@ namespace Azure.ResourceManager.Core
             }
         }
 
-        /// <inheritdoc/>
-        public override async Task<Response<GenericResource>> GetAsync(string resourceId, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Gets details for this resource from the service.
+        /// </summary>
+        /// <param name="resourceId"> The ID of the resource to get. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="Response{GenericResource}"/> operation for this resource. </returns>
+        /// <exception cref="ArgumentException"> resourceId cannot be null or a whitespace. </exception>
+        public virtual async Task<Response<GenericResource>> GetAsync(string resourceId, CancellationToken cancellationToken = default)
         {
             using var scope = Diagnostics.CreateScope("GenericResourceContainer.Get");
             scope.Start();

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Generated/ResourceGroupContainer.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Generated/ResourceGroupContainer.cs
@@ -277,8 +277,14 @@ namespace Azure.ResourceManager.Core
             return PageableHelpers.CreateAsyncEnumerable(FirstPageFunc, NextPageFunc);
         }
 
-        /// <inheritdoc />
-        public override Response<ResourceGroup> Get(string resourceGroupName, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Gets details for this resource group from the service.
+        /// </summary>
+        /// <param name="resourceGroupName"> The name of the resource group get. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A response with the <see cref="Response{ResourceGroup}"/> operation for this resource group. </returns>
+        /// <exception cref="ArgumentException"> resourceGroupName cannot be null or a whitespace. </exception>
+        public Response<ResourceGroup> Get(string resourceGroupName, CancellationToken cancellationToken = default)
         {
             using var scope = Diagnostics.CreateScope("ResourceGroupContainer.Get");
             scope.Start();
@@ -295,8 +301,14 @@ namespace Azure.ResourceManager.Core
             }
         }
 
-        /// <inheritdoc/>
-        public override async Task<Response<ResourceGroup>> GetAsync(string resourceGroupName, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Gets details for this resource group from the service.
+        /// </summary>
+        /// <param name="resourceGroupName"> The name of the resource group get. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="Response{ResourceGroup}"/> operation for this resource group. </returns>
+        /// <exception cref="ArgumentException"> resourceGroupName cannot be null or a whitespace. </exception>
+        public virtual async Task<Response<ResourceGroup>> GetAsync(string resourceGroupName, CancellationToken cancellationToken = default)
         {
             using var scope = Diagnostics.CreateScope("ResourceGroupContainer.Get");
             scope.Start();

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Generated/SubscriptionContainer.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Generated/SubscriptionContainer.cs
@@ -135,16 +135,28 @@ namespace Azure.ResourceManager.Core
                 throw new ArgumentException("Invalid parent for subscription container", nameof(identifier));
         }
 
-        /// <inheritdoc />
-        public override Response<Subscription> Get(string subscriptionGuid, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Gets details for this subscription from the service.
+        /// </summary>
+        /// <param name="subscriptionGuid"> The Id of the subscription to get. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A response with the <see cref="Response{Subscription}"/> operation for this subscription. </returns>
+        /// <exception cref="ArgumentException"> subscriptionGuid cannot be null or a whitespace. </exception>
+        public Response<Subscription> Get(string subscriptionGuid, CancellationToken cancellationToken = default)
         {
             return new SubscriptionOperations(
                     new ClientContext(ClientOptions, Credential, BaseUri, Pipeline),
                     subscriptionGuid).Get(cancellationToken);
         }
 
-        /// <inheritdoc />
-        public override Task<Response<Subscription>> GetAsync(string subscriptionGuid, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Gets details for this subscription from the service.
+        /// </summary>
+        /// <param name="subscriptionGuid"> The Id of the subscription to get. </param>
+        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
+        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="Response{TOperations}"/> operation for this subscription. </returns>
+        /// <exception cref="ArgumentException"> subscriptionGuid cannot be null or a whitespace. </exception>
+        public virtual Task<Response<Subscription>> GetAsync(string subscriptionGuid, CancellationToken cancellationToken = default)
         {
             return new SubscriptionOperations(
                 new ClientContext(ClientOptions, Credential, BaseUri, Pipeline),

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceContainerBase.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/ResourceContainerBase.cs
@@ -95,24 +95,6 @@ namespace Azure.ResourceManager.Core
         }
 
         /// <summary>
-        /// Gets details for this resource from the service.
-        /// </summary>
-        /// <param name="resourceName"> The name of the resource to get. </param>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A response with the <see cref="Response{TOperations}"/> operation for this resource. </returns>
-        /// <exception cref="ArgumentException"> resourceName cannot be null or a whitespace. </exception>
-        public abstract Response<TOperations> Get(string resourceName, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Gets details for this resource from the service.
-        /// </summary>
-        /// <param name="resourceName"> The name of the resource to get. </param>
-        /// <param name="cancellationToken"> A token to allow the caller to cancel the call to the service. The default value is <see cref="CancellationToken.None" />. </param>
-        /// <returns> A <see cref="Task"/> that on completion returns a response with the <see cref="Response{TOperations}"/> operation for this resource. </returns>
-        /// <exception cref="ArgumentException"> resourceName cannot be null or a whitespace. </exception>
-        public abstract Task<Response<TOperations>> GetAsync(string resourceName, CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Returns the resource from Azure if it exists.
         /// </summary>
         /// <param name="resourceName"> The name of the resource you want to get. </param>

--- a/sdk/resourcemanager/Proto.Client/authorization/RoleAssignmentContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/authorization/RoleAssignmentContainer.cs
@@ -64,7 +64,7 @@ namespace Proto.Authorization
         /// <param name="resourceName"> The role assignment name. </param>
         /// <param name="cancellationToken"> A token that allows cancellation of any blockign API calls made during this method. </param>
         /// <returns> The role assignment. </returns>
-        public override Response<RoleAssignment> Get(string resourceName, CancellationToken cancellationToken = default)
+        public Response<RoleAssignment> Get(string resourceName, CancellationToken cancellationToken = default)
         {
             var response = Operations.Get(Id, resourceName, cancellationToken);
             return Response.FromValue(new RoleAssignment(this, new RoleAssignmentData(response.Value)), response.GetRawResponse());
@@ -76,7 +76,7 @@ namespace Proto.Authorization
         /// <param name="resourceName"> The role assignment name. </param>
         /// <param name="cancellationToken"> A token that allows cancellation of any blockign API calls made during this method. </param>
         /// <returns> The role assignment. </returns>
-        public async override Task<Response<RoleAssignment>> GetAsync(string resourceName, CancellationToken cancellationToken = default)
+        public async Task<Response<RoleAssignment>> GetAsync(string resourceName, CancellationToken cancellationToken = default)
         {
             var response = await Operations.GetAsync(Id, resourceName, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(new RoleAssignment(this, new RoleAssignmentData(response.Value)), response.GetRawResponse());

--- a/sdk/resourcemanager/Proto.Client/compute/AvailabilitySetContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/compute/AvailabilitySetContainer.cs
@@ -152,14 +152,14 @@ namespace Proto.Compute
 
 
         /// <inheritdoc />
-        public override Response<AvailabilitySet> Get(string availabilitySetName, CancellationToken cancellationToken = default)
+        public Response<AvailabilitySet> Get(string availabilitySetName, CancellationToken cancellationToken = default)
         {
             var response = Operations.Get(Id.ResourceGroupName, availabilitySetName);
             return Response.FromValue(new AvailabilitySet(Parent, new AvailabilitySetData(response.Value)), response.GetRawResponse());
         }
 
         /// <inheritdoc/>
-        public override async Task<Response<AvailabilitySet>> GetAsync(string availabilitySetName, CancellationToken cancellationToken = default)
+        public async Task<Response<AvailabilitySet>> GetAsync(string availabilitySetName, CancellationToken cancellationToken = default)
         {
             var response = await Operations.GetAsync(Id.ResourceGroupName, availabilitySetName, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(new AvailabilitySet(Parent, new AvailabilitySetData(response.Value)), response.GetRawResponse());

--- a/sdk/resourcemanager/Proto.Client/compute/VirtualMachineContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/compute/VirtualMachineContainer.cs
@@ -195,14 +195,14 @@ namespace Proto.Compute
         }
 
         /// <inheritdoc />
-        public override Response<VirtualMachine> Get(string virtualMachineName, CancellationToken cancellationToken = default)
+        public Response<VirtualMachine> Get(string virtualMachineName, CancellationToken cancellationToken = default)
         {
             var response = Operations.Get(Id.ResourceGroupName, virtualMachineName, cancellationToken);
             return Response.FromValue(new VirtualMachine(Parent, new VirtualMachineData(response.Value)), response.GetRawResponse());
         }
 
         /// <inheritdoc/>
-        public override async Task<Response<VirtualMachine>> GetAsync(string virtualMachineName, CancellationToken cancellationToken = default)
+        public async Task<Response<VirtualMachine>> GetAsync(string virtualMachineName, CancellationToken cancellationToken = default)
         {
             var response = await Operations.GetAsync(Id.ResourceGroupName, virtualMachineName, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(new VirtualMachine(Parent, new VirtualMachineData(response.Value)), response.GetRawResponse());

--- a/sdk/resourcemanager/Proto.Client/compute/VirtualMachineScaleSetContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/compute/VirtualMachineScaleSetContainer.cs
@@ -67,14 +67,14 @@ namespace Proto.Compute
         }
 
         /// <inheritdoc />
-        public override Response<VirtualMachineScaleSet> Get(string virtualMachineScaleSetName, CancellationToken cancellationToken = default)
+        public Response<VirtualMachineScaleSet> Get(string virtualMachineScaleSetName, CancellationToken cancellationToken = default)
         {
             var response = Operations.Get(Id.ResourceGroupName, virtualMachineScaleSetName, cancellationToken);
             return Response.FromValue(new VirtualMachineScaleSet(Parent, new VirtualMachineScaleSetData(response.Value)), response.GetRawResponse());
         }
 
         /// <inheritdoc/>
-        public override async Task<Response<VirtualMachineScaleSet>> GetAsync(string virtualMachineScaleSetName, CancellationToken cancellationToken = default)
+        public async Task<Response<VirtualMachineScaleSet>> GetAsync(string virtualMachineScaleSetName, CancellationToken cancellationToken = default)
         {
             var response = await Operations.GetAsync(Id.ResourceGroupName, virtualMachineScaleSetName, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(new VirtualMachineScaleSet(Parent, new VirtualMachineScaleSetData(response.Value)), response.GetRawResponse());

--- a/sdk/resourcemanager/Proto.Client/network/LoadBalancerContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/LoadBalancerContainer.cs
@@ -95,7 +95,7 @@ namespace Proto.Network
         }
 
         /// <inheritdoc/>
-        public override Response<LoadBalancer> Get(string loadBalancerName, CancellationToken cancellationToken = default)
+        public Response<LoadBalancer> Get(string loadBalancerName, CancellationToken cancellationToken = default)
         {
             var response = Operations.Get(Id.ResourceGroupName, loadBalancerName, null, cancellationToken: cancellationToken);
             return Response.FromValue(new LoadBalancer(Parent, new LoadBalancerData(response.Value)), response.GetRawResponse());
@@ -103,7 +103,7 @@ namespace Proto.Network
         }
         
         /// <inheritdoc/>
-        public override async Task<Response<LoadBalancer>> GetAsync(string loadBalancerName, CancellationToken cancellationToken = default)
+        public async Task<Response<LoadBalancer>> GetAsync(string loadBalancerName, CancellationToken cancellationToken = default)
         {
             var response = await Operations.GetAsync(Id.ResourceGroupName, loadBalancerName, null, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(new LoadBalancer(Parent, new LoadBalancerData(response.Value)), response.GetRawResponse());

--- a/sdk/resourcemanager/Proto.Client/network/NetworkInterfaceContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/NetworkInterfaceContainer.cs
@@ -198,14 +198,14 @@ namespace Proto.Network
         }
 
         /// <inheritdoc />
-        public override Response<NetworkInterface> Get(string networkInterfaceName, CancellationToken cancellationToken = default)
+        public Response<NetworkInterface> Get(string networkInterfaceName, CancellationToken cancellationToken = default)
         {
             var response = Operations.Get(Id.ResourceGroupName, networkInterfaceName, cancellationToken: cancellationToken);
             return Response.FromValue(new NetworkInterface(Parent, new NetworkInterfaceData(response.Value)), response.GetRawResponse());
         }
 
         /// <inheritdoc/>
-        public override async Task<Response<NetworkInterface>> GetAsync(string networkInterfaceName, CancellationToken cancellationToken = default)
+        public async Task<Response<NetworkInterface>> GetAsync(string networkInterfaceName, CancellationToken cancellationToken = default)
         {
             var response = await Operations.GetAsync(Id.ResourceGroupName, networkInterfaceName, null, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(new NetworkInterface(Parent, new NetworkInterfaceData(response.Value)), response.GetRawResponse());

--- a/sdk/resourcemanager/Proto.Client/network/NetworkSecurityGroupContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/NetworkSecurityGroupContainer.cs
@@ -234,14 +234,14 @@ namespace Proto.Network
         }
 
         /// <inheritdoc />
-        public override Response<NetworkSecurityGroup> Get(string networkSecurityGroup, CancellationToken cancellationToken = default)
+        public Response<NetworkSecurityGroup> Get(string networkSecurityGroup, CancellationToken cancellationToken = default)
         {
             var response = Operations.Get(Id.ResourceGroupName, networkSecurityGroup, cancellationToken: cancellationToken);
             return Response.FromValue(new NetworkSecurityGroup(Parent, new NetworkSecurityGroupData(response.Value)), response.GetRawResponse());
         }
 
         /// <inheritdoc/>
-        public override async Task<Response<NetworkSecurityGroup>> GetAsync(string networkSecurityGroup, CancellationToken cancellationToken = default)
+        public async Task<Response<NetworkSecurityGroup>> GetAsync(string networkSecurityGroup, CancellationToken cancellationToken = default)
         {
             var response = await Operations.GetAsync(Id.ResourceGroupName, networkSecurityGroup, null, cancellationToken);
             return Response.FromValue(new NetworkSecurityGroup(Parent, new NetworkSecurityGroupData(response.Value)), response.GetRawResponse());

--- a/sdk/resourcemanager/Proto.Client/network/PublicIpAddressContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/PublicIpAddressContainer.cs
@@ -184,14 +184,14 @@ namespace Proto.Network
             return s => new PublicIpAddress(Parent, new PublicIPAddressData(s));
         }
                 /// <inheritdoc />
-        public override Response<PublicIpAddress> Get(string publicIpAddressesName, CancellationToken cancellationToken = default)
+        public Response<PublicIpAddress> Get(string publicIpAddressesName, CancellationToken cancellationToken = default)
         {
             var response = Operations.Get(Id.ResourceGroupName, publicIpAddressesName, cancellationToken: cancellationToken);
             return Response.FromValue(new PublicIpAddress(Parent, new PublicIPAddressData(response.Value)), response.GetRawResponse());
         }
 
         /// <inheritdoc/>
-        public override async Task<Response<PublicIpAddress>> GetAsync(string publicIpAddressesName, CancellationToken cancellationToken = default)
+        public async Task<Response<PublicIpAddress>> GetAsync(string publicIpAddressesName, CancellationToken cancellationToken = default)
         {
             var response = await Operations.GetAsync(Id.ResourceGroupName, publicIpAddressesName, cancellationToken: cancellationToken).ConfigureAwait(false);
             return Response.FromValue(new PublicIpAddress(Parent, new PublicIPAddressData(response.Value)), response.GetRawResponse());

--- a/sdk/resourcemanager/Proto.Client/network/SubnetContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/SubnetContainer.cs
@@ -154,14 +154,14 @@ namespace Proto.Network
         }
 
         /// <inheritdoc/>
-        public override Response<Subnet> Get(string subnetName, CancellationToken cancellationToken = default)
+        public Response<Subnet> Get(string subnetName, CancellationToken cancellationToken = default)
         {
             var response = Operations.Get(Id.ResourceGroupName, Id.Name, subnetName, cancellationToken: cancellationToken);
             return Response.FromValue(new Subnet(Parent, new SubnetData(response.Value)), response.GetRawResponse());
         }
 
         /// <inheritdoc/>
-        public override async Task<Response<Subnet>> GetAsync(string subnetName, CancellationToken cancellationToken = default)
+        public async Task<Response<Subnet>> GetAsync(string subnetName, CancellationToken cancellationToken = default)
         {
             var response = await Operations.GetAsync(Id.ResourceGroupName, Id.Name, subnetName, null, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(new Subnet(Parent, new SubnetData(response.Value)), response.GetRawResponse());

--- a/sdk/resourcemanager/Proto.Client/network/VirtualNetworkContainer.cs
+++ b/sdk/resourcemanager/Proto.Client/network/VirtualNetworkContainer.cs
@@ -184,14 +184,14 @@ namespace Proto.Network
         }
 
         /// <inheritdoc/>
-        public override Response<VirtualNetwork> Get(string virtualNetworkName, CancellationToken cancellationToken = default)
+        public Response<VirtualNetwork> Get(string virtualNetworkName, CancellationToken cancellationToken = default)
         {
             var response = Operations.Get(Id.ResourceGroupName, virtualNetworkName, cancellationToken: cancellationToken);
             return Response.FromValue(new VirtualNetwork(Parent, new VirtualNetworkData(response.Value)), response.GetRawResponse());
         }
 
         /// <inheritdoc/>
-        public override async Task<Response<VirtualNetwork>> GetAsync(string virtualNetworkName, CancellationToken cancellationToken = default)
+        public async Task<Response<VirtualNetwork>> GetAsync(string virtualNetworkName, CancellationToken cancellationToken = default)
         {
             var response = await Operations.GetAsync(Id.ResourceGroupName, virtualNetworkName, null, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(new VirtualNetwork(Parent, new VirtualNetworkData(response.Value)), response.GetRawResponse());


### PR DESCRIPTION
Current container API is base on a consumption that a resource can be identified by one string - its name; however this is not true when it comes to tuple resources.

This PR removes Get() / GetAsync() from `ResourceContainerBase` to give code generator the freedom to generate whatever API according to whether the resource is a tuple.

In theory not only Get but also TryGet / DoesExist need to be removed. However I'm afraid that will be too much code change and better to be done seperately. I'll create an ADO item to track that.