### PR TITLE
[Storage] Cache encryption key if high level api spans across multiple service calls.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added support for listing deleted root blobs with versions to BlobContainerClient.GetBlobs() and .GetBlobsByHierarchy()
 - Added support for OAuth copy sources for synchronous copy operations.
 - Added support for Parquet as an input format in BlockBlobClient.Query().
+- Added optimization to unwrap encryption key once for DownloadTo and OpenRead when Client Side Encryption is enabled.
 
 ## 12.9.0 (2021-06-08)
 - Includes all features from 12.9.0-beta.4.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -1787,6 +1787,10 @@ namespace Azure.Storage.Blobs.Specialized
         {
             PartitionedDownloader downloader = new PartitionedDownloader(this, transferOptions);
 
+            if (UsingClientSideEncryption)
+            {
+                ClientSideDecryptor.BeginContentEncryptionKeyCaching();
+            }
             if (async)
             {
                 return await downloader.DownloadToAsync(destination, conditions, cancellationToken).ConfigureAwait(false);
@@ -2077,12 +2081,22 @@ namespace Azure.Storage.Blobs.Specialized
                         readConditions = readConditions?.WithIfMatch(etag) ?? new BlobRequestConditions { IfMatch = etag };
                     }
 
+                    ClientSideDecryptor.ContentEncryptionKeyCache contentEncryptionKeyCache = default;
+                    if (UsingClientSideEncryption && !allowModifications)
+                    {
+                        contentEncryptionKeyCache = new();
+                    }
+
                     return new LazyLoadingReadOnlyStream<BlobProperties>(
                         async (HttpRange range,
                         bool rangeGetContentHash,
                         bool async,
                         CancellationToken cancellationToken) =>
                         {
+                            if (UsingClientSideEncryption)
+                            {
+                                ClientSideDecryptor.BeginContentEncryptionKeyCaching(contentEncryptionKeyCache);
+                            }
                             Response<BlobDownloadStreamingResult> response = await DownloadStreamingInternal(
                                 range,
                                 readConditions,

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -107,6 +107,18 @@ namespace Azure.Storage.Blobs.Test
             return keyMock;
         }
 
+        private void VerifyUnwrappedKeyWasCached(Mock<IKeyEncryptionKey> keyMock)
+        {
+            if (IsAsync)
+            {
+                keyMock.Verify(k => k.UnwrapKeyAsync(s_algorithmName, IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
+            }
+            else
+            {
+                keyMock.Verify(k => k.UnwrapKey(s_algorithmName, IsNotNull<ReadOnlyMemory<byte>>(), s_cancellationToken), Times.Once);
+            }
+        }
+
         private Mock<IKeyEncryptionKeyResolver> GetAlwaysFailsKeyResolver(bool throws)
         {
             var mock = new Mock<IKeyEncryptionKeyResolver>(MockBehavior.Strict);
@@ -288,20 +300,21 @@ namespace Azure.Storage.Blobs.Test
             }
         }
 
-        [TestCase(16)] // a single cipher block
-        [TestCase(14)] // a single unalligned cipher block
-        [TestCase(Constants.KB)] // multiple blocks
-        [TestCase(Constants.KB - 4)] // multiple unalligned blocks
+        [TestCase(16, null)] // a single cipher block
+        [TestCase(14, null)] // a single unalligned cipher block
+        [TestCase(Constants.KB, null)] // multiple blocks
+        [TestCase(Constants.KB - 4, null)] // multiple unalligned blocks
+        [TestCase(Constants.MB, 64*Constants.KB)] // make sure we cache unwrapped key for large downloads
         [LiveOnly] // cannot seed content encryption key
-        public async Task RoundtripAsync(long dataSize)
+        public async Task RoundtripAsync(long dataSize, long? initialDownloadRequestSize)
         {
             var data = GetRandomBuffer(dataSize);
-            var mockKey = GetIKeyEncryptionKey().Object;
-            var mockKeyResolver = GetIKeyEncryptionKeyResolver(mockKey).Object;
+            var mockKey = GetIKeyEncryptionKey();
+            var mockKeyResolver = GetIKeyEncryptionKeyResolver(mockKey.Object).Object;
             await using (var disposable = await GetTestContainerEncryptionAsync(
                 new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)
                 {
-                    KeyEncryptionKey = mockKey,
+                    KeyEncryptionKey = mockKey.Object,
                     KeyResolver = mockKeyResolver,
                     KeyWrapAlgorithm = s_algorithmName
                 }))
@@ -315,12 +328,50 @@ namespace Azure.Storage.Blobs.Test
                 byte[] downloadData;
                 using (var stream = new MemoryStream())
                 {
-                    await blob.DownloadToAsync(stream, cancellationToken: s_cancellationToken);
+                    await blob.DownloadToAsync(stream,
+                        transferOptions: new StorageTransferOptions() { InitialTransferSize = initialDownloadRequestSize },
+                        cancellationToken: s_cancellationToken);
                     downloadData = stream.ToArray();
                 }
 
                 // compare data
                 Assert.AreEqual(data, downloadData);
+                VerifyUnwrappedKeyWasCached(mockKey);
+            }
+        }
+
+        [TestCase(Constants.MB, 64*Constants.KB)]
+        [LiveOnly] // cannot seed content encryption key
+        public async Task RoundtripAsyncWithOpenRead(long dataSize, int bufferSize)
+        {
+            var data = GetRandomBuffer(dataSize);
+            var mockKey = GetIKeyEncryptionKey();
+            var mockKeyResolver = GetIKeyEncryptionKeyResolver(mockKey.Object).Object;
+            await using (var disposable = await GetTestContainerEncryptionAsync(
+                new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)
+                {
+                    KeyEncryptionKey = mockKey.Object,
+                    KeyResolver = mockKeyResolver,
+                    KeyWrapAlgorithm = s_algorithmName
+                }))
+            {
+                var blob = InstrumentClient(disposable.Container.GetBlobClient(GetNewBlobName()));
+
+                // upload with encryption
+                await blob.UploadAsync(new MemoryStream(data), cancellationToken: s_cancellationToken);
+
+                // download with decryption
+                byte[] downloadData;
+                using (var stream = new MemoryStream())
+                {
+                    using var blobStream = await blob.OpenReadAsync(new BlobOpenReadOptions(false) { BufferSize = bufferSize }, cancellationToken: s_cancellationToken);
+                    await blobStream.CopyToAsync(stream, bufferSize, s_cancellationToken);
+                    downloadData = stream.ToArray();
+                }
+
+                // compare data
+                Assert.AreEqual(data, downloadData);
+                VerifyUnwrappedKeyWasCached(mockKey);
             }
         }
 
@@ -529,6 +580,31 @@ namespace Azure.Storage.Blobs.Test
 
                 var downloadStream = new MemoryStream();
                 await blob.DownloadToAsync(downloadStream, cancellationToken: s_cancellationToken);
+
+                Assert.AreEqual(data, downloadStream.ToArray());
+            }
+        }
+
+        [TestCase(Constants.MB, 64*Constants.KB)]
+        [LiveOnly] // need access to keyvault service && cannot seed content encryption key
+        public async Task RoundtripWithKeyvaultProviderOpenRead(long dataSize, int bufferSize)
+        {
+            var data = GetRandomBuffer(dataSize);
+            IKeyEncryptionKey key = await GetKeyvaultIKeyEncryptionKey();
+            await using (var disposable = await GetTestContainerEncryptionAsync(
+                new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)
+                {
+                    KeyEncryptionKey = key,
+                    KeyWrapAlgorithm = "RSA-OAEP-256"
+                }))
+            {
+                var blob = disposable.Container.GetBlobClient(GetNewBlobName());
+
+                await blob.UploadAsync(new MemoryStream(data), cancellationToken: s_cancellationToken);
+
+                var downloadStream = new MemoryStream();
+                using var blobStream = await blob.OpenReadAsync(new BlobOpenReadOptions(false) { BufferSize = bufferSize});
+                await blobStream.CopyToAsync(downloadStream);
 
                 Assert.AreEqual(data, downloadStream.ToArray());
             }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -14,6 +14,11 @@ namespace Azure.Storage.Cryptography
     internal class ClientSideDecryptor
     {
         /// <summary>
+        /// A cache for encryption key if high level API spans across multiple service calls.
+        /// </summary>
+        private static readonly AsyncLocal<ContentEncryptionKeyCache> s_contentEncryptionKeyCache = new();
+
+        /// <summary>
         /// Clients that can upload data have a key encryption key stored on them. Checking if
         /// a cached key exists and matches a given <see cref="EncryptionData"/> saves a call
         /// to the external key resolver implementation when available.
@@ -179,6 +184,11 @@ namespace Azure.Storage.Cryptography
             bool async,
             CancellationToken cancellationToken)
         {
+            if (s_contentEncryptionKeyCache.Value?.Key.HasValue ?? false)
+            {
+                return s_contentEncryptionKeyCache.Value.Key.Value;
+            }
+
             IKeyEncryptionKey key = default;
 
             // If we already have a local key and it is the correct one, use that.
@@ -201,7 +211,7 @@ namespace Azure.Storage.Cryptography
                 throw Errors.ClientSideEncryption.KeyNotFound(encryptionData.WrappedContentKey.KeyId);
             }
 
-            return async
+            var contentEncryptionKey = async
                 ? await key.UnwrapKeyAsync(
                     encryptionData.WrappedContentKey.Algorithm,
                     encryptionData.WrappedContentKey.EncryptedKey,
@@ -210,6 +220,13 @@ namespace Azure.Storage.Cryptography
                     encryptionData.WrappedContentKey.Algorithm,
                     encryptionData.WrappedContentKey.EncryptedKey,
                     cancellationToken);
+
+            if (s_contentEncryptionKeyCache.Value != default)
+            {
+                s_contentEncryptionKeyCache.Value.Key = contentEncryptionKey;
+            }
+
+            return contentEncryptionKey;
         }
 
         /// <summary>
@@ -249,6 +266,16 @@ namespace Azure.Storage.Cryptography
             }
 
             throw Errors.ClientSideEncryption.BadEncryptionAlgorithm(encryptionData.EncryptionAgent.EncryptionAlgorithm.ToString());
+        }
+
+        internal static void BeginContentEncryptionKeyCaching(ContentEncryptionKeyCache cache = default)
+        {
+            s_contentEncryptionKeyCache.Value = cache ?? new ContentEncryptionKeyCache();
+        }
+
+        internal class ContentEncryptionKeyCache
+        {
+            public Memory<byte>? Key { get; set; }
         }
     }
 }


### PR DESCRIPTION
When user is using client side encryption and uses relatively small buffer to perform download/openread operations then this puts unnecessary pressure on keyvault because we'd call to unwrap encryption key for each chunk.
For example OpenRead for 4GB blob and reading it's content will issue ~1000 unwrap requests as openread uses 4MB buffer by default.

This PR has optimization that caches encryption key for the lifespan of DownloadTo and Stream returned from OpenRead to avoid this.

