### PR TITLE
update SnippetGenerator to add language hint

### DIFF
--- a/eng/SnippetGenerator/CSharpProcessor.cs
+++ b/eng/SnippetGenerator/CSharpProcessor.cs
@@ -14,7 +14,7 @@ namespace SnippetGenerator
         private static readonly string _snippetFormat = "{3} <code snippet=\"{0}\" language=\"csharp\">{1}{2} </code>";
         private static readonly string _snippetExampleFormat = "{3} <example snippet=\"{0}\">{1}{3} <code language=\"csharp\">{1}{2} </code>{1}{3} </example>";
 
-        private static readonly Regex _snippetRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<code snippet=\"(?<name>[\\w:]+)\">.*?\\s*<\\/code>",
+        private static readonly Regex _snippetRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<code snippet=\"(?<name>[\\w:]+)\"( +language=\"csharp\")?>.*?\\s*<\\/code>",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.IgnoreCase);
 
         private static readonly Regex _snippetExampleRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<example snippet=\"(?<name>[\\w:]+)\">.*?\\s*<\\/example>",

--- a/eng/SnippetGenerator/CSharpProcessor.cs
+++ b/eng/SnippetGenerator/CSharpProcessor.cs
@@ -11,8 +11,8 @@ namespace SnippetGenerator
 {
     public class CSharpProcessor
     {
-        private static readonly string _snippetFormat = "{3} <code snippet=\"{0}\">{1}{2} </code>";
-        private static readonly string _snippetExampleFormat = "{3} <example snippet=\"{0}\">{1}{3} <code>{1}{2} </code>{1}{3} </example>";
+        private static readonly string _snippetFormat = "{3} <code snippet=\"{0}\" language=\"csharp\">{1}{2} </code>";
+        private static readonly string _snippetExampleFormat = "{3} <example snippet=\"{0}\">{1}{3} <code language=\"csharp\">{1}{2} </code>{1}{3} </example>";
 
         private static readonly Regex _snippetRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<code snippet=\"(?<name>[\\w:]+)\">.*?\\s*<\\/code>",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.IgnoreCase);

--- a/eng/SnippetGenerator/CSharpProcessor.cs
+++ b/eng/SnippetGenerator/CSharpProcessor.cs
@@ -14,7 +14,7 @@ namespace SnippetGenerator
         private static readonly string _snippetFormat = "{3} <code snippet=\"{0}\" language=\"csharp\">{1}{2} </code>";
         private static readonly string _snippetExampleFormat = "{3} <example snippet=\"{0}\">{1}{3} <code language=\"csharp\">{1}{2} </code>{1}{3} </example>";
 
-        private static readonly Regex _snippetRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<code snippet=\"(?<name>[\\w:]+)\"( +language=\"csharp\")?>.*?\\s*<\\/code>",
+        private static readonly Regex _snippetRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<code snippet=\"(?<name>[\\w:]+)\"[^>]*?>.*?\\s*<\\/code>",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.IgnoreCase);
 
         private static readonly Regex _snippetExampleRegex = new Regex("^(?<indent>\\s*)\\/{3}\\s*<example snippet=\"(?<name>[\\w:]+)\">.*?\\s*<\\/example>",

--- a/eng/SnippetGenerator/DirectoryProcessor.cs
+++ b/eng/SnippetGenerator/DirectoryProcessor.cs
@@ -91,10 +91,17 @@ namespace SnippetGenerator
             var snippets = await _snippets.Value;
             var unUsedSnippets = snippets
                 .Where(s => !s.IsUsed)
-                .Select(s => s.Name)
-                .ToList();
+                .Select(s => $"{GetServiceDirName(s.FilePath)}: {s.Name}");
             return unUsedSnippets;
 
+        }
+
+        private string GetServiceDirName(string path)
+        {
+            string sdk = $"{Path.DirectorySeparatorChar}sdk{Path.DirectorySeparatorChar}";
+            int start = path.IndexOf(sdk) + sdk.Length;
+            int end = path.IndexOf(Path.DirectorySeparatorChar, start);
+            return path.Substring(start, end - start);
         }
 
         private async Task<List<Snippet>> DiscoverSnippetsAsync()

--- a/eng/SnippetGenerator/DirectoryProcessor.cs
+++ b/eng/SnippetGenerator/DirectoryProcessor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -37,9 +38,8 @@ namespace SnippetGenerator
             _snippets = new Lazy<Task<List<Snippet>>>(DiscoverSnippetsAsync);
         }
 
-        public async Task ProcessAsync()
+        public async Task<IEnumerable<string>> ProcessAsync()
         {
-
             List<string> files = new List<string>();
             files.AddRange(Directory.EnumerateFiles(_directory, "*.md", SearchOption.AllDirectories));
             files.AddRange(Directory.EnumerateFiles(_directory, "*.cs", SearchOption.AllDirectories));
@@ -61,8 +61,10 @@ namespace SnippetGenerator
                     }
 
                     var selectedSnippet = selectedSnippets.Single();
+                    selectedSnippet.IsUsed = true;
                     Console.WriteLine($"Replaced {selectedSnippet.Name} in {file}");
-                    return FormatSnippet(selectedSnippet.Text);
+                    var result = FormatSnippet(selectedSnippet.Text);
+                    return result;
                 }
 
                 var originalText = await File.ReadAllTextAsync(file);
@@ -86,13 +88,23 @@ namespace SnippetGenerator
                     await File.WriteAllTextAsync(file, text, _utf8EncodingWithoutBOM);
                 }
             }
+            var snippets = await _snippets.Value;
+            var unUsedSnippets = snippets
+                .Where(s => !s.IsUsed)
+                .Select(s => s.Name)
+                .ToList();
+            return unUsedSnippets;
+
         }
 
         private async Task<List<Snippet>> DiscoverSnippetsAsync()
         {
             var snippets = await GetSnippetsInDirectoryAsync(_directory);
+            if (snippets.Count == 0)
+            {
+                return snippets;
+            }
             Console.WriteLine($"Discovered snippets:");
-
             foreach (var snippet in snippets)
             {
                 Console.WriteLine($" {snippet.Name} in {snippet.FilePath}");

--- a/eng/SnippetGenerator/Program.cs
+++ b/eng/SnippetGenerator/Program.cs
@@ -41,6 +41,7 @@ namespace SnippetGenerator
                 unUsedSnippets = await new DirectoryProcessor(BasePath).ProcessAsync();
             }
             Console.WriteLine();
+            Console.ForegroundColor = ConsoleColor.Red;
             string message = $"Not all snippets were used.\n{string.Join(Environment.NewLine, unUsedSnippets)}";
             if (StrictMode)
             {

--- a/eng/SnippetGenerator/Program.cs
+++ b/eng/SnippetGenerator/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -13,27 +14,47 @@ namespace SnippetGenerator
 {
     public class Program
     {
-
-        [Option(ShortName = "b")]
-        public string BasePath { get; set; }
+        [Option(ShortName = "b")] public string BasePath { get; set; }
+        [Option(ShortName = "sm")] public bool StrictMode { get; set; }
 
         public async Task OnExecuteAsync()
         {
+            IEnumerable<string> unUsedSnippets = null;
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
             var baseDirectory = new DirectoryInfo(BasePath).Name;
             if (baseDirectory.Equals("sdk"))
             {
-                var tasks = new List<Task>();
+                var tasks = new List<Task<IEnumerable<string>>>();
                 foreach (var sdkDir in Directory.GetDirectories(BasePath))
                 {
                     tasks.Add(new DirectoryProcessor(sdkDir).ProcessAsync());
                 }
 
                 await Task.WhenAll(tasks);
+                unUsedSnippets = tasks
+                    .SelectMany(t => t.Result)
+                    .ToList();
             }
             else
             {
-                await new DirectoryProcessor(BasePath).ProcessAsync();
+                unUsedSnippets = await new DirectoryProcessor(BasePath).ProcessAsync();
             }
+            Console.WriteLine();
+            string message = $"Not all snippets were used.\n{string.Join(Environment.NewLine, unUsedSnippets)}";
+            if (StrictMode)
+            {
+                if (unUsedSnippets.Any())
+                {
+                    throw new InvalidOperationException(message);
+                }
+            }
+            else
+            {
+                Console.WriteLine(message);
+            }
+            sw.Stop();
+            Console.WriteLine($"SnippetGenerator completed in {sw.Elapsed}");
         }
 
         public static int Main(string[] args)

--- a/eng/SnippetGenerator/Program.cs
+++ b/eng/SnippetGenerator/Program.cs
@@ -19,7 +19,7 @@ namespace SnippetGenerator
 
         public async Task OnExecuteAsync()
         {
-            IEnumerable<string> unUsedSnippets = null;
+            List<string> unUsedSnippets = null;
             Stopwatch sw = new Stopwatch();
             sw.Start();
             var baseDirectory = new DirectoryInfo(BasePath).Name;
@@ -38,11 +38,12 @@ namespace SnippetGenerator
             }
             else
             {
-                unUsedSnippets = await new DirectoryProcessor(BasePath).ProcessAsync();
+                unUsedSnippets = (await new DirectoryProcessor(BasePath).ProcessAsync()).ToList();
             }
             Console.WriteLine();
             Console.ForegroundColor = ConsoleColor.Red;
             string message = $"Not all snippets were used.\n{string.Join(Environment.NewLine, unUsedSnippets)}";
+            unUsedSnippets.Sort();
             if (StrictMode)
             {
                 if (unUsedSnippets.Any())

--- a/eng/SnippetGenerator/Snippet.cs
+++ b/eng/SnippetGenerator/Snippet.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace SnippetGenerator
 {
-    internal class Snippet
+    public class Snippet
     {
         public string Name { get; }
         public SourceText Text { get; }

--- a/eng/SnippetGenerator/Snippet.cs
+++ b/eng/SnippetGenerator/Snippet.cs
@@ -10,6 +10,7 @@ namespace SnippetGenerator
         public string Name { get; }
         public SourceText Text { get; }
         public string FilePath { get; }
+        public bool IsUsed { get; set; }
 
         public Snippet(string name, SourceText text, string filePath)
         {

--- a/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
+++ b/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NUnit.Framework;
-using SnippetGenerator;
 
 namespace SnippetGenerator.Tests
 {
@@ -11,16 +11,16 @@ namespace SnippetGenerator.Tests
 
         [Test]
         [TestCaseSource(nameof(CodeInputs))]
-        public void CSharpProcsesorFindsCodeXMLDocs(string code, string expected)
+        public async Task CSharpProcsesorFindsCodeXMLDocs(string code, string expected)
         {
-            var actual = CSharpProcessor.Process(code, SnippetProvider);
+            var actual = await CSharpProcessor.ProcessAsync(code, SnippetProvider);
             Assert.AreEqual(expected, actual);
 
-            var reProcessed = CSharpProcessor.Process(actual, SnippetProvider);
+            var reProcessed = await CSharpProcessor.ProcessAsync(actual, SnippetProvider);
             Assert.AreEqual(expected, reProcessed);
         }
 
-        private string SnippetProvider(string s) => Processed;
+        private ValueTask<string> SnippetProvider(string s) => new(Processed);
 
         public static IEnumerable<object[]> CodeInputs()
         {
@@ -31,7 +31,7 @@ namespace SnippetGenerator.Tests
                 "    foo" + Environment.NewLine +
                 "        {",
                 @"    /// </remarks>" + Environment.NewLine +
-                @"    /// <code snippet=""Snippet:A"">" + Environment.NewLine +
+                @"    /// <code snippet=""Snippet:A"" language=""csharp"">" + Environment.NewLine +
                 $"    /// {Processed} </code>" + Environment.NewLine +
                 "    foo" + Environment.NewLine +
                 "        {"
@@ -40,7 +40,7 @@ namespace SnippetGenerator.Tests
             yield return new[]
             {
                 @"/// <code snippet=""Snippet:B""></code>",
-                @"/// <code snippet=""Snippet:B"">" + Environment.NewLine +
+                @"/// <code snippet=""Snippet:B"" language=""csharp"">" + Environment.NewLine +
                 $"/// {Processed} </code>"
             };
 
@@ -50,7 +50,7 @@ namespace SnippetGenerator.Tests
                 @"    /// <code snippet=""Snippet:C""></code>" + Environment.NewLine +
                 "     foo",
                 @"    /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:" + Environment.NewLine +
-                @"    /// <code snippet=""Snippet:C"">" + Environment.NewLine +
+                @"    /// <code snippet=""Snippet:C"" language=""csharp"">" + Environment.NewLine +
                 $"    /// {Processed} </code>" + Environment.NewLine +
                 "     foo"
             };
@@ -62,7 +62,7 @@ namespace SnippetGenerator.Tests
                 "     foo",
                 @"    /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:" + Environment.NewLine +
                 @"    /// <example snippet=""Snippet:Example"">" + Environment.NewLine +
-                @"    /// <code>" + Environment.NewLine +
+                @"    /// <code language=""csharp"">" + Environment.NewLine +
                 $"    /// {Processed} </code>" + Environment.NewLine +
                 @"    /// </example>" + Environment.NewLine +
                 "     foo"

--- a/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
+++ b/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
@@ -8,6 +8,7 @@ namespace SnippetGenerator.Tests
     public class Tests
     {
         private const string Processed = "processed";
+        private const string ProcessedAgain = "processed again";
 
         [Test]
         [TestCaseSource(nameof(CodeInputs))]
@@ -16,11 +17,12 @@ namespace SnippetGenerator.Tests
             var actual = await CSharpProcessor.ProcessAsync(code, SnippetProvider);
             Assert.AreEqual(expected, actual);
 
-            var reProcessed = await CSharpProcessor.ProcessAsync(actual, SnippetProvider);
-            Assert.AreEqual(expected, reProcessed);
+            var reProcessed = await CSharpProcessor.ProcessAsync(actual, SnippetProvider2);
+            Assert.AreEqual(expected.Replace(Processed, ProcessedAgain), reProcessed);
         }
 
         private ValueTask<string> SnippetProvider(string s) => new(Processed);
+        private ValueTask<string> SnippetProvider2(string s) => new(ProcessedAgain);
 
         public static IEnumerable<object[]> CodeInputs()
         {

--- a/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
+++ b/eng/SnippetGenerator/SnippetGenerator.Tests/CSharpProcessorTests.cs
@@ -69,6 +69,14 @@ namespace SnippetGenerator.Tests
                 @"    /// </example>" + Environment.NewLine +
                 "     foo"
             };
+
+            yield return new[]
+            {
+                @"/// <code snippet=""Snippet:AcceptsAnyTagSuffix"" any string here></code>",
+                @"/// <code snippet=""Snippet:AcceptsAnyTagSuffix"" language=""csharp"">" + Environment.NewLine +
+                $"/// {Processed} </code>"
+            };
+
         }
     }
 }

--- a/eng/SnippetGenerator/SnippetGenerator.Tests/SnippetGenerator.Tests.csproj
+++ b/eng/SnippetGenerator/SnippetGenerator.Tests/SnippetGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/eng/SnippetGenerator/SnippetGenerator.sln
+++ b/eng/SnippetGenerator/SnippetGenerator.sln
@@ -20,6 +20,7 @@ Global
 		{49A0F579-8121-472C-A2A7-B812FEC8CA18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{49A0F579-8121-472C-A2A7-B812FEC8CA18}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{49A0F579-8121-472C-A2A7-B812FEC8CA18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49A0F579-8121-472C-A2A7-B812FEC8CA18}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/eng/scripts/Update-Snippets.ps1
+++ b/eng/scripts/Update-Snippets.ps1
@@ -17,6 +17,8 @@ if ($ServiceDirectory -and ($ServiceDirectory -ne "*")) {
     $root += '/' + $ServiceDirectory
 }
 
+if (-not (Test-Path env:TF_BUILD)) { $StrictMode = $true }
+
 if($StrictMode) {
     Resolve-Path "$root" | %{ dotnet run -p $generatorProject -b "$_" -sm -c Release }
 } else {

--- a/eng/scripts/Update-Snippets.ps1
+++ b/eng/scripts/Update-Snippets.ps1
@@ -2,7 +2,10 @@
 param (
     [Parameter(Position=0)]
     [ValidateNotNullOrEmpty()]
-    [string] $ServiceDirectory
+    [string] $ServiceDirectory,
+
+    [Parameter()]
+    [switch] $StrictMode
 )
 
 $generatorProject = "$PSScriptRoot/../SnippetGenerator/SnippetGenerator.csproj";
@@ -14,4 +17,8 @@ if ($ServiceDirectory -and ($ServiceDirectory -ne "*")) {
     $root += '/' + $ServiceDirectory
 }
 
-Resolve-Path "$root" | %{ dotnet run -p $generatorProject -b "$_" -c Release }
+if($StrictMode) {
+    Resolve-Path "$root" | %{ dotnet run -p $generatorProject -b "$_" -sm -c Release }
+} else {
+    Resolve-Path "$root" | %{ dotnet run -p $generatorProject -b "$_" -c Release }
+}

--- a/sdk/attestation/Azure.Security.Attestation/src/AttestationAdministrationClient.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/AttestationAdministrationClient.cs
@@ -198,7 +198,7 @@ namespace Azure.Security.Attestation
         /// </item>
         /// </list>
         /// To verify the hash, clients can generate an attestation token and verify the hash generated from that token:
-        /// <code snippet="Snippet:VerifySigningHash">
+        /// <code snippet="Snippet:VerifySigningHash" language="csharp">
         /// // The SetPolicyAsync API will create an AttestationToken signed with the TokenSigningKey to transmit the policy.
         /// // To verify that the policy specified by the caller was received by the service inside the enclave, we
         /// // verify that the hash of the policy document returned from the Attestation Service matches the hash
@@ -282,7 +282,7 @@ namespace Azure.Security.Attestation
         /// </item>
         /// </list>
         /// To verify the hash, clients can generate an attestation token and verify the hash generated from that token:
-        /// <code snippet="Snippet:VerifySigningHash">
+        /// <code snippet="Snippet:VerifySigningHash" language="csharp">
         /// // The SetPolicyAsync API will create an AttestationToken signed with the TokenSigningKey to transmit the policy.
         /// // To verify that the policy specified by the caller was received by the service inside the enclave, we
         /// // verify that the hash of the policy document returned from the Attestation Service matches the hash

--- a/sdk/core/Azure.Core/src/AsyncPageable.cs
+++ b/sdk/core/Azure.Core/src/AsyncPageable.cs
@@ -15,7 +15,7 @@ namespace Azure
     /// <typeparam name="T">The type of the values.</typeparam>
     /// <example>
     /// Example of enumerating an AsyncPageable using the <c> async foreach </c> loop:
-    /// <code snippet="Snippet:AsyncPageable">
+    /// <code snippet="Snippet:AsyncPageable" language="csharp">
     /// // call a service method, which returns AsyncPageable&lt;T&gt;
     /// AsyncPageable&lt;SecretProperties&gt; allSecretProperties = client.GetPropertiesOfSecretsAsync();
     ///
@@ -25,7 +25,7 @@ namespace Azure
     /// }
     /// </code>
     /// or using a while loop:
-    /// <code snippet="Snippet:AsyncPageableLoop">
+    /// <code snippet="Snippet:AsyncPageableLoop" language="csharp">
     /// // call a service method, which returns AsyncPageable&lt;T&gt;
     /// AsyncPageable&lt;SecretProperties&gt; allSecretProperties = client.GetPropertiesOfSecretsAsync();
     ///

--- a/sdk/core/Azure.Core/src/AzureNamedKeyCredential.cs
+++ b/sdk/core/Azure.Core/src/AzureNamedKeyCredential.cs
@@ -62,7 +62,7 @@ namespace Azure
         /// <param name="name">The name of the <paramref name="key"/>.</param>
         /// <param name="key">The key to use for authenticating with the Azure service.</param>
         /// <example>
-        /// <code snippet="Snippet:AzureNamedKeyCredential_Deconstruct">
+        /// <code snippet="Snippet:AzureNamedKeyCredential_Deconstruct" language="csharp">
         /// var credential = new AzureNamedKeyCredential(&quot;SomeName&quot;, &quot;SomeKey&quot;);
         ///
         /// (string name, string key) = credential;

--- a/sdk/core/Azure.Core/src/GeoJson/GeoLineString.cs
+++ b/sdk/core/Azure.Core/src/GeoJson/GeoLineString.cs
@@ -12,7 +12,7 @@ namespace Azure.Core.GeoJson
     /// </summary>
     /// <example>
     /// Creating a line:
-    /// <code snippet="Snippet:CreateLineString">
+    /// <code snippet="Snippet:CreateLineString" language="csharp">
     /// var line = new GeoLineString(new[]
     /// {
     ///     new GeoPosition(-122.108727, 47.649383),

--- a/sdk/core/Azure.Core/src/GeoJson/GeoPoint.cs
+++ b/sdk/core/Azure.Core/src/GeoJson/GeoPoint.cs
@@ -11,7 +11,7 @@ namespace Azure.Core.GeoJson
     /// </summary>
     /// <example>
     /// Creating a point:
-    /// <code snippet="Snippet:CreatePoint">
+    /// <code snippet="Snippet:CreatePoint" language="csharp">
     /// var point = new GeoPoint(-122.091954, 47.607148);
     /// </code>
     /// </example>

--- a/sdk/core/Azure.Core/src/GeoJson/GeoPolygon.cs
+++ b/sdk/core/Azure.Core/src/GeoJson/GeoPolygon.cs
@@ -12,7 +12,7 @@ namespace Azure.Core.GeoJson
     /// </summary>
     /// <example>
     /// Creating a polygon:
-    /// <code snippet="Snippet:CreatePolygon">
+    /// <code snippet="Snippet:CreatePolygon" language="csharp">
     /// var polygon = new GeoPolygon(new[]
     /// {
     ///     new GeoPosition(-122.108727, 47.649383),
@@ -23,7 +23,7 @@ namespace Azure.Core.GeoJson
     /// });
     /// </code>
     /// Creating a polygon with holes:
-    /// <code snippet="Snippet:CreatePolygonWithHoles">
+    /// <code snippet="Snippet:CreatePolygonWithHoles" language="csharp">
     /// var polygon = new GeoPolygon(new[]
     /// {
     ///     // Outer ring

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
@@ -117,7 +117,7 @@ namespace Azure.Core.Pipeline
         /// <returns>The <see cref="IDisposable"/> instance that needs to be disposed when client request id shouldn't be sent anymore.</returns>
         /// <example>
         /// Sample usage:
-        /// <code snippet="Snippet:ClientRequestId">
+        /// <code snippet="Snippet:ClientRequestId" language="csharp">
         /// var secretClient = new SecretClient(new Uri(&quot;http://example.com&quot;), new DefaultAzureCredential());
         ///
         /// using (HttpPipeline.CreateClientRequestIdScope(&quot;&lt;custom-client-request-id&gt;&quot;))

--- a/sdk/core/Azure.Core/src/SyncAsyncEventArgs.cs
+++ b/sdk/core/Azure.Core/src/SyncAsyncEventArgs.cs
@@ -35,7 +35,7 @@ namespace Azure
         /// how the event is being raised and implement your handler
         /// accordingly.  Here's an example handler that's safe to invoke from
         /// both sync and async code paths.
-        /// <code snippet="Snippet:Azure_Core_Samples_EventSamples_CombinedHandler">
+        /// <code snippet="Snippet:Azure_Core_Samples_EventSamples_CombinedHandler" language="csharp">
         /// var client = new AlarmClient();
         /// client.Ring += async (SyncAsyncEventArgs e) =&gt;
         /// {

--- a/sdk/core/Azure.Core/src/SyncAsyncEventHandler.cs
+++ b/sdk/core/Azure.Core/src/SyncAsyncEventHandler.cs
@@ -31,7 +31,7 @@ namespace Azure.Core
     /// of your handler returns a <see cref="Task"/>, you should write regular
     /// sync code that blocks and return <see cref="Task.CompletedTask"/> when
     /// finished.
-    /// <code snippet="Snippet:Azure_Core_Samples_EventSamples_SyncHandler">
+    /// <code snippet="Snippet:Azure_Core_Samples_EventSamples_SyncHandler" language="csharp">
     /// var client = new AlarmClient();
     /// client.Ring += (SyncAsyncEventArgs e) =&gt;
     /// {
@@ -58,7 +58,7 @@ namespace Azure.Core
     /// If you're using the asynchronous, non-blocking methods of a client
     /// (i.e., methods with an Async suffix), they will raise events that
     /// expect handlers to execute asynchronously.
-    /// <code snippet="Snippet:Azure_Core_Samples_EventSamples_AsyncHandler">
+    /// <code snippet="Snippet:Azure_Core_Samples_EventSamples_AsyncHandler" language="csharp">
     /// var client = new AlarmClient();
     /// client.Ring += async (SyncAsyncEventArgs e) =&gt;
     /// {
@@ -78,7 +78,7 @@ namespace Azure.Core
     /// property to check how the event is being raised and implement your
     /// handler accordingly.  Here's an example handler that's safe to invoke
     /// from both sync and async code paths.
-    /// <code snippet="Snippet:Azure_Core_Samples_EventSamples_CombinedHandler">
+    /// <code snippet="Snippet:Azure_Core_Samples_EventSamples_CombinedHandler" language="csharp">
     /// var client = new AlarmClient();
     /// client.Ring += async (SyncAsyncEventArgs e) =&gt;
     /// {
@@ -110,7 +110,7 @@ namespace Azure.Core
     /// <see cref="AggregateException.Flatten"/> and
     /// <see cref="AggregateException.Handle(Func{Exception, bool})"/> to make
     /// complex failures easier to work with.
-    /// <code snippet="Snippet:Azure_Core_Samples_EventSamples_Exceptions">
+    /// <code snippet="Snippet:Azure_Core_Samples_EventSamples_Exceptions" language="csharp">
     /// var client = new AlarmClient();
     /// client.Ring += (SyncAsyncEventArgs e) =&gt;
     ///     throw new InvalidOperationException(&quot;Alarm unplugged.&quot;);

--- a/sdk/identity/Azure.Identity/src/ChainedTokenCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ChainedTokenCredential.cs
@@ -20,7 +20,7 @@ namespace Azure.Identity
     /// The following example demonstrates creating a credential which will attempt to authenticate using managed identity, and fall back to Azure CLI for authentication
     /// if a managed identity is unavailable in the current environment.
     /// </para>
-    /// <code snippet="Snippet:CustomChainedTokenCredential">
+    /// <code snippet="Snippet:CustomChainedTokenCredential" language="csharp">
     /// // Authenticate using managed identity if it is available; otherwise use the Azure CLI to authenticate.
     ///
     /// var credential = new ChainedTokenCredential(new ManagedIdentityCredential(), new AzureCliCredential());

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -36,7 +36,7 @@ namespace Azure.Identity
     /// This example demonstrates authenticating the BlobClient from the Azure.Storage.Blobs client library using the DefaultAzureCredential,
     /// deployed to an Azure resource with a user assigned managed identity configured.
     /// </para>
-    /// <code snippet="Snippet:UserAssignedManagedIdentity">
+    /// <code snippet="Snippet:UserAssignedManagedIdentity" language="csharp">
     /// // When deployed to an azure host, the default azure credential will authenticate the specified user assigned managed identity.
     ///
     /// string userAssignedClientId = &quot;&lt;your managed identity client Id&gt;&quot;;

--- a/sdk/iot/Azure.IoT.Hub.Service/src/DevicesClient.cs
+++ b/sdk/iot/Azure.IoT.Hub.Service/src/DevicesClient.cs
@@ -57,12 +57,12 @@ namespace Azure.IoT.Hub.Service
         /// </param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The created device identity and the http response <see cref="Response{T}"/>.</returns>
-        /// <code snippet="Snippet:IotHubCreateDeviceIdentity">
+        /// <code snippet="Snippet:IotHubCreateDeviceIdentity" language="csharp">
         /// Response&lt;DeviceIdentity&gt; response = await IoTHubServiceClient.Devices.CreateOrUpdateIdentityAsync(deviceIdentity);
         ///
         /// SampleLogger.PrintSuccess($&quot;Successfully create a new device identity with Id: &apos;{response.Value.DeviceId}&apos;, ETag: &apos;{response.Value.Etag}&apos;&quot;);
         /// </code>
-        /// <code snippet="Snippet:IotHubUpdateDeviceIdentity">
+        /// <code snippet="Snippet:IotHubUpdateDeviceIdentity" language="csharp">
         /// Response&lt;DeviceIdentity&gt; getResponse = await IoTHubServiceClient.Devices.GetIdentityAsync(deviceId);
         ///
         /// DeviceIdentity deviceIdentity = getResponse.Value;
@@ -113,7 +113,7 @@ namespace Azure.IoT.Hub.Service
         /// <param name="deviceId">The unique identifier of the device identity to get.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The retrieved device identity and the http response <see cref="Response{T}"/>.</returns>
-        /// <code snippet="Snippet:IotHubGetDeviceIdentity">
+        /// <code snippet="Snippet:IotHubGetDeviceIdentity" language="csharp">
         /// Response&lt;DeviceIdentity&gt; response = await IoTHubServiceClient.Devices.GetIdentityAsync(deviceId);
         ///
         /// DeviceIdentity deviceIdentity = response.Value;
@@ -143,7 +143,7 @@ namespace Azure.IoT.Hub.Service
         /// <param name="precondition">The condition on which to delete the device.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The http response <see cref="Response{T}"/>.</returns>
-        /// <code snippet="Snippet:IotHubDeleteDeviceIdentity">
+        /// <code snippet="Snippet:IotHubDeleteDeviceIdentity" language="csharp">
         /// Response response = await IoTHubServiceClient.Devices.DeleteIdentityAsync(deviceIdentity);
         ///
         /// SampleLogger.PrintSuccess($&quot;Successfully deleted device identity with Id: &apos;{deviceIdentity.DeviceId}&apos;&quot;);
@@ -421,7 +421,7 @@ namespace Azure.IoT.Hub.Service
         /// <param name="deviceId">The unique identifier of the device identity to get the twin of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The device's twin, including reported properties and desired properties and the http response <see cref="Response{T}"/>.</returns>
-        /// <code snippet="Snippet:IotHubGetDeviceTwin">
+        /// <code snippet="Snippet:IotHubGetDeviceTwin" language="csharp">
         /// Response&lt;TwinData&gt; response = await IoTHubServiceClient.Devices.GetTwinAsync(deviceId);
         ///
         /// SampleLogger.PrintSuccess($&quot;\t- Device Twin: DeviceId: &apos;{response.Value.DeviceId}&apos;, Status: &apos;{response.Value.Status}&apos;, ETag: &apos;{response.Value.Etag}&apos;&quot;);
@@ -449,7 +449,7 @@ namespace Azure.IoT.Hub.Service
         /// <param name="precondition">The condition for which this operation will execute.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The new representation of the device twin and the http response <see cref="Response{T}"/>.</returns>
-        /// <code snippet="Snippet:IotHubUpdateDeviceTwin">
+        /// <code snippet="Snippet:IotHubUpdateDeviceTwin" language="csharp">
         /// Response&lt;TwinData&gt; getResponse = await IoTHubServiceClient.Devices.GetTwinAsync(deviceId);
         /// TwinData deviceTwin = getResponse.Value;
         ///

--- a/sdk/iot/Azure.IoT.Hub.Service/src/IotHubServiceClient.cs
+++ b/sdk/iot/Azure.IoT.Hub.Service/src/IotHubServiceClient.cs
@@ -123,7 +123,7 @@ namespace Azure.IoT.Hub.Service
         /// <param name="options">
         /// (optional) Options that allow configuration of requests sent to the IoT Hub service.
         /// </param>
-        /// <code snippet="Snippet:IotHubServiceClientInitializeWithIotHubSasCredential">
+        /// <code snippet="Snippet:IotHubServiceClientInitializeWithIotHubSasCredential" language="csharp">
         /// // Create an IotHubSasCredential type to use sas tokens to authenticate against your IoT Hub instance.
         /// // The default lifespan of the sas token is 30 minutes, and it is set to be renewed when at 15% or less of its lifespan.
         /// var credential = new IotHubSasCredential(options.IotHubSharedAccessPolicy, options.IotHubSharedAccessKey);

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatePolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatePolicy.cs
@@ -127,7 +127,7 @@ namespace Azure.Security.KeyVault.Certificates
         /// Use this constructor if, for example, you want to import a PEM-encoded certificate. The <see cref="IssuerName"/> will be
         /// <see cref="WellKnownIssuerNames.Unknown"/> and the <see cref="Subject"/> and <see cref="SubjectAlternativeNames"/> will
         /// be parsed from the imported certificate.
-        /// <code snippet="Snippet:CertificateClientLiveTests_VerifyImportCertificatePem">
+        /// <code snippet="Snippet:CertificateClientLiveTests_VerifyImportCertificatePem" language="csharp">
         /// byte[] certificateBytes = File.ReadAllBytes(&quot;certificate.pem&quot;);
         ///
         /// ImportCertificateOptions options = new ImportCertificateOptions(certificateName, certificateBytes)

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/README.md
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/README.md
@@ -44,7 +44,7 @@ Once you have the Azure resource credentials and the Event Hubs namespace hostna
 ```C# Snippet:SchemaRegistryCreateSchemaRegistryClient
 // Create a new SchemaRegistry client using the default credential from Azure.Identity using environment variables previously set,
 // including AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID.
-// For more information on Azure.Identity usage, see: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
+// For more information on Azure.Identity usage, see: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/identity/Azure.Identity/README.md
 var client = new SchemaRegistryClient(endpoint: endpoint, credential: new DefaultAzureCredential());
 ```
 

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/README.md
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/README.md
@@ -44,7 +44,7 @@ Once you have the Azure resource credentials and the Event Hubs namespace hostna
 ```C# Snippet:SchemaRegistryCreateSchemaRegistryClient
 // Create a new SchemaRegistry client using the default credential from Azure.Identity using environment variables previously set,
 // including AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID.
-// For more information on Azure.Identity usage, see: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/identity/Azure.Identity/README.md
+// For more information on Azure.Identity usage, see: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 var client = new SchemaRegistryClient(endpoint: endpoint, credential: new DefaultAzureCredential());
 ```
 

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
@@ -44,7 +44,7 @@ Once you have the Azure resource credentials and the Event Hubs namespace hostna
 ```C# Snippet:SchemaRegistryAvroCreateSchemaRegistryClient
 // Create a new SchemaRegistry client using the default credential from Azure.Identity using environment variables previously set,
 // including AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID.
-// For more information on Azure.Identity usage, see: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/identity/Azure.Identity/README.md
+// For more information on Azure.Identity usage, see: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 var schemaRegistryClient = new SchemaRegistryClient(endpoint: endpoint, credential: new DefaultAzureCredential());
 ```
 

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
@@ -44,7 +44,7 @@ Once you have the Azure resource credentials and the Event Hubs namespace hostna
 ```C# Snippet:SchemaRegistryAvroCreateSchemaRegistryClient
 // Create a new SchemaRegistry client using the default credential from Azure.Identity using environment variables previously set,
 // including AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID.
-// For more information on Azure.Identity usage, see: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
+// For more information on Azure.Identity usage, see: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/identity/Azure.Identity/README.md
 var schemaRegistryClient = new SchemaRegistryClient(endpoint: endpoint, credential: new DefaultAzureCredential());
 ```
 

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/SearchIndex.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/SearchIndex.cs
@@ -76,7 +76,7 @@ namespace Azure.Search.Documents.Indexes.Models
         /// </summary>
         /// <example>
         /// You can create fields from a model class using <see cref="FieldBuilder"/>:
-        /// <code snippet="Snippet:Azure_Search_Tests_Samples_Readme_CreateIndex_New_SearchIndex">
+        /// <code snippet="Snippet:Azure_Search_Tests_Samples_Readme_CreateIndex_New_SearchIndex" language="csharp">
         /// SearchIndex index = new SearchIndex(&quot;hotels&quot;)
         /// {
         ///     Fields = new FieldBuilder().Build(typeof(Hotel)),
@@ -89,7 +89,7 @@ namespace Azure.Search.Documents.Indexes.Models
         /// </code>
         /// For this reason, <see cref="Fields"/> is settable. In scenarios when the model is not known or cannot be modified, you can
         /// also create fields manually using helper classes:
-        /// <code snippet="Snippet:Azure_Search_Tests_Samples_Readme_CreateManualIndex_New_SearchIndex">
+        /// <code snippet="Snippet:Azure_Search_Tests_Samples_Readme_CreateManualIndex_New_SearchIndex" language="csharp">
         /// SearchIndex index = new SearchIndex(&quot;hotels&quot;)
         /// {
         ///     Fields =

--- a/sdk/storage/Azure.Storage.Common/src/StorageExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageExtensions.cs
@@ -29,7 +29,7 @@ namespace Azure.Storage
         /// <returns>The <see cref="IDisposable"/> instance that needs to be disposed when server timeout shouldn't be used anymore.</returns>
         /// <example>
         /// Sample usage:
-        /// <code snippet="Snippet:Sample_StorageServerTimeout">
+        /// <code snippet="Snippet:Sample_StorageServerTimeout" language="csharp">
         /// BlobServiceClient client = new BlobServiceClient(connectionString, options);
         /// using (StorageExtensions.CreateServiceTimeoutScope(TimeSpan.FromSeconds(10)))
         /// {

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
@@ -149,7 +149,7 @@ namespace Azure.Storage.Queues
         /// <para>The handler is potentially invoked by both synchronous and asynchronous receive and peek APIs. Therefore implementation of the handler should align with
         /// <see cref="QueueClient"/> APIs that are being used.
         /// See <see cref="SyncAsyncEventHandler{T}"/> about how to implement handler correctly. The example below shows a handler with all possible cases explored.
-        /// <code snippet="Snippet:Azure_Storage_Queues_Samples_Sample03_MessageEncoding_MessageDecodingFailedHandlerAsync">
+        /// <code snippet="Snippet:Azure_Storage_Queues_Samples_Sample03_MessageEncoding_MessageDecodingFailedHandlerAsync" language="csharp">
         /// QueueClientOptions queueClientOptions = new QueueClientOptions()
         /// {
         ///     MessageEncoding = QueueMessageEncoding.Base64

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsClient.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsClient.cs
@@ -84,7 +84,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// and controlling <see href="https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/samples/Configuration.md">retry strategy</see>.
         /// </seealso>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleCreateServiceClientWithClientSecret">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleCreateServiceClientWithClientSecret" language="csharp">
         /// // DefaultAzureCredential supports different authentication mechanisms and determines the appropriate credential type based on the environment it is executing in.
         /// // It attempts to use multiple credential types in an order until it finds a working credential.
         /// var tokenCredential = new DefaultAzureCredential();

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsHierarchies.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsHierarchies.cs
@@ -41,7 +41,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The pageable list <see cref="AsyncPageable{TimeSeriesHierarchy}"/> of Time Series hierarchies with the http response.</returns>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleGetAllHierarchies">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleGetAllHierarchies" language="csharp">
         /// // Get all Time Series hierarchies in the environment
         /// AsyncPageable&lt;TimeSeriesHierarchy&gt; getAllHierarchies = hierarchiesClient.GetAsync();
         /// await foreach (TimeSeriesHierarchy hierarchy in getAllHierarchies)
@@ -285,7 +285,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// The exception is thrown when <paramref name="timeSeriesHierarchyIds"/> is empty.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleGetHierarchiesById">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleGetHierarchiesById" language="csharp">
         /// var tsiHierarchyIds = new List&lt;string&gt;
         /// {
         ///     &quot;sampleHierarchyId&quot;
@@ -413,7 +413,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// The exception is thrown when <paramref name="timeSeriesHierarchies"/> is empty.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleCreateHierarchies">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleCreateHierarchies" language="csharp">
         /// TimeSeriesInsightsHierarchies hierarchiesClient = client.GetHierarchiesClient();
         ///
         /// var hierarchySource = new TimeSeriesHierarchySource();
@@ -651,7 +651,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// The exception is thrown when <paramref name="timeSeriesHierarchyIds"/> is empty.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleDeleteHierarchiesById">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleDeleteHierarchiesById" language="csharp">
         /// // Delete Time Series hierarchies with Ids
         /// var tsiHierarchyIdsToDelete = new List&lt;string&gt;
         /// {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsInstances.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsInstances.cs
@@ -44,7 +44,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples">our repo samples</see>.
         /// </remarks>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsGetAllInstances">
+        /// <code snippet="Snippet:TimeSeriesInsightsGetAllInstances" language="csharp">
         /// // Get all instances for the Time Series Insights environment
         /// AsyncPageable&lt;TimeSeriesInstance&gt; tsiInstances = instancesClient.GetAsync();
         /// await foreach (TimeSeriesInstance tsiInstance in tsiInstances)
@@ -281,7 +281,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples">our repo samples</see>.
         /// </remarks>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsGetnstancesById">
+        /// <code snippet="Snippet:TimeSeriesInsightsGetnstancesById" language="csharp">
         /// // Get Time Series Insights instances by Id
         /// // tsId is created above using `TimeSeriesIdHelper.CreateTimeSeriesId`.
         /// var timeSeriesIds = new List&lt;TimeSeriesId&gt;
@@ -413,7 +413,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples">our repo samples</see>.
         /// </remarks>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleCreateInstance">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleCreateInstance" language="csharp">
         /// // Create a Time Series Instance object with the default Time Series Insights type Id.
         /// // The default type Id can be obtained programmatically by using the ModelSettings client.
         /// // tsId is created above using `TimeSeriesIdHelper.CreateTimeSeriesId`.
@@ -557,7 +557,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples">our repo samples</see>.
         /// </remarks>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsReplaceInstance">
+        /// <code snippet="Snippet:TimeSeriesInsightsReplaceInstance" language="csharp">
         /// // Get Time Series Insights instances by Id
         /// // tsId is created above using `TimeSeriesIdHelper.CreateTimeSeriesId`.
         /// var instanceIdsToGet = new List&lt;TimeSeriesId&gt;
@@ -699,7 +699,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples">our repo samples</see>.
         /// </remarks>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleDeleteInstanceById">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleDeleteInstanceById" language="csharp">
         /// // tsId is created above using `TimeSeriesIdHelper.CreateTimeSeriesId`.
         /// var instancesToDelete = new List&lt;TimeSeriesId&gt;
         /// {

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsModelSettings.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsModelSettings.cs
@@ -42,7 +42,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// http response <see cref="Response{TimeSeriesModelSettings}"/>.
         /// </returns>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleGetModelSettings">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleGetModelSettings" language="csharp">
         /// TimeSeriesInsightsModelSettings modelSettingsClient = client.GetModelSettingsClient();
         /// TimeSeriesInsightsTypes typesClient = client.GetTypesClient();
         /// Response&lt;TimeSeriesModelSettings&gt; getModelSettingsResponse = await modelSettingsClient.GetAsync();
@@ -105,7 +105,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleUpdateModelSettingsName">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleUpdateModelSettingsName" language="csharp">
         /// Response&lt;TimeSeriesModelSettings&gt; updateModelSettingsNameResponse = await modelSettingsClient.UpdateNameAsync(&quot;NewModelSettingsName&quot;);
         /// Console.WriteLine($&quot;Updated Time Series Insights model settings name: &quot; +
         ///     $&quot;{updateModelSettingsNameResponse.Value.Name}&quot;);
@@ -162,7 +162,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The updated model settings with the http response <see cref="Response{TimeSeriesModelSettings}"/>.</returns>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleUpdateModelSettingsDefaultType">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleUpdateModelSettingsDefaultType" language="csharp">
         /// Response&lt;TimeSeriesModelSettings&gt; updateDefaultTypeIdResponse = await modelSettingsClient
         ///     .UpdateDefaultTypeIdAsync(tsiTypeId);
         /// Console.WriteLine($&quot;Updated Time Series Insights model settings default type Id: &quot; +

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsQueries.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsQueries.cs
@@ -42,7 +42,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="TimeSeriesQueryAnalyzer"/> object that can be used to retrieve the pageable list <see cref="AsyncPageable{TimeSeriesPoint}"/>.</returns>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleQueryEvents">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleQueryEvents" language="csharp">
         /// Console.WriteLine(&quot;\n\nQuery for raw temperature events over the past 10 minutes.\n&quot;);
         ///
         /// // Get events from last 10 minute
@@ -112,7 +112,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="TimeSeriesQueryAnalyzer"/> object that can be used to retrieve the pageable list <see cref="AsyncPageable{TimeSeriesPoint}"/>.</returns>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleQueryEventsUsingTimeSpan">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleQueryEventsUsingTimeSpan" language="csharp">
         /// Console.WriteLine(&quot;\n\nQuery for raw humidity events over the past 30 seconds.\n&quot;);
         ///
         /// TimeSeriesQueryAnalyzer humidityEventsQuery = queriesClient.CreateEventsQuery(tsId, TimeSpan.FromSeconds(30));
@@ -180,7 +180,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="TimeSeriesQueryAnalyzer"/> object that can be used to retrieve the pageable list <see cref="AsyncPageable{TimeSeriesPoint}"/>.</returns>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleQuerySeries">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleQuerySeries" language="csharp">
         /// Console.WriteLine($&quot;\n\nQuery for temperature series in Celsius and Fahrenheit over the past 10 minutes. &quot; +
         ///     $&quot;The Time Series instance belongs to a type that has predefined numeric variable that represents the temperature &quot; +
         ///     $&quot;in Celsuis, and a predefined numeric variable that represents the temperature in Fahrenheit.\n&quot;);
@@ -241,7 +241,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="TimeSeriesQueryAnalyzer"/> object that can be used to retrieve the pageable list <see cref="AsyncPageable{TimeSeriesPoint}"/>.</returns>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleQuerySeriesWithInlineVariables">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleQuerySeriesWithInlineVariables" language="csharp">
         /// Console.WriteLine(&quot;\n\nQuery for temperature series in Celsius and Fahrenheit over the past 10 minutes.\n&quot;);
         ///
         /// var celsiusVariable = new NumericVariable(
@@ -312,7 +312,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="TimeSeriesQueryAnalyzer"/> object that can be used to retrieve the pageable list <see cref="AsyncPageable{TimeSeriesPoint}"/>.</returns>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleQueryAggregateSeriesWithAggregateVariable">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleQueryAggregateSeriesWithAggregateVariable" language="csharp">
         /// Console.WriteLine(&quot;\n\nCount the number of temperature events over the past 3 minutes, in 1-minute time slots.\n&quot;);
         ///
         /// // Get the count of events in 60-second time slots over the past 3 minutes
@@ -383,7 +383,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="TimeSeriesQueryAnalyzer"/> object that can be used to retrieve the pageable list <see cref="AsyncPageable{TimeSeriesPoint}"/>.</returns>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleQueryAggregateSeriesWithNumericVariable">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleQueryAggregateSeriesWithNumericVariable" language="csharp">
         /// Console.WriteLine(&quot;\n\nQuery for the average temperature over the past 30 seconds, in 2-second time slots.\n&quot;);
         ///
         /// var numericVariable = new NumericVariable(

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsTypes.cs
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/TimeSeriesInsightsTypes.cs
@@ -41,7 +41,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The pageable list <see cref="AsyncPageable{TimeSeriesType}"/> of Time Series types with the http response.</returns>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleGetAllTypes">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleGetAllTypes" language="csharp">
         /// // Get all Time Series types in the environment
         /// AsyncPageable&lt;TimeSeriesType&gt; getAllTypesResponse = typesClient.GetTypesAsync();
         ///
@@ -286,7 +286,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// The exception is thrown when <paramref name="timeSeriesTypeIds"/> is empty.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleGetTypeById">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleGetTypeById" language="csharp">
         /// // Code snippet below shows getting a default Type using Id
         /// // The default type Id can be obtained programmatically by using the ModelSettings client.
         ///
@@ -414,7 +414,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// The exception is thrown when <paramref name="timeSeriesTypes"/> is empty.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleCreateType">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleCreateType" language="csharp">
         /// TimeSeriesInsightsTypes typesClient = client.GetTypesClient();
         ///
         /// // Create a type with an aggregate variable
@@ -649,7 +649,7 @@ namespace Azure.IoT.TimeSeriesInsights
         /// The exception is thrown when <paramref name="timeSeriesTypeIds"/> is empty.
         /// </exception>
         /// <example>
-        /// <code snippet="Snippet:TimeSeriesInsightsSampleDeleteTypeById">
+        /// <code snippet="Snippet:TimeSeriesInsightsSampleDeleteTypeById" language="csharp">
         /// // Delete Time Series types with Ids
         ///
         /// var typesIdsToDelete = new List&lt;string&gt; { &quot;Type1Id&quot;, &quot; Type2Id&quot; };


### PR DESCRIPTION
This change adds the `language="csharp"` property to the `<code>` xml tag and also makes it possible to error on unused snippets.

For unused snippet validation, there is a new switch added to `Update-Snippets.ps1` called `-StrictMode`. Usage is as follows:

The default behavior is to print the names of unused snippets, but not to thow:

```
 .\eng\scripts\Update-Snippets.ps1 tables
Discovered snippets:
<...>

Not all snippets were used.
Snippet:TablesSample1CreateTableAsync
Snippet:TablesSample1DeleteTableAsync
<...>
Snippet:TablesSample5UpsertWithReplace
Snippet:TablesSample5UpdateEntity
SnippetGenerator completed in 00:00:00.5049468
```

With the StrictMode switch, it looks like this:

```
 .\eng\scripts\Update-Snippets.ps1 tables -StrictMode
Discovered snippets:
<...>

System.InvalidOperationException: Not all snippets were used.
Snippet:TablesSample1CreateTableAsync
Snippet:TablesSample1DeleteTableAsync
<...>
Snippet:TablesSample5UpsertWithReplace
Snippet:TablesSample5UpdateEntity
SnippetGenerator completed in 00:00:00.5049468
```

created the following issues to track remediation of unused snippets https://github.com/Azure/azure-sdk-for-net/search?q=Remove+unused+snippets&type=issues