### PR TITLE
Add PropertyReferenceType attribute in ResourceIdentity

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/PropertyReferenceTypeAttribute.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/PropertyReferenceTypeAttribute.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.ResourceManager.Core
+{
+    /// <summary>
+    /// An attribute class indicating a reference type for code generation.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class PropertyReferenceTypeAttribute : Attribute
+    {
+        /// <summary>
+        /// Instatiate a new reference type attribute.
+        /// </summary>
+        /// <param name="skipType"> Type to skip for this reference type. </param>
+        public PropertyReferenceTypeAttribute(Type skipType)
+        {
+            SkipType = skipType;
+        }
+
+        /// <summary>
+        /// Instatiate a new reference type attribute.
+        /// </summary>
+        public PropertyReferenceTypeAttribute() : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Get the skip type for this reference type.
+        /// </summary>
+        public Type SkipType { get; }
+    }
+}

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/PropertyReferenceTypeAttribute.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/PropertyReferenceTypeAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 
 namespace Azure.ResourceManager.Core
 {
@@ -14,10 +15,10 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Instatiate a new reference type attribute.
         /// </summary>
-        /// <param name="skipType"> Type to skip for this reference type. </param>
-        public PropertyReferenceTypeAttribute(Type skipType)
+        /// <param name="skipTypes"> An array of types to skip for this reference type. </param>
+        public PropertyReferenceTypeAttribute(Type[] skipTypes)
         {
-            SkipType = skipType;
+            SkipTypes = skipTypes;
         }
 
         /// <summary>
@@ -28,8 +29,8 @@ namespace Azure.ResourceManager.Core
         }
 
         /// <summary>
-        /// Get the skip type for this reference type.
+        /// Get an array of types to skip for this reference type.
         /// </summary>
-        public Type SkipType { get; }
+        public Type[] SkipTypes { get; }
     }
 }

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceIdentity.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceIdentity.cs
@@ -11,6 +11,7 @@ namespace Azure.ResourceManager.Core
     /// <summary>
     /// Represents a managed identity
     /// </summary>
+    [PropertyReferenceType(typeof(ResourceIdentityType))]
     public class ResourceIdentity : IEquatable<ResourceIdentity>
     {
         private const string SystemAssigned = "SystemAssigned";
@@ -20,6 +21,7 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceIdentity"/> class.
         /// </summary>
+        [InitializationConstructor]
         public ResourceIdentity()
             : this(null, false)
         {
@@ -30,6 +32,7 @@ namespace Azure.ResourceManager.Core
         /// </summary>
         /// <param name="user"> Dictionary with a <see cref="ResourceIdentifier"/> key and a <see cref="UserAssignedIdentity"/> object value. </param>
         /// <param name="useSystemAssigned"> Flag for using <see cref="SystemAssignedIdentity"/> or not. </param>
+        [SerializationConstructor]
         public ResourceIdentity(Dictionary<ResourceGroupResourceIdentifier, UserAssignedIdentity> user, bool useSystemAssigned)
         {
             // check for combination of user and system on the impact to type value
@@ -78,7 +81,9 @@ namespace Azure.ResourceManager.Core
         /// </summary>
         /// <param name="element"> A <see cref="JsonElement"/> containing an <see cref="ResourceIdentity"/>. </param>
         /// <returns> New Identity object with JSON values. </returns>
-        internal static ResourceIdentity Deserialize(JsonElement element)
+#pragma warning disable AZC0014 // Avoid using banned types in public API
+        public static ResourceIdentity DeserializeResourceIdentity(JsonElement element)
+#pragma warning restore AZC0014 // Avoid using banned types in public API
         {
             if (element.ValueKind == JsonValueKind.Undefined)
             {

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceIdentity.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceIdentity.cs
@@ -11,7 +11,7 @@ namespace Azure.ResourceManager.Core
     /// <summary>
     /// Represents a managed identity
     /// </summary>
-    [PropertyReferenceType(typeof(ResourceIdentityType))]
+    [PropertyReferenceType(new Type[] { typeof(ResourceIdentityType) })]
     public class ResourceIdentity : IEquatable<ResourceIdentity>
     {
         private const string SystemAssigned = "SystemAssigned";

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/UserAssignedIdentity.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/UserAssignedIdentity.cs
@@ -26,12 +26,12 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Gets or sets the Client ID.
         /// </summary>
-        public Guid ClientId { get; set; }
+        public Guid ClientId { get; }
 
         /// <summary>
         /// Gets or sets the Principal ID.
         /// </summary>
-        public Guid PrincipalId { get; set; }
+        public Guid PrincipalId { get; }
 
         /// <summary>
         /// Converts a <see cref="JsonElement"/> into an <see cref="UserAssignedIdentity"/> object.

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/tests/Unit/IdentityTests.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/tests/Unit/IdentityTests.cs
@@ -151,7 +151,7 @@ namespace Azure.ResourceManager.Core.Tests
         public void TestDeserializerInvalidDefaultJson()
         {
             JsonElement invalid = default(JsonElement);
-            Assert.Throws<ArgumentException>(delegate { ResourceIdentity.Deserialize(invalid); });
+            Assert.Throws<ArgumentException>(delegate { ResourceIdentity.DeserializeResourceIdentity(invalid); });
         }
 
         public JsonProperty DeserializerHelper(string filename)
@@ -166,14 +166,14 @@ namespace Azure.ResourceManager.Core.Tests
         public void TestDeserializerInvalidNullType()
         {
             var identityJsonProperty = DeserializerHelper("InvalidTypeIsNull.json");
-            Assert.Throws<InvalidOperationException>(delegate { ResourceIdentity.Deserialize(identityJsonProperty.Value); });
+            Assert.Throws<InvalidOperationException>(delegate { ResourceIdentity.DeserializeResourceIdentity(identityJsonProperty.Value); });
         }
 
         [TestCase]
         public void TestDeserializerValidSystemAndUserAssigned()
         {
             var identityJsonProperty = DeserializerHelper("SystemAndUserAssignedValid.json");
-            ResourceIdentity back = ResourceIdentity.Deserialize(identityJsonProperty.Value);
+            ResourceIdentity back = ResourceIdentity.DeserializeResourceIdentity(identityJsonProperty.Value);
             Assert.IsTrue("22fdaec1-8b9f-49dc-bd72-ddaf8f215577".Equals(back.SystemAssignedIdentity.PrincipalId.ToString()));
             Assert.IsTrue("72f988af-86f1-41af-91ab-2d7cd011db47".Equals(back.SystemAssignedIdentity.TenantId.ToString()));
             var user = back.UserAssignedIdentities;
@@ -186,7 +186,7 @@ namespace Azure.ResourceManager.Core.Tests
         public void TestDeserializerInvalidType()
         {
             var identityJsonProperty = DeserializerHelper("InvalidType.json");
-            ResourceIdentity back = ResourceIdentity.Deserialize(identityJsonProperty.Value);
+            ResourceIdentity back = ResourceIdentity.DeserializeResourceIdentity(identityJsonProperty.Value);
             var user = back.UserAssignedIdentities;
             Assert.AreEqual("/subscriptions/d96407f5-db8f-4325-b582-84ad21310bd8/resourceGroups/tester/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity", user.Keys.First().ToString());
             Assert.AreEqual("9a2eaa6a-b49c-4a63-afb5-3b72e3e65422", user.Values.First().ClientId.ToString());
@@ -197,7 +197,7 @@ namespace Azure.ResourceManager.Core.Tests
         public void TestDeserializerValidInnerExtraField()
         {
             var identityJsonProperty = DeserializerHelper("SystemAndUserAssignedInnerExtraField.json");
-            ResourceIdentity back = ResourceIdentity.Deserialize(identityJsonProperty.Value);
+            ResourceIdentity back = ResourceIdentity.DeserializeResourceIdentity(identityJsonProperty.Value);
             Assert.IsTrue("22fddec1-8b9f-49dc-bd72-ddaf8f215577".Equals(back.SystemAssignedIdentity.PrincipalId.ToString()));
             Assert.IsTrue("72f988bf-86f1-41af-91ab-2d7cd011db47".Equals(back.SystemAssignedIdentity.TenantId.ToString()));
             var user = back.UserAssignedIdentities;
@@ -210,7 +210,7 @@ namespace Azure.ResourceManager.Core.Tests
         public void TestDeserializerValidMiddleExtraField()
         {
             var identityJsonProperty = DeserializerHelper("SystemAndUserAssignedMiddleExtraField.json");
-            ResourceIdentity back = ResourceIdentity.Deserialize(identityJsonProperty.Value);
+            ResourceIdentity back = ResourceIdentity.DeserializeResourceIdentity(identityJsonProperty.Value);
             Assert.IsTrue("22fddec1-8b9f-49dc-bd72-ddaf8f215577".Equals(back.SystemAssignedIdentity.PrincipalId.ToString()));
             Assert.IsTrue("72f988bf-86f1-41af-91ab-2d7cd011db47".Equals(back.SystemAssignedIdentity.TenantId.ToString()));
             var user = back.UserAssignedIdentities;
@@ -226,7 +226,7 @@ namespace Azure.ResourceManager.Core.Tests
             JsonDocument document = JsonDocument.Parse(json);
             JsonElement rootElement = document.RootElement;
             var identityJsonProperty = rootElement.EnumerateObject().ElementAt(1);
-            ResourceIdentity back = ResourceIdentity.Deserialize(identityJsonProperty.Value);
+            ResourceIdentity back = ResourceIdentity.DeserializeResourceIdentity(identityJsonProperty.Value);
             Assert.IsTrue("22fddec1-8b9f-49dc-bd72-ddaf8f215577".Equals(back.SystemAssignedIdentity.PrincipalId.ToString()));
             Assert.IsTrue("72f988bf-86f1-41af-91ab-2d7cd011db47".Equals(back.SystemAssignedIdentity.TenantId.ToString()));
             var user = back.UserAssignedIdentities;
@@ -239,7 +239,7 @@ namespace Azure.ResourceManager.Core.Tests
         public void TestDeserializerValidSystemAndMultUser()
         {
             var identityJsonProperty = DeserializerHelper("SystemAndUserAssignedValidMultIdentities.json");
-            ResourceIdentity back = ResourceIdentity.Deserialize(identityJsonProperty.Value);
+            ResourceIdentity back = ResourceIdentity.DeserializeResourceIdentity(identityJsonProperty.Value);
             Assert.IsTrue("22fddec1-8b9f-49dc-bd72-ddaf8f215570".Equals(back.SystemAssignedIdentity.PrincipalId.ToString()));
             Assert.IsTrue("72f988bf-86f1-41af-91ab-2d7cd011db40".Equals(back.SystemAssignedIdentity.TenantId.ToString()));
             var user = back.UserAssignedIdentities;
@@ -255,7 +255,7 @@ namespace Azure.ResourceManager.Core.Tests
         public void TestDeserializerValidSystemAssigned()
         {
             var identityJsonProperty = DeserializerHelper("SystemAssigned.json");
-            ResourceIdentity back = ResourceIdentity.Deserialize(identityJsonProperty.Value);
+            ResourceIdentity back = ResourceIdentity.DeserializeResourceIdentity(identityJsonProperty.Value);
             Assert.IsTrue("22fddec1-8b9f-49dc-bd72-ddaf8f215577".Equals(back.SystemAssignedIdentity.PrincipalId.ToString()));
             Assert.IsTrue("72f988bf-86f1-41af-91ab-2d7cd011db47".Equals(back.SystemAssignedIdentity.TenantId.ToString()));
             Assert.IsTrue(back.UserAssignedIdentities.Count == 0);            
@@ -265,7 +265,7 @@ namespace Azure.ResourceManager.Core.Tests
         public void TestDeserializerValidUserAssigned()
         {
             var identityJsonProperty = DeserializerHelper("UserAssigned.json");
-            ResourceIdentity back = ResourceIdentity.Deserialize(identityJsonProperty.Value);
+            ResourceIdentity back = ResourceIdentity.DeserializeResourceIdentity(identityJsonProperty.Value);
             Assert.IsNull(back.SystemAssignedIdentity);
             var user = back.UserAssignedIdentities;
             Assert.AreEqual("/subscriptions/db1ab6f0-4769-4b2e-930e-01e2ef9c123c/resourceGroups/tester-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity", user.Keys.First().ToString());

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/tests/Unit/PropertyReferenceTypeTests.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/tests/Unit/PropertyReferenceTypeTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Azure.ResourceManager.Core.Tests
+{
+    public class PropertyReferenceTypeTests
+    {
+        private static readonly Type PropertyReferenceTypeAttribute = typeof(PropertyReferenceTypeAttribute);
+        private static readonly Type SerializationConstructor = typeof(SerializationConstructorAttribute);
+        private static readonly Type InitializationConstructor = typeof(InitializationConstructorAttribute);
+        private static readonly IEnumerable<Type> AssemblyTypes = typeof(ArmClient).Assembly.GetTypes();
+
+        [Test]
+        public void ValidatePropertyReferenceTypeAttribute()
+        {
+            var type = typeof(PropertyReferenceTypeAttribute);
+            var fieldInfo = type.GetProperties(BindingFlags.Instance | BindingFlags.Public).FirstOrDefault(p => p.Name == "SkipType");
+            Assert.NotNull(fieldInfo, $"Field 'SkipType' is not found");
+            Assert.True(fieldInfo.CanRead);
+            Assert.False(fieldInfo.CanWrite);
+        }
+
+        [Test]
+        public void ValidateSerializationConstructor()
+        {
+            foreach (var refType in AssemblyTypes.Where(t => HasAttribute(t.GetCustomAttributes<Attribute>(false), PropertyReferenceTypeAttribute)))
+            {
+                var serializationCtor = refType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                    .Where(c => HasAttribute(c.GetCustomAttributes<Attribute>(false), SerializationConstructor)).FirstOrDefault();
+                Assert.IsNotNull(serializationCtor);
+                Assert.IsTrue(serializationCtor.IsPublic, $"Serialization ctor for {refType.Name} should not be public");
+            }
+        }
+
+        [Test]
+        public void ValidateInitializationConstructor()
+        {
+            foreach (var refType in AssemblyTypes.Where(t => HasAttribute(t.GetCustomAttributes<Attribute>(false), PropertyReferenceTypeAttribute)))
+            {
+                var initializationCtor = refType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                    .Where(c => HasAttribute(c.GetCustomAttributes<Attribute>(false), InitializationConstructor)).FirstOrDefault();
+                Assert.IsNotNull(initializationCtor);
+                Assert.IsTrue(refType.IsAbstract == initializationCtor.IsFamily, $"If {refType.Name} is abstract then its initialization ctor should be protected");
+                Assert.IsTrue(refType.IsAbstract != initializationCtor.IsPublic, $"If {refType.Name} is abstract then its initialization ctor should be public");
+                Assert.IsFalse(initializationCtor.IsAssembly, $"Initialization ctor for {refType.Name} should not be internal");
+            }
+        }
+
+        public bool HasAttribute(IEnumerable<Attribute> list, Type attributeType)
+        {
+            return list.FirstOrDefault(a => a.GetType() == attributeType) is not null;
+        }
+    }
+}

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/tests/Unit/PropertyReferenceTypeTests.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/tests/Unit/PropertyReferenceTypeTests.cs
@@ -17,8 +17,9 @@ namespace Azure.ResourceManager.Core.Tests
         public void ValidatePropertyReferenceTypeAttribute()
         {
             var type = typeof(PropertyReferenceTypeAttribute);
-            var fieldInfo = type.GetProperties(BindingFlags.Instance | BindingFlags.Public).FirstOrDefault(p => p.Name == "SkipType");
-            Assert.NotNull(fieldInfo, $"Field 'SkipType' is not found");
+            var fieldInfo = type.GetProperties(BindingFlags.Instance | BindingFlags.Public).FirstOrDefault(p => p.Name == "SkipTypes");
+            Assert.NotNull(fieldInfo, $"Field 'SkipTypes' is not found");
+            Assert.AreEqual(fieldInfo.PropertyType, typeof(Type[]));
             Assert.True(fieldInfo.CanRead);
             Assert.False(fieldInfo.CanWrite);
         }


### PR DESCRIPTION
Issue: https://dev.azure.com/azure-mgmt-ex/DotNET%20Management%20SDK/_workitems/edit/4929

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
