### PR TITLE
[AWPS_Function] Fix parameter AutorResolve under WebPubSubTrigger.

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubConfigProvider.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubConfigProvider.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
 
             // Trigger binding
             context.AddBindingRule<WebPubSubTriggerAttribute>()
-                .BindToTrigger(new WebPubSubTriggerBindingProvider(_dispatcher, _options, webhookException));
+                .BindToTrigger(new WebPubSubTriggerBindingProvider(_dispatcher, _nameResolver, _options, webhookException));
 
             var webpubsubConnectionAttributeRule = context.AddBindingRule<WebPubSubConnectionAttribute>();
             webpubsubConnectionAttributeRule.AddValidator(ValidateWebPubSubConnectionAttributeBinding);

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerBinding.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerBinding.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerBindingProvider.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerBindingProvider.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
-
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
@@ -12,12 +12,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
     internal class WebPubSubTriggerBindingProvider : ITriggerBindingProvider
     {
         private readonly IWebPubSubTriggerDispatcher _dispatcher;
+        private readonly INameResolver _nameResolver;
         private readonly WebPubSubOptions _options;
         private readonly Exception _webhookException;
 
-        public WebPubSubTriggerBindingProvider(IWebPubSubTriggerDispatcher dispatcher, WebPubSubOptions options, Exception webhookException)
+        public WebPubSubTriggerBindingProvider(IWebPubSubTriggerDispatcher dispatcher, INameResolver nameResolver, WebPubSubOptions options, Exception webhookException)
         {
             _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+            _nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _webhookException = webhookException;
         }
@@ -41,7 +43,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
                 throw new NotSupportedException($"WebPubSubTrigger is disabled due to 'AzureWebJobsStorage' connection string is not set or invalid. {_webhookException}");
             }
 
-            return Task.FromResult<ITriggerBinding>(new WebPubSubTriggerBinding(parameterInfo, attribute, _options, _dispatcher));
+            return Task.FromResult<ITriggerBinding>(new WebPubSubTriggerBinding(parameterInfo, GetResolvedAttribute(attribute), _options, _dispatcher));
+        }
+
+        internal WebPubSubTriggerAttribute GetResolvedAttribute(WebPubSubTriggerAttribute attribute)
+        {
+            // Try resolve and throw exception if not able to find one.
+            if (!_nameResolver.TryResolveWholeString(attribute.Hub, out var hub))
+            {
+                throw new ArgumentException($"Failed to resolve substitute confingure: {attribute.Hub}, please add.");
+            }
+            if (!_nameResolver.TryResolveWholeString(attribute.EventName, out var eventName))
+            {
+                throw new ArgumentException($"Failed to resolve substitute confingure: {attribute.EventName}, please add.");
+            }
+
+            return new WebPubSubTriggerAttribute(
+                hub,
+                attribute.EventType,
+                eventName);
         }
     }
 }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerBindingProvider.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerBindingProvider.cs
@@ -51,11 +51,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
             // Try resolve and throw exception if not able to find one.
             if (!_nameResolver.TryResolveWholeString(attribute.Hub, out var hub))
             {
-                throw new ArgumentException($"Failed to resolve substitute confingure: {attribute.Hub}, please add.");
+                throw new ArgumentException($"Failed to resolve substitute configure: {attribute.Hub}, please add.");
             }
             if (!_nameResolver.TryResolveWholeString(attribute.EventName, out var eventName))
             {
-                throw new ArgumentException($"Failed to resolve substitute confingure: {attribute.EventName}, please add.");
+                throw new ArgumentException($"Failed to resolve substitute configure: {attribute.EventName}, please add.");
             }
 
             return new WebPubSubTriggerAttribute(

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerBindingProviderTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerBindingProviderTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
+{
+    public class WebPubSubTriggerBindingProviderTests
+    {
+        private readonly WebPubSubTriggerBindingProvider _provider;
+        private readonly IConfiguration _configuration;
+
+        private const string TestHub = "test_hub";
+
+        public WebPubSubTriggerBindingProviderTests()
+        {
+            _configuration = new ConfigurationBuilder()
+                .AddEnvironmentVariables()
+                .AddInMemoryCollection()
+                .Build();
+            _configuration["testhub"] = TestHub;
+            var resolver = new DefaultNameResolver(_configuration);
+            var mockDispater = new Mock<IWebPubSubTriggerDispatcher>(MockBehavior.Strict);
+            var config = new WebPubSubOptions();
+            _provider = new WebPubSubTriggerBindingProvider(mockDispater.Object, resolver, config, null);
+        }
+
+        [TestCase]
+        public void ResolveTriggerAttributeTest()
+        {
+            var attribute = new WebPubSubTriggerAttribute("%testhub%", WebPubSubEventType.System, "testevent");
+            var resolvedAttr = _provider.GetResolvedAttribute(attribute);
+            Assert.AreEqual(resolvedAttr.Hub, TestHub);
+            Assert.AreEqual(resolvedAttr.EventName, "testevent");
+        }
+
+        [TestCase]
+        public void DefaultTriggerAttributeTest()
+        {
+            var attribute = new WebPubSubTriggerAttribute("defaulthub", WebPubSubEventType.System, "testevent");
+            var resolvedAttr = _provider.GetResolvedAttribute(attribute);
+            Assert.AreEqual(resolvedAttr.Hub, "defaulthub");
+            Assert.AreEqual(resolvedAttr.EventName, "testevent");
+        }
+
+        [TestCase]
+        public void ResolveTriggerAttributeTest_NotConfigureThrows()
+        {
+            var attribute = new WebPubSubTriggerAttribute("%nullhub%", WebPubSubEventType.System, "testevent");
+            Assert.Throws<ArgumentException>(() => _provider.GetResolvedAttribute(attribute),
+                "Failed to resolve substitute confingure: %nullhub%, please add.");
+        }
+
+        [TestCase]
+        public async Task TestCreateAsyncTests()
+        {
+            var parameter = GetType().GetMethod("TestFunc").GetParameters()[0];
+            var context = new TriggerBindingProviderContext(parameter, CancellationToken.None);
+            var binding = await _provider.TryCreateAsync(context);
+
+            Assert.NotNull(binding);
+        }
+
+        public static void TestFunc(
+            [WebPubSubTrigger("%testhub%", WebPubSubEventType.System, "testevent")]ConnectionContext context)
+        {
+        }
+    }
+}

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerBindingProviderTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerBindingProviderTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
         {
             var attribute = new WebPubSubTriggerAttribute("%nullhub%", WebPubSubEventType.System, "testevent");
             Assert.Throws<ArgumentException>(() => _provider.GetResolvedAttribute(attribute),
-                "Failed to resolve substitute confingure: %nullhub%, please add.");
+                "Failed to resolve substitute configure: %nullhub%, please add.");
         }
 
         [TestCase]


### PR DESCRIPTION
# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
