### PR TITLE
[Event Hubs Client] Repeated Amqp Header Property

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -371,11 +371,6 @@ namespace Azure.Messaging.EventHubs.Amqp
                 {
                     message.Header.FirstAcquirer = sourceMessage.Header.FirstAcquirer;
                 }
-
-                if (sourceMessage.Header.DeliveryCount.HasValue)
-                {
-                    message.Header.DeliveryCount = sourceMessage.Header.DeliveryCount;
-                }
             }
 
             // Properties


### PR DESCRIPTION
# Summary

The focus of these changes is to remove a redundant conditional that sets one of the AMQP header properties during event conversion.
