### PR TITLE
Read package information from msbuild

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -264,5 +264,23 @@
   <Target Name="RunApiCompat" DependsOnTargets="ValidateApiCompatForSrc" Condition="'$(ApiCompatVersion)' != ''">
   </Target>
 
+  <Target Name="GetPackageInfo">
+    <PropertyGroup>
+      <PackageIsNewSdk>false</PackageIsNewSdk>
+      <PackageIsNewSdk Condition="'$(IsClientLibrary)' == 'true'">true</PackageIsNewSdk>
+
+      <PackageSdkType>data</PackageSdkType>
+      <PackageSdkType Condition="'$(IsClientLibrary)' == 'true'">client</PackageSdkType>
+      <PackageSdkType Condition="'$(IsMgmtLibrary)' == 'true'">mgmt</PackageSdkType>
+
+      <PackageRootDirectory>$([MSBuild]::NormalizeDirectory($(MSBuildProjectDirectory)/../).Trim("/").Trim("\\"))</PackageRootDirectory>
+
+      <!-- Parse out the service directory based on the relative path to the sdk folder -->
+      <ServiceDirectory><![CDATA[$([System.Text.RegularExpressions.Regex]::Replace($(PackageRootDirectory), '^.*[\\/]+sdk[\\/]+([^\\/]+).*$', '$1'))]]></ServiceDirectory>
+    </PropertyGroup>
+
+    <Message Condition="'$(IsShippingLibrary)' == 'true'" Text="'$(PackageRootDirectory)' '$(ServiceDirectory)' '$(PackageId)' '$(_VersionInProject)' '$(PackageSdkType)' '$(PackageIsNewSdk)'" Importance="High" />
+  </Target>
+
   <Import Project="$(CentralPackageVersionPackagePath)\Sdk.targets" />
 </Project>

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -13,6 +13,8 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
 
   foreach ($projectOutput in $msbuildOutput)
   {
+    if (!$projectOutput) { continue }
+
     $pkgPath, $serviceDirectory, $pkgName, $pkgVersion, $sdkType, $isNewSdk = $projectOutput.Split(' ',[System.StringSplitOptions]::RemoveEmptyEntries).Trim("'")
 
     $pkgProp = [PackageProps]::new($pkgName, $pkgVersion, $pkgPath, $serviceDirectory)

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -9,7 +9,7 @@ $BlobStorageUrl = "https://azuresdkdocs.blob.core.windows.net/%24web?restype=con
 function Get-AllPackageInfoFromRepo($serviceDirectory)
 {
   $allPackageProps = @()
-  $msbuildOutput = dotnet msbuild /nologo /t:GetAllPackageInfo $EngDir/service.proj /p:ServiceDirectory=$serviceDirectory
+  $msbuildOutput = dotnet msbuild /nologo /t:GetPackageInfo $EngDir/service.proj /p:ServiceDirectory=$serviceDirectory
 
   foreach ($projectOutput in $msbuildOutput)
   {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -6,46 +6,24 @@ $packagePattern = "*.nupkg"
 $MetadataUri = "https://raw.githubusercontent.com/Azure/azure-sdk/main/_data/releases/latest/dotnet-packages.csv"
 $BlobStorageUrl = "https://azuresdkdocs.blob.core.windows.net/%24web?restype=container&comp=list&prefix=dotnet%2F&delimiter=%2F"
 
-function Get-dotnet-PackageInfoFromRepo ($pkgPath, $serviceDirectory)
+function Get-AllPackageInfoFromRepo($serviceDirectory)
 {
-  $projDirPath = (Join-Path $pkgPath "src")
+  $allPackageProps = @()
+  $msbuildOutput = dotnet msbuild /nologo /t:GetAllPackageInfo $EngDir/service.proj /p:ServiceDirectory=$serviceDirectory
 
-  if (!(Test-Path $projDirPath))
+  foreach ($projectOutput in $msbuildOutput)
   {
-    return $null
-  }
+    $pkgPath, $serviceDirectory, $pkgName, $pkgVersion, $sdkType, $isNewSdk = $projectOutput.Split(' ',[System.StringSplitOptions]::RemoveEmptyEntries).Trim("'")
 
-  $projectPaths = @(Resolve-Path (Join-Path $projDirPath "*.csproj"))
-
-  if ($projectpaths.Count -ge 1) {
-    $projectPath = $projectPaths[0].path
-    if ($projectPaths.Count -gt 1) {
-      LogWarning "There is more than on csproj file in the projectpath/src directory. First project picked."
-    }
-  }
-  else {
-    return $null
-  }
-
-  if ($projectPath -and (Test-Path $projectPath))
-  {
-    $pkgName = Split-Path -Path $projectPath -LeafBase
-    $projectData = New-Object -TypeName XML
-    $projectData.load($projectPath)
-    $pkgVersion = Select-XML -Xml $projectData -XPath '/Project/PropertyGroup/Version'
-    $sdkType = "client"
-    if ($pkgName -match "\.ResourceManager\." -or $pkgName -match "\.Management\.")
-    {
-      $sdkType = "mgmt"
-    }
     $pkgProp = [PackageProps]::new($pkgName, $pkgVersion, $pkgPath, $serviceDirectory)
     $pkgProp.SdkType = $sdkType
-    $pkgProp.IsNewSdk = $pkgName.StartsWith("Azure")
+    $pkgProp.IsNewSdk = ($isNewSdk -eq 'true')
     $pkgProp.ArtifactName = $pkgName
-    return $pkgProp
+
+    $allPackageProps += $pkgProp
   }
 
-  return $null
+  return $allPackageProps
 }
 
 # Returns the nuget publish status of a package id and version.

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -63,4 +63,12 @@
     <Message Text="Final Build References:" Importance="high"/>
     <Message Text="  %(ProjectReference.Identity)" Importance="high"/>
   </Target>
+
+  <Target Name="GetAllPackageInfo">
+    <MSBuild Projects="@(ProjectReference)"
+            Targets="GetPackageInfo"
+            BuildInParallel="$(BuildInParallel)"
+            SkipNonexistentProjects="false"
+            SkipNonexistentTargets="true" />
+  </Target>
 </Project>

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -64,7 +64,7 @@
     <Message Text="  %(ProjectReference.Identity)" Importance="high"/>
   </Target>
 
-  <Target Name="GetAllPackageInfo">
+  <Target Name="GetPackageInfo">
     <MSBuild Projects="@(ProjectReference)"
             Targets="GetPackageInfo"
             BuildInParallel="$(BuildInParallel)"


### PR DESCRIPTION
In order to avoid duplication of logic we are creating an
msbuild target that dumps out the properties for each of the
projects and then parsing that for our other engineering system
needs.

Fixes https://github.com/Azure/azure-sdk-tools/issues/1673
