### PR TITLE
Upgrade open telemetry package dependencies for Azure Monitor OpenTelemetry Exporter

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -98,7 +98,7 @@
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
 
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="1.0.1"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
+    <PackageReference Update="OpenTelemetry" Version="1.1.0-beta4"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
   </ItemGroup>
 
   <!--
@@ -210,9 +210,9 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc2" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc2" />
+    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc5" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc5" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc5" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Update="PublicApiGenerator" Version="10.0.1" />


### PR DESCRIPTION
1) Upgrading OpenTelemetry to use 1.1.0-beta4
2) Updgrading OpenTelemetry.Extensions.Hosting, OpenTelemetry.Instrumentation.AspNetCore and OpenTelemetry.Instrumentation.Http to 1.0.0-rc5