### PR TITLE
[MetricsAdvisor] Made DataSourceCredentialEntity abstract

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Moved property `DataFeed.SourceType` to `DataFeedSource.DataSourceType`.
 - In `MetricsAdvisorKeyCredential`, merged `UpdateSubscriptionKey` and `UpdateApiKey` into a single method, `Update`, to make it an atomic operation.
 - The class `NotificationHook` is now abstract.
+- The class `DatasourceCredential` (now called `DataSourceCredentialEntity`) is now abstract.
 
 ## 1.0.0-beta.4 (2021-06-07)
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -314,7 +314,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
         public DataLakeSharedKeyCredentialEntity(string name, string accountKey) { }
         public void UpdateAccountKey(string accountKey) { }
     }
-    public partial class DataSourceCredentialEntity
+    public abstract partial class DataSourceCredentialEntity
     {
         internal DataSourceCredentialEntity() { }
         public string Description { get { throw null; } set { } }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataSourceCredentialEntity.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/DataSourceCredentialEntity.Serialization.cs
@@ -5,8 +5,8 @@
 
 #nullable disable
 
+using System;
 using System.Text.Json;
-using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Administration
@@ -26,48 +26,6 @@ namespace Azure.AI.MetricsAdvisor.Administration
                 writer.WriteStringValue(Description);
             }
             writer.WriteEndObject();
-        }
-
-        internal static DataSourceCredentialEntity DeserializeDataSourceCredentialEntity(JsonElement element)
-        {
-            if (element.TryGetProperty("dataSourceCredentialType", out JsonElement discriminator))
-            {
-                switch (discriminator.GetString())
-                {
-                    case "AzureSQLConnectionString": return SqlConnectionStringCredentialEntity.DeserializeSqlConnectionStringCredentialEntity(element);
-                    case "DataLakeGen2SharedKey": return DataLakeSharedKeyCredentialEntity.DeserializeDataLakeSharedKeyCredentialEntity(element);
-                    case "ServicePrincipal": return ServicePrincipalCredentialEntity.DeserializeServicePrincipalCredentialEntity(element);
-                    case "ServicePrincipalInKV": return ServicePrincipalInKeyVaultCredentialEntity.DeserializeServicePrincipalInKeyVaultCredentialEntity(element);
-                }
-            }
-            DataSourceCredentialType dataSourceCredentialType = default;
-            Optional<string> dataSourceCredentialId = default;
-            string dataSourceCredentialName = default;
-            Optional<string> dataSourceCredentialDescription = default;
-            foreach (var property in element.EnumerateObject())
-            {
-                if (property.NameEquals("dataSourceCredentialType"))
-                {
-                    dataSourceCredentialType = new DataSourceCredentialType(property.Value.GetString());
-                    continue;
-                }
-                if (property.NameEquals("dataSourceCredentialId"))
-                {
-                    dataSourceCredentialId = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("dataSourceCredentialName"))
-                {
-                    dataSourceCredentialName = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("dataSourceCredentialDescription"))
-                {
-                    dataSourceCredentialDescription = property.Value.GetString();
-                    continue;
-                }
-            }
-            return new DataSourceCredentialEntity(dataSourceCredentialType, dataSourceCredentialId.Value, dataSourceCredentialName, dataSourceCredentialDescription.Value);
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/DataSourceCredentialEntity.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/Credential/DataSourceCredentialEntity.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Text.Json;
 using Azure.AI.MetricsAdvisor.Models;
 using Azure.Core;
 
@@ -18,7 +19,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
     /// </list>
     /// </summary>
     [CodeGenModel("DataSourceCredential")]
-    public partial class DataSourceCredentialEntity
+    public abstract partial class DataSourceCredentialEntity
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DataSourceCredentialEntity"/> class.
@@ -76,13 +77,68 @@ namespace Azure.AI.MetricsAdvisor.Administration
                 {
                     Parameters = new() { ConnectionString = c.ConnectionString }
                 },
-                _ => throw new InvalidOperationException("Invalid data source credential type")
+                _ => new DataSourceCredentialPatch()
             };
 
+            patch.DataSourceCredentialType = DataSourceCredentialType;
             patch.DataSourceCredentialName = Name;
             patch.DataSourceCredentialDescription = Description;
 
             return patch;
+        }
+
+        internal static DataSourceCredentialEntity DeserializeDataSourceCredentialEntity(JsonElement element)
+        {
+            if (element.TryGetProperty("dataSourceCredentialType", out JsonElement discriminator))
+            {
+                switch (discriminator.GetString())
+                {
+                    case "AzureSQLConnectionString":
+                        return SqlConnectionStringCredentialEntity.DeserializeSqlConnectionStringCredentialEntity(element);
+                    case "DataLakeGen2SharedKey":
+                        return DataLakeSharedKeyCredentialEntity.DeserializeDataLakeSharedKeyCredentialEntity(element);
+                    case "ServicePrincipal":
+                        return ServicePrincipalCredentialEntity.DeserializeServicePrincipalCredentialEntity(element);
+                    case "ServicePrincipalInKV":
+                        return ServicePrincipalInKeyVaultCredentialEntity.DeserializeServicePrincipalInKeyVaultCredentialEntity(element);
+                }
+            }
+            DataSourceCredentialType dataSourceCredentialType = default;
+            Optional<string> dataSourceCredentialId = default;
+            string dataSourceCredentialName = default;
+            Optional<string> dataSourceCredentialDescription = default;
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("dataSourceCredentialType"))
+                {
+                    dataSourceCredentialType = new DataSourceCredentialType(property.Value.GetString());
+                    continue;
+                }
+                if (property.NameEquals("dataSourceCredentialId"))
+                {
+                    dataSourceCredentialId = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("dataSourceCredentialName"))
+                {
+                    dataSourceCredentialName = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("dataSourceCredentialDescription"))
+                {
+                    dataSourceCredentialDescription = property.Value.GetString();
+                    continue;
+                }
+            }
+            return new UnknownCredentialEntity(dataSourceCredentialType, dataSourceCredentialId.Value, dataSourceCredentialName, dataSourceCredentialDescription.Value);
+        }
+
+        private class UnknownCredentialEntity : DataSourceCredentialEntity
+        {
+            public UnknownCredentialEntity(DataSourceCredentialType dataSourceCredentialType, string id, string name, string description)
+                : base(dataSourceCredentialType, id, name, description)
+            {
+            }
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataSourceCredentialEntitiesTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataSourceCredentialEntitiesTests.cs
@@ -38,6 +38,15 @@ namespace Azure.AI.MetricsAdvisor.Tests
         }
         ";
 
+        private string UnknownCredentialContent => $@"
+        {{
+            ""dataSourceCredentialType"": ""unknownType"",
+            ""dataSourceCredentialId"": ""{FakeGuid}"",
+            ""dataSourceCredentialName"": ""unknownCredentialName"",
+            ""dataSourceCredentialDescription"": ""unknown credential description""
+        }}
+        ";
+
         [Test]
         [TestCaseSource(nameof(DataSourceCredentialEntityTestCases))]
         public async Task DataSourceCredentialEntitySendsSecretDuringCreation(DataSourceCredentialEntity credential, string expectedSubstring)
@@ -153,6 +162,47 @@ namespace Azure.AI.MetricsAdvisor.Tests
             string content = ReadContent(request);
 
             Assert.That(content, ContainsJsonString("connectionString", "secret"));
+        }
+
+        [Test]
+        public async Task DataSourceCredentialEntityGetsUnknownCredential()
+        {
+            MockResponse getResponse = new MockResponse(200);
+            getResponse.SetContent(UnknownCredentialContent);
+
+            MetricsAdvisorAdministrationClient adminClient = CreateInstrumentedAdministrationClient(getResponse);
+            DataSourceCredentialEntity credential = await adminClient.GetDataSourceCredentialAsync(FakeGuid);
+
+            Assert.That(credential.Id, Is.EqualTo(FakeGuid));
+            Assert.That(credential.Name, Is.EqualTo("unknownCredentialName"));
+            Assert.That(credential.Description, Is.EqualTo("unknown credential description"));
+        }
+
+        [Test]
+        public async Task DataSourceCredentialEntityUpdatesUnknownCredential()
+        {
+            MockResponse getResponse = new MockResponse(200);
+            getResponse.SetContent(UnknownCredentialContent);
+
+            MockResponse updateResponse = new MockResponse(200);
+            updateResponse.SetContent(UnknownCredentialContent);
+
+            MockTransport mockTransport = new MockTransport(getResponse, updateResponse);
+            MetricsAdvisorAdministrationClient adminClient = CreateInstrumentedAdministrationClient(mockTransport);
+            DataSourceCredentialEntity credential = await adminClient.GetDataSourceCredentialAsync(FakeGuid);
+
+            credential.Name = "newCredentialName";
+            credential.Description = "new description";
+
+            await adminClient.UpdateDataSourceCredentialAsync(credential);
+
+            MockRequest request = mockTransport.Requests.Last();
+            string content = ReadContent(request);
+
+            Assert.That(request.Uri.Path, Contains.Substring(FakeGuid));
+            Assert.That(content, ContainsJsonString("dataSourceCredentialName", "newCredentialName"));
+            Assert.That(content, ContainsJsonString("dataSourceCredentialType", "unknownType"));
+            Assert.That(content, ContainsJsonString("dataSourceCredentialDescription", "new description"));
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/azure/azure-sdk-for-net/issues/16333.

Making it abstract as part of architect feedback. Also, improving behavior so it won't break the SDK when the service adds a new credential type in the future.