### PR TITLE
Fixed bug where ShareDirectoryClient.SetMetadataAsync() would not pro…

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -172,6 +172,7 @@ namespace Azure.Storage
             public const string ContentRange = "Content-Range";
             public const string VersionId = "x-ms-version-id";
             public const string LeaseTime = "x-ms-lease-time";
+            public const string LastModified = "Last-Modified";
         }
 
         internal static class ErrorCodes

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added support for service version 2020-10-02.
 - Added support for OAuth copy sources in ShareFileClient.UploadRangeFromUri()
 - Added support for including additional information in ShareDirectoryClient.GetFilesAndDirectories().
+- Fixed bug where ShareDirectoryClient.SetMetadataAsync() would not property parse Last-Modified response header.
 
 ## 12.7.0 (2021-06-08)
 - Includes all features from 12.7.0-beta.4.

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareExtensions.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareExtensions.cs
@@ -172,11 +172,12 @@ namespace Azure.Storage.Files.Shares
                 return null;
             }
 
-            // Set Directory metadata returns limited resposne headers - https://docs.microsoft.com/en-us/rest/api/storageservices/set-directory-metadata.
+            // Set Directory metadata returns limited response headers - https://docs.microsoft.com/en-us/rest/api/storageservices/set-directory-metadata.
             return new ShareDirectoryInfo
             {
                 ETag = response.GetRawResponse().Headers.ETag.GetValueOrDefault(),
-                SmbProperties = new FileSmbProperties()
+                SmbProperties = new FileSmbProperties(),
+                LastModified = response.GetRawResponse().Headers.ExtractLastModified()
             };
         }
 
@@ -200,6 +201,7 @@ namespace Azure.Storage.Files.Shares
             {
                 return null;
             }
+
             return new StorageClosedHandlesSegment
             {
                 Marker = response.Headers.Marker,
@@ -893,6 +895,18 @@ namespace Azure.Storage.Files.Shares
                 changedOn: fileProperty.ChangeTime,
                 lastModified: fileProperty.LastModified,
                 eTag: fileProperty.Etag == null ? null : new ETag(fileProperty.Etag));
+        }
+
+        internal static DateTimeOffset ExtractLastModified(this ResponseHeaders responseHeaders)
+        {
+            DateTimeOffset lastModified = DateTimeOffset.MinValue;
+
+            if (responseHeaders.TryGetValue(Constants.HeaderNames.LastModified, out string lastModifiedString))
+            {
+                lastModified = DateTimeOffset.Parse(lastModifiedString, CultureInfo.InvariantCulture);
+            }
+
+            return lastModified;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -703,7 +703,8 @@ namespace Azure.Storage.Files.Shares.Tests
             IDictionary<string, string> metadata = BuildMetadata();
 
             // Act
-            await directory.SetMetadataAsync(metadata);
+            Response<ShareDirectoryInfo> setMetadataResponse = await directory.SetMetadataAsync(metadata);
+            Assert.AreNotEqual(DateTimeOffset.MinValue, setMetadataResponse.Value.LastModified);
 
             // Assert
             Response<ShareDirectoryProperties> response = await directory.GetPropertiesAsync();


### PR DESCRIPTION
…perty parse Last-Modified response header.

Resolves https://github.com/Azure/azure-sdk-for-net/issues/22217