### PR TITLE
Update Delete Sample

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
@@ -158,6 +158,9 @@ image.UpdateTagProperties("latest", new ArtifactTagProperties()
 ### Delete images
 
 ```C# Snippet:ContainerRegistry_Tests_Samples_DeleteImage
+using Azure.Containers.ContainerRegistry;
+using Azure.Identity;
+
 // Get the service endpoint from the environment
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 
@@ -177,13 +180,15 @@ foreach (string repositoryName in repositoryNames)
     // Delete images older than the first three.
     foreach (ArtifactManifestProperties imageManifest in imageManifests.Skip(3))
     {
+        RegistryArtifact image = repository.GetArtifact(imageManifest.Digest);
         Console.WriteLine($"Deleting image with digest {imageManifest.Digest}.");
-        Console.WriteLine($"   This image has the following tags: ");
+        Console.WriteLine($"   Deleting the following tags from the image: ");
         foreach (var tagName in imageManifest.Tags)
         {
             Console.WriteLine($"        {imageManifest.RepositoryName}:{tagName}");
+            image.DeleteTag(tagName);
         }
-        repository.GetArtifact(imageManifest.Digest).Delete();
+        image.Delete();
     }
 }
 ```
@@ -251,6 +256,10 @@ await image.UpdateTagPropertiesAsync("latest", new ArtifactTagProperties()
 ### Delete images asynchronously
 
 ```C# Snippet:ContainerRegistry_Tests_Samples_DeleteImageAsync
+using System.Linq;
+using Azure.Containers.ContainerRegistry;
+using Azure.Identity;
+
 // Get the service endpoint from the environment
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 
@@ -270,13 +279,15 @@ await foreach (string repositoryName in repositoryNames)
     // Delete images older than the first three.
     await foreach (ArtifactManifestProperties imageManifest in imageManifests.Skip(3))
     {
+        RegistryArtifact image = repository.GetArtifact(imageManifest.Digest);
         Console.WriteLine($"Deleting image with digest {imageManifest.Digest}.");
-        Console.WriteLine($"   This image has the following tags: ");
+        Console.WriteLine($"   Deleting the following tags from the image: ");
         foreach (var tagName in imageManifest.Tags)
         {
             Console.WriteLine($"        {imageManifest.RepositoryName}:{tagName}");
+            await image.DeleteTagAsync(tagName);
         }
-        await repository.GetArtifact(imageManifest.Digest).DeleteAsync();
+        await image.DeleteAsync();
     }
 }
 ```

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/samples/Sample02a_DeleteImages.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/samples/Sample02a_DeleteImages.md
@@ -3,6 +3,9 @@
 A common use case for Azure Container Registries is to scan the repositories in a registry and delete all but the most recent *n* images, or all images older than a certain date.  This sample illustrates how to use the .NET ACR SDK to delete all but the latest three images.
 
 ```C# Snippet:ContainerRegistry_Tests_Samples_DeleteImage
+using Azure.Containers.ContainerRegistry;
+using Azure.Identity;
+
 // Get the service endpoint from the environment
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 
@@ -22,13 +25,15 @@ foreach (string repositoryName in repositoryNames)
     // Delete images older than the first three.
     foreach (ArtifactManifestProperties imageManifest in imageManifests.Skip(3))
     {
+        RegistryArtifact image = repository.GetArtifact(imageManifest.Digest);
         Console.WriteLine($"Deleting image with digest {imageManifest.Digest}.");
-        Console.WriteLine($"   This image has the following tags: ");
+        Console.WriteLine($"   Deleting the following tags from the image: ");
         foreach (var tagName in imageManifest.Tags)
         {
             Console.WriteLine($"        {imageManifest.RepositoryName}:{tagName}");
+            image.DeleteTag(tagName);
         }
-        repository.GetArtifact(imageManifest.Digest).Delete();
+        image.Delete();
     }
 }
 ```

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/samples/Sample02b_DeleteImagesAsync.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/samples/Sample02b_DeleteImagesAsync.md
@@ -2,7 +2,17 @@
 
 A common use case for Azure Container Registries is to scan the repositories in a registry and delete all but the most recent *n* images, or all images older than a certain date.  This sample illustrates how to use the .NET ACR SDK to delete all but the latest three images.
 
+Please note:
+
+- The `System.Linq.Async` package provides the LINQ `Skip` method. For more information on using this package with AsyncPageable, please see [Using System.Linq.Async with AsyncPageable](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Response.md#using-systemlinqasync-with-asyncpageable).
+
+- The operations in this sample are run in series, but could be parallelized using the new `Parallel.ForEachAsync` method in [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0).
+
 ```C# Snippet:ContainerRegistry_Tests_Samples_DeleteImageAsync
+using System.Linq;
+using Azure.Containers.ContainerRegistry;
+using Azure.Identity;
+
 // Get the service endpoint from the environment
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 
@@ -22,13 +32,15 @@ await foreach (string repositoryName in repositoryNames)
     // Delete images older than the first three.
     await foreach (ArtifactManifestProperties imageManifest in imageManifests.Skip(3))
     {
+        RegistryArtifact image = repository.GetArtifact(imageManifest.Digest);
         Console.WriteLine($"Deleting image with digest {imageManifest.Digest}.");
-        Console.WriteLine($"   This image has the following tags: ");
+        Console.WriteLine($"   Deleting the following tags from the image: ");
         foreach (var tagName in imageManifest.Tags)
         {
             Console.WriteLine($"        {imageManifest.RepositoryName}:{tagName}");
+            await image.DeleteTagAsync(tagName);
         }
-        await repository.GetArtifact(imageManifest.Digest).DeleteAsync();
+        await image.DeleteAsync();
     }
 }
 ```

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/Samples/Sample02_DeleteImages.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/Samples/Sample02_DeleteImages.cs
@@ -20,6 +20,11 @@ namespace Azure.Containers.ContainerRegistry.Tests.Samples
             Environment.SetEnvironmentVariable("REGISTRY_ENDPOINT", TestEnvironment.Endpoint);
 
             #region Snippet:ContainerRegistry_Tests_Samples_DeleteImage
+#if SNIPPET
+            using Azure.Containers.ContainerRegistry;
+            using Azure.Identity;
+#endif
+
             // Get the service endpoint from the environment
             Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 
@@ -39,13 +44,15 @@ namespace Azure.Containers.ContainerRegistry.Tests.Samples
                 // Delete images older than the first three.
                 foreach (ArtifactManifestProperties imageManifest in imageManifests.Skip(3))
                 {
+                    RegistryArtifact image = repository.GetArtifact(imageManifest.Digest);
                     Console.WriteLine($"Deleting image with digest {imageManifest.Digest}.");
-                    Console.WriteLine($"   This image has the following tags: ");
+                    Console.WriteLine($"   Deleting the following tags from the image: ");
                     foreach (var tagName in imageManifest.Tags)
                     {
                         Console.WriteLine($"        {imageManifest.RepositoryName}:{tagName}");
+                        image.DeleteTag(tagName);
                     }
-                    repository.GetArtifact(imageManifest.Digest).Delete();
+                    image.Delete();
                 }
             }
             #endregion
@@ -57,7 +64,13 @@ namespace Azure.Containers.ContainerRegistry.Tests.Samples
         {
             Environment.SetEnvironmentVariable("REGISTRY_ENDPOINT", TestEnvironment.Endpoint);
 
-            # region Snippet:ContainerRegistry_Tests_Samples_DeleteImageAsync
+            #region Snippet:ContainerRegistry_Tests_Samples_DeleteImageAsync
+#if SNIPPET
+            using System.Linq;
+            using Azure.Containers.ContainerRegistry;
+            using Azure.Identity;
+#endif
+
             // Get the service endpoint from the environment
             Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 
@@ -77,13 +90,15 @@ namespace Azure.Containers.ContainerRegistry.Tests.Samples
                 // Delete images older than the first three.
                 await foreach (ArtifactManifestProperties imageManifest in imageManifests.Skip(3))
                 {
+                    RegistryArtifact image = repository.GetArtifact(imageManifest.Digest);
                     Console.WriteLine($"Deleting image with digest {imageManifest.Digest}.");
-                    Console.WriteLine($"   This image has the following tags: ");
+                    Console.WriteLine($"   Deleting the following tags from the image: ");
                     foreach (var tagName in imageManifest.Tags)
                     {
                         Console.WriteLine($"        {imageManifest.RepositoryName}:{tagName}");
+                        await image.DeleteTagAsync(tagName);
                     }
-                    await repository.GetArtifact(imageManifest.Digest).DeleteAsync();
+                    await image.DeleteAsync();
                 }
             }
 


### PR DESCRIPTION
We considered parallelizing the asynchronous Delete sample by adding functionality into `Azure.Core`.  We learned, however, that .NET 6 will be providing an implementation of `Parallel.ForEachAsync`, and that `IAsyncEnumerable.ForEachAsync` is implemented in the `System.Linq.Async` package.  Given this, it doesn't make sense to add this functionality to Core.  Instead, we're noting the recommended path for parallelizing the sample and leaving it sequential.

Fixes https://github.com/azure/azure-sdk-for-net/issues/21675
Fixes https://github.com/azure/azure-sdk-for-net/issues/21820