### PR TITLE
Enable Activity Links export

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartB.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartB.cs
@@ -11,6 +11,8 @@ using Azure.Monitor.OpenTelemetry.Exporter.Models;
 
 using OpenTelemetry.Logs;
 using OpenTelemetry.Trace;
+using System.Linq;
+using System.Text;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
@@ -26,6 +28,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             string url = null;
             string urlAuthority = null;
             var monitorTags = EnumerateActivityTags(activity);
+
+            AddActivityLinksToPartCTags(activity.Links, ref monitorTags.PartCTags);
 
             switch (monitorTags.activityType)
             {
@@ -54,6 +58,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         internal static RemoteDependencyData GetRemoteDependencyData(Activity activity)
         {
             var monitorTags = EnumerateActivityTags(activity);
+
+            AddActivityLinksToPartCTags(activity.Links, ref monitorTags.PartCTags);
 
             var dependency = new RemoteDependencyData(2, activity.DisplayName, activity.Duration.ToString("c", CultureInfo.InvariantCulture))
             {
@@ -120,6 +126,43 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             for (int i = 0; i < PartCTags.Length; i++)
             {
                 destination.Add(PartCTags[i].Key, PartCTags[i].Value?.ToString());
+            }
+        }
+
+        private static void AddActivityLinksToPartCTags(IEnumerable<ActivityLink> links, ref AzMonList PartCTags)
+        {
+            string msLinks = "_MS.links";
+            if (links != null && links.Any())
+            {
+                var linksJson = new StringBuilder();
+                linksJson.Append('[');
+                foreach (var link in links)
+                {
+                    var linkTraceId = link.Context.TraceId.ToHexString();
+                    linksJson
+                        .Append('{')
+                        .Append("\"operation_Id\":")
+                        .Append('\"')
+                        .Append(linkTraceId)
+                        .Append('\"')
+                        .Append(',');
+                    linksJson
+                        .Append("\"id\":")
+                        .Append('\"')
+                        .Append(link.Context.SpanId.ToHexString())
+                        .Append('\"');
+                    linksJson.Append("},");
+                }
+
+                if (linksJson.Length > 0)
+                {
+                    // trim trailing comma - json does not support it
+                    linksJson.Remove(linksJson.Length - 1, 1);
+                }
+
+                linksJson.Append(']');
+
+                AzMonList.Add(ref PartCTags, new KeyValuePair<string, object>(msLinks, linksJson.ToString()));
             }
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartB.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartB.cs
@@ -138,12 +138,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 linksJson.Append('[');
                 foreach (var link in links)
                 {
-                    var linkTraceId = link.Context.TraceId.ToHexString();
                     linksJson
                         .Append('{')
                         .Append("\"operation_Id\":")
                         .Append('\"')
-                        .Append(linkTraceId)
+                        .Append(link.Context.TraceId.ToHexString())
                         .Append('\"')
                         .Append(',');
                     linksJson
@@ -152,6 +151,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                         .Append(link.Context.SpanId.ToHexString())
                         .Append('\"');
                     linksJson.Append("},");
+
+                    //TODO: Confirm if we need to capture other information like traceflags, tracestate, isRemote from the context.
                 }
 
                 if (linksJson.Length > 0)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
@@ -4,19 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using Xunit;
-
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using OpenTelemetry.Resources;
-using OpenTelemetry;
-using OpenTelemetry.Trace;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 {
     public class TelemetryPartATests
     {
-        private const string ResourcePropertyName = "OTel.Resource";
         private const string ActivitySourceName = "TelemetryPartATests";
         private const string ActivityName = "TestActivity";
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
+{
+    public class TelemetryPartBTests
+    {
+        private const string ActivitySourceName = "TelemetryPartBTests";
+        private const string ActivityName = "TestActivity";
+        private const string msLinks = "_MS.links";
+
+        static TelemetryPartBTests()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+
+            var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+            };
+
+            ActivitySource.AddActivityListener(listener);
+        }
+
+        [Fact]
+        public void RequestDataPropertiesDoesNotContainMSLinksWhenActivityHasNoLinks()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                parentContext: default,
+                startTime: DateTime.UtcNow);
+
+            var telemetryPartBRequestData = TelemetryPartB.GetRequestData(activity);
+            Assert.False(telemetryPartBRequestData.Properties.TryGetValue(msLinks, out var mslinks));
+        }
+
+        [Fact]
+        public void RequestDataPropertiesContainsMSLinksWhenActivityHasLinks()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            ActivityLink activityLink1 = new ActivityLink(new ActivityContext(
+                ActivityTraceId.CreateRandom(),
+                ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None), null);
+            ActivityLink activityLink2 = new ActivityLink(new ActivityContext(
+                ActivityTraceId.CreateRandom(),
+                ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None), null);
+
+            List<ActivityLink> links = new List<ActivityLink>();
+            links.Add(activityLink1);
+            links.Add(activityLink2);
+
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                parentContext: default,
+                null,
+                links,
+                startTime: DateTime.UtcNow);
+
+            string expectedMSlinks = $"[{{\"operation_Id\":\"{activityLink1.Context.TraceId}\",\"id\":\"{activityLink1.Context.SpanId}\"}},{{\"operation_Id\":\"{activityLink2.Context.TraceId}\",\"id\":\"{activityLink2.Context.SpanId}\"}}]";
+            var telemetryPartBRequestData = TelemetryPartB.GetRequestData(activity);
+
+            Assert.True(telemetryPartBRequestData.Properties.TryGetValue(msLinks, out var actualMSlinks));
+            Assert.Equal(expectedMSlinks, actualMSlinks);
+        }
+
+        [Fact]
+        public void RemoteDependencyDataPropertiesDoesNotContainMSLinksWhenActivityHasNoLinks()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                parentContext: default,
+                startTime: DateTime.UtcNow);
+
+            var telemetryPartBRemoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity);
+            Assert.False(telemetryPartBRemoteDependencyData.Properties.TryGetValue(msLinks, out var mslinks));
+        }
+
+        [Fact]
+        public void RemoteDependencyDataPropertiesContainsMSLinksWhenActivityHasLinks()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            ActivityLink activityLink1 = new ActivityLink(new ActivityContext(
+                ActivityTraceId.CreateRandom(),
+                ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None), null);
+            ActivityLink activityLink2 = new ActivityLink(new ActivityContext(
+                ActivityTraceId.CreateRandom(),
+                ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None), null);
+
+            List<ActivityLink> links = new List<ActivityLink>();
+            links.Add(activityLink1);
+            links.Add(activityLink2);
+
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                parentContext: default,
+                null,
+                links,
+                startTime: DateTime.UtcNow);
+
+            string expectedMSlinks = $"[{{\"operation_Id\":\"{activityLink1.Context.TraceId}\",\"id\":\"{activityLink1.Context.SpanId}\"}},{{\"operation_Id\":\"{activityLink2.Context.TraceId}\",\"id\":\"{activityLink2.Context.SpanId}\"}}]";
+            var telemetryPartBRemoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity);
+
+            Assert.True(telemetryPartBRemoteDependencyData.Properties.TryGetValue(msLinks, out var actualMSlinks));
+            Assert.Equal(expectedMSlinks, actualMSlinks);
+        }
+    }
+}


### PR DESCRIPTION
If Links is set for activity, it is ignored by the exporter. 

Links are supported as per opentelemetry-spec here:
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#specifying-links

Enabling Links export as PartC field called "_MS.links". 