### PR TITLE
[TA] Make actions errors more resilient

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
@@ -300,6 +300,15 @@ namespace Azure.AI.TextAnalytics
 
             Response rawResponse = response.GetRawResponse();
 
+            if (response.Value.Status == TextAnalyticsOperationStatus.Failed)
+            {
+                if (CheckIfGenericError(response.Value))
+                {
+                    RequestFailedException requestFailedException = await ClientCommon.CreateExceptionForFailedOperationAsync(async, _diagnostics, rawResponse, response.Value.Errors).ConfigureAwait(false);
+                    return OperationState<AsyncPageable<AnalyzeActionsResult>>.Failure(rawResponse, requestFailedException);
+                }
+            }
+
             if (response.Value.Status == TextAnalyticsOperationStatus.Succeeded ||
                 response.Value.Status == TextAnalyticsOperationStatus.Failed)
             {
@@ -311,6 +320,16 @@ namespace Azure.AI.TextAnalytics
             }
 
             return OperationState<AsyncPageable<AnalyzeActionsResult>>.Pending(rawResponse);
+        }
+
+        private static bool CheckIfGenericError(AnalyzeJobState jobState)
+        {
+            foreach (TextAnalyticsErrorInternal error in jobState.Errors)
+            {
+                if (string.IsNullOrEmpty(error.Target))
+                    return true;
+            }
+            return false;
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
@@ -488,7 +488,7 @@ namespace Azure.AI.TextAnalytics
                 {
                     string[] targetPair = parseActionErrorTarget(error.Target);
                     if (targetPair == null)
-                        throw new InvalidOperationException("Invalid action/id error");
+                        throw new InvalidOperationException($"Invalid action/id error. \n Additional information: Error code: {error.Code} Error message: {error.Message}");
 
                     string taskName = targetPair[0];
                     int taskIndex = int.Parse(targetPair[1], CultureInfo.InvariantCulture);
@@ -515,7 +515,7 @@ namespace Azure.AI.TextAnalytics
                     }
                     else
                     {
-                        throw new InvalidOperationException($"Invalid task name in target reference - {taskName}");
+                        throw new InvalidOperationException($"Invalid task name in target reference - {taskName}. \n Additional information: Error code: {error.Code} Error message: {error.Message}");
                     }
                 }
             }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationMockTests.cs
@@ -295,16 +295,75 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.Throws<InvalidOperationException>(() => entitiesActionsResults.DocumentsResults.GetType());
 
             Assert.IsTrue(keyPhrasesActionsResults.HasError);
-            Assert.Throws<InvalidOperationException>(() => entitiesActionsResults.DocumentsResults.GetType());
+            Assert.Throws<InvalidOperationException>(() => keyPhrasesActionsResults.DocumentsResults.GetType());
 
             Assert.IsTrue(piiActionsResults.HasError);
-            Assert.Throws<InvalidOperationException>(() => entitiesActionsResults.DocumentsResults.GetType());
+            Assert.Throws<InvalidOperationException>(() => piiActionsResults.DocumentsResults.GetType());
 
             Assert.IsTrue(entityLinkingActionsResults.HasError);
-            Assert.Throws<InvalidOperationException>(() => entitiesActionsResults.DocumentsResults.GetType());
+            Assert.Throws<InvalidOperationException>(() => entityLinkingActionsResults.DocumentsResults.GetType());
 
             Assert.IsTrue(analyzeSentimentActionsResults.HasError);
-            Assert.Throws<InvalidOperationException>(() => entitiesActionsResults.DocumentsResults.GetType());
+            Assert.Throws<InvalidOperationException>(() => analyzeSentimentActionsResults.DocumentsResults.GetType());
+        }
+
+        [Test]
+        public void AnalyzeOperationWithGenericError()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(@"
+                {
+                    ""displayName"": ""AnalyzeOperationBatchWithErrorTest"",
+                    ""jobId"": ""75d521bc-c2aa-4d8a-aabe-713e72d53a2d"",
+                    ""lastUpdateDateTime"": ""2021-03-03T22:39:37Z"",
+                    ""createdDateTime"": ""2021-03-03T22:39:36Z"",
+                    ""expirationDateTime"": ""2021-03-04T22:39:36Z"",
+                    ""status"": ""failed"",
+                    ""errors"": [
+                      {
+                        ""code"": ""InternalServerError"",
+                        ""message"": ""Some error""
+                      }
+                    ],
+                    ""tasks"": {
+                      ""details"": {
+                        ""name"": ""AnalyzeOperationBatchWithErrorTest"",
+                        ""lastUpdateDateTime"": ""2021-03-03T22:39:37Z""
+                      },
+                      ""completed"": 0,
+                      ""failed"": 1,
+                      ""inProgress"": 0,
+                      ""total"": 1,
+                      ""entityRecognitionTasks"": [
+                        {
+                          ""lastUpdateDateTime"": ""2021-03-03T22:39:37.1716697Z"",
+                          ""taskName"": ""something"",
+                          ""state"": ""failed""
+                        }
+                      ]
+                    }
+                }"));
+
+            var mockResponse = new MockResponse(200);
+            mockResponse.ContentStream = stream;
+
+            var mockTransport = new MockTransport(new[] { mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+                DisplayName = "AnalyzeOperationBatchWithErrorTest"
+            };
+
+            var operation = new AnalyzeActionsOperation("75d521bc-c2aa-4d8a-aabe-713e72d53a2d", client);
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.UpdateStatusAsync());
+            Assert.AreEqual("InternalServerError", ex.ErrorCode);
+            Assert.IsTrue(ex.Message.Contains("Some error"));
         }
 
         private static string GetString(RequestContent content)


### PR DESCRIPTION
In recent conversation with the service team, and after a casual error I got, I noticed how the .NET SDK was making an assumption that the service will always return errors with targets and that it will always be related to the tasks.

Although we don't have a concrete case yet, I added some code to make our SDK more resilient in case this ever happens.
The major problem is that our exceptions were custom and hiding the error code and message the service was sending, and this is important information we should share with the user.

By coincidence, it addressed: https://github.com/Azure/azure-sdk-for-net/issues/16686 as it validates the method works. FYI @mohamedshabanofficial 