### PR TITLE
[TA] Move action name to TextAnalyticsActionResult

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -92,7 +92,6 @@ namespace Azure.AI.TextAnalytics
     public partial class AnalyzeSentimentActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal AnalyzeSentimentActionResult() { }
-        public string ActionName { get { throw null; } }
         public Azure.AI.TextAnalytics.AnalyzeSentimentResultCollection DocumentsResults { get { throw null; } }
     }
     public partial class AnalyzeSentimentOptions : Azure.AI.TextAnalytics.TextAnalyticsRequestOptions
@@ -240,7 +239,6 @@ namespace Azure.AI.TextAnalytics
     public partial class ExtractKeyPhrasesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal ExtractKeyPhrasesActionResult() { }
-        public string ActionName { get { throw null; } }
         public Azure.AI.TextAnalytics.ExtractKeyPhrasesResultCollection DocumentsResults { get { throw null; } }
     }
     public partial class ExtractKeyPhrasesResult : Azure.AI.TextAnalytics.TextAnalyticsResult
@@ -622,7 +620,6 @@ namespace Azure.AI.TextAnalytics
     public partial class RecognizeEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal RecognizeEntitiesActionResult() { }
-        public string ActionName { get { throw null; } }
         public Azure.AI.TextAnalytics.RecognizeEntitiesResultCollection DocumentsResults { get { throw null; } }
     }
     public partial class RecognizeEntitiesResult : Azure.AI.TextAnalytics.TextAnalyticsResult
@@ -647,7 +644,6 @@ namespace Azure.AI.TextAnalytics
     public partial class RecognizeLinkedEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal RecognizeLinkedEntitiesActionResult() { }
-        public string ActionName { get { throw null; } }
         public Azure.AI.TextAnalytics.RecognizeLinkedEntitiesResultCollection DocumentsResults { get { throw null; } }
     }
     public partial class RecognizeLinkedEntitiesResult : Azure.AI.TextAnalytics.TextAnalyticsResult
@@ -674,7 +670,6 @@ namespace Azure.AI.TextAnalytics
     public partial class RecognizePiiEntitiesActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
         internal RecognizePiiEntitiesActionResult() { }
-        public string ActionName { get { throw null; } }
         public Azure.AI.TextAnalytics.RecognizePiiEntitiesResultCollection DocumentsResults { get { throw null; } }
     }
     public partial class RecognizePiiEntitiesOptions : Azure.AI.TextAnalytics.TextAnalyticsRequestOptions
@@ -735,6 +730,7 @@ namespace Azure.AI.TextAnalytics
     public partial class TextAnalyticsActionResult
     {
         internal TextAnalyticsActionResult() { }
+        public string ActionName { get { throw null; } }
         public System.DateTimeOffset CompletedOn { get { throw null; } }
         public Azure.AI.TextAnalytics.TextAnalyticsError Error { get { throw null; } }
         public bool HasError { get { throw null; } }
@@ -937,8 +933,6 @@ namespace Azure.AI.TextAnalytics
         public static Azure.AI.TextAnalytics.SentenceSentiment SentenceSentiment(Azure.AI.TextAnalytics.TextSentiment sentiment, string text, double positiveScore, double neutralScore, double negativeScore, int offset, int length, System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.SentenceOpinion> opinions) { throw null; }
         public static Azure.AI.TextAnalytics.SentimentConfidenceScores SentimentConfidenceScores(double positiveScore, double neutralScore, double negativeScore) { throw null; }
         public static Azure.AI.TextAnalytics.TargetSentiment TargetSentiment(Azure.AI.TextAnalytics.TextSentiment sentiment, string text, double positiveScore, double negativeScore, int offset, int length) { throw null; }
-        public static Azure.AI.TextAnalytics.TextAnalyticsActionResult TextAnalyticsActionResult(System.DateTimeOffset completedOn) { throw null; }
-        public static Azure.AI.TextAnalytics.TextAnalyticsActionResult TextAnalyticsActionResult(System.DateTimeOffset completedOn, string code, string message) { throw null; }
         public static Azure.AI.TextAnalytics.TextAnalyticsError TextAnalyticsError(string code, string message, string target = null) { throw null; }
         public static Azure.AI.TextAnalytics.TextAnalyticsWarning TextAnalyticsWarning(string code, string message) { throw null; }
         public static Azure.AI.TextAnalytics.TextDocumentBatchStatistics TextDocumentBatchStatistics(int documentCount, int validDocumentCount, int invalidDocumentCount, long transactionCount) { throw null; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentActionResult.cs
@@ -17,20 +17,16 @@ namespace Azure.AI.TextAnalytics
         /// Successful action.
         /// </summary>
         internal AnalyzeSentimentActionResult(AnalyzeSentimentResultCollection result, string actionName, DateTimeOffset completedOn)
-            : base(completedOn)
+            : base(completedOn, actionName)
         {
             _documentsResults = result;
-            ActionName = actionName;
         }
 
         /// <summary>
         /// Action with an error.
         /// </summary>
         internal AnalyzeSentimentActionResult(string actionName, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
-            : base(completedOn, error)
-        {
-            ActionName = actionName;
-        }
+            : base(completedOn, actionName, error) { }
 
         /// <summary>
         /// Gets the result of the execution of an <see cref="AnalyzeSentimentAction"/> per each input document.
@@ -46,10 +42,5 @@ namespace Azure.AI.TextAnalytics
                 return _documentsResults;
             }
         }
-
-        /// <summary>
-        /// Gets the name for this action.
-        /// </summary>
-        public string ActionName { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesActionResult.cs
@@ -17,20 +17,16 @@ namespace Azure.AI.TextAnalytics
         /// Successful action.
         /// </summary>
         internal ExtractKeyPhrasesActionResult(ExtractKeyPhrasesResultCollection result, string actionName, DateTimeOffset completedOn)
-            : base(completedOn)
+            : base(completedOn, actionName)
         {
             _documentsResults = result;
-            ActionName = actionName;
         }
 
         /// <summary>
         /// Action with an error.
         /// </summary>
         internal ExtractKeyPhrasesActionResult(string actionName, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
-            : base(completedOn, error)
-        {
-            ActionName = actionName;
-        }
+            : base(completedOn, actionName, error) { }
 
         /// <summary>
         /// Gets the result of the execution of an <see cref="ExtractKeyPhrasesAction"/> per each input document.
@@ -48,10 +44,5 @@ namespace Azure.AI.TextAnalytics
                 return _documentsResults;
             }
         }
-
-        /// <summary>
-        /// Gets the name for this action.
-        /// </summary>
-        public string ActionName { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesActionResult.cs
@@ -17,20 +17,16 @@ namespace Azure.AI.TextAnalytics
         /// Successful action.
         /// </summary>
         internal RecognizeEntitiesActionResult(RecognizeEntitiesResultCollection result, string actionName, DateTimeOffset completedOn)
-            : base(completedOn)
+            : base(completedOn, actionName)
         {
             _documentsResults = result;
-            ActionName = actionName;
         }
 
         /// <summary>
         /// Action with an error.
         /// </summary>
         internal RecognizeEntitiesActionResult(string actionName, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
-            : base(completedOn, error)
-        {
-            ActionName = actionName;
-        }
+            : base(completedOn, actionName, error) { }
 
         /// <summary>
         /// Gets the result of the execution of a <see cref="RecognizeEntitiesAction"/> per each input document.
@@ -48,10 +44,5 @@ namespace Azure.AI.TextAnalytics
                 return _documentsResults;
             }
         }
-
-        /// <summary>
-        /// Gets the name for this action.
-        /// </summary>
-        public string ActionName { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesActionResult.cs
@@ -17,20 +17,16 @@ namespace Azure.AI.TextAnalytics
         /// Successful action.
         /// </summary>
         internal RecognizeLinkedEntitiesActionResult(RecognizeLinkedEntitiesResultCollection result, string actionName, DateTimeOffset completedOn)
-            : base(completedOn)
+            : base(completedOn, actionName)
         {
             _documentsResults = result;
-            ActionName = actionName;
         }
 
         /// <summary>
         /// Action with an error.
         /// </summary>
         internal RecognizeLinkedEntitiesActionResult(string actionName, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
-            : base(completedOn, error)
-        {
-            ActionName = actionName;
-        }
+            : base(completedOn, actionName, error) { }
 
         /// <summary>
         /// Gets the result of the execution of a <see cref="RecognizeLinkedEntitiesAction"/> per each input document.
@@ -48,10 +44,5 @@ namespace Azure.AI.TextAnalytics
                 return _documentsResults;
             }
         }
-
-        /// <summary>
-        /// Gets the name for this action.
-        /// </summary>
-        public string ActionName { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesActionResult.cs
@@ -17,20 +17,16 @@ namespace Azure.AI.TextAnalytics
         /// Successful action.
         /// </summary>
         internal RecognizePiiEntitiesActionResult(RecognizePiiEntitiesResultCollection result, string actionName, DateTimeOffset completedOn)
-            : base(completedOn)
+            : base(completedOn, actionName)
         {
             _documentsResults = result;
-            ActionName = actionName;
         }
 
         /// <summary>
         /// Action with an error.
         /// </summary>
         internal RecognizePiiEntitiesActionResult(string actionName, DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
-            : base(completedOn, error)
-        {
-            ActionName = actionName;
-        }
+            : base(completedOn, actionName, error) { }
 
         /// <summary>
         /// Gets the result of the execution of a <see cref="RecognizePiiEntitiesAction"/> per each input document.
@@ -48,10 +44,5 @@ namespace Azure.AI.TextAnalytics
                 return _documentsResults;
             }
         }
-
-        /// <summary>
-        /// Gets the name for this action.
-        /// </summary>
-        public string ActionName { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActionResult.cs
@@ -11,21 +11,28 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class TextAnalyticsActionResult
     {
-        internal TextAnalyticsActionResult (DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
+        internal TextAnalyticsActionResult (DateTimeOffset completedOn, string actionName, TextAnalyticsErrorInternal error)
         {
             CompletedOn = completedOn;
+            ActionName = actionName;
             Error = error != null ? Transforms.ConvertToError(error) : default;
         }
 
-        internal TextAnalyticsActionResult(DateTimeOffset completedOn)
+        internal TextAnalyticsActionResult(DateTimeOffset completedOn, string actionName)
         {
             CompletedOn = completedOn;
+            ActionName = actionName;
         }
 
         /// <summary>
         /// Indicates the time at which the action was last updated on.
         /// </summary>
         public DateTimeOffset CompletedOn { get; }
+
+        /// <summary>
+        /// Gets the name for this action.
+        /// </summary>
+        public string ActionName { get; }
 
         /// <summary>
         /// Determines the TextAnalyticsError object for an action result.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
@@ -615,7 +615,7 @@ namespace Azure.AI.TextAnalytics
         /// Initializes a new instance of <see cref="TextAnalytics.ExtractKeyPhrasesActionResult"/> for mocking purposes.
         /// </summary>
         /// <param name="result">Sets the <see cref="ExtractKeyPhrasesActionResult.DocumentsResults"/> property.</param>
-        /// <param name="actionName">Sets the <see cref="ExtractKeyPhrasesActionResult.ActionName"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="TextAnalyticsActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.ExtractKeyPhrasesActionResult"/> for mocking purposes.</returns>
         public static ExtractKeyPhrasesActionResult ExtractKeyPhrasesActionResult(
@@ -629,7 +629,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.ExtractKeyPhrasesActionResult"/> for mocking purposes.
         /// </summary>
-        /// <param name="actionName">Sets the <see cref="ExtractKeyPhrasesActionResult.ActionName"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="TextAnalyticsActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
         /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
@@ -647,7 +647,7 @@ namespace Azure.AI.TextAnalytics
         /// Initializes a new instance of <see cref="TextAnalytics.AnalyzeSentimentActionResult"/> for mocking purposes.
         /// </summary>
         /// <param name="result">Sets the <see cref="AnalyzeSentimentActionResult.DocumentsResults"/> property.</param>
-        /// <param name="actionName">Sets the <see cref="AnalyzeSentimentActionResult.ActionName"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="TextAnalyticsActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.AnalyzeSentimentActionResult"/> for mocking purposes.</returns>
         public static AnalyzeSentimentActionResult AnalyzeSentimentActionResult(
@@ -661,7 +661,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.AnalyzeSentimentActionResult"/> for mocking purposes.
         /// </summary>
-        /// <param name="actionName">Sets the <see cref="AnalyzeSentimentActionResult.ActionName"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="TextAnalyticsActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
         /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
@@ -676,36 +676,10 @@ namespace Azure.AI.TextAnalytics
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="TextAnalytics.TextAnalyticsActionResult"/> for mocking purposes.
-        /// </summary>
-        /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
-        /// <returns>A new instance of <see cref="TextAnalytics.TextAnalyticsActionResult"/> for mocking purposes.</returns>
-        public static TextAnalyticsActionResult TextAnalyticsActionResult(
-            DateTimeOffset completedOn)
-        {
-            return new TextAnalyticsActionResult(completedOn);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="TextAnalytics.TextAnalyticsActionResult"/> for mocking purposes.
-        /// </summary>
-        /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
-        /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
-        /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
-        /// <returns>A new instance of <see cref="TextAnalytics.TextAnalyticsActionResult"/> for mocking purposes.</returns>
-        public static TextAnalyticsActionResult TextAnalyticsActionResult(
-            DateTimeOffset completedOn,
-            string code,
-            string message)
-        {
-            return new TextAnalyticsActionResult(completedOn, new TextAnalyticsErrorInternal(code, message));
-        }
-
-        /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesActionResult"/> for mocking purposes.
         /// </summary>
         /// <param name="result">Sets the <see cref="RecognizeLinkedEntitiesActionResult.DocumentsResults"/> property.</param>
-        /// <param name="actionName">Sets the <see cref="RecognizeLinkedEntitiesActionResult.ActionName"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="TextAnalyticsActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesActionResult"/> for mocking purposes.</returns>
         public static RecognizeLinkedEntitiesActionResult RecognizeLinkedEntitiesActionResult(
@@ -719,7 +693,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesActionResult"/> for mocking purposes.
         /// </summary>
-        /// <param name="actionName">Sets the <see cref="RecognizeLinkedEntitiesActionResult.ActionName"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="TextAnalyticsActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
         /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
@@ -737,7 +711,7 @@ namespace Azure.AI.TextAnalytics
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizeEntitiesActionResult"/> for mocking purposes.
         /// </summary>
         /// <param name="result">Sets the <see cref="RecognizeEntitiesActionResult.DocumentsResults"/> property.</param>
-        /// <param name="actionName">Sets the <see cref="RecognizePiiEntitiesActionResult.ActionName"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="TextAnalyticsActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.RecognizeEntitiesActionResult"/> for mocking purposes.</returns>
         public static RecognizeEntitiesActionResult RecognizeEntitiesActionResult(
@@ -751,7 +725,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizeEntitiesActionResult"/> for mocking purposes.
         /// </summary>
-        /// <param name="actionName">Sets the <see cref="RecognizeEntitiesActionResult.ActionName"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="TextAnalyticsActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
         /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
@@ -769,7 +743,7 @@ namespace Azure.AI.TextAnalytics
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizePiiEntitiesActionResult"/> for mocking purposes.
         /// </summary>
         /// <param name="result">Sets the <see cref="RecognizePiiEntitiesActionResult.DocumentsResults"/> property.</param>
-        /// <param name="actionName">Sets the <see cref="RecognizePiiEntitiesActionResult.ActionName"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="TextAnalyticsActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.RecognizePiiEntitiesActionResult"/> for mocking purposes.</returns>
         public static RecognizePiiEntitiesActionResult RecognizePiiEntitiesActionResult(
@@ -783,7 +757,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizePiiEntitiesActionResult"/> for mocking purposes.
         /// </summary>
-        /// <param name="actionName">Sets the <see cref="RecognizePiiEntitiesActionResult.ActionName"/> property.</param>
+        /// <param name="actionName">Sets the <see cref="TextAnalyticsActionResult.ActionName"/> property.</param>
         /// <param name="completedOn">Sets the <see cref="TextAnalyticsActionResult.CompletedOn"/> property.</param>
         /// <param name="code">Sets the <see cref="TextAnalyticsError.ErrorCode"/> property.</param>
         /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>


### PR DESCRIPTION
Following Java's design. This doesn't affect our users or our tests.

Also removing the `TextAnalyticsActionResult` methods in the Modelfactory class as this is not intended to be exposed. 