### PR TITLE
Standardize timeouts and remove sync over async in tests

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/README.md
+++ b/sdk/core/Azure.Core.TestFramework/README.md
@@ -524,8 +524,8 @@ var isSet = AppContext.TryGetSwitch("Azure.Core.Pipeline.DisableHttpWebRequestTr
 This type contains static helper methods that cover some of the gaps in NUnit when it comes to async assertions. For instance, attempting to assert that a specific exception is thrown using Assert.That, Assert.Throws, or Assert.ThrowsAsync all result in sync over async code, which can lead to test flakiness. 
 
 #### Example usage
-```c#
-var exception = await AsyncAssert.ThrowsAsync<ServiceBusException>(
+```c# 
+ServiceBusException exception = await AsyncAssert.ThrowsAsync<ServiceBusException>(
     async () => await args.CompleteMessageAsync(message, args.CancellationToken));
-Assert.AreEqual(ServiceBusFailureReason.MessageLockLost, ((ServiceBusException) exception).Reason);
+Assert.AreEqual(ServiceBusFailureReason.MessageLockLost, exception.Reason);
 ```

--- a/sdk/core/Azure.Core.TestFramework/README.md
+++ b/sdk/core/Azure.Core.TestFramework/README.md
@@ -519,3 +519,13 @@ using (var _ = new TestAppContextSwitch("Azure.Core.Pipeline.DisableHttpWebReque
 var isSet = AppContext.TryGetSwitch("Azure.Core.Pipeline.DisableHttpWebRequestTransport", out val))
 // isSet is false
 ```
+
+### AsyncAssert
+This type contains static helper methods that cover some of the gaps in NUnit when it comes to async assertions. For instance, attempting to assert that a specific exception is thrown using Assert.That, Assert.Throws, or Assert.ThrowsAsync all result in sync over async code, which can lead to test flakiness. 
+
+#### Example usage
+```c#
+var exception = await AsyncAssert.ThrowsAsync<ServiceBusException>(
+    async () => await args.CompleteMessageAsync(message, args.CancellationToken));
+Assert.AreEqual(ServiceBusFailureReason.MessageLockLost, ((ServiceBusException) exception).Reason);
+```

--- a/sdk/core/Azure.Core.TestFramework/src/AsyncAssert.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/AsyncAssert.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Azure.Core.TestFramework
+{
+    public static class AsyncAssert
+    {
+        public static async Task<T> ThrowsAsync<T>(Func<Task> action) where T : Exception
+        {
+            Exception triggeredException = null;
+            try
+            {
+                await action.Invoke();
+            }
+            catch (Exception ex)
+            {
+                triggeredException = ex;
+            }
+            if (triggeredException is not T exception)
+            {
+                // intentionally not using Assert.IsInstanceOf for testability
+                throw new AssertionException($"\r\nExpected: {typeof(T)}\r\nBut was: {triggeredException?.GetType().ToString() ?? "null"}");
+            }
+            return exception;
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/AsyncAssertTests.cs
+++ b/sdk/core/Azure.Core/tests/AsyncAssertTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class AsyncAssertTests
+    {
+        [Test]
+        public async Task ReturnsExpectedException()
+        {
+            var exception = await AsyncAssert.ThrowsAsync<ExpectedException>(() => throw new ExpectedException());
+            Assert.NotNull(exception);
+        }
+
+        [Test]
+        public async Task ThrowsWhenWrongException()
+        {
+            bool failed = false;
+            try
+            {
+                await AsyncAssert.ThrowsAsync<ExpectedException>(() => throw new Exception());
+            }
+            catch (AssertionException)
+            {
+                failed = true;
+            }
+            Assert.IsTrue(failed);
+        }
+
+        [Test]
+        public async Task ThrowsWhenNoException()
+        {
+            bool failed = false;
+            try
+            {
+                await AsyncAssert.ThrowsAsync<ExpectedException>(() => Task.CompletedTask);
+            }
+            catch (AssertionException)
+            {
+                failed = true;
+            }
+            Assert.IsTrue(failed);
+        }
+    }
+
+#pragma warning disable SA1402 // File may only contain a single type
+    public class ExpectedException : Exception
+#pragma warning restore SA1402 // File may only contain a single type
+    {
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -30,7 +30,7 @@ namespace Azure.Messaging.ServiceBus
         protected readonly IList<ServiceBusPlugin> _plugins;
 
         protected bool AutoRenewLock => ProcessorOptions.MaxAutoLockRenewalDuration > TimeSpan.Zero;
-        
+
         public ReceiverManager(
             ServiceBusProcessor processor,
             EntityScopeFactory scopeFactory,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
@@ -14,6 +14,9 @@ namespace Azure.Messaging.ServiceBus.Tests
     {
         private const int DefaultTryTimeout = 15;
 
+        // for tests that use short lock durations, don't go below 10 seconds to avoid flakiness.
+        protected TimeSpan ShortLockDuration = TimeSpan.FromSeconds(10);
+
         public ServiceBusTestEnvironment TestEnvironment { get; } = ServiceBusTestEnvironment.Instance;
 
         protected ServiceBusClient CreateNoRetryClient(int tryTimeout = DefaultTryTimeout)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
@@ -14,8 +14,8 @@ namespace Azure.Messaging.ServiceBus.Tests
     {
         private const int DefaultTryTimeout = 10;
 
-        // for tests that use short lock durations, don't go below 5 seconds to avoid flakiness.
-        protected TimeSpan ShortLockDuration = TimeSpan.FromSeconds(5);
+        // for tests that use short lock durations, don't go below 10 seconds to avoid flakiness.
+        protected TimeSpan ShortLockDuration = TimeSpan.FromSeconds(10);
 
         public ServiceBusTestEnvironment TestEnvironment { get; } = ServiceBusTestEnvironment.Instance;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
@@ -14,8 +14,8 @@ namespace Azure.Messaging.ServiceBus.Tests
     {
         private const int DefaultTryTimeout = 10;
 
-        // for tests that use short lock durations, don't go below 10 seconds to avoid flakiness.
-        protected TimeSpan ShortLockDuration = TimeSpan.FromSeconds(10);
+        // for tests that use short lock durations, don't go below 15 seconds to avoid flakiness.
+        protected TimeSpan ShortLockDuration = TimeSpan.FromSeconds(15);
 
         public ServiceBusTestEnvironment TestEnvironment { get; } = ServiceBusTestEnvironment.Instance;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
@@ -12,10 +12,10 @@ namespace Azure.Messaging.ServiceBus.Tests
     [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
     public abstract class ServiceBusLiveTestBase : ServiceBusTestBase
     {
-        private const int DefaultTryTimeout = 15;
+        private const int DefaultTryTimeout = 10;
 
-        // for tests that use short lock durations, don't go below 10 seconds to avoid flakiness.
-        protected TimeSpan ShortLockDuration = TimeSpan.FromSeconds(10);
+        // for tests that use short lock durations, don't go below 5 seconds to avoid flakiness.
+        protected TimeSpan ShortLockDuration = TimeSpan.FromSeconds(5);
 
         public ServiceBusTestEnvironment TestEnvironment { get; } = ServiceBusTestEnvironment.Instance;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
@@ -14,8 +14,7 @@ namespace Azure.Messaging.ServiceBus.Tests
     {
         private const int DefaultTryTimeout = 10;
 
-        // for tests that use short lock durations, don't go below 15 seconds to avoid flakiness.
-        protected TimeSpan ShortLockDuration = TimeSpan.FromSeconds(15);
+        protected TimeSpan ShortLockDuration = TimeSpan.FromSeconds(10);
 
         public ServiceBusTestEnvironment TestEnvironment { get; } = ServiceBusTestEnvironment.Instance;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -294,7 +294,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                         // only do the assertion if cancellation wasn't requested as otherwise
                         // the exception we would get is a TaskCanceledException rather than ServiceBusException
                         Assert.AreEqual(lockedUntil, message.LockedUntil);
-                        var exception = await AsyncAssert.ThrowsAsync<ServiceBusException>(
+                        ServiceBusException exception = await AsyncAssert.ThrowsAsync<ServiceBusException>(
                             async () => await args.CompleteMessageAsync(message, args.CancellationToken));
                         Assert.AreEqual(ServiceBusFailureReason.MessageLockLost, exception.Reason);
                         Interlocked.Increment(ref messageCt);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -248,7 +248,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         [TestCase(20, 1)]
         public async Task MaxAutoLockRenewalDurationRespected(int numThreads, int autoLockRenewalDuration)
         {
-            var lockDuration = TimeSpan.FromSeconds(5);
+            var lockDuration = ShortLockDuration;
             await using (var scope = await ServiceBusScope.CreateWithQueue(
                 enablePartitioning: false,
                 enableSession: false,
@@ -604,7 +604,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(
                 enablePartitioning: false,
-                enableSession: false))
+                enableSession: false,
+                lockDuration: ShortLockDuration))
             {
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
@@ -655,7 +656,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 await tcs.Task;
                 await processor.StopProcessingAsync();
                 var receiver = client.CreateReceiver(scope.QueueName);
-                var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+                var msg = await receiver.ReceiveMessageAsync(ShortLockDuration);
                 if (settleMethod == "" || settleMethod == "Abandon")
                 {
                     // if the message is abandoned (whether by user callback or

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -296,7 +296,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                         Assert.AreEqual(lockedUntil, message.LockedUntil);
                         var exception = await AsyncAssert.ThrowsAsync<ServiceBusException>(
                             async () => await args.CompleteMessageAsync(message, args.CancellationToken));
-                        Assert.AreEqual(ServiceBusFailureReason.MessageLockLost, ((ServiceBusException) exception).Reason);
+                        Assert.AreEqual(ServiceBusFailureReason.MessageLockLost, exception.Reason);
                         Interlocked.Increment(ref messageCt);
                         var setIndex = Interlocked.Increment(ref completionSourceIndex);
                         if (setIndex < numThreads)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -765,7 +765,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         [Test]
         public async Task StopProcessingDoesNotCancelAutoCompletion()
         {
-            var lockDuration = TimeSpan.FromSeconds(5);
+            var lockDuration = ShortLockDuration;
             await using (var scope = await ServiceBusScope.CreateWithQueue(
                 enablePartitioning: false,
                 enableSession: true,
@@ -809,7 +809,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             await using (var scope = await ServiceBusScope.CreateWithQueue(
                 enablePartitioning: false,
                 enableSession: true,
-                lockDuration: TimeSpan.FromSeconds(5)))
+                lockDuration: ShortLockDuration))
             {
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
@@ -859,7 +859,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 if (settleMethod == "" || settleMethod == "Abandon")
                 {
                     var receiver = await client.AcceptNextSessionAsync(scope.QueueName);
-                    var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+                    var msg = await receiver.ReceiveMessageAsync(ShortLockDuration);
                     Assert.IsNotNull(msg);
                 }
                 else
@@ -992,7 +992,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         [TestCase(10, 10, 3)]
         public async Task SessionLockLostWhenProcessSessionMessages(int numSessions, int numThreads, int lockLostCount)
         {
-            var lockDuration = TimeSpan.FromSeconds(5);
+            var lockDuration = ShortLockDuration;
             await using (var scope = await ServiceBusScope.CreateWithQueue(
                 enablePartitioning: false,
                 enableSession: true,
@@ -1090,7 +1090,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                                 args.SessionId,
                                 1,
                                 (key, oldValue) => oldValue + 1);
-                            await Task.Delay(lockDuration.Add(TimeSpan.FromSeconds(5)));
+                            await Task.Delay(lockDuration.Add(lockDuration));
 
                             // we expect a lock lost exception
                             // when the message is auto-completed
@@ -1144,7 +1144,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         [Test]
         public async Task UserErrorHandlerInvokedOnceIfSessionLockLost()
         {
-            var lockDuration = TimeSpan.FromSeconds(10);
+            var lockDuration = ShortLockDuration;
             await using (var scope = await ServiceBusScope.CreateWithQueue(
                 enablePartitioning: false,
                 enableSession: true,
@@ -1166,7 +1166,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var options = new ServiceBusSessionProcessorOptions
                 {
                     MaxConcurrentSessions = 1,
-                    MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(10),
+                    MaxAutoLockRenewalDuration = lockDuration,
                     SessionIds = { sessionId }
                 };
 
@@ -1244,9 +1244,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             await using (var scope = await ServiceBusScope.CreateWithQueue(
                 enablePartitioning: false,
                 enableSession: true,
-                lockDuration: TimeSpan.FromSeconds(5)))
+                lockDuration: ShortLockDuration))
             {
-                var delayDuration = TimeSpan.FromSeconds(10);
+                var delayDuration = ShortLockDuration.Add(ShortLockDuration);
                 await using var client = CreateClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
@@ -1416,7 +1416,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         [Test]
         public async Task SessionOpenEventDoesNotLoseLock()
         {
-            var lockDuration = TimeSpan.FromSeconds(10);
+            var lockDuration = ShortLockDuration;
             await using (var scope = await ServiceBusScope.CreateWithQueue(
                 enablePartitioning: false,
                 enableSession: true,
@@ -1461,7 +1461,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     {
                         var message = args.Message;
                         await args.CompleteMessageAsync(message);
-                        await Task.Delay(lockDuration.Add(TimeSpan.FromSeconds(10)));
+                        await Task.Delay(lockDuration.Add(lockDuration));
 
                         sessions.TryRemove(message.SessionId, out bool _);
                         Assert.IsTrue(sessionId.Contains(message.SessionId));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -1437,7 +1437,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var options = new ServiceBusSessionProcessorOptions
                 {
                     MaxConcurrentSessions = 1,
-                    MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(30),
+                    MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(45),
                     SessionIds = { sessionId }
                 };
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -1437,7 +1437,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var options = new ServiceBusSessionProcessorOptions
                 {
                     MaxConcurrentSessions = 1,
-                    MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(45),
+                    MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(30),
                     SessionIds = { sessionId }
                 };
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -567,7 +567,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 "  \"MaxAutoLockRenewalDuration\": \"00:05:00\",",
                $"  \"MaxConcurrentCalls\": {16 * Utility.GetProcessorCount()},",
                 "  \"MaxConcurrentSessions\": 8,",
-                "  \"MaxBatchSize\": 1000,",
+                "  \"MaxMessageBatchSize\": 1000,",
                 "  \"SessionIdleTimeout\": \"\"",
                 "  \"ClientRetryOptions\": {",
                 "       \"Mode\": \"Exponential\",",


### PR DESCRIPTION
Fixes flaky tests - https://dev.azure.com/azure-sdk/internal/_build/results?buildId=977144&view=ms.vss-test-web.build-test-results-tab&runId=21008528&resultId=100302&paneView=debug