### PR TITLE
Added AzureKeyCredential.KeyChanged event.

### DIFF
--- a/sdk/core/Azure.Core/Azure.Core.sln
+++ b/sdk/core/Azure.Core/Azure.Core.sln
@@ -21,13 +21,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Core.Spatia
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Core.Spatial.NewtonsoftJson.Tests", "..\Microsoft.Azure.Core.Spatial.NewtonsoftJson\tests\Microsoft.Azure.Core.Spatial.NewtonsoftJson.Tests.csproj", "{622772C8-A2CB-4F8B-82EB-2A46BCC21DAE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Core.Spatial", "..\Microsoft.Azure.Core.Spatial\src\Microsoft.Azure.Core.Spatial.csproj", "{25A7E209-D5D2-41F1-AFE9-E860D6294EF5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Core.Spatial", "..\Microsoft.Azure.Core.Spatial\src\Microsoft.Azure.Core.Spatial.csproj", "{25A7E209-D5D2-41F1-AFE9-E860D6294EF5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Core.Spatial.Tests", "..\Microsoft.Azure.Core.Spatial\tests\Microsoft.Azure.Core.Spatial.Tests.csproj", "{36FF59A9-D6C9-4226-A0FE-47C879F3EB94}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Core.Spatial.Tests", "..\Microsoft.Azure.Core.Spatial\tests\Microsoft.Azure.Core.Spatial.Tests.csproj", "{36FF59A9-D6C9-4226-A0FE-47C879F3EB94}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.Perf", "perf\Azure.Core.Perf.csproj", "{B6D7909F-4DE6-4895-BF39-EF892BA64BA3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Perf", "perf\Azure.Core.Perf.csproj", "{B6D7909F-4DE6-4895-BF39-EF892BA64BA3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{33A10110-D88A-459B-82C1-FECEF86A822A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{33A10110-D88A-459B-82C1-FECEF86A822A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.AI.TextAnalytics", "..\..\textanalytics\Azure.AI.TextAnalytics\src\Azure.AI.TextAnalytics.csproj", "{0DF4B490-E1B3-410F-B514-08EC00767736}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -87,6 +89,10 @@ Global
 		{33A10110-D88A-459B-82C1-FECEF86A822A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{33A10110-D88A-459B-82C1-FECEF86A822A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33A10110-D88A-459B-82C1-FECEF86A822A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0DF4B490-E1B3-410F-B514-08EC00767736}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0DF4B490-E1B3-410F-B514-08EC00767736}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0DF4B490-E1B3-410F-B514-08EC00767736}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0DF4B490-E1B3-410F-B514-08EC00767736}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/core/Azure.Core/src/AzureKeyCredential.cs
+++ b/sdk/core/Azure.Core/src/AzureKeyCredential.cs
@@ -65,10 +65,13 @@ namespace Azure
             var oldKey = Key;
             Key = key;
 
-            if (!string.Equals(oldKey, key, StringComparison.Ordinal))
+            var changed = KeyChanged;
+            if (changed != null)
             {
-                var changed = KeyChanged;
-                changed(this, Key);
+                if (!string.Equals(oldKey, key, StringComparison.Ordinal))
+                {
+                    changed(this, Key);
+                }
             }
         }
     }

--- a/sdk/core/Azure.Core/src/AzureKeyCredential.cs
+++ b/sdk/core/Azure.Core/src/AzureKeyCredential.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.ComponentModel;
 using System.Threading;
 using Azure.Core;
@@ -24,6 +25,12 @@ namespace Azure
             get => Volatile.Read(ref _key);
             private set => Volatile.Write(ref _key, value);
         }
+
+        /// <summary>
+        /// The event is raised after the AzureKeyCredential.Update method updates the key.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<string> KeyChanged;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureKeyCredential"/> class.
@@ -54,7 +61,15 @@ namespace Azure
         public void Update(string key)
         {
             Argument.AssertNotNullOrEmpty(key, nameof(key));
+
+            var oldKey = Key;
             Key = key;
+
+            if (!string.Equals(oldKey, key, StringComparison.Ordinal))
+            {
+                var changed = KeyChanged;
+                changed(this, Key);
+            }
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/AzureKeyCredentialTests.cs
+++ b/sdk/core/Azure.Core/tests/AzureKeyCredentialTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class AzureKeyCredentialTests
+    {
+        [Test]
+        public void KeyChanged()
+        {
+            var akc = new AzureKeyCredential("1");
+            var updateTo = "2";
+
+            akc.KeyChanged += (object sender, string newKey) =>
+            {
+                Assert.AreEqual(updateTo, newKey);
+                Assert.AreEqual(updateTo, akc.Key);
+                Assert.AreEqual(sender, akc);
+            };
+
+            akc.Update(updateTo);
+        }
+    }
+}


### PR DESCRIPTION
The event is needed such that clients don't have to transform the string key to byte[] every time they need byte[].