### PR TITLE
Always set otel.status_code

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
@@ -94,6 +94,11 @@ namespace Azure.Core.Pipeline
                 {
                     activity.AddTag("otel.status_code", "ERROR");
                 }
+                else
+                {
+                    // Set the status to UNSET so the AppInsights doesn't try to infer it from the status code
+                    activity.AddTag("otel.status_code", "UNSET");
+                }
             }
             finally
             {

--- a/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
@@ -61,9 +61,9 @@ namespace Azure.Core.Tests
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("http.user_agent", "agent"));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("requestId", clientRequestId));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("serviceRequestId", "server request id"));
+            CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("otel.status_code", "UNSET"));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("kind", "client"));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("az.namespace", "Microsoft.Azure.Core.Cool.Tests"));
-            CollectionAssert.DoesNotContain(activity.Tags.Select(t=>t.Key), "otel.status_code");
         }
 
         [Test]


### PR DESCRIPTION
This change makes it so the later versions of AppInsights don't have to infer the http span success based on the HTTP status code.

ResponseClassifier implementations that Azure SDKs provide have more context and better logic so flow the information through.

The actual customer experience depends on https://github.com/microsoft/ApplicationInsights-dotnet/pull/2200