### PR TITLE
Fix ParentOperationId for out of proc Activity Parent

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -43,9 +43,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = RoleInstance;
             telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString()] = activity.TraceId.ToHexString();
 
-            if (activity.Parent != null)
+            if (activity.ParentSpanId != default)
             {
-                telemetryItem.Tags[ContextTagKeys.AiOperationParentId.ToString()] = activity.Parent.SpanId.ToHexString();
+                telemetryItem.Tags[ContextTagKeys.AiOperationParentId.ToString()] = activity.ParentSpanId.ToHexString();
             }
 
             telemetryItem.Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.SdkVersion;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
@@ -155,7 +155,24 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             Assert.Throws<KeyNotFoundException>(() => telemetryItem.Tags[ContextTagKeys.AiOperationParentId.ToString()]);
         }
 
-        // TODO: GeneratePartAEnvelope_WithActivityParent
+        [Fact]
+        public void PartAEnvelopeContainsParentOperationIdWhenActivityHasParent()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            var parentContext = new ActivityContext(
+                ActivityTraceId.CreateRandom(),
+                ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                parentContext: parentContext,
+                startTime: DateTime.UtcNow);
+
+            var telemetryItem = TelemetryPartA.GetTelemetryItem(activity, null, null);
+
+            Assert.Equal(parentContext.SpanId.ToHexString(), telemetryItem.Tags[ContextTagKeys.AiOperationParentId.ToString()]);
+        }
 
         /// <summary>
         /// If SERVICE.NAME is not defined, it will fall-back to "unknown_service".


### PR DESCRIPTION
Currently Activity.Parent is used for assigning AiOperationParentId - This is only applicable for parent activites that are created Inproc. Changing it to use Activity.ParentSpanId instead which will correctly assign parentId for parent activities that are created out of proc as well.
