### PR TITLE
Fix the timing-out problem in UsGov cloud

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -118,7 +118,7 @@ namespace Azure.Core.TestFramework
         /// <summary>
         ///   The name of the Azure Active Directory tenant that holds the service principal to use during Live tests. Recorded.
         /// </summary>
-        public string TenantId => GetRecordedVariable("tenantId");
+        public string TenantId => GetRecordedVariable("TENANT_ID");
 
         /// <summary>
         ///   The URL of the Azure Resource Manager to be used for management plane operations. Recorded.

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -118,7 +118,7 @@ namespace Azure.Core.TestFramework
         /// <summary>
         ///   The name of the Azure Active Directory tenant that holds the service principal to use during Live tests. Recorded.
         /// </summary>
-        public string TenantId => GetRecordedVariable("TENANT_ID");
+        public string TenantId => GetRecordedVariable("tenantId");
 
         /// <summary>
         ///   The URL of the Azure Resource Manager to be used for management plane operations. Recorded.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -543,13 +543,13 @@ namespace Azure.AI.FormRecognizer.Tests
             var resourceId = TestEnvironment.TargetResourceId;
             var regionA = "regionA";
             var regionB = "regionB";
-            switch (TestEnvironment.TenantId)
+            switch (TestEnvironment.AuthorityHostUrl)
             {
-                case "72f988bf-86f1-41af-91ab-2d7cd011db47":
+                case "https://login.microsoftonline.com/":
                     regionA = "westcentralus";
                     regionB = "eastus2";
                     break;
-                case "63296244-ce2c-46d8-bc36-3e558792fbee":
+                case "https://login.microsoftonline.us/":
                     regionA = "usgovarizona";
                     regionB = "usgovvirginia";
                     break;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -541,7 +541,24 @@ namespace Azure.AI.FormRecognizer.Tests
             var sourceClient = CreateFormTrainingClient();
             var targetClient = CreateFormTrainingClient();
             var resourceId = TestEnvironment.TargetResourceId;
-            var wrongRegion = TestEnvironment.TargetResourceRegion == "westcentralus" ? "eastus2" : "westcentralus";
+            var regionA = "regionA";
+            var regionB = "regionB";
+            switch (TestEnvironment.TenantId)
+            {
+                case "72f988bf-86f1-41af-91ab-2d7cd011db47":
+                    regionA = "westcentralus";
+                    regionB = "eastus2";
+                    break;
+                case "63296244-ce2c-46d8-bc36-3e558792fbee":
+                    regionA = "usgovarizona";
+                    regionB = "usgovvirginia";
+                    break;
+                default:
+                    regionA = "westcentralus";
+                    regionB = "eastus2";
+                    break;
+            }
+            var wrongRegion = TestEnvironment.TargetResourceRegion == regionA ? regionB : regionA;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: true);
             CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceId, wrongRegion);

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -15,7 +15,4 @@ extends:
       UsGov:
         SubscriptionConfiguration: $(sub-config-gov-test-resources)
         Location: 'usgovvirginia'
-      China:
-        SubscriptionConfiguration: $(sub-config-cn-test-resources)
-        Location: 'chinaeast2'
-    SupportedClouds: 'Public,Canary,UsGov,China'
+    SupportedClouds: 'Public,Canary,UsGov'


### PR DESCRIPTION
1. Fix Issue #13669

2. Azure Form Recognizer is not available in Azure China Cloud now, so we should not run form recognizer live tests in this cloud. [Details](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=cognitive-services)