### PR TITLE
Azure Monitor Exporter: Add ApplicationInsightsSampler for OpenTelemetry

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 1.0.0-beta.3 (Unreleased)
-
+* [ApplicationInsightsSampler introduced for compatibility with Application Insights SDKs. Implements the same hash algorithm](https://github.com/Azure/azure-sdk-for-net/pull/22288).
 
 ## 1.0.0-beta.2 (2021-03-04)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 1.0.0-beta.3 (Unreleased)
-* [ApplicationInsightsSampler introduced for compatibility with Application Insights SDKs. Implements the same hash algorithm](https://github.com/Azure/azure-sdk-for-net/pull/22288).
+* [ApplicationInsightsSampler introduced for compatibility with Application Insights SDKs. Implements the same hash algorithm](#22288).
 
 ## 1.0.0-beta.2 (2021-03-04)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 1.0.0-beta.3 (Unreleased)
-* [ApplicationInsightsSampler introduced for compatibility with Application Insights SDKs. Implements the same hash algorithm](#22288).
+* ApplicationInsightsSampler introduced for compatibility with Application Insights SDKs, as it implements the same hash algorithm to decide to sample. (#22288)
 
 ## 1.0.0-beta.2 (2021-03-04)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -1,5 +1,10 @@
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
+    public partial class ApplicationInsightsSampler : OpenTelemetry.Trace.Sampler
+    {
+        public ApplicationInsightsSampler(float samplingRatio) { }
+        public override OpenTelemetry.Trace.SamplingResult ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) { throw null; }
+    }
     public static partial class AzureMonitorExporterHelperExtensions
     {
         public static OpenTelemetry.Trace.TracerProviderBuilder AddAzureMonitorTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null) { throw null; }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ApplicationInsightsSampler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ApplicationInsightsSampler.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter
+{
+    public class ApplicationInsightsSampler : Sampler
+    {
+        private readonly float samplingRatio;
+
+        public ApplicationInsightsSampler(float samplingRatio)
+        {
+            // Ensure passed ratio is between 0 and 1, inclusive
+            if (samplingRatio < 0 || samplingRatio > 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(samplingRatio), "Ratio must be between 0 and 1, inclusive.");
+            }
+            this.samplingRatio = samplingRatio;
+            Description = "ApplicationInsightsSampler{" + samplingRatio + "}";
+        }
+
+        public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+        {
+            double sampleScore = DJB2SampleScore(samplingParameters.TraceId.ToHexString());
+            return new SamplingResult(sampleScore < samplingRatio);
+        }
+
+        private static double DJB2SampleScore(string traceIdHex)
+        {
+            // Calculate DJB2 hash code from hex-converted TraceId
+            int hash = 5381;
+
+            for (int i = 0; i < traceIdHex.Length; i++)
+            {
+                hash = ((hash << 5) + hash) + (int)traceIdHex[i];
+            }
+
+            // Take the absolute value of the hash
+            if (hash == int.MinValue)
+            {
+                hash = int.MaxValue;
+            }
+            else
+            {
+                hash = Math.Abs(hash);
+            }
+
+            // Divide by MaxValue for value between 0 and 1 for sampling score
+            double samplingScore = (double)hash / int.MaxValue;
+            return samplingScore;
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ApplicationInsightsSampler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ApplicationInsightsSampler.cs
@@ -27,7 +27,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
         {
-            double sampleScore = DJB2SampleScore(samplingParameters.TraceId.ToHexString());
+            double sampleScore = DJB2SampleScore(samplingParameters.TraceId.ToHexString().ToLowerInvariant());
             return new SamplingResult(sampleScore < samplingRatio);
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ApplicationInsightsSamplerTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ApplicationInsightsSamplerTests.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+
+using OpenTelemetry.Trace;
+
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
+{
+    public class ApplicationInsightsSamplerTests
+    {
+        [Fact]
+        public void VerifyHashAlgorithmCorrectness()
+        {
+            byte[] testBytes = new byte[]
+            {
+                          0x8F, 0xFF, 0xFF, 0xFF,
+                          0xFF, 0xFF, 0xFF, 0xFF,
+                          0, 0, 0, 0, 0, 0, 0, 0,
+            };
+            byte[] testBytes2 = new byte[]
+{
+                          0x0F, 0x1F, 0x2F, 0x3F,
+                          0x4F, 0x5F, 0x6F, 0x7F,
+                          0x8F, 0x9F, 0xAF, 0xBF,
+                          0xCF, 0xDF, 0xEF, 0xFF,
+};
+            ActivityTraceId testId = ActivityTraceId.CreateFromBytes(testBytes);
+            ActivityTraceId testId2 = ActivityTraceId.CreateFromBytes(testBytes2);
+
+            ActivityContext parentContext = new ActivityContext();
+            SamplingParameters testParams = new SamplingParameters(parentContext, testId, "TestActivity", ActivityKind.Internal);
+            SamplingParameters testParams2 = new SamplingParameters(parentContext, testId2, "TestActivity", ActivityKind.Internal);
+
+            ApplicationInsightsSampler zeroSampler = new ApplicationInsightsSampler(0);
+            ApplicationInsightsSampler oneSampler = new ApplicationInsightsSampler(1);
+
+            // 0.86 is below the sample score for testId1, but strict enough to drop testId2
+            ApplicationInsightsSampler ratioSampler = new ApplicationInsightsSampler(0.86f);
+
+            Assert.Equal(SamplingDecision.Drop, zeroSampler.ShouldSample(testParams).Decision);
+            Assert.Equal(SamplingDecision.Drop, zeroSampler.ShouldSample(testParams2).Decision);
+
+            Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams).Decision);
+            Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams2).Decision);
+
+            Assert.Equal(SamplingDecision.Drop, ratioSampler.ShouldSample(testParams).Decision);
+            Assert.Equal(SamplingDecision.RecordAndSample, ratioSampler.ShouldSample(testParams2).Decision);
+        }
+
+        [Fact]
+        public void ApplicationInsightsSamplerGoodArgs()
+        {
+            ApplicationInsightsSampler pointFiveSampler = new ApplicationInsightsSampler(0.5f);
+            Assert.NotNull(pointFiveSampler);
+
+            ApplicationInsightsSampler zeroSampler = new ApplicationInsightsSampler(0f);
+            Assert.NotNull(zeroSampler);
+
+            ApplicationInsightsSampler oneSampler = new ApplicationInsightsSampler(1f);
+            Assert.NotNull(oneSampler);
+        }
+
+        [Fact]
+        public void ApplicationInsightsSamplerBadArgs()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ApplicationInsightsSampler(-2f));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ApplicationInsightsSampler(2f));
+        }
+
+        [Fact]
+        public void GetDescriptionMatchesSpec()
+        {
+            var expectedDescription = "ApplicationInsightsSampler{0.5}";
+            Assert.Equal(expectedDescription, new ApplicationInsightsSampler(0.5f).Description);
+        }
+    }
+}


### PR DESCRIPTION
Azure Monitor's OpenTelemetry Exporter lacks a sampler that is compatible with the Application Insights SDK, due to AI's use of the DJB2 Hash Algorithm. This sampler samples on just that, [following this specification](https://github.com/microsoft/Telemetry-Collection-Spec/blob/main/OpenTelemetry/trace/ApplicationInsightsSampler.md). Note that this sampler is meant to be used as a delegate to a base sampler which considers whether the span's parents were sampled, as explained in more detail in the linked spec.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
