### PR TITLE
Edit pass on server timeout section in Monitor Query README

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/README.md
+++ b/sdk/monitor/Azure.Monitor.Query/README.md
@@ -187,14 +187,19 @@ foreach (var row in table.Rows)
 
 ### Increase query timeout
 
-Some queries take longer to execute than the default service timeout allows. You can use the `LogsQueryOptions` parameter to specify the service timeout.
+Some Logs queries take longer than 3 minutes to execute. The default server timeout is 3 minutes. You can increase the server timeout to a maximum of 10 minutes. In the following example, the `LogsQueryOptions` object's `ServerTimeout` property is used to set the server timeout to 5 minutes:
 
 ```C# Snippet:QueryLogsPrintTable
 Uri endpoint = new Uri("https://api.loganalytics.io");
 string workspaceId = "<workspace_id>";
 
 LogsQueryClient client = new LogsQueryClient(endpoint, new DefaultAzureCredential());
-Response<LogsQueryResult> response = await client.QueryAsync(workspaceId, "AzureActivity | top 10 by TimeGenerated", TimeSpan.FromDays(1));
+Response<LogsQueryResult> response = await client.QueryAsync(
+    workspaceId, "AzureActivity | top 10 by TimeGenerated", TimeSpan.FromDays(1),
+    new LogsQueryOptions
+    {
+        ServerTimeout = TimeSpan.FromMinutes(5)
+    });
 
 LogsQueryResultTable table = response.Value.PrimaryTable;
 

--- a/sdk/monitor/Azure.Monitor.Query/README.md
+++ b/sdk/monitor/Azure.Monitor.Query/README.md
@@ -187,38 +187,26 @@ foreach (var row in table.Rows)
 
 ### Increase query timeout
 
-Some Logs queries take longer than 3 minutes to execute. The default server timeout is 3 minutes. You can increase the server timeout to a maximum of 10 minutes. In the following example, the `LogsQueryOptions` object's `ServerTimeout` property is used to set the server timeout to 5 minutes:
+Some Logs queries take longer than 3 minutes to execute. The default server timeout is 3 minutes. You can increase the server timeout to a maximum of 10 minutes. In the following example, the `LogsQueryOptions` object's `ServerTimeout` property is used to set the server timeout to 10 minutes:
 
-```C# Snippet:QueryLogsPrintTable
+```C# Snippet:QueryLogsWithTimeout
 Uri endpoint = new Uri("https://api.loganalytics.io");
 string workspaceId = "<workspace_id>";
 
 LogsQueryClient client = new LogsQueryClient(endpoint, new DefaultAzureCredential());
-Response<LogsQueryResult> response = await client.QueryAsync(
-    workspaceId, "AzureActivity | top 10 by TimeGenerated", TimeSpan.FromDays(1),
-    new LogsQueryOptions
+
+// Query TOP 10 resource groups by event count
+Response<IReadOnlyList<int>> response = await client.QueryAsync<int>(workspaceId,
+    "AzureActivity | summarize count()",
+    TimeSpan.FromDays(1),
+    options: new LogsQueryOptions()
     {
-        ServerTimeout = TimeSpan.FromMinutes(5)
+        ServerTimeout = TimeSpan.FromMinutes(10)
     });
 
-LogsQueryResultTable table = response.Value.PrimaryTable;
-
-foreach (var column in table.Columns)
+foreach (var resourceGroup in response.Value)
 {
-    Console.Write(column.Name + ";");
-}
-
-Console.WriteLine();
-
-var columnCount = table.Columns.Count;
-foreach (var row in table.Rows)
-{
-    for (int i = 0; i < columnCount; i++)
-    {
-        Console.Write(row[i] + ";");
-    }
-
-    Console.WriteLine();
+    Console.WriteLine(resourceGroup);
 }
 ```
 


### PR DESCRIPTION
Update the https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/monitor/Azure.Monitor.Query#increase-query-timeout section of the Azure Monitor Query SDK README to:
- Set the appropriate `LogsQueryOptions` property.
- Mention the service's default and maximum timeout values.