### PR TITLE
[MetricsAdvisor] Made NotificationHook abstract

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Optional properties `GetAllFeedbackOptions.Filter`, `GetAnomalyDimensionValuesOptions.DimensionToFilter`, and `FeedbackDimensionFilter.DimensionFilter` must now be manually added with setters to be used.
 - Moved property `DataFeed.SourceType` to `DataFeedSource.DataSourceType`.
 - In `MetricsAdvisorKeyCredential`, merged `UpdateSubscriptionKey` and `UpdateApiKey` into a single method, `Update`, to make it an atomic operation.
+- The class `NotificationHook` is now abstract.
 
 ## 1.0.0-beta.4 (2021-06-07)
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -493,7 +493,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
         public string Query { get { throw null; } set { } }
         public void UpdateConnectionString(string connectionString) { }
     }
-    public partial class NotificationHook
+    public abstract partial class NotificationHook
     {
         internal NotificationHook() { }
         public System.Collections.Generic.IReadOnlyList<string> AdministratorEmails { get { throw null; } }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/NotificationHook.Serialization.cs
@@ -5,9 +5,8 @@
 
 #nullable disable
 
-using System.Collections.Generic;
+using System;
 using System.Text.Json;
-using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Administration
@@ -42,68 +41,6 @@ namespace Azure.AI.MetricsAdvisor.Administration
                 writer.WriteEndArray();
             }
             writer.WriteEndObject();
-        }
-
-        internal static NotificationHook DeserializeNotificationHook(JsonElement element)
-        {
-            if (element.TryGetProperty("hookType", out JsonElement discriminator))
-            {
-                switch (discriminator.GetString())
-                {
-                    case "Email": return EmailNotificationHook.DeserializeEmailNotificationHook(element);
-                    case "Webhook": return WebNotificationHook.DeserializeWebNotificationHook(element);
-                }
-            }
-            HookType hookType = default;
-            Optional<string> hookId = default;
-            string hookName = default;
-            Optional<string> description = default;
-            Optional<string> externalLink = default;
-            Optional<IReadOnlyList<string>> admins = default;
-            foreach (var property in element.EnumerateObject())
-            {
-                if (property.NameEquals("hookType"))
-                {
-                    hookType = new HookType(property.Value.GetString());
-                    continue;
-                }
-                if (property.NameEquals("hookId"))
-                {
-                    hookId = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("hookName"))
-                {
-                    hookName = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("description"))
-                {
-                    description = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("externalLink"))
-                {
-                    externalLink = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("admins"))
-                {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        property.ThrowNonNullablePropertyIsNull();
-                        continue;
-                    }
-                    List<string> array = new List<string>();
-                    foreach (var item in property.Value.EnumerateArray())
-                    {
-                        array.Add(item.GetString());
-                    }
-                    admins = array;
-                    continue;
-                }
-            }
-            return new NotificationHook(hookType, hookId.Value, hookName, description.Value, externalLink.Value, Optional.ToList(admins));
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/NotificationHookTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/NotificationHookTests.cs
@@ -27,7 +27,6 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var name = "hookName";
             var endpoint = new Uri("http://fakeendpoint.com");
 
-            var genericHook = new NotificationHook(name);
             var emailHook = new EmailNotificationHook(name) { Name = null, EmailsToAlert = { "fake@email.com" } };
             var webHook = new WebNotificationHook(name, endpoint) { Name = null };
 
@@ -57,9 +56,6 @@ namespace Azure.AI.MetricsAdvisor.Tests
             webHook.Endpoint = null;
             Assert.That(() => adminClient.CreateHookAsync(webHook), Throws.InstanceOf<ArgumentNullException>());
             Assert.That(() => adminClient.CreateHook(webHook), Throws.InstanceOf<ArgumentNullException>());
-
-            Assert.That(() => adminClient.CreateHookAsync(genericHook), Throws.InstanceOf<ArgumentException>());
-            Assert.That(() => adminClient.CreateHook(genericHook), Throws.InstanceOf<ArgumentException>());
         }
 
         [Test]

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MockClientTestBase.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MockClientTestBase.cs
@@ -4,9 +4,13 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using Azure.AI.MetricsAdvisor.Administration;
+using Azure.Core;
 using Azure.Core.TestFramework;
 using Newtonsoft.Json;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
 
 namespace Azure.AI.MetricsAdvisor.Tests
 {
@@ -75,5 +79,20 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             return new MemoryStream(Encoding.UTF8.GetBytes(jsonStr));
         }
+
+        public string ReadContent(Request request)
+        {
+            using MemoryStream stream = new MemoryStream();
+            request.Content.WriteTo(stream, CancellationToken.None);
+
+            return Encoding.UTF8.GetString(stream.ToArray());
+        }
+
+        public SubstringConstraint ContainsJsonString(string propertyName, string propertyValue) =>
+            Contains.Substring($"\"{propertyName}\":\"{propertyValue}\"");
+
+        // Currently only supports a single-element array.
+        public SubstringConstraint ContainsJsonStringArray(string propertyName, string elementValue) =>
+            Contains.Substring($"\"{propertyName}\":[\"{elementValue}\"]");
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.MetricsAdvisor.Administration;
 using Azure.AI.MetricsAdvisor.Models;
@@ -93,9 +90,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MockRequest request = mockTransport.Requests.First();
             string content = ReadContent(request);
-            string expectedSubstring = $"\"{secretPropertyName}\":\"secret\"";
 
-            Assert.That(content, Contains.Substring(expectedSubstring));
+            Assert.That(content, ContainsJsonString(secretPropertyName, "secret"));
         }
 
         [Test]
@@ -125,7 +121,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MockRequest request = mockTransport.Requests.First();
             string content = ReadContent(request);
 
-            Assert.That(content, Contains.Substring($"\"{secretPropertyName}\":\"new_secret\""));
+            Assert.That(content, ContainsJsonString(secretPropertyName, "new_secret"));
         }
 
         private void UpdateSecret(DataFeedSource dataSource, string secretPropertyName)
@@ -175,14 +171,6 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 default:
                     throw new ArgumentOutOfRangeException($"Unknown data source type: {dataSource.GetType()}");
             };
-        }
-
-        private string ReadContent(Request request)
-        {
-            using MemoryStream stream = new MemoryStream();
-            request.Content.WriteTo(stream, CancellationToken.None);
-
-            return Encoding.UTF8.GetString(stream.ToArray());
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataSourceCredentialEntitiesTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataSourceCredentialEntitiesTests.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.MetricsAdvisor.Administration;
 using Azure.AI.MetricsAdvisor.Models;
@@ -83,7 +80,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MockRequest request = mockTransport.Requests.First();
             string content = ReadContent(request);
 
-            Assert.That(content, Contains.Substring("\"accountKey\":\"secret\""));
+            Assert.That(content, ContainsJsonString("accountKey", "secret"));
         }
 
         [Test]
@@ -107,7 +104,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MockRequest request = mockTransport.Requests.First();
             string content = ReadContent(request);
 
-            Assert.That(content, Contains.Substring("\"clientSecret\":\"secret\""));
+            Assert.That(content, ContainsJsonString("clientSecret", "secret"));
         }
 
         [Test]
@@ -131,7 +128,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MockRequest request = mockTransport.Requests.First();
             string content = ReadContent(request);
 
-            Assert.That(content, Contains.Substring("\"keyVaultClientSecret\":\"secret\""));
+            Assert.That(content, ContainsJsonString("keyVaultClientSecret", "secret"));
         }
 
         [Test]
@@ -155,15 +152,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MockRequest request = mockTransport.Requests.First();
             string content = ReadContent(request);
 
-            Assert.That(content, Contains.Substring("\"connectionString\":\"secret\""));
-        }
-
-        private string ReadContent(Request request)
-        {
-            using MemoryStream stream = new MemoryStream();
-            request.Content.WriteTo(stream, CancellationToken.None);
-
-            return Encoding.UTF8.GetString(stream.ToArray());
+            Assert.That(content, ContainsJsonString("connectionString", "secret"));
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/NotificationHookModelTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/NotificationHookModelTests.cs
@@ -67,7 +67,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MockRequest request = mockTransport.Requests.Last();
             string content = ReadContent(request);
 
-            Assert.That(request.Uri.Path, Is.EqualTo($"/metricsadvisor/v1.0/hooks/{FakeGuid}"));
+            Assert.That(request.Uri.Path, Contains.Substring(FakeGuid));
             Assert.That(content, ContainsJsonString("hookName", "newHookName"));
             Assert.That(content, ContainsJsonString("hookType", "unknownType"));
             Assert.That(content, ContainsJsonString("externalLink", "https://newfakeuri.com/"));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/NotificationHookModelTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/NotificationHookModelTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.AI.MetricsAdvisor.Administration;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.AI.MetricsAdvisor.Tests
+{
+    public class NotificationHookModelTests : MockClientTestBase
+    {
+        public NotificationHookModelTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        private string UnknownHookContent => $@"
+        {{
+            ""hookId"": ""{FakeGuid}"",
+            ""hookName"": ""unknownHookName"",
+            ""hookType"": ""unknownType"",
+            ""externalLink"": ""https://fakeuri.com/"",
+            ""description"": ""unknown hook description"",
+            ""admins"": [
+              ""foo@contoso.com""
+            ]
+        }}
+        ";
+
+        [Test]
+        public async Task NotificationHookGetsUnknownHook()
+        {
+            MockResponse getResponse = new MockResponse(200);
+            getResponse.SetContent(UnknownHookContent);
+
+            MetricsAdvisorAdministrationClient adminClient = CreateInstrumentedAdministrationClient(getResponse);
+            NotificationHook hook = await adminClient.GetHookAsync(FakeGuid);
+
+            Assert.That(hook.Id, Is.EqualTo(FakeGuid));
+            Assert.That(hook.Name, Is.EqualTo("unknownHookName"));
+            Assert.That(hook.ExternalUri.AbsoluteUri, Is.EqualTo("https://fakeuri.com/"));
+            Assert.That(hook.Description, Is.EqualTo("unknown hook description"));
+            Assert.That(hook.AdministratorEmails.Single(), Is.EqualTo("foo@contoso.com"));
+        }
+
+        [Test]
+        public async Task NotificationHookUpdatesUnknownHook()
+        {
+            MockResponse getResponse = new MockResponse(200);
+            getResponse.SetContent(UnknownHookContent);
+
+            MockResponse updateResponse = new MockResponse(200);
+            updateResponse.SetContent(UnknownHookContent);
+
+            MockTransport mockTransport = new MockTransport(getResponse, updateResponse);
+            MetricsAdvisorAdministrationClient adminClient = CreateInstrumentedAdministrationClient(mockTransport);
+            NotificationHook hook = await adminClient.GetHookAsync(FakeGuid);
+
+            hook.Name = "newHookName";
+            hook.ExternalUri = new Uri("https://newfakeuri.com/");
+            hook.Description = "new description";
+
+            await adminClient.UpdateHookAsync(hook);
+
+            MockRequest request = mockTransport.Requests.Last();
+            string content = ReadContent(request);
+
+            Assert.That(request.Uri.Path, Is.EqualTo($"/metricsadvisor/v1.0/hooks/{FakeGuid}"));
+            Assert.That(content, ContainsJsonString("hookName", "newHookName"));
+            Assert.That(content, ContainsJsonString("hookType", "unknownType"));
+            Assert.That(content, ContainsJsonString("externalLink", "https://newfakeuri.com/"));
+            Assert.That(content, ContainsJsonString("description", "new description"));
+            Assert.That(content, ContainsJsonStringArray("admins", "foo@contoso.com"));
+        }
+    }
+}


### PR DESCRIPTION
Making `NotificationHook` abstract after architect feedback.

Similar changes are expected for `MetricFeedback`, `DataFeedSource`, and `DataSourceCredentialEntity`.