### PR TITLE
[Event Hubs] Incorporate `AmqpAnnotatedMessage` into `EventData`

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -747,5 +747,38 @@ namespace Azure.Messaging.EventHubs
                 return ResourceManager.GetString("ListCheckpointsAsyncObsolete", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The type of AMQP body for the message could not be determined..
+        /// </summary>
+        internal static string UnknownAmqpBodyType
+        {
+            get
+            {
+                return ResourceManager.GetString("UnknownAmqpBodyType", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The event body cannot be retrieved using the {1} property of {0}.  A body of type {2} can be accessed using the {3} method of {0} and inspecting the underlying AMQP message..
+        /// </summary>
+        internal static string RawAmqpBodyTypeMask
+        {
+            get
+            {
+                return ResourceManager.GetString("RawAmqpBodyTypeMask", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The given key '{0}' was not present in the dictionary..
+        /// </summary>
+        internal static string DictionaryKeyNotFoundMask
+        {
+            get
+            {
+                return ResourceManager.GetString("DictionaryKeyNotFoundMask", resourceCulture);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -300,4 +300,13 @@
   <data name="ListCheckpointsAsyncObsolete" xml:space="preserve">
     <value>The ListCheckpointsAsync method has been superseded by GetCheckpointAsync and should no longer be called.</value>
   </data>
+  <data name="UnknownAmqpBodyType" xml:space="preserve">
+    <value>The type of AMQP body for the message could not be determined.</value>
+  </data>
+  <data name="RawAmqpBodyTypeMask" xml:space="preserve">
+    <value>The event body cannot be retrieved using the {1} property of {0}.  A body of type {2} can be accessed using the {3} method of {0} and inspecting the underlying AMQP message.</value>
+  </data>
+  <data name="DictionaryKeyNotFoundMask" xml:space="preserve">
+    <value>The given key '{0}' was not present in the dictionary.</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{2DB233D3-E757-423C-8F8D-742B0AFF4713}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Amqp", "..\..\core\Azure.Core.Amqp\src\Azure.Core.Amqp.csproj", "{03A5F81B-A355-4F9E-98D5-288D515D9FDA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,12 +59,25 @@ Global
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433}.Release|x64.Build.0 = Release|Any CPU
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433}.Release|x86.ActiveCfg = Release|Any CPU
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433}.Release|x86.Build.0 = Release|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Debug|x64.Build.0 = Debug|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Debug|x86.Build.0 = Debug|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Release|x64.ActiveCfg = Release|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Release|x64.Build.0 = Release|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Release|x86.ActiveCfg = Release|Any CPU
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
+		{03A5F81B-A355-4F9E-98D5-288D515D9FDA} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {509F2EE0-3348-4506-8AC7-9945B602CB43}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -8,12 +8,16 @@ namespace Azure.Messaging.EventHubs
         public EventData(System.ReadOnlyMemory<byte> eventBody) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected EventData(System.ReadOnlyMemory<byte> eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = (long)-9223372036854775808, long offset = (long)-9223372036854775808, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset), string partitionKey = null) { }
+        public EventData(string eventBody) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.ReadOnlyMemory<byte> Body { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.IO.Stream BodyAsStream { get { throw null; } }
+        public string ContentType { get { throw null; } set { } }
+        public string CorrelationId { get { throw null; } set { } }
         public System.DateTimeOffset EnqueuedTime { get { throw null; } }
         public System.BinaryData EventBody { get { throw null; } }
+        public string MessageId { get { throw null; } set { } }
         public long Offset { get { throw null; } }
         public string PartitionKey { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
@@ -23,6 +27,7 @@ namespace Azure.Messaging.EventHubs
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
+        public Azure.Core.Amqp.AmqpAnnotatedMessage GetRawAmqpMessage() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpAnnotatedMessageExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpAnnotatedMessageExtensions.cs
@@ -1,0 +1,408 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Azure.Core.Amqp;
+
+namespace Azure.Messaging.EventHubs.Amqp
+{
+    /// <summary>
+    ///   The set of extension methods for the <see cref="AmqpAnnotatedMessage" /> class.
+    /// </summary>
+    ///
+    internal static class AmqpAnnotatedMessageExtensions
+    {
+        /// <summary>
+        ///   Populates the <paramref name="instance"/> from a set of well-known <see cref="EventData"/>
+        ///   attributes, setting only those values which are populated.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="properties">The set of free-form application properties to send with the event.</param>
+        /// <param name="sequenceNumber">The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.</param>
+        /// <param name="offset">The offset of the event when it was received from the associated Event Hub partition.</param>
+        /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
+        /// <param name="partitionKey">The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.</param>
+        /// <param name="lastPartitionSequenceNumber">The sequence number that was last enqueued into the Event Hub partition.</param>
+        /// <param name="lastPartitionOffset">The offset that was last enqueued into the Event Hub partition.</param>
+        /// <param name="lastPartitionEnqueuedTime">The date and time, in UTC, of the event that was last enqueued into the Event Hub partition.</param>
+        /// <param name="lastPartitionPropertiesRetrievalTime">The date and time, in UTC, that the last event information for the Event Hub partition was retrieved from the service.</param>
+        ///
+        public static void PopulateFromEventProperties(this AmqpAnnotatedMessage instance,
+                                                       IDictionary<string, object> properties = null,
+                                                       long? sequenceNumber = null,
+                                                       long? offset = null,
+                                                       DateTimeOffset? enqueuedTime = null,
+                                                       string partitionKey = null,
+                                                       long? lastPartitionSequenceNumber = null,
+                                                       long? lastPartitionOffset = null,
+                                                       DateTimeOffset? lastPartitionEnqueuedTime = null,
+                                                       DateTimeOffset? lastPartitionPropertiesRetrievalTime = null)
+        {
+           if (properties != null)
+           {
+               CopyDictionary(properties, instance.ApplicationProperties);
+           }
+
+           if (sequenceNumber.HasValue)
+           {
+               instance.MessageAnnotations[AmqpProperty.SequenceNumber.ToString()] = sequenceNumber.Value;
+           }
+
+           if (offset.HasValue)
+           {
+               instance.MessageAnnotations[AmqpProperty.Offset.ToString()] = offset.Value;
+           }
+
+           if (enqueuedTime.HasValue)
+           {
+               instance.MessageAnnotations[AmqpProperty.EnqueuedTime.ToString()] = enqueuedTime.Value;
+           }
+
+           if (!string.IsNullOrEmpty(partitionKey))
+           {
+               instance.MessageAnnotations[AmqpProperty.PartitionKey.ToString()] = partitionKey;
+           }
+
+           if (lastPartitionSequenceNumber.HasValue)
+           {
+               instance.DeliveryAnnotations[AmqpProperty.PartitionLastEnqueuedSequenceNumber.ToString()] = lastPartitionSequenceNumber.Value;
+           }
+
+           if (lastPartitionOffset.HasValue)
+           {
+               instance.DeliveryAnnotations[AmqpProperty.PartitionLastEnqueuedOffset.ToString()] = lastPartitionOffset.Value;
+           }
+
+           if (lastPartitionEnqueuedTime.HasValue)
+           {
+               instance.DeliveryAnnotations[AmqpProperty.PartitionLastEnqueuedTimeUtc.ToString()] = lastPartitionEnqueuedTime.Value;
+           }
+
+           if (lastPartitionPropertiesRetrievalTime.HasValue)
+           {
+               instance.DeliveryAnnotations[AmqpProperty.LastPartitionPropertiesRetrievalTimeUtc.ToString()] = lastPartitionPropertiesRetrievalTime.Value;
+           }
+        }
+
+        /// <summary>
+        ///   Creates a new copy of the <paramref name="instance"/>, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        ///
+        /// <returns>A copy of <see cref="AmqpAnnotatedMessage" /> containing the same data.</returns>
+        ///
+        public static AmqpAnnotatedMessage Clone(this AmqpAnnotatedMessage instance)
+        {
+           if (instance == null)
+           {
+               return null;
+           }
+
+           var clone = new AmqpAnnotatedMessage(CloneBody(instance.Body));
+
+           if (instance.HasSection(AmqpMessageSection.Header))
+           {
+               CopyHeaderSection(instance.Header, clone.Header);
+           }
+
+           if (instance.HasSection(AmqpMessageSection.Properties))
+           {
+               CopyPropertiesSection(instance.Properties, clone.Properties);
+           }
+
+           if (instance.HasSection(AmqpMessageSection.Footer))
+           {
+               CopyDictionary(instance.Footer, clone.Footer);
+           }
+
+           if (instance.HasSection(AmqpMessageSection.DeliveryAnnotations))
+           {
+               CopyDictionary(instance.DeliveryAnnotations, clone.DeliveryAnnotations);
+           }
+
+           if (instance.HasSection(AmqpMessageSection.MessageAnnotations))
+           {
+               CopyDictionary(instance.MessageAnnotations, clone.MessageAnnotations);
+           }
+
+           if (instance.HasSection(AmqpMessageSection.ApplicationProperties))
+           {
+               CopyDictionary(instance.ApplicationProperties, clone.ApplicationProperties);
+           }
+
+           return clone;
+        }
+
+        /// <summary>
+        ///   Retrieves the body of an <see cref="AmqpAnnotatedMessage" /> in the form
+        ///   needed  by the <see cref="EventData.EventBody" /> accessor.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        ///
+        /// <returns>The body of the <paramref name="instance"/>, in the appropriate form for use by an <see cref="EventData" /> instance.</returns>
+        ///
+        /// <exception cref="NotSupportedException">The body of the <paramref name="instance" /> cannot be used directly by <see cref="EventData" />.</exception>
+        ///
+        public static BinaryData GetEventBody(this AmqpAnnotatedMessage instance)
+        {
+            if (instance.Body.TryGetData(out IEnumerable<ReadOnlyMemory<byte>> dataBody))
+            {
+                return BinaryData.FromBytes(MessageBody.FromReadOnlyMemorySegments(dataBody));
+            }
+
+            throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, Resources.RawAmqpBodyTypeMask, nameof(EventData), nameof(EventData.EventBody), instance.Body.BodyType, nameof(EventData.GetRawAmqpMessage)));
+        }
+
+        /// <summary>
+        ///   Retrieves the sequence number of an event from an <see cref="AmqpAnnotatedMessage" />.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="defaultValue">The value to return if the sequence number is not represented in the <paramref name="instance"/>.</param>
+        ///
+        /// <returns>The sequence number, if represented in the <paramref name="instance"/>; otherwise, <paramref name="defaultValue"/>.</returns>
+        ///
+        public static long GetSequenceNumber(this AmqpAnnotatedMessage instance,
+                                             long defaultValue = long.MinValue)
+        {
+            if ((instance.HasSection(AmqpMessageSection.MessageAnnotations))
+                && (instance.MessageAnnotations.TryGetValue(AmqpProperty.SequenceNumber.ToString(), out var value)))
+            {
+                return (long)value;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        ///   Retrieves the offset of an event from an <see cref="AmqpAnnotatedMessage" />.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="defaultValue">The value to return if the offset is not represented in the <paramref name="instance"/>.</param>
+        ///
+        /// <returns>The offset, if represented in the <paramref name="instance"/>; otherwise, <paramref name="defaultValue"/>.</returns>
+        ///
+        public static long GetOffset(this AmqpAnnotatedMessage instance,
+                                     long defaultValue = long.MinValue)
+        {
+            if ((instance.HasSection(AmqpMessageSection.MessageAnnotations))
+                && (instance.MessageAnnotations.TryGetValue(AmqpProperty.Offset.ToString(), out var value)))
+            {
+                return (long)value;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        ///   Retrieves the time that an event was enqueued in the partition from an <see cref="AmqpAnnotatedMessage" />.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="defaultValue">The value to return if the enqueue time is not represented in the <paramref name="instance"/>.</param>
+        ///
+        /// <returns>The enqueued time, if represented in the <paramref name="instance"/>; otherwise, <paramref name="defaultValue"/>.</returns>
+        ///
+        public static DateTimeOffset GetEnqueuedTime(this AmqpAnnotatedMessage instance,
+                                                     DateTimeOffset defaultValue = default)
+        {
+            if ((instance.HasSection(AmqpMessageSection.MessageAnnotations))
+                && (instance.MessageAnnotations.TryGetValue(AmqpProperty.EnqueuedTime.ToString(), out var value)))
+            {
+                return (DateTimeOffset)value;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        ///   Retrieves the partition key of an event from an <see cref="AmqpAnnotatedMessage" />.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="defaultValue">The value to return if the partition key is not represented in the <paramref name="instance"/>.</param>
+        ///
+        /// <returns>The partition key, if represented in the <paramref name="instance"/>; otherwise, <paramref name="defaultValue"/>.</returns>
+        ///
+        public static string GetPartitionKey(this AmqpAnnotatedMessage instance,
+                                             string defaultValue = default)
+        {
+            if ((instance.HasSection(AmqpMessageSection.MessageAnnotations))
+                && (instance.MessageAnnotations.TryGetValue(AmqpProperty.PartitionKey.ToString(), out var value)))
+            {
+                return (string)value;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        ///   Retrieves the sequence number of the last event published to the partition from an <see cref="AmqpAnnotatedMessage" />.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="defaultValue">The value to return if the last sequence number is not represented in the <paramref name="instance"/>.</param>
+        ///
+        /// <returns>The sequence number of the last event published to the partition, if represented in the <paramref name="instance"/>; otherwise, <paramref name="defaultValue"/>.</returns>
+        ///
+        public static long? GetLastPartitionSequenceNumber(this AmqpAnnotatedMessage instance,
+                                                           long? defaultValue = default)
+        {
+            if ((instance.HasSection(AmqpMessageSection.DeliveryAnnotations))
+                && (instance.DeliveryAnnotations.TryGetValue(AmqpProperty.PartitionLastEnqueuedSequenceNumber.ToString(), out var value)))
+            {
+                return (long)value;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        ///   Retrieves the offset of the last event published to the partition from an <see cref="AmqpAnnotatedMessage" />.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="defaultValue">The value to return if the last offset is not represented in the <paramref name="instance"/>.</param>
+        ///
+        /// <returns>The offset of the last event published to the partition, if represented in the <paramref name="instance"/>; otherwise, <paramref name="defaultValue"/>.</returns>
+        ///
+        public static long? GetLastPartitionOffset(this AmqpAnnotatedMessage instance,
+                                                   long? defaultValue = default)
+        {
+            if ((instance.HasSection(AmqpMessageSection.DeliveryAnnotations))
+                && (instance.DeliveryAnnotations.TryGetValue(AmqpProperty.PartitionLastEnqueuedOffset.ToString(), out var value)))
+            {
+                return (long)value;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        ///   Retrieves the time that the last event was enqueued in the partition from an <see cref="AmqpAnnotatedMessage" />.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="defaultValue">The value to return if the last enqueue time is not represented in the <paramref name="instance"/>.</param>
+        ///
+        /// <returns>The time that the last event was enqueued in the partition, if represented in the <paramref name="instance"/>; otherwise, <paramref name="defaultValue"/>.</returns>
+        ///
+        public static DateTimeOffset? GetLastPartitionEnqueuedTime(this AmqpAnnotatedMessage instance,
+                                                                   DateTimeOffset? defaultValue = default)
+        {
+            if ((instance.HasSection(AmqpMessageSection.DeliveryAnnotations))
+                && (instance.DeliveryAnnotations.TryGetValue(AmqpProperty.PartitionLastEnqueuedTimeUtc.ToString(), out var value)))
+            {
+                return (DateTimeOffset)value;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        ///   Retrieves the time that the information about the last event enqueued in the partition was reported from an <see cref="AmqpAnnotatedMessage" />.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="defaultValue">The value to return if the last retrieval time is not represented in the <paramref name="instance"/>.</param>
+        ///
+        /// <returns>The time that the information about the last event enqueued in the partition was reported, if represented in the <paramref name="instance"/>; otherwise, <paramref name="defaultValue"/>.</returns>
+        ///
+        public static DateTimeOffset? GetLastPartitionPropertiesRetrievalTime(this AmqpAnnotatedMessage instance,
+                                                                              DateTimeOffset? defaultValue = default)
+        {
+            if ((instance.HasSection(AmqpMessageSection.DeliveryAnnotations))
+                && (instance.DeliveryAnnotations.TryGetValue(AmqpProperty.LastPartitionPropertiesRetrievalTimeUtc.ToString(), out var value)))
+            {
+                return (DateTimeOffset)value;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        ///   Clones the body of an <see cref="AmqpAnnotatedMessage" />.
+        /// </summary>
+        ///
+        /// <param name="amqpBody">The <see cref="AmqpMessageBody" /> instance to clone.</param>
+        ///
+        /// <returns>A shallow clone of the <paramref name="amqpBody" />.</returns>
+        ///
+        private static AmqpMessageBody CloneBody(AmqpMessageBody amqpBody) =>
+            amqpBody switch
+            {
+                null => null,
+                _ when (amqpBody.TryGetData(out var data)) => AmqpMessageBody.FromData(data),
+                _ when (amqpBody.TryGetValue(out var value)) => AmqpMessageBody.FromValue(value),
+                _ when (amqpBody.TryGetSequence(out var sequence)) => AmqpMessageBody.FromSequence(sequence),
+                _ => throw new ArgumentException(Resources.UnknownAmqpBodyType, nameof(amqpBody))
+            };
+
+        /// <summary>
+        ///   Copies data from one <see cref="AmqpMessageHeader" /> instance to another.
+        /// </summary>
+        ///
+        /// <param name="source">The source instance to copy from.</param>
+        /// <param name="destination">The destination instance to write to.</param>
+        ///
+        private static void CopyHeaderSection(AmqpMessageHeader source,
+                                              AmqpMessageHeader destination)
+        {
+            destination.DeliveryCount = source.DeliveryCount;
+            destination.Durable = source.Durable;
+            destination.FirstAcquirer = source.FirstAcquirer;
+            destination.Priority = source.Priority;
+            destination.TimeToLive = source.TimeToLive;
+        }
+
+        /// <summary>
+        ///   Copies data from one <see cref="AmqpMessageProperties" /> instance to another.
+        /// </summary>
+        ///
+        /// <param name="source">The source instance to copy from.</param>
+        /// <param name="destination">The destination instance to write to.</param>
+        ///
+        private static void CopyPropertiesSection(AmqpMessageProperties source,
+                                                  AmqpMessageProperties destination)
+        {
+            destination.AbsoluteExpiryTime = source.AbsoluteExpiryTime;
+            destination.ContentEncoding = source.ContentEncoding;
+            destination.ContentType = source.ContentType;
+            destination.CorrelationId = source.CorrelationId;
+            destination.CreationTime = source.CreationTime;
+            destination.GroupId = source.GroupId;
+            destination.GroupSequence = source.GroupSequence;
+            destination.MessageId = source.MessageId;
+            destination.ReplyTo = source.ReplyTo;
+            destination.ReplyToGroupId = source.ReplyToGroupId;
+            destination.Subject = source.Subject;
+            destination.To = source.To;
+            destination.UserId = source.UserId;
+        }
+
+        /// <summary>
+        ///   Copies data from one dictionary instance to another.
+        /// </summary>
+        ///
+        /// <typeparam name="TKey">The type of the key used in the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of the value used in the dictionary.</typeparam>
+        ///
+        /// <param name="source">The source instance to copy from.</param>
+        /// <param name="destination">The destination instance to write to.</param>
+        ///
+        private static void CopyDictionary<TKey, TValue>(IDictionary<TKey, TValue> source,
+                                                         IDictionary<TKey, TValue> destination)
+        {
+            foreach (var key in source.Keys)
+            {
+                destination[key] = source[key];
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpSystemProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpSystemProperties.cs
@@ -1,0 +1,380 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using Azure.Core.Amqp;
+using Microsoft.Azure.Amqp.Framing;
+
+namespace Azure.Messaging.EventHubs.Amqp
+{
+    /// <summary>
+    ///   Provides an abstraction over an <see cref="AmqpAnnotatedMessage" /> to represent
+    ///   broker-owned data in the form of a "system properties" dictionary for the
+    ///   associated <see cref="EventData" /> instance.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///   This wrapper is necessary to preserve the behavior of the <see cref="EventData.SystemProperties" />
+    ///   member without potentially drifting from the mutable data that exists on the AMQP message.
+    /// </remarks>
+    ///
+    /// <seealso cref="IReadOnlyDictionary{TKey, TValue}" />
+    ///
+    internal class AmqpSystemProperties : IReadOnlyDictionary<string, object>
+    {
+        /// <summary>The set of system properties that are sourced from the Properties section of the <see cref="AmqpAnnotatedMessage" />.</summary>
+        private static readonly string[] PropertySectionNames = new[]
+        {
+           Properties.MessageIdName,
+           Properties.UserIdName,
+           Properties.ToName,
+           Properties.SubjectName,
+           Properties.ReplyToName,
+           Properties.CorrelationIdName,
+           Properties.ContentTypeName,
+           Properties.ContentEncodingName,
+           Properties.AbsoluteExpiryTimeName,
+           Properties.CreationTimeName,
+           Properties.GroupIdName,
+           Properties.GroupSequenceName,
+           Properties.ReplyToGroupIdName
+        };
+
+        /// <summary>The AMQP message to use as the source for the system properties data.</summary>
+        private readonly AmqpAnnotatedMessage _amqpMessage;
+
+        /// <summary>
+        ///   Attempts to retrieve the value of the requested <paramref name="key" />
+        ///   from the dictionary.
+        /// </summary>
+        ///
+        /// <param name="key">The key of the dictionary item to retrieve.</param>
+        ///
+        /// <returns>The value in the dictionary associated with the specified <paramref name="key"/>.</returns>
+        ///
+        /// <exception cref="KeyNotFoundException">Occurs when the specified <paramref name="key" /> does not exist in the dictionary.</exception>
+        ///
+        public object this[string key]
+        {
+            get
+            {
+                if (_amqpMessage.HasSection(AmqpMessageSection.Properties))
+                {
+                    if (key == Properties.MessageIdName)
+                    {
+                        return _amqpMessage.Properties.MessageId;
+                    }
+
+                    if (key == Properties.UserIdName)
+                    {
+                        return _amqpMessage.Properties.UserId;
+                    }
+
+                    if (key == Properties.ToName)
+                    {
+                        return _amqpMessage.Properties.To;
+                    }
+
+                    if (key == Properties.SubjectName)
+                    {
+                        return _amqpMessage.Properties.Subject;
+                    }
+
+                    if (key == Properties.ReplyToName)
+                    {
+                        return _amqpMessage.Properties.ReplyTo;
+                    }
+
+                    if (key == Properties.CorrelationIdName)
+                    {
+                        return _amqpMessage.Properties.CorrelationId;
+                    }
+
+                    if (key == Properties.ContentTypeName)
+                    {
+                        return _amqpMessage.Properties.ContentType;
+                    }
+
+                    if (key == Properties.ContentEncodingName)
+                    {
+                        return _amqpMessage.Properties.ContentEncoding;
+                    }
+
+                    if (key == Properties.AbsoluteExpiryTimeName)
+                    {
+                        return _amqpMessage.Properties.AbsoluteExpiryTime;
+                    }
+
+                    if (key == Properties.CreationTimeName)
+                    {
+                        return _amqpMessage.Properties.CreationTime;
+                    }
+
+                    if (key == Properties.GroupIdName)
+                    {
+                        return _amqpMessage.Properties.GroupId;
+                    }
+
+                    if (key == Properties.GroupSequenceName)
+                    {
+                        return _amqpMessage.Properties.GroupSequence;
+                    }
+
+                    if (key == Properties.ReplyToGroupIdName)
+                    {
+                        return _amqpMessage.Properties.ReplyToGroupId;
+                    }
+                }
+
+                if (_amqpMessage.HasSection(AmqpMessageSection.MessageAnnotations))
+                {
+                   return _amqpMessage.MessageAnnotations[key];
+                }
+
+                // If no section was available to delegate to, mimic the behavior of the standard dictionary implementation.
+
+                throw new KeyNotFoundException(string.Format(CultureInfo.InvariantCulture, Resources.DictionaryKeyNotFoundMask, key));
+            }
+        }
+
+        /// <summary>
+        ///   Allows iteration over the keys contained in the dictionary.
+        /// </summary>
+        ///
+        public IEnumerable<string> Keys
+        {
+            get
+            {
+                if (_amqpMessage.HasSection(AmqpMessageSection.Properties))
+                {
+                    foreach (var name in PropertySectionNames)
+                    {
+                        if (ContainsKey(name))
+                        {
+                            yield return name;
+                        }
+                    }
+                }
+
+                if (_amqpMessage.HasSection(AmqpMessageSection.MessageAnnotations))
+                {
+                    foreach (var name in _amqpMessage.MessageAnnotations.Keys)
+                    {
+                        yield return name;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Allows iteration over the values contained in the dictionary.
+        /// </summary>
+        ///
+        public IEnumerable<object> Values
+        {
+            get
+            {
+                if (_amqpMessage.HasSection(AmqpMessageSection.Properties))
+                {
+                    foreach (var name in PropertySectionNames)
+                    {
+                        if (ContainsKey(name))
+                        {
+                            yield return this[name];
+                        }
+                    }
+                }
+
+                if (_amqpMessage.HasSection(AmqpMessageSection.MessageAnnotations))
+                {
+                    foreach (var name in _amqpMessage.MessageAnnotations.Keys)
+                    {
+                        yield return _amqpMessage.MessageAnnotations[name];
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   The number of items contained in the dictionary.
+        /// </summary>
+        ///
+        public int Count
+        {
+            get
+            {
+                var count = 0;
+
+                if (_amqpMessage.HasSection(AmqpMessageSection.Properties))
+                {
+                    foreach (var name in PropertySectionNames)
+                    {
+                        if (ContainsKey(name))
+                        {
+                            ++count;
+                        }
+                    }
+                }
+
+                if (_amqpMessage.HasSection(AmqpMessageSection.MessageAnnotations))
+                {
+                    foreach (var name in _amqpMessage.MessageAnnotations.Keys)
+                    {
+                        ++count;
+                    }
+                }
+
+                return count;
+            }
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="AmqpSystemProperties"/> class.
+        /// </summary>
+        ///
+        /// <param name="amqpMessage">The <see cref="AmqpAnnotatedMessage" /> to use as the source of the system properties data.</param>
+        ///
+        public AmqpSystemProperties(AmqpAnnotatedMessage amqpMessage) => _amqpMessage = amqpMessage;
+
+        /// <summary>
+        ///   Determines whether the specified key exists in the dictionary.
+        /// </summary>
+        ///
+        /// <param name="key">The key to locate.</param>
+        ///
+        /// <returns><c>true</c> if the dictionary contains the specified key; otherwise, <c>false</c>.</returns>
+        ///
+        public bool ContainsKey(string key)
+        {
+            // Check the set of well-known items from the Properties section.  For the key to be considered present,
+            // the section must exist and there must be a value present.  This logic is necessary to preserve the behavior
+            // of system properties in EventData before the AMQP annotated message abstraction was incorporated.
+
+            if (_amqpMessage.HasSection(AmqpMessageSection.Properties))
+            {
+                if (key == Properties.MessageIdName)
+                {
+                    return (_amqpMessage.Properties.MessageId != null);
+                }
+
+                if (key == Properties.UserIdName)
+                {
+                    return (_amqpMessage.Properties.UserId != null);
+                }
+
+                if (key == Properties.ToName)
+                {
+                    return (_amqpMessage.Properties.To != null);
+                }
+
+                if (key == Properties.SubjectName)
+                {
+                    return (_amqpMessage.Properties.Subject != null);
+                }
+
+                if (key == Properties.ReplyToName)
+                {
+                    return (_amqpMessage.Properties.ReplyTo != null);
+                }
+
+                if (key == Properties.CorrelationIdName)
+                {
+                    return (_amqpMessage.Properties.CorrelationId != null);
+                }
+
+                if (key == Properties.ContentTypeName)
+                {
+                    return (_amqpMessage.Properties.ContentType != null);
+                }
+
+                if (key == Properties.ContentEncodingName)
+                {
+                    return (_amqpMessage.Properties.ContentEncoding != null);
+                }
+
+                if (key == Properties.AbsoluteExpiryTimeName)
+                {
+                    return (_amqpMessage.Properties.AbsoluteExpiryTime != null);
+                }
+
+                if (key == Properties.CreationTimeName)
+                {
+                    return (_amqpMessage.Properties.CreationTime != null);
+                }
+
+                if (key == Properties.GroupIdName)
+                {
+                    return (_amqpMessage.Properties.GroupId != null);
+                }
+
+                if (key == Properties.GroupSequenceName)
+                {
+                    return (_amqpMessage.Properties.GroupSequence != null);
+                }
+
+                if (key == Properties.ReplyToGroupIdName)
+                {
+                    return (_amqpMessage.Properties.ReplyToGroupId != null);
+                }
+            }
+
+            // If the well-known property items were not found, then any message annotation with a matching
+            // key is acceptable.
+
+            if (_amqpMessage.HasSection(AmqpMessageSection.MessageAnnotations))
+            {
+                return _amqpMessage.MessageAnnotations.ContainsKey(key);
+            }
+
+            // If neither a well-known property or message annotation matched, the key
+            // does not exist.
+
+            return false;
+        }
+
+        /// <summary>
+        ///   Attempts to retrieve the value that is associated with the specified key from the dictionary.
+        /// </summary>
+        ///
+        /// <param name="key">The key to locate.</param>
+        /// <param name="value">The value associated with the specified key, if the key is found; otherwise, <c>null</c>.  This parameter should be passed uninitialized.</param>
+        ///
+        /// <returns><c>true</c> the dictionary contains the specified <paramref name="key" />; otherwise, <c>false</c>.</returns>
+        ///
+        public bool TryGetValue(string key, out object value)
+        {
+            if (!ContainsKey(key))
+            {
+                value = default;
+                return false;
+            }
+
+            value = this[key];
+            return true;
+        }
+
+        /// <summary>
+        ///   Produces an enumerator for the items in the dictionary.
+        /// </summary>
+        ///
+        /// <returns>An enumerator can be used to iterate through the items in the dictionary.</returns>
+        ///
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            foreach (var key in Keys)
+            {
+                yield return new KeyValuePair<string, object>(key, this[key]);
+            }
+        }
+
+        /// <summary>
+        ///   Produces an enumerator for the items in the dictionary.
+        /// </summary>
+        ///
+        /// <returns>An enumerator can be used to iterate through the items in the dictionary.</returns>
+        ///
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/MessageBody.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/MessageBody.cs
@@ -1,0 +1,273 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Core;
+using Azure.Core.Amqp;
+using Azure.Messaging.EventHubs;
+using Microsoft.Azure.Amqp.Framing;
+
+namespace Azure.Messaging.EventHubs.Amqp
+{
+    /// <summary>
+    ///   A set of abstractions for an AMQP message body to allow optimization of allocations when using <see cref="EventData" />.
+    ///   The goal of the approach is to ensure that body memory is converted on-demand and as infrequently as possible.
+    /// </summary>
+    ///
+    internal abstract class MessageBody : IEnumerable<ReadOnlyMemory<byte>>
+    {
+        /// <summary>
+        ///   The memory that was written to the message body.
+        /// </summary>
+        ///
+        protected abstract ReadOnlyMemory<byte> WrittenMemory { get; }
+
+        /// <summary>
+        ///   Produces an enumerator for the segments of the message body.
+        /// </summary>
+        ///
+        /// <returns>An enumerator that can be used to iterate through the segments of the message body.</returns>
+        ///
+        public abstract IEnumerator<ReadOnlyMemory<byte>> GetEnumerator();
+
+        /// <summary>
+        ///   Produces an enumerator for the segments of the message body.
+        /// </summary>
+        ///
+        /// <returns>An enumerator that can be used to iterate through the segments of the message body.</returns>
+        ///
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        ///   Creates an message body instance from a set of memory segments.
+        /// </summary>
+        ///
+        /// <param name="segments">The memory segments that should comprise the message body.</param>
+        ///
+        /// <returns>The <see cref="MessageBody"/> comprised of the <paramref name="segments"/>.</returns>
+        ///
+        public static MessageBody FromReadOnlyMemorySegments(IEnumerable<ReadOnlyMemory<byte>> segments) =>
+            segments switch
+            {
+                MessageBody bodyMemory => bodyMemory,
+                _ => new CopyingOnConversionMessageBody(segments)
+            };
+
+        /// <summary>
+        ///   Creates an message body instance from a single of memory segment.
+        /// </summary>
+        ///
+        /// <param name="segment">The memory segment that should comprise the message body.</param>
+        ///
+        /// <returns>The <see cref="MessageBody"/> comprised of the <paramref name="segment"/>.</returns>
+        ///
+        public static MessageBody FromReadOnlyMemorySegment(ReadOnlyMemory<byte> segment) => new NonCopyingSingleSegmentMessageBody(segment);
+
+        /// <summary>
+        ///   Creates an message body instance from a set of AMQP <see cref="Data" /> segments.
+        /// </summary>
+        ///
+        /// <param name="segments">The data segments that should comprise the message body.</param>
+        ///
+        /// <returns>The <see cref="MessageBody"/> comprised of the <paramref name="segments"/>.</returns>
+        ///
+        public static MessageBody FromDataSegments(IEnumerable<Data> segments) => new EagerCopyingMessageBody(segments ?? Enumerable.Empty<Data>());
+
+        /// <summary>
+        ///   Performs an implicit conversion from <see cref="MessageBody"/> to <see cref="ReadOnlyMemory{Byte}"/>.
+        /// </summary>
+        ///
+        /// <param name="messageBody">The message body to convert.</param>
+        ///
+        /// <returns>The <see cref="ReadOnlyMemory{Byte}" /> produced by the conversion.</returns>
+        ///
+        public static implicit operator ReadOnlyMemory<byte>(MessageBody messageBody) => messageBody.WrittenMemory;
+
+        /// <summary>
+        ///   Represents a single memory segment as an enumerable type without allocating a copy.
+        ///   This optimizes for the most common usage scenario when the <see cref="EventData" /> body
+        ///   is set via the constructor and interacted with exclusively through that type.
+        /// </summary>
+        ///
+        private sealed class NonCopyingSingleSegmentMessageBody : MessageBody
+        {
+            /// <summary>
+            ///   The memory that was written to the message body.
+            /// </summary>
+            ///
+            protected override ReadOnlyMemory<byte> WrittenMemory { get; }
+
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="NonCopyingSingleSegmentMessageBody"/> class.
+            /// </summary>
+            ///
+            /// <param name="dataSegment">The data segment to create the body from.</param>
+            ///
+            public NonCopyingSingleSegmentMessageBody(ReadOnlyMemory<byte> dataSegment)
+            {
+                WrittenMemory = dataSegment;
+            }
+
+            /// <summary>
+            ///   Produces an enumerator for the segments of the message body.
+            /// </summary>
+            ///
+            /// <returns>An enumerator that can be used to iterate through the segments of the message body.</returns>
+            ///
+            public override IEnumerator<ReadOnlyMemory<byte>> GetEnumerator()
+            {
+                yield return WrittenMemory;
+            }
+        }
+
+        /// <summary>
+        ///   Represents multiple segments as a continuous buffer, performing the necessary copies on demand while
+        ///   continuing to track the segments individually.  This optimizes for the usage scenario of the body being
+        ///   manipulated directly via the <see cref="AmqpAnnotatedMessage"/> that owns it.
+        /// </summary>
+        ///
+        private sealed class CopyingOnConversionMessageBody : MessageBody
+        {
+            /// <summary>The writer used to build the continuous buffer from a set of segments.</summary>
+            private ArrayBufferWriter<byte> _writer;
+
+            ///<summary>The set of individual memory segments that comprise the body.</summary>
+            private IList<ReadOnlyMemory<byte>> _segments;
+
+            /// <summary>The set of individual memory segments that were captured on creation of the body, until they're copied into the buffer.</summary>
+            private IEnumerable<ReadOnlyMemory<byte>> _lazySegments;
+
+            /// <summary>
+            ///   The memory that was written to the message body.
+            /// </summary>
+            ///
+            protected override ReadOnlyMemory<byte> WrittenMemory
+            {
+                get
+                {
+                    if (_lazySegments != null)
+                    {
+                        foreach (var segment in _lazySegments)
+                        {
+                            AppendSegment(segment);
+                        }
+
+                        _lazySegments = null;
+                    }
+
+                    return _writer?.WrittenMemory ?? ReadOnlyMemory<byte>.Empty;
+                }
+            }
+
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="CopyingOnConversionMessageBody"/> class.
+            /// </summary>
+            ///
+            /// <param name="dataSegments">The data segments to create the body from.</param>
+            ///
+            public CopyingOnConversionMessageBody(IEnumerable<ReadOnlyMemory<byte>> dataSegments)
+            {
+                _lazySegments = dataSegments;
+            }
+
+            /// <summary>
+            ///   Produces an enumerator for the segments of the message body.
+            /// </summary>
+            ///
+            /// <returns>An enumerator that can be used to iterate through the segments of the message body.</returns>
+            ///
+            public override IEnumerator<ReadOnlyMemory<byte>> GetEnumerator() =>
+                _segments?.GetEnumerator() ?? _lazySegments.GetEnumerator();
+
+            /// <summary>
+            ///   Appends a memory segment to the continuous buffer.
+            /// </summary>
+            ///
+            /// <param name="segment">The memory segment to append.</param>
+            ///
+            private void AppendSegment(ReadOnlyMemory<byte> segment)
+            {
+                _writer ??= new ArrayBufferWriter<byte>();
+                _segments ??= new List<ReadOnlyMemory<byte>>();
+
+                var memory = _writer.GetMemory(segment.Length);
+                segment.CopyTo(memory);
+
+                _writer.Advance(segment.Length);
+                _segments.Add(memory.Slice(0, segment.Length));
+            }
+        }
+
+        /// <summary>
+        ///   Represents multiple segments as a continuous buffer, performing the necessary copies eagerly while
+        ///   continuing to track the segments individually.  This optimizes for the usage scenario of the body being
+        ///   created when messages are received, ensuring that buffers managed by the underling AMQP library can be safely
+        ///   released.
+        /// </summary>
+        ///
+        private sealed class EagerCopyingMessageBody : MessageBody
+        {
+            /// <summary>The writer used to build the continuous buffer from a set of segments.</summary>
+            private ArrayBufferWriter<byte> _writer;
+
+            ///<summary>The set of individual memory segments that comprise the body.</summary>
+            private IList<ReadOnlyMemory<byte>> _segments;
+
+            /// <summary>
+            ///   The memory that was written to the message body.
+            /// </summary>
+            ///
+            protected override ReadOnlyMemory<byte> WrittenMemory => _writer?.WrittenMemory ?? ReadOnlyMemory<byte>.Empty;
+
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="EagerCopyingMessageBody"/> class.
+            /// </summary>
+            ///
+            /// <param name="dataSegments">The data segments to create the body from.</param>
+            ///
+            public EagerCopyingMessageBody(IEnumerable<Data> dataSegments)
+            {
+                foreach (var segment in dataSegments)
+                {
+                    AppendSegment(segment);
+                }
+            }
+
+            /// <summary>
+            ///   Produces an enumerator for the segments of the message body.
+            /// </summary>
+            ///
+            /// <returns>An enumerator that can be used to iterate through the segments of the message body.</returns>
+            ///
+            public override IEnumerator<ReadOnlyMemory<byte>> GetEnumerator() => _segments.GetEnumerator();
+
+            /// <summary>
+            ///   Appends a memory segment to the continuous buffer.
+            /// </summary>
+            ///
+            /// <param name="segment">The memory segment to append.</param>
+            ///
+            private void AppendSegment(Data segment)
+            {
+                _writer ??= new ArrayBufferWriter<byte>();
+                _segments ??= new List<ReadOnlyMemory<byte>>();
+
+                ReadOnlyMemory<byte> dataToAppend = segment.Value switch
+                {
+                    byte[] byteArray => byteArray,
+                    ArraySegment<byte> arraySegment => arraySegment,
+                    _ => ReadOnlyMemory<byte>.Empty
+                };
+
+                var memory = _writer.GetMemory(dataToAppend.Length);
+                dataToAppend.CopyTo(memory);
+
+                _writer.Advance(dataToAppend.Length);
+                _segments.Add(memory.Slice(0, dataToAppend.Length));
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -15,6 +15,17 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
+
+    <!-- TEMP:
+        Shift to a project reference for Azure.Core.Amqp until the
+        changes with "HasSection" are released to a package.
+    -->
+
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core.Amqp\src\Azure.Core.Amqp.csproj" />
+    <!--PackageReference Include="Azure.Core.Amqp" / -->
+
+    <!-- END TEMP -->
+
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -6,8 +6,13 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
+using System.Text;
+using Azure.Core;
+using Azure.Core.Amqp;
 using Azure.Core.Serialization;
+using Azure.Messaging.EventHubs.Amqp;
 using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Producer;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -18,11 +23,11 @@ namespace Azure.Messaging.EventHubs
     ///
     public class EventData
     {
-        /// <summary>An empty default set for the <see cref="SystemProperties" /> member, intended to used when no actual property set is available.</summary>
-        private static readonly IReadOnlyDictionary<string, object> EmptySystemProperties = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>(0));
+        /// <summary>The AMQP representation of the event, allowing access to additional protocol data elements not used directly by the Event Hubs client library.</summary>
+        private readonly AmqpAnnotatedMessage _amqpMessage;
 
-        /// <summary>The backing store for the <see cref="Properties" /> member, intended to be lazily allocated.</summary>
-        private IDictionary<string, object> _properties;
+        /// <summary>The backing store for the <see cref="SystemProperties" /> member which, by default, will be a lazily initialized projection over the AMQP message.</summary>
+        private IReadOnlyDictionary<string, object> _systemProperties;
 
         /// <summary>
         ///   The data associated with the event, in <see cref="BinaryData" /> form, providing support
@@ -30,15 +35,135 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <remarks>
-        ///   <para>If the means for deserializing the raw data is not apparent to consumers, a
+        ///   If the means for deserializing the raw data is not apparent to consumers, a
         ///   common technique is to make use of <see cref="EventData.Properties" /> to associate serialization hints
-        ///   as an aid to consumers who wish to deserialize the binary data.</para>
+        ///   as an aid to consumers who wish to deserialize the binary data.
         /// </remarks>
         ///
         /// <seealso cref="BinaryData" />
         /// <seealso cref="EventData.Properties" />
         ///
-        public BinaryData EventBody { get; }
+        public BinaryData EventBody => _amqpMessage.GetEventBody();
+
+        /// <summary>
+        ///   A MIME type describing the data contained in the <see cref="EventBody" />,
+        ///   intended to allow consumers to make informed decisions for inspecting and
+        ///   processing the event.
+        /// </summary>
+        ///
+        /// <value>
+        ///   The MIME type of the <see cref="EventBody" /> content; when unknown, it is
+        ///   recommended that this value should not be set.  When the body is known to be
+        ///   truly opaque binary data, it is recommended that "application/octet-stream" be
+        ///   used.
+        /// </value>
+        ///
+        /// <remarks>
+        ///   The <see cref="ContentType" /> is intended to allow coordination between event
+        ///   producers and consumers.  It has no meaning to the Event Hubs service.
+        /// </remarks>
+        ///
+        /// <seealso href="https://datatracker.ietf.org/doc/html/rfc2046">RFC2046 (MIME Types)</seealso>
+        ///
+        public string ContentType
+        {
+            get
+            {
+                if (_amqpMessage.HasSection(AmqpMessageSection.Properties))
+                {
+                    return _amqpMessage.Properties.ContentType?.ToString();
+                }
+
+                return null;
+            }
+
+            set
+            {
+                var populated = (!string.IsNullOrEmpty(value));
+
+                if ((populated) || (_amqpMessage.HasSection(AmqpMessageSection.Properties)))
+                {
+                    _amqpMessage.Properties.ContentType = populated
+                        ? value
+                        : null;
+                }
+            }
+        }
+
+        /// <summary>
+        ///   An application-defined value that uniquely identifies the event.  The identifier is
+        ///   a free-form value and can reflect a GUID or an identifier derived from the application
+        ///   context.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   The <see cref="MessageId" /> is intended to allow coordination between event
+        ///   producers and consumers.  It has no meaning to the Event Hubs service, and does
+        ///   not influence how Event Hubs identifies the event.
+        /// </remarks>
+        ///
+
+        public string MessageId
+        {
+            get
+            {
+                if (_amqpMessage.HasSection(AmqpMessageSection.Properties))
+                {
+                    return _amqpMessage.Properties.MessageId?.ToString();
+                }
+
+                return null;
+            }
+
+            set
+            {
+                var populated = (!string.IsNullOrEmpty(value));
+
+                if ((populated) || (_amqpMessage.HasSection(AmqpMessageSection.Properties)))
+                {
+                    _amqpMessage.Properties.MessageId = populated
+                        ? new AmqpMessageId(value)
+                        : null;
+                }
+            }
+        }
+
+        /// <summary>
+        ///   An application-defined value that represents the context to use for correlation across
+        ///   one or more operations.  The identifier is a free-form value and may reflect a unique
+        ///   identity or a shared data element with significance to the application.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   The <see cref="CorrelationId" /> is intended to enable tracing of data within an application,
+        ///   such as an event's path from producer to consumer.  It has no meaning to the Event Hubs service.
+        /// </remarks>
+        ///
+
+        public string CorrelationId
+        {
+            get
+            {
+                if (_amqpMessage.HasSection(AmqpMessageSection.Properties))
+                {
+                    return _amqpMessage.Properties.CorrelationId?.ToString();
+                }
+
+                return null;
+            }
+
+            set
+            {
+                var populated = (!string.IsNullOrEmpty(value));
+
+                if ((populated) || (_amqpMessage.HasSection(AmqpMessageSection.Properties)))
+                {
+                    _amqpMessage.Properties.CorrelationId = populated
+                        ? new AmqpMessageId(value)
+                        : null;
+                }
+            }
+        }
 
         /// <summary>
         ///   The set of free-form event properties which may be used for passing metadata associated with the event body
@@ -53,14 +178,11 @@ namespace Azure.Messaging.EventHubs
         /// <example>
         ///   <code>
         ///     var eventData = new EventData(serializedTelemetryData);
-        ///     eventData.Properties["eventType"] = "com.microsoft.Azure.monitoring.EtlEvent";
+        ///     eventData.Properties["eventType"] = "com.microsoft.azure.monitoring.EtlEvent";
         ///   </code>
         /// </example>
         ///
-        public IDictionary<string, object> Properties
-        {
-            get => _properties ??= new Dictionary<string, object>();
-        }
+        public IDictionary<string, object> Properties => _amqpMessage.ApplicationProperties;
 
         /// <summary>
         ///   The set of free-form event properties which were provided by the Event Hubs service to pass metadata associated with the
@@ -72,7 +194,7 @@ namespace Azure.Messaging.EventHubs
         ///   empty.
         /// </remarks>
         ///
-        public IReadOnlyDictionary<string, object> SystemProperties { get; }
+        public IReadOnlyDictionary<string, object> SystemProperties => _systemProperties ??= new AmqpSystemProperties(_amqpMessage);
 
         /// <summary>
         ///   The publishing sequence number assigned to the event at the time it was successfully published.
@@ -101,7 +223,7 @@ namespace Azure.Messaging.EventHubs
         ///   EventData was not received from the Event Hubs service, the value is <see cref="long.MinValue"/>.
         /// </remarks>
         ///
-        public long SequenceNumber { get; }
+        public long SequenceNumber => _amqpMessage.GetSequenceNumber(long.MinValue);
 
         /// <summary>
         ///   The offset of the event when it was received from the associated Event Hub partition.
@@ -112,7 +234,7 @@ namespace Azure.Messaging.EventHubs
         ///   EventData was not received from the Event Hubs service, the value is <see cref="long.MinValue"/>.
         /// </remarks>
         ///
-        public long Offset { get; }
+        public long Offset => _amqpMessage.GetOffset(long.MinValue);
 
         /// <summary>
         ///   The date and time, in UTC, of when the event was enqueued in the Event Hub partition.
@@ -123,7 +245,7 @@ namespace Azure.Messaging.EventHubs
         ///   EventData was not received from the Event Hubs service, the value <c>default(DateTimeOffset)</c>.
         /// </remarks>
         ///
-        public DateTimeOffset EnqueuedTime { get; }
+        public DateTimeOffset EnqueuedTime => _amqpMessage.GetEnqueuedTime();
 
         /// <summary>
         ///   The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was published with.
@@ -133,7 +255,7 @@ namespace Azure.Messaging.EventHubs
         ///   This property is only populated for events received from the Event Hubs service.
         /// </remarks>
         ///
-        public string PartitionKey { get; }
+        public string PartitionKey => _amqpMessage.GetPartitionKey();
 
         /// <summary>
         ///   The data associated with the event.
@@ -179,7 +301,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <value><c>true</c> if this instance has properties; otherwise, <c>false</c>.</value>
         ///
-        internal bool HasProperties => (_properties != null);
+        internal bool HasProperties => _amqpMessage.HasSection(AmqpMessageSection.ApplicationProperties);
 
         /// <summary>
         ///   The sequence number of the event that was last enqueued into the Event Hub partition from which this
@@ -191,7 +313,7 @@ namespace Azure.Messaging.EventHubs
         ///   <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> as enabled.
         /// </remarks>
         ///
-        internal long? LastPartitionSequenceNumber { get; }
+        internal long? LastPartitionSequenceNumber => _amqpMessage.GetLastPartitionSequenceNumber();
 
         /// <summary>
         ///   The offset of the event that was last enqueued into the Event Hub partition from which this event was
@@ -203,7 +325,7 @@ namespace Azure.Messaging.EventHubs
         ///   <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> as enabled.
         /// </remarks>
         ///
-        internal long? LastPartitionOffset { get; }
+        internal long? LastPartitionOffset => _amqpMessage.GetLastPartitionOffset();
 
         /// <summary>
         ///   The date and time, in UTC, that the last event was enqueued into the Event Hub partition from
@@ -215,7 +337,7 @@ namespace Azure.Messaging.EventHubs
         ///   <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> as enabled.
         /// </remarks>
         ///
-        internal DateTimeOffset? LastPartitionEnqueuedTime { get; }
+        internal DateTimeOffset? LastPartitionEnqueuedTime => _amqpMessage.GetLastPartitionEnqueuedTime();
 
         /// <summary>
         ///   The date and time, in UTC, that the last event information for the Event Hub partition was retrieved
@@ -227,7 +349,7 @@ namespace Azure.Messaging.EventHubs
         ///   <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> as enabled.
         /// </remarks>
         ///
-        internal DateTimeOffset? LastPartitionPropertiesRetrievalTime { get; }
+        internal DateTimeOffset? LastPartitionPropertiesRetrievalTime => _amqpMessage.GetLastPartitionPropertiesRetrievalTime();
 
         /// <summary>
         ///   The publishing sequence number assigned to the event as part of a publishing operation.
@@ -301,40 +423,21 @@ namespace Azure.Messaging.EventHubs
         ///   Initializes a new instance of the <see cref="EventData"/> class.
         /// </summary>
         ///
-        /// <param name="eventBody">The raw data to use as the body of the event.</param>
-        /// <param name="properties">The set of free-form event properties to send with the event.</param>
-        /// <param name="systemProperties">The set of system properties received from the Event Hubs service.</param>
-        /// <param name="sequenceNumber">The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.</param>
-        /// <param name="offset">The offset of the event when it was received from the associated Event Hub partition.</param>
-        /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
-        /// <param name="partitionKey">The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.</param>
-        /// <param name="lastPartitionSequenceNumber">The sequence number that was last enqueued into the Event Hub partition.</param>
-        /// <param name="lastPartitionOffset">The offset that was last enqueued into the Event Hub partition.</param>
-        /// <param name="lastPartitionEnqueuedTime">The date and time, in UTC, of the event that was last enqueued into the Event Hub partition.</param>
-        /// <param name="lastPartitionPropertiesRetrievalTime">The date and time, in UTC, that the last event information for the Event Hub partition was retrieved from the service.</param>
-        /// <param name="publishedSequenceNumber">The publishing sequence number assigned to the event at the time it was successfully published.</param>
-        /// <param name="pendingPublishSequenceNumber">The publishing sequence number assigned to the event as part of a publishing operation.</param>
-        /// <param name="pendingProducerGroupId">The producer group identifier assigned to the event as part of a publishing operation.</param>
-        /// <param name="pendingOwnerLevel">The producer owner level assigned to the event as part of a publishing operation.</param>
+        /// <param name="eventBody">The data to use as the body of the event.  This will be represented as a set UTF-8 encoded bytes.</param>
         ///
-        internal EventData(ReadOnlyMemory<byte> eventBody,
-                           IDictionary<string, object> properties = null,
-                           IReadOnlyDictionary<string, object> systemProperties = null,
-                           long sequenceNumber = long.MinValue,
-                           long offset = long.MinValue,
-                           DateTimeOffset enqueuedTime = default,
-                           string partitionKey = null,
-                           long? lastPartitionSequenceNumber = null,
-                           long? lastPartitionOffset = null,
-                           DateTimeOffset? lastPartitionEnqueuedTime = null,
-                           DateTimeOffset? lastPartitionPropertiesRetrievalTime = null,
-                           int? publishedSequenceNumber = null,
-                           int? pendingPublishSequenceNumber = null,
-                           long? pendingProducerGroupId = null,
-                           short? pendingOwnerLevel = null) : this(new BinaryData(eventBody), properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey,
-                           lastPartitionSequenceNumber, lastPartitionOffset, lastPartitionEnqueuedTime, lastPartitionPropertiesRetrievalTime, publishedSequenceNumber, pendingPublishSequenceNumber,
-                           pendingProducerGroupId, pendingOwnerLevel)
+        public EventData(string eventBody) : this(new BinaryData(Encoding.UTF8.GetBytes(eventBody)), lastPartitionSequenceNumber: null)
         {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventData"/> class.
+        /// </summary>
+        ///
+        /// <param name="amqpMessage">The <see cref="AmqpAnnotatedMessage" /> on which to base the event.</param>
+        ///
+        internal EventData(AmqpAnnotatedMessage amqpMessage)
+        {
+            _amqpMessage = amqpMessage;
         }
 
         /// <summary>
@@ -360,9 +463,9 @@ namespace Azure.Messaging.EventHubs
         internal EventData(BinaryData eventBody,
                            IDictionary<string, object> properties = null,
                            IReadOnlyDictionary<string, object> systemProperties = null,
-                           long sequenceNumber = long.MinValue,
-                           long offset = long.MinValue,
-                           DateTimeOffset enqueuedTime = default,
+                           long? sequenceNumber = null,
+                           long? offset = null,
+                           DateTimeOffset? enqueuedTime = null,
                            string partitionKey = null,
                            long? lastPartitionSequenceNumber = null,
                            long? lastPartitionOffset = null,
@@ -373,22 +476,34 @@ namespace Azure.Messaging.EventHubs
                            long? pendingProducerGroupId = null,
                            short? pendingOwnerLevel = null)
         {
-            EventBody = eventBody;
-            SequenceNumber = sequenceNumber;
-            Offset = offset;
-            EnqueuedTime = enqueuedTime;
-            PartitionKey = partitionKey;
-            SystemProperties = systemProperties ?? EmptySystemProperties;
-            LastPartitionSequenceNumber = lastPartitionSequenceNumber;
-            LastPartitionOffset = lastPartitionOffset;
-            LastPartitionEnqueuedTime = lastPartitionEnqueuedTime;
-            LastPartitionPropertiesRetrievalTime = lastPartitionPropertiesRetrievalTime;
+            Argument.AssertNotNull(eventBody, nameof(eventBody));
+            _amqpMessage = new AmqpAnnotatedMessage(AmqpMessageBody.FromData(MessageBody.FromReadOnlyMemorySegment(eventBody.ToMemory())));
+
+            _amqpMessage.PopulateFromEventProperties(
+                properties,
+                sequenceNumber,
+                offset,
+                enqueuedTime,
+                partitionKey,
+                lastPartitionSequenceNumber,
+                lastPartitionOffset,
+                lastPartitionEnqueuedTime,
+                lastPartitionPropertiesRetrievalTime);
+
+            // If there was a set of system properties explicitly provided, then
+            // override the default projection with them.
+
+            if (systemProperties != null)
+            {
+                _systemProperties = systemProperties;
+            }
+
+            // Set the idempotent publishing state.
+
             PublishedSequenceNumber = publishedSequenceNumber;
             PendingPublishSequenceNumber = pendingPublishSequenceNumber;
             PendingProducerGroupId = pendingProducerGroupId;
             PendingProducerOwnerLevel = pendingOwnerLevel;
-
-            _properties = properties;
         }
 
         /// <summary>
@@ -456,6 +571,27 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
+        ///   The event representation in the AMQP protocol format.  This allows access to protocol information
+        ///   that is not relevant to Event Hubs and is not exposed by <see cref="EventData" /> directly.  This
+        ///   information can be helpful when exchanging data with other message brokers or clients that do not
+        ///   use one of the Event Hubs SDKs.
+        /// </summary>
+        ///
+        /// <returns>The event, as an <see cref="AmqpAnnotatedMessage" />.</returns>
+        ///
+        /// <remarks>
+        ///   Manipulating the raw AMQP message is an advanced operation recommended only for those with
+        ///   knowledge of the AMQP protocol and have a need outside of the normal operation of Event Hubs,
+        ///   such as inter-operating with another message broker.
+        ///
+        ///   When making direct changes to the AMQP message, it is possible to cause issues with the Event
+        ///   Hubs client library, such as invalidating the size calculations performed by the
+        ///   <see cref="EventDataBatch" /> resulting in a batch that cannot be successfully published.
+        /// </remarks>
+        ///
+        public AmqpAnnotatedMessage GetRawAmqpMessage() => _amqpMessage;
+
+        /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
         /// </summary>
         ///
@@ -511,22 +647,20 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>A new copy of <see cref="EventData" />.</returns>
         ///
-        internal EventData Clone() =>
-            new EventData
-            (
-                EventBody,
-                (_properties == null) ? null : new Dictionary<string, object>(_properties),
-                SystemProperties,
-                SequenceNumber,
-                Offset,
-                EnqueuedTime,
-                PartitionKey,
-                LastPartitionSequenceNumber,
-                LastPartitionOffset,
-                LastPartitionEnqueuedTime,
-                LastPartitionPropertiesRetrievalTime,
-                PublishedSequenceNumber,
-                PendingPublishSequenceNumber
-            );
+        internal EventData Clone()
+        {
+            var clone = new EventData(_amqpMessage.Clone())
+            {
+                PendingPublishSequenceNumber = PendingPublishSequenceNumber,
+                PublishedSequenceNumber = PublishedSequenceNumber
+            };
+
+            if ((_systemProperties != null) && (_systemProperties is not AmqpSystemProperties))
+            {
+                clone._systemProperties = _systemProperties;
+            }
+
+            return clone;
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpAnnotatedMessageExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpAnnotatedMessageExtensionsTests.cs
@@ -1,0 +1,537 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Azure.Core.Amqp;
+using Azure.Messaging.EventHubs.Amqp;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="AmqpAnnotatedMessageExtensions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class AmqpAnnotatedMessageExtensionsTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions.Clone" />
+        ///   method.
+        /// </summary>
+        [Test]
+        public void CloneKnowsAllMembersOfAmqpAnnotatedMessage()
+        {
+            // This approach is inelegant and brute force, but allows us to detect
+            // additional members added to the annotated message that we're not currently
+            // cloning and avoid drift, since Azure.Core.Amqp is an external dependency.
+
+            var knownMembers = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "Header",
+                "Properties",
+                "Footer",
+                "DeliveryAnnotations",
+                "MessageAnnotations",
+                "ApplicationProperties"
+            };
+
+            var getterSetterProperties = typeof(AmqpAnnotatedMessage)
+                .GetProperties(BindingFlags.Public | BindingFlags.GetProperty | BindingFlags.SetProperty);
+
+            foreach (var property in getterSetterProperties)
+            {
+                Assert.That(knownMembers.Contains(property.Name), $"The property: { property.Name } of AmqpAnnotatedMessage is not being cloned.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions.Clone" />
+        ///   method.
+        /// </summary>
+        [Test]
+        public void CloneKnowsAllMembersOfAmqpMessageHeader()
+        {
+            // This approach is inelegant and brute force, but allows us to detect
+            // additional members added to the annotated message that we're not currently
+            // cloning and avoid drift, since Azure.Core.Amqp is an external dependency.
+
+            var knownMembers = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "DeliveryCount",
+                "Durable",
+                "FirstAcquirer",
+                "Priority",
+                "TimeToLive"
+            };
+
+            var getterSetterProperties = typeof(AmqpMessageHeader)
+                .GetProperties(BindingFlags.Public | BindingFlags.GetProperty | BindingFlags.SetProperty);
+
+            foreach (var property in getterSetterProperties)
+            {
+                Assert.That(knownMembers.Contains(property.Name), $"The property: { property.Name } of AmqpMessageHeader is not being cloned.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions.Clone" />
+        ///   method.
+        /// </summary>
+        [Test]
+        public void CloneKnowsAllMembersOfAmqpMessageProperties()
+        {
+            // This approach is inelegant and brute force, but allows us to detect
+            // additional members added to the annotated message that we're not currently
+            // cloning and avoid drift, since Azure.Core.Amqp is an external dependency.
+
+            var knownMembers = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "AbsoluteExpiryTime",
+                "ContentEncoding",
+                "ContentType",
+                "CorrelationId",
+                "CreationTime",
+                "GroupId",
+                "GroupSequence",
+                "MessageId",
+                "ReplyTo",
+                "ReplyToGroupId",
+                "Subject",
+                "To",
+                "UserId"
+            };
+
+            var getterSetterProperties = typeof(AmqpMessageProperties)
+                .GetProperties(BindingFlags.Public | BindingFlags.GetProperty | BindingFlags.SetProperty);
+
+            foreach (var property in getterSetterProperties)
+            {
+                Assert.That(knownMembers.Contains(property.Name), $"The property: { property.Name } of AmqpMessageProperties is not being cloned.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions.Clone" />
+        ///   method.
+        /// </summary>
+        [Test]
+        public void CloneCopiesTheFullMessage()
+        {
+            var source = CreateFullyPopulatedDataBodyMessage();
+            var clone = source.Clone();
+
+            // Body
+
+            Assert.That(ReferenceEquals(clone.Body, source.Body), Is.False, "The message body should not be the same instance.");
+            Assert.That(source.Body.TryGetData(out var sourceBody), Is.True, "The source should have a data body.");
+            Assert.That(clone.Body.TryGetData(out var cloneBody), Is.True, "The clone should have a data body.");
+            Assert.That(cloneBody, Is.EquivalentTo(sourceBody), "The body data should match.");
+
+            // Header
+
+            Assert.That(ReferenceEquals(clone.Header, source.Header), Is.False, "The message header should not be the same instance.");
+            Assert.That(clone.Header, Is.Not.Null, "The message header should not be null.");
+
+            foreach (var headerProperty in typeof(AmqpMessageHeader).GetProperties(BindingFlags.Public | BindingFlags.GetProperty))
+            {
+                Assert.That(headerProperty.GetValue(clone), Is.EqualTo(headerProperty.GetValue(source)), $"The header property: { headerProperty.Name } should match.");
+            }
+
+            // Properties
+
+            Assert.That(ReferenceEquals(clone.Properties, source.Properties), Is.False, "The message properties should not be the same instance.");
+            Assert.That(clone.Properties, Is.Not.Null, "The message properties should not be null.");
+
+            foreach (var propertiesProperty in typeof(AmqpMessageProperties).GetProperties(BindingFlags.Public | BindingFlags.GetProperty))
+            {
+                Assert.That(propertiesProperty.GetValue(clone), Is.EqualTo(propertiesProperty.GetValue(source)), $"The message property: { propertiesProperty.Name } should match.");
+            }
+
+            // Footer
+
+            Assert.That(ReferenceEquals(clone.Footer, source.Footer), Is.False, "The message footer should not be the same instance.");
+            Assert.That(clone.Footer, Is.Not.Null, "The message footer should not be null.");
+            Assert.That(clone.Footer, Is.EquivalentTo(source.Footer), "The message footer items should match.");
+
+            // Delivery Annotations
+
+            Assert.That(ReferenceEquals(clone.DeliveryAnnotations, source.DeliveryAnnotations), Is.False, "The message delivery annotations should not be the same instance.");
+            Assert.That(clone.DeliveryAnnotations, Is.Not.Null, "The message delivery annotations should not be null.");
+            Assert.That(clone.DeliveryAnnotations, Is.EquivalentTo(source.DeliveryAnnotations), "The message delivery annotation items should match.");
+
+            // Message Annotations
+
+            Assert.That(ReferenceEquals(clone.MessageAnnotations, source.MessageAnnotations), Is.False, "The message annotations should not be the same instance.");
+            Assert.That(clone.MessageAnnotations, Is.Not.Null, "The message annotations should not be null.");
+            Assert.That(clone.MessageAnnotations, Is.EquivalentTo(source.MessageAnnotations), "The message annotations items should match.");
+
+            // ApplicationProperties
+
+            Assert.That(ReferenceEquals(clone.ApplicationProperties, source.ApplicationProperties), Is.False, "The application properties should not be the same instance.");
+            Assert.That(clone.ApplicationProperties, Is.Not.Null, "The application properties should not be null.");
+            Assert.That(clone.ApplicationProperties, Is.EquivalentTo(source.ApplicationProperties), "The application property items should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions.Clone" />
+        ///   method.
+        /// </summary>
+        [Test]
+        public void CloneDoesNotForceAllocationOfUnpopulatedSections()
+        {
+            var firstBody = new List<object> { 1, 2, 3 };
+            var secondBody = new List<object> { 4, 5, 6 };
+            var body = AmqpMessageBody.FromSequence(new[] { firstBody, secondBody });
+            var source = new AmqpAnnotatedMessage(body);
+            var clone = source.Clone();
+
+            // Body
+
+            Assert.That(ReferenceEquals(clone.Body, source.Body), Is.False, "The message body should not be the same instance.");
+            Assert.That(source.Body.TryGetSequence(out var sourceBody), Is.True, "The source should have a sequence body.");
+            Assert.That(clone.Body.TryGetSequence(out var cloneBody), Is.True, "The clone should have a sequence body.");
+            Assert.That(cloneBody, Is.EquivalentTo(sourceBody), "The body data should match.");
+
+            // Other sections
+
+            Assert.That(clone.HasSection(AmqpMessageSection.Body), Is.True, "The body should be populated.");
+            Assert.That(clone.HasSection(AmqpMessageSection.Header), Is.False, "The header should not be populated.");
+            Assert.That(clone.HasSection(AmqpMessageSection.Properties), Is.False, "The properties should not be populated.");
+            Assert.That(clone.HasSection(AmqpMessageSection.Footer), Is.False, "The footer should be populated.");
+            Assert.That(clone.HasSection(AmqpMessageSection.DeliveryAnnotations), Is.False, "The delivery annotations should not be populated.");
+            Assert.That(clone.HasSection(AmqpMessageSection.MessageAnnotations), Is.False, "The message annotations should not be populated.");
+            Assert.That(clone.HasSection(AmqpMessageSection.ApplicationProperties), Is.False, "The application properties should not be populated.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions.Clone" />
+        ///   method.
+        /// </summary>
+        [Test]
+        public void CloneAllocatesWhenSectionsArePopulated()
+        {
+            var body = AmqpMessageBody.FromValue("this is an awesome value!");
+            var source = new AmqpAnnotatedMessage(body);
+            source.Footer.Add("footOne", "1111");
+            source.ApplicationProperties.Add("appProp", "1111");
+
+            var clone = source.Clone();
+
+            // Body
+
+            Assert.That(ReferenceEquals(clone.Body, source.Body), Is.False, "The message body should not be the same instance.");
+            Assert.That(source.Body.TryGetValue(out var sourceBody), Is.True, "The source should have a value body.");
+            Assert.That(clone.Body.TryGetValue(out var cloneBody), Is.True, "The clone should have a value body.");
+            Assert.That(cloneBody, Is.EqualTo(sourceBody), "The body data should match.");
+
+            // Other sections
+
+            Assert.That(clone.HasSection(AmqpMessageSection.Body), Is.True, "The body should be populated.");
+            Assert.That(clone.HasSection(AmqpMessageSection.Footer), Is.True, "The footer should be populated.");
+            Assert.That(clone.HasSection(AmqpMessageSection.ApplicationProperties), Is.True, "The application properties should be populated.");
+
+            Assert.That(clone.HasSection(AmqpMessageSection.Header), Is.False, "The header should not be populated.");
+            Assert.That(clone.HasSection(AmqpMessageSection.Properties), Is.False, "The properties should not be populated.");
+            Assert.That(clone.HasSection(AmqpMessageSection.DeliveryAnnotations), Is.False, "The delivery annotations should not be populated.");
+            Assert.That(clone.HasSection(AmqpMessageSection.MessageAnnotations), Is.False, "The message annotations should not be populated.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions.Clone" />
+        ///   method.
+        /// </summary>
+        [Test]
+        public void CloneWorksWithNull() =>
+            Assert.That(AmqpAnnotatedMessageExtensions.Clone(null), Is.Null);
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions.GetEventBody" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void GetEventBodyRetrievesTheDataBody()
+        {
+            var payload = new byte[] { 0x10, 0x20, 0x30 };
+            var body = AmqpMessageBody.FromData(new ReadOnlyMemory<byte>[1] { payload });
+            var message = new AmqpAnnotatedMessage(body);
+            var eventBody = message.GetEventBody();
+
+            Assert.That(eventBody, Is.Not.Null, "The event body should be populated.");
+            Assert.That(eventBody.ToArray(), Is.EquivalentTo(payload), "The event body should match the original payload.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions.GetEventBody" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(AmqpMessageBodyType.Sequence)]
+        [TestCase(AmqpMessageBodyType.Value)]
+        public void GetEventBodyDoesNotAllowNonDataBodyTypes(AmqpMessageBodyType bodyType)
+        {
+            var body = bodyType switch
+            {
+                AmqpMessageBodyType.Sequence => AmqpMessageBody.FromSequence(new[] { new List<object> { 1, 2, 3 } }),
+                AmqpMessageBodyType.Value => AmqpMessageBody.FromValue("This is a value"),
+                _ => throw new ArgumentException($"Unsupported body type { bodyType }", nameof(bodyType))
+            };
+
+            var message = new AmqpAnnotatedMessage(body);
+            Assert.That(() => message.GetEventBody(), Throws.InstanceOf<NotSupportedException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions" />
+        ///   methods related to reading system-owned properties.
+        /// </summary>
+        ///
+        [Test]
+        public void SystemPropertiesCanBeRead()
+        {
+            var sequenceNumber = 123L;
+            var offset = 456L;
+            var enqueueTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
+            var partitionKey = "fake-key";
+            var lastSequence = 321L;
+            var lastOffset = 654L;
+            var lastEnqueue = new DateTimeOffset(2012, 03, 04, 08, 00, 00, TimeSpan.Zero);
+            var lastRetrieve = new DateTimeOffset(2020, 01, 01, 05, 15, 37, TimeSpan.Zero);
+            var message = CreateDataBodyMessageWithSystemProperties(sequenceNumber, lastSequence, offset, lastOffset, partitionKey, enqueueTime, lastEnqueue, lastRetrieve);
+
+            Assert.That(message.GetSequenceNumber(), Is.EqualTo(sequenceNumber), "The sequence number should match.");
+            Assert.That(message.GetOffset(), Is.EqualTo(offset), "The offset should match.");
+            Assert.That(message.GetEnqueuedTime(), Is.EqualTo(enqueueTime), "The enqueue time should match.");
+            Assert.That(message.GetPartitionKey(), Is.EqualTo(partitionKey), "The partition key should match.");
+            Assert.That(message.GetLastPartitionSequenceNumber(), Is.EqualTo(lastSequence), "The last sequence number should match.");
+            Assert.That(message.GetLastPartitionOffset(), Is.EqualTo(lastOffset), "The last offset should match.");
+            Assert.That(message.GetLastPartitionEnqueuedTime(), Is.EqualTo(lastEnqueue), "The last enqueue time should match.");
+            Assert.That(message.GetLastPartitionPropertiesRetrievalTime(), Is.EqualTo(lastRetrieve), "The last retrieve time should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions" />
+        ///   methods related to reading system-owned properties.
+        /// </summary>
+        ///
+        [Test]
+        public void MessageIsPopulatedFromEventHubProperties()
+        {
+            var properties = new Dictionary<string, object>
+            {
+                { "Test", 1 },
+                { "Second", "2" },
+                { "Third", TimeSpan.FromSeconds(99) }
+            };
+
+            var sequenceNumber = 123L;
+            var offset = 456L;
+            var enqueueTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
+            var partitionKey = "fake-key";
+            var lastSequence = 321L;
+            var lastOffset = 654L;
+            var lastEnqueue = new DateTimeOffset(2012, 03, 04, 08, 00, 00, TimeSpan.Zero);
+            var lastRetrieve = new DateTimeOffset(2020, 01, 01, 05, 15, 37, TimeSpan.Zero);
+
+            var message = new AmqpAnnotatedMessage(AmqpMessageBody.FromData(new[] { (ReadOnlyMemory<byte>)Array.Empty<byte>() }));
+            message.PopulateFromEventProperties(properties, sequenceNumber, offset, enqueueTime, partitionKey, lastSequence, lastOffset, lastEnqueue, lastRetrieve);
+
+            Assert.That(message.ApplicationProperties, Is.EquivalentTo(properties), "The application properties should match.");
+            Assert.That(message.GetSequenceNumber(), Is.EqualTo(sequenceNumber), "The sequence number should match.");
+            Assert.That(message.GetOffset(), Is.EqualTo(offset), "The offset should match.");
+            Assert.That(message.GetEnqueuedTime(), Is.EqualTo(enqueueTime), "The enqueue time should match.");
+            Assert.That(message.GetPartitionKey(), Is.EqualTo(partitionKey), "The partition key should match.");
+            Assert.That(message.GetLastPartitionSequenceNumber(), Is.EqualTo(lastSequence), "The last sequence number should match.");
+            Assert.That(message.GetLastPartitionOffset(), Is.EqualTo(lastOffset), "The last offset should match.");
+            Assert.That(message.GetLastPartitionEnqueuedTime(), Is.EqualTo(lastEnqueue), "The last enqueue time should match.");
+            Assert.That(message.GetLastPartitionPropertiesRetrievalTime(), Is.EqualTo(lastRetrieve), "The last retrieve time should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions" />
+        ///   methods related to reading system-owned properties.
+        /// </summary>
+        ///
+        [Test]
+        public void SystemPropertiesReturnCustomDefaultValuesWhenNotInTheMessage()
+        {
+            var sequenceNumber = 123L;
+            var offset = 456L;
+            var enqueueTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
+            var partitionKey = "fake-key";
+            var lastSequence = 321L;
+            var lastOffset = 654L;
+            var lastEnqueue = new DateTimeOffset(2012, 03, 04, 08, 00, 00, TimeSpan.Zero);
+            var lastRetrieve = new DateTimeOffset(2020, 01, 01, 05, 15, 37, TimeSpan.Zero);
+            var message = CreateDataBodyMessageWithSystemProperties(default, default, default, default, default, default, default, default);
+
+            Assert.That(message.GetSequenceNumber(sequenceNumber), Is.EqualTo(sequenceNumber), "The sequence number should match.");
+            Assert.That(message.GetOffset(offset), Is.EqualTo(offset), "The offset should match.");
+            Assert.That(message.GetEnqueuedTime(enqueueTime), Is.EqualTo(enqueueTime), "The enqueue time should match.");
+            Assert.That(message.GetPartitionKey(partitionKey), Is.EqualTo(partitionKey), "The partition key should match.");
+            Assert.That(message.GetLastPartitionSequenceNumber(lastSequence), Is.EqualTo(lastSequence), "The last sequence number should match.");
+            Assert.That(message.GetLastPartitionOffset(lastOffset), Is.EqualTo(lastOffset), "The last offset should match.");
+            Assert.That(message.GetLastPartitionEnqueuedTime(lastEnqueue), Is.EqualTo(lastEnqueue), "The last enqueue time should match.");
+            Assert.That(message.GetLastPartitionPropertiesRetrievalTime(lastRetrieve), Is.EqualTo(lastRetrieve), "The last retrieve time should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions" />
+        ///   methods related to reading system-owned properties.
+        /// </summary>
+        ///
+        [Test]
+        public void SystemPropertiesReturnExpectedDefaultValuesWhenNotInTheMessageAndNoCustom()
+        {
+            var message = CreateDataBodyMessageWithSystemProperties(default, default, default, default, default, default, default, default);
+
+            Assert.That(message.GetSequenceNumber(), Is.EqualTo(long.MinValue), "The sequence number should match.");
+            Assert.That(message.GetOffset(), Is.EqualTo(long.MinValue), "The offset should match.");
+            Assert.That(message.GetEnqueuedTime(), Is.EqualTo(default(DateTimeOffset)), "The enqueue time should match.");
+            Assert.That(message.GetPartitionKey(), Is.EqualTo(null), "The partition key should match.");
+            Assert.That(message.GetLastPartitionSequenceNumber(), Is.EqualTo(null), "The last sequence number should match.");
+            Assert.That(message.GetLastPartitionOffset(), Is.EqualTo(null), "The last offset should match.");
+            Assert.That(message.GetLastPartitionEnqueuedTime(), Is.EqualTo(null), "The last enqueue time should match.");
+            Assert.That(message.GetLastPartitionPropertiesRetrievalTime(), Is.EqualTo(null), "The last retrieve time should match.");
+        }
+
+        /// <summary>
+        ///   Creates a fully populated message with a consistent set of
+        ///   test data.
+        /// </summary>
+        ///
+        /// <returns>The populated message.</returns>
+        ///
+        private static AmqpAnnotatedMessage CreateFullyPopulatedDataBodyMessage()
+        {
+            var body = AmqpMessageBody.FromData(new[] { (ReadOnlyMemory<byte>)Array.Empty<byte>() });
+            var message = new AmqpAnnotatedMessage(body);
+
+            // Header
+
+            message.Header.DeliveryCount = 99;
+            message.Header.Durable = true;
+            message.Header.FirstAcquirer = true;
+            message.Header.Priority = 123;
+            message.Header.TimeToLive = TimeSpan.FromSeconds(10);
+
+            // Properties
+
+            message.Properties.AbsoluteExpiryTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
+            message.Properties.ContentEncoding = "fake";
+            message.Properties.ContentType = "test/unit";
+            message.Properties.CorrelationId = new AmqpMessageId("red-5");
+            message.Properties.CreationTime = new DateTimeOffset(2012, 03, 04, 08, 00, 00, 00, TimeSpan.Zero);
+            message.Properties.GroupId = "mine!";
+            message.Properties.GroupSequence = 555;
+            message.Properties.MessageId = new AmqpMessageId("red-leader");
+            message.Properties.ReplyTo = new AmqpAddress("amqps://some.namespace.com");
+            message.Properties.ReplyToGroupId = "not-mine!";
+            message.Properties.Subject = "We tried to copy an AMQP message.  You won't believe what happened next!";
+            message.Properties.To = new AmqpAddress("https://some.url.com");
+            message.Properties.UserId = new byte[] { 0x11, 0x22 };
+
+            // Footer
+
+            message.Footer.Add("one", "1111");
+            message.Footer.Add("two", "2222");
+
+            // Delivery Annotations
+
+            message.DeliveryAnnotations.Add("three", "3333");
+
+            // Message Annotations
+
+            message.MessageAnnotations.Add("four", "4444");
+            message.MessageAnnotations.Add("five", "5555");
+            message.MessageAnnotations.Add("six", "6666");
+
+            // Application Properties
+
+            message.ApplicationProperties.Add("seven", "7777");
+
+            return message;
+        }
+
+        /// <summary>
+        ///   Creates a fully populated message with a consistent set of
+        ///   test data and the specified set of system properties.
+        /// </summary>
+        ///
+        /// <param name="sequenceNumber">The sequence number of the event; if null, this will not be populated.</param>
+        /// <param name="lastSequenceNumber">The sequence number that was last enqueued in the partition; if null, this will not be populated.</param>
+        /// <param name="offset">The offset of the event; if null, this will not be populated.</param>
+        /// <param name="lastOffset">The offset that was last enqueued in the partition; if null, this will not be populated.</param>
+        /// <param name="partitionKey">The partition key of the event; if null, this will not be populated.</param>
+        /// <param name="enqueueTime">The time that the event was enqueued in the partition; if null, this will not be populated.</param>
+        /// <param name="lastEnqueueTime">The time that an event was last enqueued in the partition; if null, this will not be populated.</param>
+        /// <param name="lastRetrieveTime">The time that the information about the last event enqueued in the partition was reported; if null, this will not be populated.</param>
+        ///
+        /// <returns>The populated message.</returns>
+        ///
+        private static AmqpAnnotatedMessage CreateDataBodyMessageWithSystemProperties(long? sequenceNumber,
+                                                                                      long? lastSequenceNumber,
+                                                                                      long? offset,
+                                                                                      long? lastOffset,
+                                                                                      string partitionKey,
+                                                                                      DateTimeOffset? enqueueTime,
+                                                                                      DateTimeOffset? lastEnqueueTime,
+                                                                                      DateTimeOffset? lastRetrieveTime)
+        {
+            var message = CreateFullyPopulatedDataBodyMessage();
+
+            // Expected properties for all messages read from the service.
+
+            if (sequenceNumber.HasValue)
+            {
+                message.MessageAnnotations.Add(AmqpProperty.SequenceNumber.ToString(), sequenceNumber.Value);
+            }
+
+            if (offset.HasValue)
+            {
+                message.MessageAnnotations.Add(AmqpProperty.Offset.ToString(), offset.Value);
+            }
+
+            if (enqueueTime.HasValue)
+            {
+                message.MessageAnnotations.Add(AmqpProperty.EnqueuedTime.ToString(), enqueueTime.Value);
+            }
+
+            // Optional properties for all messages read from the service.
+
+            if (!string.IsNullOrEmpty(partitionKey))
+            {
+                message.MessageAnnotations.Add(AmqpProperty.PartitionKey.ToString(), partitionKey);
+            }
+
+            // Expected properties when tracking of the last enqueued event is enabled.
+
+            if (lastSequenceNumber.HasValue)
+            {
+                message.DeliveryAnnotations.Add(AmqpProperty.PartitionLastEnqueuedSequenceNumber.ToString(), lastSequenceNumber.Value);
+            }
+
+            if (lastOffset.HasValue)
+            {
+                message.DeliveryAnnotations.Add(AmqpProperty.PartitionLastEnqueuedOffset.ToString(), lastOffset.Value);
+            }
+
+            if (lastEnqueueTime.HasValue)
+            {
+                message.DeliveryAnnotations.Add(AmqpProperty.PartitionLastEnqueuedTimeUtc.ToString(), lastEnqueueTime.Value);
+            }
+
+            if (lastRetrieveTime.HasValue)
+            {
+                message.DeliveryAnnotations.Add(AmqpProperty.LastPartitionPropertiesRetrievalTimeUtc.ToString(), lastRetrieveTime.Value);
+            }
+
+            return message;
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpSystemPropertiesTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpSystemPropertiesTests.cs
@@ -1,0 +1,391 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core.Amqp;
+using Azure.Messaging.EventHubs.Amqp;
+using Microsoft.Azure.Amqp.Framing;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="AmqpSystemProperties" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class AmqpSystemPropertiesTests
+    {
+        /// <summary>
+        ///   Validates the dictionary operations against the set of well-known
+        ///   items from the AMQP message properties section.
+        /// </summary>
+        ///
+        [Test]
+        public void PropertiesSectionItemsAreIncluded()
+        {
+            var message = CreatePopulatedDataBodyMessage();
+            var systemProps = new AmqpSystemProperties(message);
+
+            // Set the expected values for well-known property section items.
+
+            message.Properties.MessageId = new AmqpMessageId("test");
+            message.Properties.UserId = new byte[] { 0x33, 0x44 };
+            message.Properties.To = new AmqpAddress("http://www.omgcats.com");
+            message.Properties.Subject = "test-subject";
+            message.Properties.ReplyTo = new AmqpAddress("http://some.place.ext");
+            message.Properties.CorrelationId = new AmqpMessageId("corr");
+            message.Properties.ContentType = "text/plain";
+            message.Properties.ContentEncoding = "UTF-8";
+            message.Properties.AbsoluteExpiryTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
+            message.Properties.CreationTime = new DateTimeOffset(2012, 03, 04, 08, 00, 00, TimeSpan.Zero);
+            message.Properties.GroupId = "bluebirds";
+            message.Properties.GroupSequence = 3;
+            message.Properties.ReplyToGroupId = "7";
+
+            // Validate that the properties are present.
+
+            Assert.That(systemProps.ContainsKey(Properties.MessageIdName), Is.True, "The message identifier should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.UserIdName), Is.True, "The user identifier should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.ToName), Is.True, "The \"to\" property should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.SubjectName), Is.True, "The subject should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.ReplyToName), Is.True, "The \"reply to\" property should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.CorrelationIdName), Is.True, "The correlation identifier should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.ContentTypeName), Is.True, "The content type should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.ContentEncodingName), Is.True, "The content encoding should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.AbsoluteExpiryTimeName), Is.True, "The expiration time should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.CreationTimeName), Is.True, "The creation time should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.GroupIdName), Is.True, "The group identifier should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.GroupSequenceName), Is.True, "The group sequence should be included.");
+            Assert.That(systemProps.ContainsKey(Properties.ReplyToGroupIdName), Is.True, "The reply-to group identifier should be included.");
+
+            // Validate that the properties match.
+
+            Assert.That(systemProps[Properties.MessageIdName], Is.EqualTo(message.Properties.MessageId), "The message identifier should match.");
+            Assert.That(systemProps[Properties.UserIdName], Is.EqualTo(message.Properties.UserId), "The user identifier should match.");
+            Assert.That(systemProps[Properties.ToName], Is.EqualTo(message.Properties.To), "The \"to\" property should match.");
+            Assert.That(systemProps[Properties.SubjectName], Is.EqualTo(message.Properties.Subject), "The subject should match.");
+            Assert.That(systemProps[Properties.ReplyToName], Is.EqualTo(message.Properties.ReplyTo), "The \"reply to\" property should match.");
+            Assert.That(systemProps[Properties.CorrelationIdName], Is.EqualTo(message.Properties.CorrelationId), "The correlation identifier should match.");
+            Assert.That(systemProps[Properties.ContentTypeName], Is.EqualTo(message.Properties.ContentType), "The content type should match.");
+            Assert.That(systemProps[Properties.ContentEncodingName], Is.EqualTo(message.Properties.ContentEncoding), "The content encoding should match.");
+            Assert.That(systemProps[Properties.AbsoluteExpiryTimeName], Is.EqualTo(message.Properties.AbsoluteExpiryTime), "The expiration time should match.");
+            Assert.That(systemProps[Properties.CreationTimeName], Is.EqualTo(message.Properties.CreationTime), "The creation time should match.");
+            Assert.That(systemProps[Properties.GroupIdName], Is.EqualTo(message.Properties.GroupId), "The group identifier should match.");
+            Assert.That(systemProps[Properties.GroupSequenceName], Is.EqualTo(message.Properties.GroupSequence), "The group sequence should match.");
+            Assert.That(systemProps[Properties.ReplyToGroupIdName], Is.EqualTo(message.Properties.ReplyToGroupId), "The reply-to group identifier should match.");
+        }
+
+        /// <summary>
+        ///   Validates the dictionary operations against the set of well-known
+        ///   items from the AMQP message annotations section.
+        /// </summary>
+        ///
+        [Test]
+        public void MessageAnnotationSectionItemsAreIncluded()
+        {
+            var message = CreatePopulatedDataBodyMessage();
+            var systemProps = new AmqpSystemProperties(message);
+
+            // Set the expected values for well-known property section items.
+
+            message.MessageAnnotations.Clear();
+            message.MessageAnnotations.Add("first", "one");
+            message.MessageAnnotations.Add("second", 2);
+            message.MessageAnnotations.Add("third", new object());
+
+            // Validate that the properties are present and match.
+
+            foreach (var key in message.MessageAnnotations.Keys)
+            {
+                Assert.That(systemProps.ContainsKey(key), Is.True, $"The delivery annotation key, { key }, should be included.");
+                Assert.That(systemProps[key], Is.EqualTo(message.MessageAnnotations[key]), $"The delivery annotation key, { key }, should match.");
+            }
+        }
+
+        /// <summary>
+        ///   Validates basic dictionary operations.
+        /// </summary>
+        ///
+        [Test]
+        public void KeyOperationsWorkWhenNotEmpty()
+        {
+            var message = CreateEmptydDataBodyMessage();
+            var systemProps = new AmqpSystemProperties(message);
+
+            message.Properties.MessageId = new AmqpMessageId("test");
+            message.MessageAnnotations.Add("first", "one");
+
+            var unexpectedKey = Guid.NewGuid().ToString();
+            var expectedKeys = new HashSet<string> { Properties.MessageIdName };
+
+            foreach (var key in message.MessageAnnotations.Keys)
+            {
+                expectedKeys.Add(key);
+            }
+
+            // Key counts are correct.
+
+            Assert.That(systemProps.Count, Is.EqualTo(expectedKeys.Count), "The number of items was incorrect.");
+
+            // Expected keys are returned by ContainsKey.
+
+            foreach (var key in expectedKeys)
+            {
+                Assert.That(systemProps.ContainsKey(key), Is.True, $"The key, { key }, was not contained.");
+            }
+
+            // Unexpected keys are not returned by ContainsKey.
+
+            Assert.That(systemProps.ContainsKey(unexpectedKey), Is.False, "The unexpected key was contained.");
+
+            // Enumerated keys match the expected set.
+
+            foreach (var key in systemProps.Keys)
+            {
+                Assert.That(expectedKeys.Contains(key), $"The key, { key }, was in the properties but is unexpected.");
+            }
+        }
+
+        /// <summary>
+        ///   Validates basic dictionary operations.
+        /// </summary>
+        ///
+        [Test]
+        public void ValueOperationsWorkWhenNotEmpty()
+        {
+            var message = CreateEmptydDataBodyMessage();
+            var systemProps = new AmqpSystemProperties(message);
+
+            message.Properties.MessageId = new AmqpMessageId("test");
+            message.MessageAnnotations.Add("first", "one");
+
+            var unexpectedKey = Guid.NewGuid().ToString();
+            var expectedValues = new HashSet<object> { message.Properties.MessageId };
+
+            foreach (var value in message.MessageAnnotations.Values)
+            {
+                expectedValues.Add(value);
+            }
+
+            // Count
+
+            Assert.That(systemProps.Count, Is.EqualTo(expectedValues.Count), "The number of items was incorrect.");
+
+            // System property values are correct.
+
+            Assert.That(systemProps[Properties.MessageIdName], Is.EqualTo(message.Properties.MessageId), "The message identifier did not match when read through the indexer.");
+            Assert.That(systemProps.TryGetValue(Properties.MessageIdName, out var messageId), Is.True, "The message identifier was not contained when read through TryGetValue.");
+            Assert.That(messageId, Is.EqualTo(message.Properties.MessageId), "The message identifier did not match when read through TryGetValue.");
+
+            // Message annotation values are correct.
+
+            foreach (var key in message.MessageAnnotations.Keys)
+            {
+                Assert.That(systemProps[key], Is.EqualTo(message.MessageAnnotations[key]), $"The message annotation, { key }, did not match when read through the indexer.");
+                Assert.That(systemProps.TryGetValue(key, out var currentValue), Is.True, $"The message annotation, { key }, was not contained when read through TryGetValue.");
+                Assert.That(currentValue, Is.EqualTo(message.MessageAnnotations[key]), $"The message annotation, { key }, did not match when read through TryGetValue.");
+            }
+
+            // Unexpected values are not returned.
+
+            Assert.That(() => systemProps[unexpectedKey], Throws.InstanceOf<KeyNotFoundException>(), "The unexpected key should result in an exception when read through the indexer.");
+            Assert.That(systemProps.TryGetValue(unexpectedKey, out var unexpectedValue), Is.False, "The unexpected key should not succeed for TryGetValue.");
+
+            // Enumerated Values match the expected set.
+
+            foreach (var value in systemProps.Values)
+            {
+                Assert.That(expectedValues.Contains(value), Is.True, $"The value, { value }, was in the properties but is unexpected.");
+            }
+        }
+
+        /// <summary>
+        ///   Validates basic dictionary operations.
+        /// </summary>
+        ///
+        [Test]
+        public void EnumeratorsWorkWhenNotEmpty()
+        {
+            var message = CreateEmptydDataBodyMessage();
+            var systemProps = new AmqpSystemProperties(message);
+
+            message.Properties.MessageId = new AmqpMessageId("test");
+            message.MessageAnnotations.Add("first", "one");
+
+            var expectedItems = new Dictionary<string, object>
+            {
+                { Properties.MessageIdName, message.Properties.MessageId }
+            };
+
+            foreach (var item in message.MessageAnnotations)
+            {
+                expectedItems.Add(item.Key, item.Value);
+            }
+
+            // Count
+
+            Assert.That(systemProps.Count, Is.EqualTo(expectedItems.Count), "The number of items was incorrect.");
+
+            // Enumerated Values match the expected set.
+
+           foreach (var item in systemProps)
+            {
+                Assert.That(expectedItems.ContainsKey(item.Key), Is.True, $"The item with key, { item.Key }, was in the properties but is unexpected.");
+                Assert.That(item.Value, Is.EqualTo(expectedItems[item.Key]), $"The item with key, { item.Key }, did not match the expected value.");
+            }
+        }
+
+        /// <summary>
+        ///   Validates basic dictionary operations.
+        /// </summary>
+        ///
+        [Test]
+        public void KeyOperationsWorkWhenEmpty()
+        {
+            var message = CreateEmptydDataBodyMessage();
+            var systemProps = new AmqpSystemProperties(message);
+            var unexpectedKey = Guid.NewGuid().ToString();
+
+            // Key counts are correct.
+
+            Assert.That(systemProps.Count, Is.EqualTo(0), "The number of items was incorrect.");
+
+            // Unexpected keys are not returned by ContainsKey.
+
+            Assert.That(systemProps.ContainsKey(unexpectedKey), Is.False, "The unexpected key was contained.");
+
+            // Enumerated keys are empty
+
+            foreach (var key in systemProps.Keys)
+            {
+                Assert.Fail($"The key, { key }, was found in the set that should be empty.");
+            }
+        }
+
+        /// <summary>
+        ///   Validates basic dictionary operations.
+        /// </summary>
+        ///
+        [Test]
+        public void ValueOperationsWorkWhenEmpty()
+        {
+            var message = CreateEmptydDataBodyMessage();
+            var systemProps = new AmqpSystemProperties(message);
+            var unexpectedKey = Guid.NewGuid().ToString();
+
+            // Count
+
+            Assert.That(systemProps.Count, Is.EqualTo(0), "The number of items was incorrect.");
+
+            // Unexpected values are not returned.
+
+            Assert.That(() => systemProps[unexpectedKey], Throws.InstanceOf<KeyNotFoundException>(), "The unexpected key should result in an exception when read through the indexer.");
+            Assert.That(systemProps.TryGetValue(unexpectedKey, out var unexpectedValue), Is.False, "The unexpected key should not succeed for TryGetValue.");
+
+            // Enumerated Values are empty.
+
+            foreach (var value in systemProps.Values)
+            {
+                Assert.Fail($"The value, { value }, was found in the set that should be empty.");
+            }
+        }
+
+        /// <summary>
+        ///   Validates basic dictionary operations.
+        /// </summary>
+        ///
+        [Test]
+        public void EnumeratorsWorkWhenEmpty()
+        {
+            var message = CreateEmptydDataBodyMessage();
+            var systemProps = new AmqpSystemProperties(message);
+
+            // Count
+
+            Assert.That(systemProps.Count, Is.EqualTo(0), "The number of items was incorrect.");
+
+            // Enumerated Values are empty.
+
+           foreach (var item in systemProps)
+            {
+                Assert.Fail($"The key, { item.Key }, was found in the set that should be empty.");
+            }
+        }
+
+        /// <summary>
+        ///   Creates a fully populated message with a consistent set of
+        ///   test data.
+        /// </summary>
+        ///
+        /// <returns>The populated message.</returns>
+        ///
+        private static AmqpAnnotatedMessage CreatePopulatedDataBodyMessage()
+        {
+            var body = AmqpMessageBody.FromData(new[] { (ReadOnlyMemory<byte>)Array.Empty<byte>() });
+            var message = new AmqpAnnotatedMessage(body);
+
+            // Header
+
+            message.Header.DeliveryCount = 99;
+            message.Header.Durable = true;
+            message.Header.FirstAcquirer = true;
+            message.Header.Priority = 123;
+            message.Header.TimeToLive = TimeSpan.FromSeconds(10);
+
+            // Properties
+
+            message.Properties.AbsoluteExpiryTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
+            message.Properties.ContentEncoding = "fake";
+            message.Properties.ContentType = "test/unit";
+            message.Properties.CorrelationId = new AmqpMessageId("red-5");
+            message.Properties.CreationTime = new DateTimeOffset(2012, 03, 04, 08, 00, 00, 00, TimeSpan.Zero);
+            message.Properties.GroupId = "mine!";
+            message.Properties.GroupSequence = 555;
+            message.Properties.MessageId = new AmqpMessageId("red-leader");
+            message.Properties.ReplyTo = new AmqpAddress("amqps://some.namespace.com");
+            message.Properties.ReplyToGroupId = "not-mine!";
+            message.Properties.Subject = "We tried to copy an AMQP message.  You won't believe what happened next!";
+            message.Properties.To = new AmqpAddress("https://some.url.com");
+            message.Properties.UserId = new byte[] { 0x11, 0x22 };
+
+            // Footer
+
+            message.Footer.Add("one", "1111");
+            message.Footer.Add("two", "2222");
+
+            // Delivery Annotations
+
+            message.DeliveryAnnotations.Add("three", "3333");
+
+            // Message Annotations
+
+            message.MessageAnnotations.Add("four", "4444");
+            message.MessageAnnotations.Add("five", "5555");
+            message.MessageAnnotations.Add("six", "6666");
+
+            // Application Properties
+
+            message.ApplicationProperties.Add("seven", "7777");
+
+            return message;
+        }
+
+        /// <summary>
+        ///   Creates a fully populated message with a consistent set of
+        ///   test data.
+        /// </summary>
+        ///
+        /// <returns>The populated message.</returns>
+        ///
+        private static AmqpAnnotatedMessage CreateEmptydDataBodyMessage()
+        {
+            var body = AmqpMessageBody.FromData(new[] { (ReadOnlyMemory<byte>)Array.Empty<byte>() });
+            var message = new AmqpAnnotatedMessage(body);
+
+            return message;
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/MessageBodyTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/MessageBodyTests.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using Azure.Core.Amqp;
+using Azure.Messaging.EventHubs.Amqp;
+using Microsoft.Azure.Amqp.Framing;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="MessageBody" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class MessageBodyTests
+    {
+        /// <summary>
+        ///   Verifies behavior of the <see cref="MessageBody" />
+        ///   when a single segment is specified.
+        /// </summary>
+        ///
+        [Test]
+        public void ManagesSingleReadOnlyMemoryWithoutCopying()
+        {
+            var singleReadOnlyMemory = new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3 });
+            var message = new AmqpMessageBody(MessageBody.FromReadOnlyMemorySegment(singleReadOnlyMemory));
+
+            message.TryGetData(out var body);
+            var fromReadOnlyMemorySegments = (ReadOnlyMemory<byte>)MessageBody.FromReadOnlyMemorySegments(body);
+
+            Assert.That(fromReadOnlyMemorySegments, Is.EqualTo(singleReadOnlyMemory));
+        }
+
+        /// <summary>
+        ///   Verifies behavior of the <see cref="MessageBody" /> when multiple
+        ///   segments are specified and copying is lazy.
+        /// </summary>
+        ///
+        [Test]
+        public void ManagesMultipleReadOnlyMemoriesByCopyingOnConversion()
+        {
+            var firstSegment = new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3 });
+            var secondSegment = new ReadOnlyMemory<byte>(new byte[] { 4, 5, 6 });
+            var allSegmentsArray = new byte[] { 1, 2, 3, 4, 5, 6 };
+
+            var message = new AmqpMessageBody(MessageBody.FromReadOnlyMemorySegments(new ReadOnlyMemory<byte>[]{ firstSegment, secondSegment }));
+            message.TryGetData(out var body);
+
+            var firstSegmentBeforeConversion = body.ElementAt(0);
+            var secondSegmentBeforeConversion = body.ElementAt(1);
+            var fromReadOnlyMemorySegments = (ReadOnlyMemory<byte>)MessageBody.FromReadOnlyMemorySegments(body);
+            var convertedASecondTime = (ReadOnlyMemory<byte>)MessageBody.FromReadOnlyMemorySegments(body);
+            var firstSegmentAfterConversion = body.ElementAt(0);
+            var secondSegmentAfterConversion = body.ElementAt(1);
+
+            Assert.That(firstSegmentBeforeConversion, Is.EqualTo(firstSegment), "The first segment should match before conversion.");
+            Assert.That(secondSegmentBeforeConversion, Is.EqualTo(secondSegment), "The second segment should match before conversion.");
+            Assert.That(firstSegmentAfterConversion, Is.Not.EqualTo(firstSegment), "The first segment should not match after conversion.");
+            Assert.That(secondSegmentAfterConversion, Is.Not.EqualTo(secondSegment), "The second segment should not match after conversion.");
+            Assert.That(fromReadOnlyMemorySegments.ToArray(), Is.EquivalentTo(allSegmentsArray), "The unified segments should match.");
+            Assert.That(convertedASecondTime, Is.EqualTo(fromReadOnlyMemorySegments), "The unified segments should match when converted a second time.");
+        }
+
+        /// <summary>
+        ///   Verifies behavior of the <see cref="MessageBody" /> when multiple
+        ///   <see cref="Data" /> segments are specified and copying is eager.
+        /// </summary>
+        ///
+        [Test]
+        public void ManagesMultipleAmqpDataSegmentsByCopyingEagerly()
+        {
+            var firstSegment = new byte[] {1, 2, 3};
+            var secondSegment = new byte[] { 4, 5, 6 };
+            var allSegmentsArray = new byte[] { 1, 2, 3, 4, 5, 6 };
+
+            var message = new AmqpMessageBody(MessageBody.FromDataSegments(new[]
+            {
+                new Data { Value = new ArraySegment<byte>(firstSegment) },
+                new Data { Value = new ArraySegment<byte>(secondSegment) }
+            }));
+
+            message.TryGetData(out var body);
+
+            var firstSegmentBeforeConversion = body.ElementAt(0);
+            var secondSegmentBeforeConversion = body.ElementAt(1);
+            var fromReadOnlyMemorySegments = (ReadOnlyMemory<byte>)MessageBody.FromReadOnlyMemorySegments(body);
+            var convertedASecondTime = (ReadOnlyMemory<byte>)MessageBody.FromReadOnlyMemorySegments(body);
+            var firstSegmentAfterConversion = body.ElementAt(0);
+            var secondSegmentAfterConversion = body.ElementAt(1);
+
+            Assert.That(firstSegmentBeforeConversion, Is.Not.EqualTo(firstSegment), "The first segment should not match before conversion.");
+            Assert.That(secondSegmentBeforeConversion, Is.Not.EqualTo(secondSegment), "The second segment should not match before conversion.");
+            Assert.That(firstSegmentAfterConversion, Is.Not.EqualTo(firstSegment), "The first segment should not match after conversion.");
+            Assert.That(secondSegmentAfterConversion, Is.Not.EqualTo(secondSegment), "The second segment should not match after conversion.");
+            Assert.That(fromReadOnlyMemorySegments.ToArray(), Is.EquivalentTo(allSegmentsArray), "The unified segments should match.");
+            Assert.That(convertedASecondTime, Is.EqualTo(fromReadOnlyMemorySegments), "The unified segments should match when converted a second time.");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/PartitionContextTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/PartitionContextTests.cs
@@ -53,7 +53,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var lastEvent = new EventData
             (
-                eventBody: Array.Empty<byte>(),
+                eventBody: new BinaryData(Array.Empty<byte>()),
                 lastPartitionSequenceNumber: 1234,
                 lastPartitionOffset: 42,
                 lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T00:00:00Z"),
@@ -81,7 +81,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task TheConsumerIsNotKeptAlive()
         {
             var partitionId = "id-value";
-            var mockConsumer = new LastEventConsumerMock(new EventData(Array.Empty<byte>()));
+            var mockConsumer = new LastEventConsumerMock(new EventData(new BinaryData(Array.Empty<byte>())));
             var context = new PartitionContext(partitionId, mockConsumer);
 
             // Attempt to clear out the consumer and force GC.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using Azure.Core.Amqp;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Tests
@@ -22,12 +24,12 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void ConstructorDoesNotCreatePropertiesyDefault()
+        public void ConstructorDoesNotCreatePropertiesByDefault()
         {
-            var eventData = new EventData(Array.Empty<byte>());
+            var eventData = new EventData(new BinaryData(Array.Empty<byte>()));
 
-            Assert.That(GetPropertiesBackingStore(eventData), Is.Null, "The user properties should be created lazily.");
-            Assert.That(eventData.SystemProperties, Is.SameAs(GetEmptySystemProperties()), "The system properties should be the static empty set.");
+            Assert.That(eventData.HasProperties, Is.False, "The user properties should be created lazily.");
+            Assert.That(GetSystemPropertiesBackingStore(eventData), Is.Null, "The system properties should be the static empty set.");
         }
 
         /// <summary>
@@ -41,11 +43,11 @@ namespace Azure.Messaging.EventHubs.Tests
             var systemProperties = (IReadOnlyDictionary<string, object>)new Dictionary<string, object>();
 
             var eventData = new EventData(
-                eventBody: Array.Empty<byte>(),
+                eventBody: new BinaryData(Array.Empty<byte>()),
                 properties: properties,
                 systemProperties: systemProperties);
 
-            Assert.That(GetPropertiesBackingStore(eventData), Is.SameAs(properties), "The passed properties dictionary should have been used.");
+            Assert.That(eventData.Properties, Is.EquivalentTo(properties), "The passed properties dictionary should have been used.");
             Assert.That(eventData.SystemProperties, Is.SameAs(systemProperties), "The system properties dictionary should have been used.");
         }
 
@@ -55,13 +57,118 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void ApplicationPropertiesDictionaryIsLazilyCreated()
+        public void SystemPropertiesDictionaryIsLazilyCreated()
         {
-            var eventData = new EventData(Array.Empty<byte>());
-            eventData.Properties.Add("test", "value");
+            var eventData = new EventData(new BinaryData(Array.Empty<byte>()));
+            eventData.SystemProperties.ContainsKey("fake");
 
-            Assert.That(GetPropertiesBackingStore(eventData), Is.Not.Null, "The properties dictionary should have been crated on demand.");
-            Assert.That(eventData.Properties.Count, Is.EqualTo(1), "The property that triggered creation should have been included in the set.");
+            Assert.That(GetSystemPropertiesBackingStore(eventData), Is.Not.Null, "The system properties dictionary should have been crated on demand.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData" />
+        ///   mutable properties.
+        /// </summary>
+        ///
+        [Test]
+        public void ReadingUnpopulatedMutablePropertiesDoesNotCreateTheSection()
+        {
+            var amqpMessage = new AmqpAnnotatedMessage(AmqpMessageBody.FromData(new[] { ReadOnlyMemory<byte>.Empty }));
+            var eventData = new EventData(amqpMessage);
+
+            Assert.That(eventData.MessageId, Is.Null, "The message identifier should not be populated.");
+            Assert.That(amqpMessage.HasSection(AmqpMessageSection.Properties), Is.False, "Reading the message identifier should not create the section.");
+
+            Assert.That(eventData.CorrelationId, Is.Null, "The correlation identifier should not be populated.");
+            Assert.That(amqpMessage.HasSection(AmqpMessageSection.Properties), Is.False, "Reading the correlation identifier should not create the section.");
+
+            Assert.That(eventData.ContentType, Is.Null, "The content type should not be populated.");
+            Assert.That(amqpMessage.HasSection(AmqpMessageSection.Properties), Is.False, "Reading the content type should not create the section.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData" />
+        ///   mutable properties.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void DefaultingUnpopulatedMutablePropertiesDoesNotCreateTheSection(string defaultValue)
+        {
+            var amqpMessage = new AmqpAnnotatedMessage(AmqpMessageBody.FromData(new[] { ReadOnlyMemory<byte>.Empty }));
+            var eventData = new EventData(amqpMessage);
+
+            eventData.MessageId = null;
+            Assert.That(amqpMessage.HasSection(AmqpMessageSection.Properties), Is.False, "Setting an empty value for the message identifier should not create the section.");
+            Assert.That(eventData.MessageId, Is.Null, "The message identifier should not be populated.");
+
+            eventData.CorrelationId = null;
+            Assert.That(amqpMessage.HasSection(AmqpMessageSection.Properties), Is.False, "Setting an empty value for the correlation identifier should not create the section.");
+            Assert.That(eventData.CorrelationId, Is.Null, "The correlation identifier should not be populated.");
+
+            eventData.ContentType = null;
+            Assert.That(amqpMessage.HasSection(AmqpMessageSection.Properties), Is.False, "Setting an empty value for the content type should not create the section.");
+            Assert.That(eventData.ContentType, Is.Null, "The content type should not be populated.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData" />
+        ///   mutable properties.
+        /// </summary>
+        ///
+        [Test]
+        public void MutablePropertySettersPopulateTheAmqpMessage()
+        {
+            var messageId = "message-id-value";
+            var correlationId = "correlation-id-value";
+            var contentType = "text/content-type";
+            var amqpMessage = new AmqpAnnotatedMessage(AmqpMessageBody.FromData(new[] { ReadOnlyMemory<byte>.Empty }));
+            var eventData = new EventData(amqpMessage);
+
+            eventData.MessageId = messageId;
+            Assert.That(amqpMessage.Properties.MessageId.ToString(), Is.EqualTo(messageId), "The AMQP message identifier should match.");
+
+            eventData.CorrelationId = correlationId;
+            Assert.That(amqpMessage.Properties.CorrelationId.ToString(), Is.EqualTo(correlationId), "The AMQP message correlation identifier should match.");
+
+            eventData.ContentType = contentType;
+            Assert.That(amqpMessage.Properties.ContentType, Is.EqualTo(contentType), "The AMQP message content type should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData" />
+        ///   properties not related to idempotent publishing state.
+        /// </summary>
+        ///
+        [Test]
+        public void NonIdempotentStatePropertyAcessorsDeferToTheAmqpMessage()
+        {
+            var sequenceNumber = 123L;
+            var offset = 456L;
+            var enqueueTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
+            var partitionKey = "fake-key";
+            var lastSequence = 321L;
+            var lastOffset = 654L;
+            var lastEnqueue = new DateTimeOffset(2012, 03, 04, 08, 00, 00, TimeSpan.Zero);
+            var lastRetrieve = new DateTimeOffset(2020, 01, 01, 05, 15, 37, TimeSpan.Zero);
+            var message = CreateFullyPopulatedAmqpMessage(sequenceNumber, lastSequence, offset, lastOffset, partitionKey, enqueueTime, lastEnqueue, lastRetrieve);
+            var eventData = new EventData(message);
+
+            Assert.That(message.Body.TryGetData(out var messageBody), Is.True, "The message body should have been read.");
+            Assert.That(eventData.EventBody.ToArray(), Is.EquivalentTo(messageBody.First().ToArray()), "The message body should match.");
+            Assert.That(eventData.Properties, Is.EquivalentTo(message.ApplicationProperties), "The application properties should match.");
+            Assert.That(eventData.Offset, Is.EqualTo(offset), "The offset should match.");
+            Assert.That(eventData.SequenceNumber, Is.EqualTo(sequenceNumber), "The sequence number should match.");
+            Assert.That(eventData.EnqueuedTime, Is.EqualTo(enqueueTime), "The enqueued time should match.");
+            Assert.That(eventData.PartitionKey, Is.EqualTo(partitionKey), "The partition key should match.");
+            Assert.That(eventData.LastPartitionOffset, Is.EqualTo(lastOffset), "The last offset should match.");
+            Assert.That(eventData.LastPartitionSequenceNumber, Is.EqualTo(lastSequence), "The last sequence number should match.");
+            Assert.That(eventData.LastPartitionEnqueuedTime, Is.EqualTo(lastEnqueue), "The last enqueued time should match.");
+            Assert.That(eventData.LastPartitionPropertiesRetrievalTime, Is.EqualTo(lastRetrieve), "The last retrieval time should match.");
+            Assert.That(eventData.MessageId, Is.EqualTo(message.Properties.MessageId.ToString()), "The message identifier should match.");
+            Assert.That(eventData.CorrelationId, Is.EqualTo(message.Properties.CorrelationId.ToString()), "The correlation identifier should match.");
+            Assert.That(eventData.ContentType, Is.EqualTo(message.Properties.ContentType), "The content type should match.");
         }
 
         /// <summary>
@@ -72,7 +179,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void BodyAsStreamReturnsTheBody()
         {
-            var eventData = new EventData(new byte[] { 0x11, 0x22, 0x65, 0x78 });
+            var eventData = new EventData(new BinaryData(new byte[] { 0x11, 0x22, 0x65, 0x78 }));
 
             using var eventDataStream = eventData.BodyAsStream;
             using var bodyStream = new MemoryStream();
@@ -91,7 +198,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void BodyAsStreamAllowsAnEmptyBody()
         {
-            var eventData = new EventData(Array.Empty<byte>());
+            var eventData = new EventData(new BinaryData(Array.Empty<byte>()));
 
             using var eventDataStream = eventData.BodyAsStream;
             using var bodyStream = new MemoryStream();
@@ -112,7 +219,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedSequence = 8675309;
 
-            var eventData = new EventData(Array.Empty<byte>())
+            var eventData = new EventData(new BinaryData(Array.Empty<byte>()))
             {
                 PendingPublishSequenceNumber = expectedSequence
             };
@@ -134,7 +241,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CloneProducesACopyWhenPropertyDictionariesAreSet()
         {
             var sourceEvent = new EventData(
-                new byte[] { 0x21, 0x22 },
+                new BinaryData(new byte[] { 0x21, 0x22 }),
                 new Dictionary<string, object> { { "Test", 123 } },
                 new Dictionary<string, object> { { "System", "Hello" } },
                 33334444,
@@ -164,7 +271,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CloneProducesACopyWhenPropertyDictionariesAreNotSet()
         {
             var sourceEvent = new EventData(
-                new byte[] { 0x21, 0x22 },
+                new BinaryData(new byte[] { 0x21, 0x22 }),
                 null,
                 null,
                 33334444,
@@ -180,8 +287,6 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var clone = sourceEvent.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
-            Assert.That(GetPropertiesBackingStore(clone), Is.Null, "The user properties should be created lazily.");
-            Assert.That(clone.SystemProperties, Is.SameAs(GetEmptySystemProperties()), "The system properties should be the static empty set.");
             Assert.That(clone.IsEquivalentTo(sourceEvent, false), Is.True, "The clone should be equivalent to the source event.");
             Assert.That(clone, Is.Not.SameAs(sourceEvent), "The clone should be a distinct reference.");
         }
@@ -195,7 +300,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CloneIsolatesPropertyChanges()
         {
             var sourceEvent = new EventData(
-                new byte[] { 0x21, 0x22 },
+                new BinaryData(new byte[] { 0x21, 0x22 }),
                 new Dictionary<string, object> { { "Test", 123 } },
                 new Dictionary<string, object> { { "System", "Hello" } },
                 33334444,
@@ -219,31 +324,92 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Retrieves the empty system properties dictionary from the Event Data
-        ///   type, using its private field.
+        ///   Creates a fully populated message with a consistent set of
+        ///   test data and the specified set of system properties.
         /// </summary>
         ///
-        /// <returns>The empty dictionary used as the default for the <see cref="EventData.SystemProperties" /> set.</returns>
+        /// <param name="sequenceNumber">The sequence number of the event; if null, this will not be populated.</param>
+        /// <param name="lastSequenceNumber">The sequence number that was last enqueued in the partition; if null, this will not be populated.</param>
+        /// <param name="offset">The offset of the event; if null, this will not be populated.</param>
+        /// <param name="lastOffset">The offset that was last enqueued in the partition; if null, this will not be populated.</param>
+        /// <param name="partitionKey">The partition key of the event; if null, this will not be populated.</param>
+        /// <param name="enqueueTime">The time that the event was enqueued in the partition; if null, this will not be populated.</param>
+        /// <param name="lastEnqueueTime">The time that an event was last enqueued in the partition; if null, this will not be populated.</param>
+        /// <param name="lastRetrieveTime">The time that the information about the last event enqueued in the partition was reported; if null, this will not be populated.</param>
         ///
-        private static IReadOnlyDictionary<string, object> GetEmptySystemProperties() =>
-            (IReadOnlyDictionary<string, object>)
-                typeof(EventData)
-                    .GetField("EmptySystemProperties", BindingFlags.Static | BindingFlags.NonPublic)
-                    .GetValue(null);
+        /// <returns>The populated message.</returns>
+        ///
+        private static AmqpAnnotatedMessage CreateFullyPopulatedAmqpMessage(long sequenceNumber,
+                                                                            long lastSequenceNumber,
+                                                                            long offset,
+                                                                            long lastOffset,
+                                                                            string partitionKey,
+                                                                            DateTimeOffset enqueueTime,
+                                                                            DateTimeOffset lastEnqueueTime,
+                                                                            DateTimeOffset lastRetrieveTime)
+        {
+            var body = AmqpMessageBody.FromData(new ReadOnlyMemory<byte>[] { new byte[] { 0x65, 0x66, 0x67, 0x68 } });
+            var message = new AmqpAnnotatedMessage(body);
+
+            // Header
+
+            message.Header.DeliveryCount = 99;
+            message.Header.Durable = true;
+            message.Header.FirstAcquirer = true;
+            message.Header.Priority = 123;
+            message.Header.TimeToLive = TimeSpan.FromSeconds(10);
+
+            // Properties
+
+            message.Properties.AbsoluteExpiryTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
+            message.Properties.ContentEncoding = "fake";
+            message.Properties.ContentType = "test/unit";
+            message.Properties.CorrelationId = new AmqpMessageId("red-5");
+            message.Properties.CreationTime = new DateTimeOffset(2012, 03, 04, 08, 00, 00, 00, TimeSpan.Zero);
+            message.Properties.GroupId = "mine!";
+            message.Properties.GroupSequence = 555;
+            message.Properties.MessageId = new AmqpMessageId("red-leader");
+            message.Properties.ReplyTo = new AmqpAddress("amqps://some.namespace.com");
+            message.Properties.ReplyToGroupId = "not-mine!";
+            message.Properties.Subject = "We tried to copy an AMQP message.  You won't believe what happened next!";
+            message.Properties.To = new AmqpAddress("https://some.url.com");
+            message.Properties.UserId = new byte[] { 0x11, 0x22 };
+
+            // Application Properties
+
+            message.ApplicationProperties.Add("first", 1);
+            message.ApplicationProperties.Add("second", "two");
+
+            // Message Annotations
+
+            message.MessageAnnotations.Add(AmqpProperty.SequenceNumber.ToString(), sequenceNumber);
+            message.MessageAnnotations.Add(AmqpProperty.Offset.ToString(), offset);
+            message.MessageAnnotations.Add(AmqpProperty.EnqueuedTime.ToString(), enqueueTime);
+            message.MessageAnnotations.Add(AmqpProperty.PartitionKey.ToString(), partitionKey);
+
+            // Delivery annotations
+
+            message.DeliveryAnnotations.Add(AmqpProperty.PartitionLastEnqueuedSequenceNumber.ToString(), lastSequenceNumber);
+            message.DeliveryAnnotations.Add(AmqpProperty.PartitionLastEnqueuedOffset.ToString(), lastOffset);
+            message.DeliveryAnnotations.Add(AmqpProperty.PartitionLastEnqueuedTimeUtc.ToString(), lastEnqueueTime);
+            message.DeliveryAnnotations.Add(AmqpProperty.LastPartitionPropertiesRetrievalTimeUtc.ToString(), lastRetrieveTime);
+
+            return message;
+        }
 
         /// <summary>
-        ///   Retrieves the backing store for the Properties dictionary from the Event Data
+        ///   Retrieves the backing store for the System Properties dictionary from the Event Data
         ///   type, using its private field.
         /// </summary>
         ///
         /// <param name="eventData">The instance to read the field from.</param>
         ///
-        /// <returns>The backing store for the <see cref="EventData.Properties" /> set.</returns>
+        /// <returns>The backing store for the <see cref="EventData.SystemProperties" /> set.</returns>
         ///
-        private static IReadOnlyDictionary<string, object> GetPropertiesBackingStore(EventData eventData) =>
+        private static IReadOnlyDictionary<string, object> GetSystemPropertiesBackingStore(EventData eventData) =>
             (IReadOnlyDictionary<string, object>)
                 typeof(EventData)
-                    .GetField("_properties", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetField("_systemProperties", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(eventData);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventHubsModelFactoryTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventHubsModelFactoryTests.cs
@@ -175,7 +175,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void EventDataBatchInitializesProperties()
         {
             var size = 1024;
-            var store = new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) };
+            var store = new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>())) };
             var options = new CreateBatchOptions { MaximumSizeInBytes = 2048 };
             var batch = EventHubsModelFactory.EventDataBatch(size, store, options);
 
@@ -220,7 +220,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void EventDataBatchIsSafeToDispose()
         {
             var size = 1024;
-            var store = new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) };
+            var store = new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>())) };
             var options = new CreateBatchOptions { MaximumSizeInBytes = 2048 };
             var batch = EventHubsModelFactory.EventDataBatch(size, store, options, _ => false);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -270,8 +270,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             await producer.SendAsync(new[]
             {
-                new EventData(ReadOnlyMemory<byte>.Empty, new Dictionary<string, object> { { DiagnosticProperty.DiagnosticIdAttribute, "id" } }),
-                new EventData(ReadOnlyMemory<byte>.Empty, new Dictionary<string, object> { { DiagnosticProperty.DiagnosticIdAttribute, "id2" } })
+                new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { DiagnosticProperty.DiagnosticIdAttribute, "id" } }),
+                new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { DiagnosticProperty.DiagnosticIdAttribute, "id2" } })
             });
 
             ClientDiagnosticListener.ProducedDiagnosticScope sendScope = testListener.Scopes.Single(s => s.Name == DiagnosticProperty.ProducerActivityName);
@@ -320,9 +320,9 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var producer = new EventHubProducerClient(fakeConnection, transportMock.Object);
 
-            var eventData1 = new EventData(ReadOnlyMemory<byte>.Empty, new Dictionary<string, object> { { DiagnosticProperty.DiagnosticIdAttribute, "id" } });
-            var eventData2 = new EventData(ReadOnlyMemory<byte>.Empty, new Dictionary<string, object> { { DiagnosticProperty.DiagnosticIdAttribute, "id2" } });
-            var eventData3 = new EventData(ReadOnlyMemory<byte>.Empty, new Dictionary<string, object> { { DiagnosticProperty.DiagnosticIdAttribute, "id3" } });
+            var eventData1 = new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { DiagnosticProperty.DiagnosticIdAttribute, "id" } });
+            var eventData2 = new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { DiagnosticProperty.DiagnosticIdAttribute, "id2" } });
+            var eventData3 = new EventData(new BinaryData(ReadOnlyMemory<byte>.Empty), new Dictionary<string, object> { { DiagnosticProperty.DiagnosticIdAttribute, "id3" } });
 
             EventDataBatch batch = await producer.CreateBatchAsync();
 
@@ -363,8 +363,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var eventBatch = new List<EventData>
             {
-                new EventData(Array.Empty<byte>(), enqueuedTime: enqueuedTime),
-                new EventData(Array.Empty<byte>(), enqueuedTime: enqueuedTime)
+                new EventData(new BinaryData(Array.Empty<byte>()), enqueuedTime: enqueuedTime),
+                new EventData(new BinaryData(Array.Empty<byte>()), enqueuedTime: enqueuedTime)
             };
 
             eventBatch.ForEach(evt => evt.Properties.Add(DiagnosticProperty.DiagnosticIdAttribute, (++diagnosticId).ToString()));
@@ -413,7 +413,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var enqueuedTime = DateTimeOffset.UtcNow;
             var diagnosticId = "OMGHAI2U!";
-            var eventBatch = new List<EventData> { new EventData(Array.Empty<byte>(), enqueuedTime: enqueuedTime) };
+            var eventBatch = new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>()), enqueuedTime: enqueuedTime) };
             var partition = new EventProcessorPartition { PartitionId = "123" };
             var fullyQualifiedNamespace = "namespace";
             var eventHubName = "eventHub";

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
@@ -226,7 +226,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var storageManager = EventProcessor<EventProcessorPartition>.CreateStorageManager(mockProcessor.Object);
             Assert.That(storageManager, Is.Not.Null, "The storage manager should have been created.");
 
-            Assert.That(() => storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint(), new EventData(Array.Empty<byte>()), CancellationToken.None), Throws.InstanceOf<NotImplementedException>(), "Calling to update checkpoints should not be implemented.");
+            Assert.That(() => storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint(), new EventData(new BinaryData(Array.Empty<byte>())), CancellationToken.None), Throws.InstanceOf<NotImplementedException>(), "Calling to update checkpoints should not be implemented.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -66,7 +66,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
-            var eventBatch = new[] { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) };
+            var eventBatch = new[] { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>())) };
             var partition = new EventProcessorPartition { PartitionId = "123" };
             var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(67, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
 
@@ -281,7 +281,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = true };
-            var lastEvent = new EventData(Array.Empty<byte>(), lastPartitionSequenceNumber: 123, lastPartitionOffset: 887, lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2021-03-04T08:30:00Z"));
+            var lastEvent = new EventData(new BinaryData(Array.Empty<byte>()), lastPartitionSequenceNumber: 123, lastPartitionOffset: 887, lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2021-03-04T08:30:00Z"));
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockConnection = Mock.Of<EventHubConnection>();
             var mockConsumer = new Mock<SettableTransportConsumer>();
@@ -330,7 +330,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = true, RetryOptions = retryOptions };
-            var lastEvent = new EventData(Array.Empty<byte>(), lastPartitionSequenceNumber: 123, lastPartitionOffset: 887, lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2021-03-04T08:30:00Z"));
+            var lastEvent = new EventData(new BinaryData(Array.Empty<byte>()), lastPartitionSequenceNumber: 123, lastPartitionOffset: 887, lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2021-03-04T08:30:00Z"));
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockConnection = Mock.Of<EventHubConnection>();
             var mockConsumer = new Mock<SettableTransportConsumer>();
@@ -408,7 +408,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConsumer
                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) })
+                .ReturnsAsync(new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>())) })
                 .Callback(() => completionSource.TrySetResult(true));
 
             mockProcessor
@@ -465,7 +465,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConsumer
                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) })
+                .ReturnsAsync(new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>())) })
                 .Callback(() => completionSource.TrySetResult(true));
 
             mockProcessor
@@ -519,7 +519,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConsumer
                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) })
+                .ReturnsAsync(new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>())) })
                 .Callback(() => completionSource.TrySetResult(true));
 
             mockProcessor
@@ -770,7 +770,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConsumer
                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) });
+                .ReturnsAsync(new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>())) });
 
             mockProcessor
                 .Setup(processor => processor.CreateConnection())
@@ -1055,7 +1055,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConsumer
                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) });
+                .ReturnsAsync(new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>())) });
 
             mockProcessor
                 .Setup(processor => processor.CreateConnection())
@@ -1114,7 +1114,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConsumer
                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) });
+                .ReturnsAsync(new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>())) });
 
             mockProcessor.Object.Logger = mockLogger.Object;
 
@@ -1176,7 +1176,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConsumer
                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) });
+                .ReturnsAsync(new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>())) });
 
             mockProcessor
                 .Setup(processor => processor.CreateConnection())
@@ -1464,7 +1464,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
             var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
             var partition = new EventProcessorPartition { PartitionId = "4" };
-            var lastEventBatch = new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>(), offset: 9987) };
+            var lastEventBatch = new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>()), offset: 9987) };
             var initialStartingPosition = EventPosition.FromSequenceNumber(332);
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockConnection = Mock.Of<EventHubConnection>();
@@ -1478,7 +1478,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             badMockConsumer
                 .SetupSequence(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()) })
+                .ReturnsAsync(new List<EventData> { new EventData(new BinaryData(Array.Empty<byte>())) })
                 .ReturnsAsync(lastEventBatch)
                 .Throws(new DllNotFoundException());
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
@@ -781,7 +781,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var lastEvent = new EventData
             (
-                eventBody: Array.Empty<byte>(),
+                eventBody: new BinaryData(Array.Empty<byte>()),
                 lastPartitionSequenceNumber: 1234,
                 lastPartitionOffset: 42,
                 lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T00:00:00Z"),

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -191,10 +191,10 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(batch.TryAdd(new EventData(new byte[] { 0x21 })), Is.True, "The event should have been accepted before locking.");
 
             batch.Lock();
-            Assert.That(() => batch.TryAdd(new EventData(Array.Empty<byte>())), Throws.InstanceOf<InvalidOperationException>(), "The batch should not accept events when locked.");
+            Assert.That(() => batch.TryAdd(new EventData(new BinaryData(Array.Empty<byte>()))), Throws.InstanceOf<InvalidOperationException>(), "The batch should not accept events when locked.");
 
             batch.Unlock();
-            Assert.That(batch.TryAdd(new EventData(Array.Empty<byte>())), Is.True, "The event should have been accepted after unlocking.");
+            Assert.That(batch.TryAdd(new EventData(new BinaryData(Array.Empty<byte>()))), Is.True, "The event should have been accepted after unlocking.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
@@ -325,9 +325,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     EventData[] events = new[]
                     {
-                        new EventData(Array.Empty<byte>()),
-                        new EventData(Array.Empty<byte>()),
-                        new EventData(Array.Empty<byte>())
+                        new EventData(new BinaryData(Array.Empty<byte>())),
+                        new EventData(new BinaryData(Array.Empty<byte>())),
+                        new EventData(new BinaryData(Array.Empty<byte>()))
                     };
 
                     Assert.That(async () => await producer.SendAsync(events), Throws.Nothing);
@@ -490,7 +490,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 await using (var producer = new EventHubProducerClient(connectionString))
                 {
                     using EventDataBatch batch = await producer.CreateBatchAsync();
-                    batch.TryAdd(new EventData(Array.Empty<byte>()));
+                    batch.TryAdd(new EventData(new BinaryData(Array.Empty<byte>())));
 
                     Assert.That(batch.Count, Is.EqualTo(1), "The batch should contain a single event.");
                     Assert.That(async () => await producer.SendAsync(batch), Throws.Nothing);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -665,7 +665,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task SendWithoutOptionsInvokesTheTransportProducer()
         {
-            var events = new[] { new EventData(Array.Empty<byte>()) };
+            var events = new[] { new EventData(new BinaryData(Array.Empty<byte>())) };
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
@@ -685,7 +685,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task SendInvokesTheTransportProducer()
         {
-            var events = new[] { new EventData(Array.Empty<byte>()) };
+            var events = new[] { new EventData(new BinaryData(Array.Empty<byte>())) };
             var options = new SendEventOptions();
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
@@ -1803,15 +1803,15 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(transport => transport.SendAsync(It.IsAny<EventDataBatch>(), It.IsAny<CancellationToken>()))
                 .Returns(async () => await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token)));
 
-            Assert.That(batch.TryAdd(new EventData(Array.Empty<byte>())), Is.True, "The batch should not be locked before sending.");
+            Assert.That(batch.TryAdd(new EventData(new BinaryData(Array.Empty<byte>()))), Is.True, "The batch should not be locked before sending.");
             var sendTask = producer.SendAsync(batch);
 
-            Assert.That(() => batch.TryAdd(new EventData(Array.Empty<byte>())), Throws.InstanceOf<InvalidOperationException>(), "The batch should be locked while sending.");
+            Assert.That(() => batch.TryAdd(new EventData(new BinaryData(Array.Empty<byte>()))), Throws.InstanceOf<InvalidOperationException>(), "The batch should be locked while sending.");
             completionSource.TrySetResult(true);
 
             await sendTask;
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-            Assert.That(batch.TryAdd(new EventData(Array.Empty<byte>())), Is.True, "The batch should not be locked after sending.");
+            Assert.That(batch.TryAdd(new EventData(new BinaryData(Array.Empty<byte>()))), Is.True, "The batch should not be locked after sending.");
 
             cancellationSource.Cancel();
         }
@@ -2049,7 +2049,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task EventHubProducerClientShouldCloseAProducer()
         {
             var options = new SendEventOptions { PartitionId = "0" };
-            var events = new[] { new EventData(Array.Empty<byte>()) };
+            var events = new[] { new EventData(new BinaryData(Array.Empty<byte>())) };
             var transportProducer = new ObservableTransportProducerMock();
             var eventHubConnection = new MockConnection(() => transportProducer);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -2077,7 +2077,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockTransportProducerPool = new MockTransportProducerPool(transportProducer.Object, eventHubConnection, retryPolicy);
             var mockPooledProducer = mockTransportProducerPool.GetPooledProducer(options.PartitionId) as MockPooledProducer;
             var producerClient = new EventHubProducerClient(eventHubConnection, transportProducer.Object, mockTransportProducerPool);
-            var events = new[] { new EventData(Array.Empty<byte>()) };
+            var events = new[] { new EventData(new BinaryData(Array.Empty<byte>())) };
 
             transportProducer
                 .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(),
@@ -2205,7 +2205,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDoesNotStartWhenPartitionIdIsNull()
         {
             var options = new SendEventOptions { PartitionId = "0" };
-            var events = new[] { new EventData(Array.Empty<byte>()) };
+            var events = new[] { new EventData(new BinaryData(Array.Empty<byte>())) };
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -2265,7 +2265,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task RetryLogicDoesNotWorkForClosedConnections()
         {
             var options = new SendEventOptions { PartitionId = "0" };
-            var events = new[] { new EventData(Array.Empty<byte>()) };
+            var events = new[] { new EventData(new BinaryData(Array.Empty<byte>())) };
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -2336,7 +2336,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDoesNotWorkForClosedEventHubProducerClients()
         {
             var options = new SendEventOptions { PartitionId = "0" };
-            var events = new[] { new EventData(Array.Empty<byte>()) };
+            var events = new[] { new EventData(new BinaryData(Array.Empty<byte>())) };
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -2407,7 +2407,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicShouldNotStartWhenCancellationTriggered()
         {
             var options = new SendEventOptions { PartitionId = "0" };
-            var events = new[] { new EventData(Array.Empty<byte>()) };
+            var events = new[] { new EventData(new BinaryData(Array.Empty<byte>())) };
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -2462,7 +2462,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDetectsAnEmbeddedAmqpErrorForOperationCanceled()
         {
             var options = new SendEventOptions { PartitionId = "0" };
-            var events = new[] { new EventData(Array.Empty<byte>()) };
+            var events = new[] { new EventData(new BinaryData(Array.Empty<byte>())) };
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();


### PR DESCRIPTION
# Summary

The focus of these changes is to introduce the `AmqpAnnotatedMessage` abstraction as the basis for `EventData`, allowing access to the full set of AMQP message data.  This enables scenarios such as interaction with other message brokers that make use of the protocol in ways that are not otherwise exposed within the Event Hubs client.

This set of changes will be followed by refactoring of the `AmqpMessageConverter` to work with the full AMQP message rather only than the known `EventData` subset.

# References and Related

- [Event Hubs: Extend EventData with AMQP Message Details (#20105)](https://github.com/Azure/azure-sdk-for-net/issues/20105)