### PR TITLE
Expose ArmClient ctor w/ baseUri

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/ArmClient.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/ArmClient.cs
@@ -51,7 +51,7 @@ namespace Azure.ResourceManager.Core
         /// <param name="defaultSubscriptionId"> The id of the default Azure subscription. </param>
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
         /// <param name="options"> The client parameters to use in these operations. </param>
-        /// <exception cref="ArgumentNullException"> If <see cref="TokenCredential"/> is null. </exception> 
+        /// <exception cref="ArgumentNullException"> If <see cref="TokenCredential"/> is null. </exception>
         public ArmClient(
             string defaultSubscriptionId,
             TokenCredential credential,
@@ -82,11 +82,11 @@ namespace Azure.ResourceManager.Core
         /// <param name="baseUri"> The base URI of the service. </param>
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
         /// <param name="options"> The client parameters to use in these operations. </param>
-        private ArmClient(
+        public ArmClient(
             string defaultSubscriptionId,
             Uri baseUri,
             TokenCredential credential,
-            ArmClientOptions options)
+            ArmClientOptions options = default)
         {
             if (credential is null)
                 throw new ArgumentNullException(nameof(credential));


### PR DESCRIPTION
If we are to mock Azure service when testing, we need a contructor of ArmClient that accepts both `BaseUri` and `SubscriptionId` -- the only one matching that requirement is private.
This pull request makes it public.

Besides, the "= default" was due to rule AZC0006: Client type should have public constructor with equivalent parameters taking a ClientOptions type as last argument.