### PR TITLE
[MetricsAdvisor] Renamed DimensionKey properties

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Breaking Changes
 - Removed methods `AddDimensionColumn` and `RemoveDimensionColumn` from `DimensionKey`. In order to access elements, the new method `TryGetValue` must be used. Once the instance has been created, the columns can't be modified anymore.
 - `DimensionKey` is not an `IEquatable` anymore. Equality will be calculated based on reference only.
-- `DimensionKey` constructor now takes the required `dimension` parameter.
+- `DimensionKey` constructor now takes the required `dimensions` parameter.
 - The whole `DatasourceCredential` API has been renamed to `DataSourceCredential`. This includes renames in methods, method parameters, and properties.
   - Renamed class `DatasourceCredential` to `DataSourceCredentialEntity`.
   - Renamed class `DataLakeGen2SharedKeyDatasourceCredential` to `DataLakeSharedKeyCredentialEntity`.
@@ -55,6 +55,14 @@
 - Changed order of parameters of `MetricsAdvisorClient.GetMetricEnrichedSeriesData`. Now, `detectionConfigurationId` appears first.
 - Optional properties `GetAllFeedbackOptions.Filter`, `GetAnomalyDimensionValuesOptions.DimensionToFilter`, and `FeedbackDimensionFilter.DimensionFilter` must now be manually added with setters to be used.
 - Moved property `DataFeed.SourceType` to `DataFeedSource.DataSourceType`.
+- In `GetAnomaliesForDetectionConfigurationFilter`, renamed `SeriesGroupKeys` to `DimensionKeys`.
+- In `GetAnomalyDimensionValuesOptions`, renamed `DimensionToFilter` to `SeriesGroupKey`.
+- In `GetIncidentsForAlertOptions`, renamed `DimensionsToFilter` to `DimensionKeys`.
+- In `GetMetricDimensionValuesOptions`, renamed `DimensionValueToFilter` to `DimensionValueFilter`.
+- In `GetMetricSeriesDataOptions`, renamed `SeriesToFilter` to `SeriesKeys`.
+- In `GetMetricSeriesDefinitionsOptions`, renamed `DimensionCombinationsToFilter` to `DimensionCombinationsFilter`.
+- In `AnomalyIncident`, renamed `RootDimensionKey` to `RootSeriesKey`.
+- In `FeedbackDimensionFilter`, renamed `DimensionFilter` to `DimensionKey`.
 - In `MetricsAdvisorKeyCredential`, merged `UpdateSubscriptionKey` and `UpdateApiKey` into a single method, `Update`, to make it an atomic operation.
 - Removed setters from `StartTime` and `EndTime`, both in `MetricAnomalyFeedback` and in `MetricChangePointFeedback`.
 - The class `NotificationHook` is now abstract.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
@@ -233,7 +233,7 @@ foreach (DataFeedMetric metric in createdDataFeed.Schema.MetricColumns)
     Console.WriteLine($" - {metric.Name}: {metric.Id}");
 }
 
-Console.WriteLine($"Dimension columns:");
+Console.WriteLine($"Dimensions:");
 foreach (DataFeedDimension dimension in createdDataFeed.Schema.DimensionColumns)
 {
     Console.WriteLine($" - {dimension.Name}");
@@ -415,9 +415,9 @@ await foreach (DataPointAnomaly anomaly in client.GetAnomaliesForAlertAsync(aler
     Console.WriteLine($"Severity: {anomaly.Severity}");
     Console.WriteLine("Series key:");
 
-    foreach (KeyValuePair<string, string> dimensionColumn in anomaly.SeriesKey)
+    foreach (KeyValuePair<string, string> dimension in anomaly.SeriesKey)
     {
-        Console.WriteLine($"  Dimension '{dimensionColumn.Key}': {dimensionColumn.Value}");
+        Console.WriteLine($"  Dimension '{dimension.Key}': {dimension.Value}");
     }
 
     Console.WriteLine();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -67,9 +67,9 @@ namespace Azure.AI.MetricsAdvisor
     {
         public GetAnomaliesForDetectionConfigurationFilter() { }
         public GetAnomaliesForDetectionConfigurationFilter(Azure.AI.MetricsAdvisor.Models.AnomalySeverity minimumSeverity, Azure.AI.MetricsAdvisor.Models.AnomalySeverity maximumSeverity) { }
+        public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DimensionKey> DimensionKeys { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.AnomalySeverity? MaximumSeverity { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.AnomalySeverity? MinimumSeverity { get { throw null; } }
-        public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DimensionKey> SeriesGroupKeys { get { throw null; } }
     }
     public partial class GetAnomaliesForDetectionConfigurationOptions
     {
@@ -83,9 +83,9 @@ namespace Azure.AI.MetricsAdvisor
     public partial class GetAnomalyDimensionValuesOptions
     {
         public GetAnomalyDimensionValuesOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
-        public Azure.AI.MetricsAdvisor.Models.DimensionKey DimensionToFilter { get { throw null; } set { } }
         public System.DateTimeOffset EndTime { get { throw null; } }
         public int? MaxPageSize { get { throw null; } set { } }
+        public Azure.AI.MetricsAdvisor.Models.DimensionKey SeriesGroupKey { get { throw null; } set { } }
         public int? Skip { get { throw null; } set { } }
         public System.DateTimeOffset StartTime { get { throw null; } }
     }
@@ -98,7 +98,7 @@ namespace Azure.AI.MetricsAdvisor
     public partial class GetIncidentsForDetectionConfigurationOptions
     {
         public GetIncidentsForDetectionConfigurationOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
-        public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DimensionKey> DimensionsToFilter { get { throw null; } }
+        public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DimensionKey> DimensionKeys { get { throw null; } }
         public System.DateTimeOffset EndTime { get { throw null; } }
         public int? MaxPageSize { get { throw null; } set { } }
         public System.DateTimeOffset StartTime { get { throw null; } }
@@ -106,7 +106,7 @@ namespace Azure.AI.MetricsAdvisor
     public partial class GetMetricDimensionValuesOptions
     {
         public GetMetricDimensionValuesOptions() { }
-        public string DimensionValueToFilter { get { throw null; } set { } }
+        public string DimensionValueFilter { get { throw null; } set { } }
         public int? MaxPageSize { get { throw null; } set { } }
         public int? Skip { get { throw null; } set { } }
     }
@@ -122,14 +122,14 @@ namespace Azure.AI.MetricsAdvisor
     {
         public GetMetricSeriesDataOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
         public System.DateTimeOffset EndTime { get { throw null; } }
-        public System.Collections.Generic.ICollection<Azure.AI.MetricsAdvisor.Models.DimensionKey> SeriesToFilter { get { throw null; } }
+        public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DimensionKey> SeriesKeys { get { throw null; } }
         public System.DateTimeOffset StartTime { get { throw null; } }
     }
     public partial class GetMetricSeriesDefinitionsOptions
     {
         public GetMetricSeriesDefinitionsOptions(System.DateTimeOffset activeSince) { }
         public System.DateTimeOffset ActiveSince { get { throw null; } }
-        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<string>> DimensionCombinationsToFilter { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<string>> DimensionCombinationsFilter { get { throw null; } }
         public int? MaxPageSize { get { throw null; } set { } }
         public int? Skip { get { throw null; } set { } }
     }
@@ -594,7 +594,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string Id { get { throw null; } }
         public System.DateTimeOffset LastDetectedOn { get { throw null; } }
         public string MetricId { get { throw null; } }
-        public Azure.AI.MetricsAdvisor.Models.DimensionKey RootDimensionKey { get { throw null; } }
+        public Azure.AI.MetricsAdvisor.Models.DimensionKey RootSeriesKey { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.AnomalySeverity Severity { get { throw null; } }
         public System.DateTimeOffset StartedOn { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.AnomalyIncidentStatus Status { get { throw null; } }
@@ -1027,11 +1027,11 @@ namespace Azure.AI.MetricsAdvisor.Models
     }
     public partial class DimensionKey : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
     {
-        public DimensionKey(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> dimension) { }
-        public bool Contains(string columnName) { throw null; }
+        public DimensionKey(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> dimensions) { }
+        public bool Contains(string dimensionName) { throw null; }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, string>> GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public bool TryGetValue(string columnName, out string value) { throw null; }
+        public bool TryGetValue(string dimensionName, out string value) { throw null; }
     }
     public partial class EnrichmentStatus
     {
@@ -1043,7 +1043,7 @@ namespace Azure.AI.MetricsAdvisor.Models
     public partial class FeedbackDimensionFilter
     {
         public FeedbackDimensionFilter() { }
-        public Azure.AI.MetricsAdvisor.Models.DimensionKey DimensionFilter { get { throw null; } set { } }
+        public Azure.AI.MetricsAdvisor.Models.DimensionKey DimensionKey { get { throw null; } set { } }
     }
     public partial class HardThresholdCondition
     {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAnomaliesForDetectionConfigurationFilter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAnomaliesForDetectionConfigurationFilter.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.MetricsAdvisor
         /// </summary>
         public GetAnomaliesForDetectionConfigurationFilter()
         {
-            SeriesGroupKeys = new ChangeTrackingList<DimensionKey>();
+            DimensionKeys = new ChangeTrackingList<DimensionKey>();
         }
 
         /// <summary>
@@ -31,14 +31,16 @@ namespace Azure.AI.MetricsAdvisor
         {
             MinimumSeverity = minimumSeverity;
             MaximumSeverity = maximumSeverity;
-            SeriesGroupKeys = new ChangeTrackingList<DimensionKey>();
+            DimensionKeys = new ChangeTrackingList<DimensionKey>();
         }
 
         /// <summary>
-        /// Filters the result by series. Only anomalies detected in the time series groups specified will
-        /// be returned.
+        /// Filters the result by time series. Each element in this list represents a set of time series, and only
+        /// anomalies detected in at least one of these sets will be returned. For each element, if all possible
+        /// dimensions are set, the key uniquely identifies a single time series for the corresponding metric. If
+        /// only a subset of dimensions are set, the key uniquely identifies a group of time series.
         /// </summary>
-        public IList<DimensionKey> SeriesGroupKeys { get; }
+        public IList<DimensionKey> DimensionKeys { get; }
 
         /// <summary>
         /// The minimum severity level an anomaly must have to be returned.
@@ -59,7 +61,7 @@ namespace Azure.AI.MetricsAdvisor
                 filterCondition.SeverityFilter = new SeverityFilterCondition(MinimumSeverity.Value, MaximumSeverity.Value);
             }
 
-            foreach (DimensionKey dimensionKey in SeriesGroupKeys)
+            foreach (DimensionKey dimensionKey in DimensionKeys)
             {
                 filterCondition.DimensionFilter.Add(dimensionKey.Clone());
             }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAnomalyDimensionValuesOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAnomalyDimensionValuesOptions.cs
@@ -34,10 +34,11 @@ namespace Azure.AI.MetricsAdvisor
         public DateTimeOffset EndTime { get; }
 
         /// <summary>
-        /// Filters the result by series. Only anomalies detected in the time series group specified will
-        /// be returned.
+        /// Filters the result by time series. Only dimension values for anomalies detected in the time series
+        /// group specified will be returned. This key represents a group of time series for the corresponding
+        /// metric, so only a subset of dimensions must be set.
         /// </summary>
-        public DimensionKey DimensionToFilter { get; set; }
+        public DimensionKey SeriesGroupKey { get; set; }
 
         /// <summary>
         /// If set, skips the first set of items returned. This property specifies the amount of items to

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetIncidentsForDetectionConfigurationOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetIncidentsForDetectionConfigurationOptions.cs
@@ -25,7 +25,7 @@ namespace Azure.AI.MetricsAdvisor
         {
             StartTime = startTime;
             EndTime = endTime;
-            DimensionsToFilter = new ChangeTrackingList<DimensionKey>();
+            DimensionKeys = new ChangeTrackingList<DimensionKey>();
         }
 
         /// <summary>
@@ -39,10 +39,12 @@ namespace Azure.AI.MetricsAdvisor
         public DateTimeOffset EndTime { get; }
 
         /// <summary>
-        /// Filters the result by series. Only incidents detected in the time series groups specified will
-        /// be returned.
+        /// Filters the result by time series. Each element in this list represents a set of time series, and only
+        /// incidents detected in at least one of these sets will be returned. For each element, if all possible
+        /// dimensions are set, the key uniquely identifies a single time series for the corresponding metric. If
+        /// only a subset of dimensions are set, the key uniquely identifies a group of time series.
         /// </summary>
-        public IList<DimensionKey> DimensionsToFilter { get; }
+        public IList<DimensionKey> DimensionKeys { get; }
 
         /// <summary>
         /// If set, specifies the maximum limit of items returned in each page of results. Note:
@@ -55,7 +57,7 @@ namespace Azure.AI.MetricsAdvisor
         {
             DetectionIncidentFilterCondition filterCondition = new DetectionIncidentFilterCondition();
 
-            foreach (DimensionKey dimensionKey in DimensionsToFilter)
+            foreach (DimensionKey dimensionKey in DimensionKeys)
             {
                 filterCondition.DimensionFilter.Add(dimensionKey.Clone());
             }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricDimensionValuesOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricDimensionValuesOptions.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// The dimension value to be filtered.
         /// </summary>
-        public string DimensionValueToFilter { get; set; }
+        public string DimensionValueFilter { get; set; }
 
         /// <summary>
         /// If set, skips the first set of items returned. This property specifies the amount of items to

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricSeriesDataOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricSeriesDataOptions.cs
@@ -21,17 +21,17 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="endTime">Filters the result. Only data points ingested up to this point in time, in UTC, will be returned.</param>
         public GetMetricSeriesDataOptions(DateTimeOffset startTime, DateTimeOffset endTime)
         {
-            SeriesToFilter = new ChangeTrackingList<DimensionKey>();
+            SeriesKeys = new ChangeTrackingList<DimensionKey>();
             StartTime = startTime;
             EndTime = endTime;
         }
 
         /// <summary>
-        /// Only time series with the specified series keys will be returned. These keys uniquely identify
-        /// a time series within a metric. Every dimension contained in the associated <see cref="DataFeed"/>
-        /// must be assigned a value.
+        /// Filters the result by time series. Each element in this list represents a single time series, and only
+        /// anomalies detected in one of these series will be returned. For every element, all possible dimensions
+        /// must be set.
         /// </summary>
-        public ICollection<DimensionKey> SeriesToFilter { get; }
+        public IList<DimensionKey> SeriesKeys { get; }
 
         /// <summary>
         /// Filters the result. Only data points ingested from this point in time, in UTC, will be returned.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricSeriesDefinitionsOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricSeriesDefinitionsOptions.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.MetricsAdvisor
         public GetMetricSeriesDefinitionsOptions(DateTimeOffset activeSince)
         {
             ActiveSince = activeSince;
-            DimensionCombinationsToFilter = new ChangeTrackingDictionary<string, IList<string>>();
+            DimensionCombinationsFilter = new ChangeTrackingDictionary<string, IList<string>>();
         }
 
         /// <summary>
@@ -32,7 +32,8 @@ namespace Azure.AI.MetricsAdvisor
         /// Filters the result, mapping a dimension's name to a list of possible values it can assume. Only time series
         /// with the specified dimension values will be returned.
         /// </summary>
-        public IDictionary<string, IList<string>> DimensionCombinationsToFilter { get; }
+        /// JS and Python use DimensionFilter
+        public IDictionary<string, IList<string>> DimensionCombinationsFilter { get; }
 
         /// <summary>
         /// If set, skips the first set of items returned. This property specifies the amount of items to

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorClient.cs
@@ -360,7 +360,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options)); // TODO: add validation for options.SeriesToFilter?
 
             Guid metricGuid = ClientCommon.ValidateGuid(metricId, nameof(metricId));
-            IEnumerable<IDictionary<string, string>> series = options.SeriesToFilter.Select(key => key.Dimension);
+            IEnumerable<IDictionary<string, string>> series = options.SeriesKeys.Select(key => key.Dimension);
             MetricDataQueryOptions queryOptions = new MetricDataQueryOptions(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime), series);
 
             async Task<Page<MetricSeriesData>> FirstPageFunc(int? pageSizeHint)
@@ -399,7 +399,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options)); // TODO: add validation for options.SeriesToFilter?
 
             Guid metricGuid = ClientCommon.ValidateGuid(metricId, nameof(metricId));
-            IEnumerable<IDictionary<string, string>> series = options.SeriesToFilter.Select(key => key.Dimension);
+            IEnumerable<IDictionary<string, string>> series = options.SeriesKeys.Select(key => key.Dimension);
             MetricDataQueryOptions queryOptions = new MetricDataQueryOptions(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime), series);
 
             Page<MetricSeriesData> FirstPageFunc(int? pageSizeHint)
@@ -1202,7 +1202,7 @@ namespace Azure.AI.MetricsAdvisor
             Guid detectionConfigurationGuid = ClientCommon.ValidateGuid(detectionConfigurationId, nameof(detectionConfigurationId));
             AnomalyDimensionQuery queryOptions = new AnomalyDimensionQuery(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime), dimensionName)
             {
-                DimensionFilter = options.DimensionToFilter?.Clone()
+                DimensionFilter = options.SeriesGroupKey?.Clone()
             };
             int? skip = options.Skip;
             int? maxPageSize = options.MaxPageSize;
@@ -1264,7 +1264,7 @@ namespace Azure.AI.MetricsAdvisor
             Guid detectionConfigurationGuid = ClientCommon.ValidateGuid(detectionConfigurationId, nameof(detectionConfigurationId));
             AnomalyDimensionQuery queryOptions = new AnomalyDimensionQuery(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime), dimensionName)
             {
-                DimensionFilter = options.DimensionToFilter?.Clone()
+                DimensionFilter = options.SeriesGroupKey?.Clone()
             };
             int? skip = options.Skip;
             int? maxPageSize = options.MaxPageSize;
@@ -1310,7 +1310,11 @@ namespace Azure.AI.MetricsAdvisor
         /// Query series enriched by anomaly detection.
         /// </summary>
         /// <param name="detectionConfigurationId">The unique identifier of the <see cref="AnomalyAlertConfiguration"/>.</param>
-        /// <param name="seriesKeys">The detection series keys.</param>
+        /// <param name="seriesKeys">
+        /// Filters the result by time series. Each element in this enumerable represents a single time series, and only
+        /// anomalies detected in one of these series will be returned. For every element, all possible dimensions must
+        /// be set.
+        /// </param>
         /// <param name="startTime">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
         /// <param name="endTime">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -1350,7 +1354,11 @@ namespace Azure.AI.MetricsAdvisor
         /// Query series enriched by anomaly detection.
         /// </summary>
         /// <param name="detectionConfigurationId">The unique identifier of the <see cref="AnomalyAlertConfiguration"/>.</param>
-        /// <param name="seriesKeys">The detection series keys.</param>
+        /// <param name="seriesKeys">
+        /// Filters the result by time series. Each element in this enumerable represents a single time series, and only
+        /// anomalies detected in one of these series will be returned. For every element, all possible dimensions must
+        /// be set.
+        /// </param>
         /// <param name="startTime">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
         /// <param name="endTime">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorClient.cs
@@ -114,7 +114,7 @@ namespace Azure.AI.MetricsAdvisor
             Guid metricGuid = ClientCommon.ValidateGuid(metricId, nameof(metricId));
             MetricDimensionQueryOptions queryOptions = new MetricDimensionQueryOptions(dimensionName)
             {
-                DimensionValueFilter = options?.DimensionValueToFilter
+                DimensionValueFilter = options?.DimensionValueFilter
             };
             int? skip = options?.Skip;
             int? maxPageSize = options?.MaxPageSize;
@@ -174,7 +174,7 @@ namespace Azure.AI.MetricsAdvisor
             Guid metricGuid = ClientCommon.ValidateGuid(metricId, nameof(metricId));
             MetricDimensionQueryOptions queryOptions = new MetricDimensionQueryOptions(dimensionName)
             {
-                DimensionValueFilter = options?.DimensionValueToFilter
+                DimensionValueFilter = options?.DimensionValueFilter
             };
             int? skip = options?.Skip;
             int? maxPageSize = options?.MaxPageSize;
@@ -238,7 +238,7 @@ namespace Azure.AI.MetricsAdvisor
 
             // Deep copy filter contents from options to queryOptions.
 
-            foreach (KeyValuePair<string, IList<string>> kvp in options.DimensionCombinationsToFilter)
+            foreach (KeyValuePair<string, IList<string>> kvp in options.DimensionCombinationsFilter)
             {
                 queryOptions.DimensionFilter.Add(kvp.Key, new List<string>(kvp.Value));
             }
@@ -302,7 +302,7 @@ namespace Azure.AI.MetricsAdvisor
 
             // Deep copy filter contents from options to queryOptions.
 
-            foreach (KeyValuePair<string, IList<string>> kvp in options.DimensionCombinationsToFilter)
+            foreach (KeyValuePair<string, IList<string>> kvp in options.DimensionCombinationsFilter)
             {
                 queryOptions.DimensionFilter.Add(kvp.Key, new List<string>(kvp.Value));
             }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/AnomalyIncident.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/AnomalyIncident.cs
@@ -25,7 +25,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             Id = id;
             StartedOn = startedOn;
             LastDetectedOn = lastDetectedOn;
-            RootDimensionKey = new DimensionKey(rootNode.Dimension);
+            RootSeriesKey = new DimensionKey(rootNode.Dimension);
             Severity = property.MaxSeverity;
             Status = property.IncidentStatus;
             ValueOfRootNode = property.ValueOfRootNode;
@@ -67,9 +67,9 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// The key that, within a metric, uniquely identifies the time series in which the data point
         /// at the root of this <see cref="AnomalyIncident"/> has been detected. The root node is defined
         /// as the data point at the root of this incident's root-cause analysis tree. In this key, a value
-        /// is assigned to every dimension column contained in the associated <see cref="DataFeed"/>.
+        /// is assigned to every possible dimension.
         /// </summary>
-        public DimensionKey RootDimensionKey { get; }
+        public DimensionKey RootSeriesKey { get; }
 
         /// <summary>
         /// Corresponds to the time, in UTC, when the first associated <see cref="DataPointAnomaly"/> occurred.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/DataPointAnomaly.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/DataPointAnomaly.cs
@@ -62,8 +62,7 @@ namespace Azure.AI.MetricsAdvisor.Models
 
         /// <summary>
         /// The key that, within a metric, uniquely identifies the time series in which this anomaly has
-        /// been detected. Every dimension contained in the associated <see cref="DataFeed"/> has been
-        /// assigned a value.
+        /// been detected. In this key, a value is assigned to every possible dimension.
         /// </summary>
         public DimensionKey SeriesKey { get; }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/IncidentRootCause.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/IncidentRootCause.cs
@@ -13,7 +13,8 @@ namespace Azure.AI.MetricsAdvisor.Models
     public partial class IncidentRootCause
     {
         /// <summary>
-        /// The key that, within a metric, uniquely identifies the time series in which this <see cref="IncidentRootCause"/> has been created.
+        /// The key that, within a metric, uniquely identifies the time series that has been detected as an
+        /// <see cref="IncidentRootCause"/>. In this key, a value is assigned to every possible dimension.
         /// </summary>
         [CodeGenMember("RootCause")]
         public DimensionKey SeriesKey { get; }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/MetricEnrichedSeriesData.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/MetricEnrichedSeriesData.cs
@@ -31,8 +31,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         }
 
         /// <summary>
-        /// The key that, within a metric, uniquely identifies a time series. Every dimension
-        /// contained in the associated <see cref="DataFeed"/> has been assigned a value.
+        /// The key that, within a metric, uniquely identifies this time series. In this key,
+        /// a value is assigned to every possible dimension.
         /// </summary>
         public DimensionKey SeriesKey { get; }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/MetricSeriesGroupDetectionCondition.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/MetricSeriesGroupDetectionCondition.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="MetricSeriesGroupDetectionCondition"/> class.
         /// </summary>
-        /// <param name="seriesGroupKey">The key that identifies the group of time series to which these conditions apply within a metric. A subset of the possible dimensions of the associated data feed must be set.</param>
+        /// <param name="seriesGroupKey">The key that identifies the group of time series to which these conditions apply within a metric. Only a subset of dimensions must be assigned a value.</param>
         /// <exception cref="ArgumentNullException"><paramref name="seriesGroupKey"/> is <c>null</c>.</exception>
         public MetricSeriesGroupDetectionCondition(DimensionKey seriesGroupKey)
         {
@@ -28,7 +28,7 @@ namespace Azure.AI.MetricsAdvisor.Models
 
         /// <summary>
         /// The key that identifies the group of time series to which these conditions apply within a metric.
-        /// A subset of the possible dimensions of the associated data feed must be set.
+        /// Only a subset of dimensions must be assigned a value.
         /// </summary>
         [CodeGenMember("Group")]
         public DimensionKey SeriesGroupKey { get; set; }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/MetricSingleSeriesDetectionCondition.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyDetection/MetricSingleSeriesDetectionCondition.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="MetricSingleSeriesDetectionCondition"/> class.
         /// </summary>
-        /// <param name="seriesKey">The key that uniquely identifies the time series to which these conditions apply within a metric. Every dimension contained in the associated <see cref="DataFeed"/> must be assigned a value.</param>
+        /// <param name="seriesKey">The key that uniquely identifies the time series to which these conditions apply within a metric. All possible dimensions must be assigned a value.</param>
         /// <exception cref="ArgumentNullException"><paramref name="seriesKey"/> is <c>null</c>.</exception>
         public MetricSingleSeriesDetectionCondition(DimensionKey seriesKey)
         {
@@ -34,7 +34,7 @@ namespace Azure.AI.MetricsAdvisor.Models
 
         /// <summary>
         /// The key that uniquely identifies the time series to which these conditions apply within a metric.
-        /// Every dimension contained in the associated <see cref="DataFeed"/> must be assigned a value.
+        /// All possible dimensions must be assigned a value.
         /// </summary>
         public DimensionKey SeriesKey { get; set; }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/FeedbackDimensionFilter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/FeedbackDimensionFilter.cs
@@ -32,18 +32,19 @@ namespace Azure.AI.MetricsAdvisor.Models
         }
 
         /// <summary>
-        /// Filters the result by series. Only feedbacks for the series in the time series group specified will
-        /// be returned.
+        /// Filters the result by time series. Only feedback for the series in the time series specified will be
+        /// returned. If all possible dimensions are set, this key uniquely identifies a single time series for the
+        /// corresponding metric. If only a subset of dimensions are set, this key identifies a group of time series.
         /// </summary>
-        public DimensionKey DimensionFilter { get; set; }
+        public DimensionKey DimensionKey { get; set; }
 
         /// <summary>
         /// Used by CodeGen during serialization.
         /// </summary>
         internal IDictionary<string, string> Dimension
         {
-            get => DimensionFilter?.Dimension ?? new Dictionary<string, string>();
-            set => DimensionFilter = new DimensionKey(value);
+            get => DimensionKey?.Dimension ?? new Dictionary<string, string>();
+            set => DimensionKey = new DimensionKey(value);
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricAnomalyFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricAnomalyFeedback.cs
@@ -21,8 +21,8 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="metricId">The identifier of the metric to which the <see cref="MetricAnomalyFeedback"/> applies.</param>
         /// <param name="dimensionKey">
         /// A key that identifies a set of time series to which the <see cref="MetricAnomalyFeedback"/> applies.
-        /// If all possible dimension columns are set, this key uniquely identifies a single time series
-        /// for the specified <paramref name="metricId"/>. If only a subset of dimension columns are set, this
+        /// If all possible dimensions are set, this key uniquely identifies a single time series
+        /// for the specified <paramref name="metricId"/>. If only a subset of dimensions are set, this
         /// key uniquely identifies a group of time series.
         /// </param>
         /// <param name="startTime">The start timestamp of feedback time range.</param>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricAnomalyFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricAnomalyFeedback.cs
@@ -47,7 +47,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="value"> The <see cref="AnomalyFeedbackValue"/> for the feedback. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="dimensionFilter"/> or <paramref name="value"/> is null. </exception>
         internal MetricAnomalyFeedback(string metricId, FeedbackDimensionFilter dimensionFilter, DateTimeOffset startTime, DateTimeOffset endTime, AnomalyFeedbackValue value)
-            : base(metricId, dimensionFilter.DimensionFilter)
+            : base(metricId, dimensionFilter.DimensionKey)
         {
             if (value == null)
             {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricChangePointFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricChangePointFeedback.cs
@@ -20,8 +20,8 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="metricId">The identifier of the metric to which the <see cref="MetricChangePointFeedback"/> applies.</param>
         /// <param name="dimensionKey">
         /// A key that identifies a set of time series to which the <see cref="MetricChangePointFeedback"/> applies.
-        /// If all possible dimension columns are set, this key uniquely identifies a single time series
-        /// for the specified <paramref name="metricId"/>. If only a subset of dimension columns are set, this
+        /// If all possible dimensions are set, this key uniquely identifies a single time series
+        /// for the specified <paramref name="metricId"/>. If only a subset of dimensions are set, this
         /// key uniquely identifies a group of time series.
         /// </param>
         /// <param name="startTime">The start timestamp of feedback time range.</param>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricChangePointFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricChangePointFeedback.cs
@@ -45,7 +45,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="endTime"> The end timestamp of feedback timerange. When this is equal to <paramref name="startTime"/> it indicates a single timestamp. </param>
         /// <param name="value"> The <see cref="Models.ChangePointFeedbackValue"/> for the feedback. </param>
         internal MetricChangePointFeedback(string metricId, FeedbackDimensionFilter dimensionFilter, DateTimeOffset startTime, DateTimeOffset endTime, ChangePointFeedbackValue value)
-            : base(metricId, dimensionFilter.DimensionFilter)
+            : base(metricId, dimensionFilter.DimensionKey)
         {
             Argument.AssertNotNull(value, nameof(value));
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricCommentFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricCommentFeedback.cs
@@ -18,8 +18,8 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="metricId">The identifier of the metric to which the <see cref="MetricCommentFeedback"/> applies.</param>
         /// <param name="dimensionKey">
         /// A key that identifies a set of time series to which the <see cref="MetricCommentFeedback"/> applies.
-        /// If all possible dimension columns are set, this key uniquely identifies a single time series
-        /// for the specified <paramref name="metricId"/>. If only a subset of dimension columns are set, this
+        /// If all possible dimensions are set, this key uniquely identifies a single time series
+        /// for the specified <paramref name="metricId"/>. If only a subset of dimensions are set, this
         /// key uniquely identifies a group of time series.
         /// </param>
         /// <param name="comment">The comment content for the feedback.</param>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricCommentFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricCommentFeedback.cs
@@ -40,7 +40,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="comment"> The comment content for the feedback. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="dimensionFilter"/> or <paramref name="comment"/> is null. </exception>
         internal MetricCommentFeedback(string metricId, FeedbackDimensionFilter dimensionFilter, CommentFeedbackValue comment)
-            : base(metricId, dimensionFilter.DimensionFilter)
+            : base(metricId, dimensionFilter.DimensionKey)
         {
             Argument.AssertNotNullOrEmpty(comment?.CommentValue, nameof(comment.CommentValue));
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricFeedback.cs
@@ -88,8 +88,8 @@ namespace Azure.AI.MetricsAdvisor
 
         /// <summary>
         /// A key that identifies a set of time series to which the <see cref="MetricFeedback"/> applies.
-        /// If all possible dimension columns are set, this key uniquely identifies a single time series
-        /// for the specified <see cref="MetricId"/>. If only a subset of dimension columns are set, this
+        /// If all possible dimensions are set, this key uniquely identifies a single time series
+        /// for the specified <see cref="MetricId"/>. If only a subset of dimensions are set, this
         /// key uniquely identifies a group of time series.
         /// </summary>
         public DimensionKey DimensionKey { get; }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricFeedback.cs
@@ -29,8 +29,8 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="metricId">The identifier of the metric to which the <see cref="MetricFeedback"/> applies.</param>
         /// <param name="dimensionKey">
         /// A key that identifies a set of time series to which the <see cref="MetricFeedback"/> applies.
-        /// If all possible dimension columns are set, this key uniquely identifies a single time series
-        /// for the specified <paramref name="metricId"/>. If only a subset of dimension columns are set, this
+        /// If all possible dimensions are set, this key uniquely identifies a single time series
+        /// for the specified <paramref name="metricId"/>. If only a subset of dimensions are set, this
         /// key uniquely identifies a group of time series.
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="metricId"/> or <paramref name="dimensionKey"/> is <c>null</c>.</exception>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricFeedback.cs
@@ -51,7 +51,7 @@ namespace Azure.AI.MetricsAdvisor
             CreatedOn = createdOn;
             UserPrincipal = userPrincipal;
             MetricId = metricId;
-            DimensionKey = dimensionFilter.DimensionFilter;
+            DimensionKey = dimensionFilter.DimensionKey;
         }
 
         /// <summary>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricPeriodFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricPeriodFeedback.cs
@@ -20,8 +20,8 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="metricId">The identifier of the metric to which the <see cref="MetricPeriodFeedback"/> applies.</param>
         /// <param name="dimensionKey">
         /// A key that identifies a set of time series to which the <see cref="MetricPeriodFeedback"/> applies.
-        /// If all possible dimension columns are set, this key uniquely identifies a single time series
-        /// for the specified <paramref name="metricId"/>. If only a subset of dimension columns are set, this
+        /// If all possible dimensions are set, this key uniquely identifies a single time series
+        /// for the specified <paramref name="metricId"/>. If only a subset of dimensions are set, this
         /// key uniquely identifies a group of time series.
         /// </param>
         /// <param name="periodType">The <see cref="MetricPeriodType"/>.</param>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricPeriodFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricPeriodFeedback.cs
@@ -41,7 +41,7 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="valueInternal"> . </param>
         /// <exception cref="ArgumentNullException"> <paramref name="metricId"/>, <paramref name="dimensionFilter"/>, or <paramref name="valueInternal"/> is null. </exception>
         internal MetricPeriodFeedback(string metricId, FeedbackDimensionFilter dimensionFilter, PeriodFeedbackValue valueInternal)
-            : base(metricId, dimensionFilter.DimensionFilter)
+            : base(metricId, dimensionFilter.DimensionKey)
         {
             if (valueInternal == null)
             {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/TimeSeries/DimensionKey.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/TimeSeries/DimensionKey.cs
@@ -10,9 +10,9 @@ using Azure.Core;
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary>
-    /// Maps dimension column names of a <see cref="DataFeed"/> to values. If values are assigned
-    /// to all possible column names, this <see cref="DimensionKey"/> uniquely identifies a time
-    /// series within a metric. However, if only a subset of column names is assigned, this instance
+    /// Maps dimension names of a <see cref="DataFeed"/> to values. If values are assigned
+    /// to all possible dimension names, this <see cref="DimensionKey"/> uniquely identifies a time
+    /// series within a metric. However, if only a subset of dimension names is assigned, this instance
     /// uniquely identifies a group of time series instead.
     /// </summary>
     [CodeGenModel("DimensionGroupIdentity")]
@@ -22,55 +22,55 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="DimensionKey"/> class.
         /// </summary>
-        /// <param name="dimension">The dimension columns to initialize this dimension key with.</param>
-        public DimensionKey(IEnumerable<KeyValuePair<string, string>> dimension)
+        /// <param name="dimensions">The dimensions to initialize this dimension key with.</param>
+        public DimensionKey(IEnumerable<KeyValuePair<string, string>> dimensions)
         {
-            Argument.AssertNotNull(dimension, nameof(dimension));
+            Argument.AssertNotNull(dimensions, nameof(dimensions));
 
-            Dimension = dimension.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Dimension = dimensions.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
         internal IDictionary<string, string> Dimension { get; }
 
         /// <summary>
-        /// Gets the value associated with the specified dimension column.
+        /// Gets the value associated with the specified dimension.
         /// </summary>
-        /// <param name="columnName">The name of the dimension column whose value to get.</param>
-        /// <param name="value">When this method returns, the value associated with the specified dimension column, if it's found. Otherwise, <c>null</c>.</param>
-        /// <returns><c>true</c> if this dimension key contains the specified column. Otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="columnName"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="columnName"/> is empty.</exception>
-        public bool TryGetValue(string columnName, out string value)
+        /// <param name="dimensionName">The name of the dimension whose value to get.</param>
+        /// <param name="value">When this method returns, the value associated with the specified dimension, if it's found. Otherwise, <c>null</c>.</param>
+        /// <returns><c>true</c> if this dimension key contains the specified dimension. Otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="dimensionName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="dimensionName"/> is empty.</exception>
+        public bool TryGetValue(string dimensionName, out string value)
         {
-            Argument.AssertNotNullOrEmpty(columnName, nameof(columnName));
+            Argument.AssertNotNullOrEmpty(dimensionName, nameof(dimensionName));
 
-            return Dimension.TryGetValue(columnName, out value);
+            return Dimension.TryGetValue(dimensionName, out value);
         }
 
         /// <summary>
-        /// Determines whether this dimension key contains a dimension column with the specified name.
+        /// Determines whether this dimension key contains a dimension with the specified name.
         /// </summary>
-        /// <param name="columnName">The name of the dimension column to locate in this key.</param>
-        /// <returns><c>true</c> if this dimension key contains a column with the specified name. Otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="columnName"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="columnName"/> is empty.</exception>
-        public bool Contains(string columnName)
+        /// <param name="dimensionName">The name of the dimension to locate in this key.</param>
+        /// <returns><c>true</c> if this dimension key contains a dimension with the specified name. Otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="dimensionName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="dimensionName"/> is empty.</exception>
+        public bool Contains(string dimensionName)
         {
-            Argument.AssertNotNullOrEmpty(columnName, nameof(columnName));
+            Argument.AssertNotNullOrEmpty(dimensionName, nameof(dimensionName));
 
-            return Dimension.ContainsKey(columnName);
+            return Dimension.ContainsKey(dimensionName);
         }
 
         /// <summary>
-        /// Returns an enumerator that iterates through the columns of this dimension key.
+        /// Returns an enumerator that iterates through the dimensions of this dimension key.
         /// </summary>
-        /// <returns>An enumerator that can be used to iterate through the columns of this dimension key.</returns>
+        /// <returns>An enumerator that can be used to iterate through the dimensions of this dimension key.</returns>
         public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => Dimension.GetEnumerator();
 
         /// <summary>
-        /// Returns an enumerator that iterates through the columns of this dimension key.
+        /// Returns an enumerator that iterates through the dimensions of this dimension key.
         /// </summary>
-        /// <returns>An enumerator that can be used to iterate through the columns of this dimension key.</returns>
+        /// <returns>An enumerator that can be used to iterate through the dimensions of this dimension key.</returns>
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         internal DimensionKey Clone() => new DimensionKey(Dimension);

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/TimeSeries/MetricSeriesData.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/TimeSeries/MetricSeriesData.cs
@@ -22,8 +22,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string MetricId => Definition.MetricId;
 
         /// <summary>
-        /// The key that, within a metric, uniquely identifies a time series. Every dimension
-        /// contained in the associated <see cref="DataFeed"/> has been assigned a value.
+        /// The key that, within a metric, uniquely identifies this time series. In this key,
+        /// a value is assigned to every possible dimension.
         /// </summary>
         public DimensionKey SeriesKey => Definition.SeriesKey;
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/TimeSeries/MetricSeriesDefinition.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/TimeSeries/MetricSeriesDefinition.cs
@@ -19,8 +19,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string MetricId { get; }
 
         /// <summary>
-        /// The key that, within a metric, uniquely identifies a time series. Every dimension
-        /// contained in the associated <see cref="DataFeed"/> has been assigned a value.
+        /// The key that, within a metric, uniquely identifies this time series. In this key,
+        /// a value is assigned to every possible dimension.
         /// </summary>
         public DimensionKey SeriesKey { get; private set; }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyAlertConfigurationLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyAlertConfigurationLiveTests.cs
@@ -76,8 +76,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
             string metricId = disposableDataFeed.DataFeed.MetricIds[TempDataFeedMetricName];
             await using DisposableDetectionConfiguration disposableDetectionConfig = await CreateTempDetectionConfigurationAsync(adminClient, metricId);
 
-            var columns = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" } };
-            DimensionKey groupKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" } };
+            DimensionKey groupKey = new DimensionKey(dimensions);
 
             var detectionConfigId = disposableDetectionConfig.Configuration.Id;
             var scope = MetricAnomalyAlertScope.CreateScopeForSeriesGroup(groupKey);

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/AnomalyDetectionConfigurationLiveTests.cs
@@ -140,14 +140,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Set the series group conditions and create the configuration.
 
-            var columns = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" } };
-            var groupConditions0 = new MetricSeriesGroupDetectionCondition(new DimensionKey(columns))
+            var dimensions = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" } };
+            var groupConditions0 = new MetricSeriesGroupDetectionCondition(new DimensionKey(dimensions))
             {
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            columns = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Kolkata" } };
-            var groupConditions1 = new MetricSeriesGroupDetectionCondition(new DimensionKey(columns))
+            dimensions = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Kolkata" } };
+            var groupConditions1 = new MetricSeriesGroupDetectionCondition(new DimensionKey(dimensions))
             {
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
@@ -241,14 +241,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Set the series conditions and create the configuration.
 
-            var columns = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" }, { TempDataFeedDimensionNameB, "Handmade" } };
-            var seriesConditions0 = new MetricSingleSeriesDetectionCondition(new DimensionKey(columns))
+            var dimensions = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" }, { TempDataFeedDimensionNameB, "Handmade" } };
+            var seriesConditions0 = new MetricSingleSeriesDetectionCondition(new DimensionKey(dimensions))
             {
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
 
-            columns = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Kolkata" }, { TempDataFeedDimensionNameB, "Grocery & Gourmet Food" } };
-            var seriesConditions1 = new MetricSingleSeriesDetectionCondition(new DimensionKey(columns))
+            dimensions = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Kolkata" }, { TempDataFeedDimensionNameB, "Grocery & Gourmet Food" } };
+            var seriesConditions1 = new MetricSingleSeriesDetectionCondition(new DimensionKey(dimensions))
             {
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
@@ -345,8 +345,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Set the series group conditions.
 
-            var columns = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Kolkata" } };
-            var groupConditions = new MetricSeriesGroupDetectionCondition(new DimensionKey(columns))
+            var dimensions = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Kolkata" } };
+            var groupConditions = new MetricSeriesGroupDetectionCondition(new DimensionKey(dimensions))
             {
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
@@ -355,8 +355,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Set the series conditions and create the configuration.
 
-            columns = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" }, { TempDataFeedDimensionNameB, "Handmade" } };
-            var seriesConditions = new MetricSingleSeriesDetectionCondition(new DimensionKey(columns))
+            dimensions = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" }, { TempDataFeedDimensionNameB, "Handmade" } };
+            var seriesConditions = new MetricSingleSeriesDetectionCondition(new DimensionKey(dimensions))
             {
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
@@ -456,8 +456,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Set the series group conditions.
 
-            var columns = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Kolkata" } };
-            var groupConditions = new MetricSeriesGroupDetectionCondition(new DimensionKey(columns))
+            var dimensions = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Kolkata" } };
+            var groupConditions = new MetricSeriesGroupDetectionCondition(new DimensionKey(dimensions))
             {
                 ChangeThresholdCondition = new(40.0, 12, false, AnomalyDetectorDirection.Up, new(5, 6.0))
             };
@@ -466,8 +466,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             // Set the series conditions and create the configuration.
 
-            columns = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" }, { TempDataFeedDimensionNameB, "Handmade" } };
-            var seriesConditions = new MetricSingleSeriesDetectionCondition(new DimensionKey(columns))
+            dimensions = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" }, { TempDataFeedDimensionNameB, "Handmade" } };
+            var seriesConditions = new MetricSingleSeriesDetectionCondition(new DimensionKey(dimensions))
             {
                 SmartDetectionCondition = new(30.0, AnomalyDetectorDirection.Both, new(3, 4.0))
             };
@@ -487,8 +487,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
             configToUpdate.WholeSeriesDetectionConditions.ChangeThresholdCondition = null;
             configToUpdate.WholeSeriesDetectionConditions.SmartDetectionCondition = new(75.0, AnomalyDetectorDirection.Both, new(15, 16.0));
 
-            columns = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" } };
-            var newGroupConditions = new MetricSeriesGroupDetectionCondition(new DimensionKey(columns))
+            dimensions = new Dictionary<string, string>() { { TempDataFeedDimensionNameA, "Delhi" } };
+            var newGroupConditions = new MetricSeriesGroupDetectionCondition(new DimensionKey(dimensions))
             {
                 SmartDetectionCondition = new(95.0, AnomalyDetectorDirection.Both, new(25, 26.0))
             };

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AlertTriggeringLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AlertTriggeringLiveTests.cs
@@ -144,7 +144,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 // Service bug: https://github.com/Azure/azure-sdk-for-net/issues/16581
                 //Assert.That(incident.Severity, Is.Not.EqualTo(default(AnomalySeverity)));
 
-                ValidateSeriesKey(incident.RootDimensionKey);
+                ValidateSeriesKey(incident.RootSeriesKey);
 
                 if (++incidentCount >= MaximumSamplesCount)
                 {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionLiveTests.cs
@@ -62,11 +62,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Filter = new GetAnomaliesForDetectionConfigurationFilter(AnomalySeverity.Medium, AnomalySeverity.Medium)
             };
 
-            var columns = new Dictionary<string, string>() { { "city", "Delhi" }, { "category", "Handmade" } };
-            var groupKey1 = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "city", "Delhi" }, { "category", "Handmade" } };
+            var groupKey1 = new DimensionKey(dimensions);
 
-            columns = new Dictionary<string, string>() { { "city", "Kolkata" } };
-            var groupKey2 = new DimensionKey(columns);
+            dimensions = new Dictionary<string, string>() { { "city", "Kolkata" } };
+            var groupKey2 = new DimensionKey(dimensions);
 
             options.Filter.DimensionKeys.Add(groupKey1);
             options.Filter.DimensionKeys.Add(groupKey2);
@@ -144,11 +144,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var options = new GetIncidentsForDetectionConfigurationOptions(SamplingStartTime, SamplingEndTime);
 
-            var columns = new Dictionary<string, string>() { { "city", "Delhi" }, { "category", "Handmade" } };
-            var groupKey1 = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "city", "Delhi" }, { "category", "Handmade" } };
+            var groupKey1 = new DimensionKey(dimensions);
 
-            columns = new Dictionary<string, string>() { { "city", "Kolkata" } };
-            var groupKey2 = new DimensionKey(columns);
+            dimensions = new Dictionary<string, string>() { { "city", "Kolkata" } };
+            var groupKey2 = new DimensionKey(dimensions);
 
             options.DimensionKeys.Add(groupKey1);
             options.DimensionKeys.Add(groupKey2);
@@ -217,8 +217,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
             // We already know the the incident we want to get, so apply filters to make the
             // service call cheaper.
 
-            var columns = new Dictionary<string, string>() { { "city", "__SUM__" }, { "category", "Grocery & Gourmet Food" } };
-            var groupKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "city", "__SUM__" }, { "category", "Grocery & Gourmet Food" } };
+            var groupKey = new DimensionKey(dimensions);
 
             options.DimensionKeys.Add(groupKey);
 
@@ -321,10 +321,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var columns = new Dictionary<string, string>() { { "category", "Handmade" } };
+            var dimensions = new Dictionary<string, string>() { { "category", "Handmade" } };
             var options = new GetAnomalyDimensionValuesOptions(SamplingStartTime, SamplingEndTime)
             {
-                SeriesGroupKey = new DimensionKey(columns)
+                SeriesGroupKey = new DimensionKey(dimensions)
             };
 
             var valueCount = 0;
@@ -349,11 +349,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient(useTokenCredential);
 
-            var columns = new Dictionary<string, string>() { { "city", "Delhi" }, { "category", "Handmade" } };
-            var seriesKey1 = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "city", "Delhi" }, { "category", "Handmade" } };
+            var seriesKey1 = new DimensionKey(dimensions);
 
-            columns = new Dictionary<string, string>() { { "city", "Kolkata" }, { "category", "__SUM__" } };
-            var seriesKey2 = new DimensionKey(columns);
+            dimensions = new Dictionary<string, string>() { { "city", "Kolkata" }, { "category", "__SUM__" } };
+            var seriesKey2 = new DimensionKey(dimensions);
 
             var seriesKeys = new List<DimensionKey>() { seriesKey1, seriesKey2 };
             var returnedKeys = new List<DimensionKey>();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionLiveTests.cs
@@ -68,8 +68,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
             columns = new Dictionary<string, string>() { { "city", "Kolkata" } };
             var groupKey2 = new DimensionKey(columns);
 
-            options.Filter.SeriesGroupKeys.Add(groupKey1);
-            options.Filter.SeriesGroupKeys.Add(groupKey2);
+            options.Filter.DimensionKeys.Add(groupKey1);
+            options.Filter.DimensionKeys.Add(groupKey2);
 
             var anomalyCount = 0;
 
@@ -126,7 +126,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Assert.That(incident.Status, Is.Not.EqualTo(default(AnomalyIncidentStatus)));
                 Assert.That(incident.Severity, Is.Not.EqualTo(default(AnomalySeverity)));
 
-                ValidateSeriesKey(incident.RootDimensionKey);
+                ValidateSeriesKey(incident.RootSeriesKey);
 
                 if (++incidentCount >= MaximumSamplesCount)
                 {
@@ -150,8 +150,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
             columns = new Dictionary<string, string>() { { "city", "Kolkata" } };
             var groupKey2 = new DimensionKey(columns);
 
-            options.DimensionsToFilter.Add(groupKey1);
-            options.DimensionsToFilter.Add(groupKey2);
+            options.DimensionKeys.Add(groupKey1);
+            options.DimensionKeys.Add(groupKey2);
 
             var incidentCount = 0;
 
@@ -168,10 +168,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Assert.That(incident.Status, Is.Not.EqualTo(default(AnomalyIncidentStatus)));
                 Assert.That(incident.Severity, Is.Not.EqualTo(default(AnomalySeverity)));
 
-                ValidateSeriesKey(incident.RootDimensionKey);
+                ValidateSeriesKey(incident.RootSeriesKey);
 
-                incident.RootDimensionKey.TryGetValue("city", out string city);
-                incident.RootDimensionKey.TryGetValue("category", out string category);
+                incident.RootSeriesKey.TryGetValue("city", out string city);
+                incident.RootSeriesKey.TryGetValue("category", out string category);
 
                 Assert.That((city == "Delhi" && category == "Handmade") || city == "Kolkata");
 
@@ -220,7 +220,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var columns = new Dictionary<string, string>() { { "city", "__SUM__" }, { "category", "Grocery & Gourmet Food" } };
             var groupKey = new DimensionKey(columns);
 
-            options.DimensionsToFilter.Add(groupKey);
+            options.DimensionKeys.Add(groupKey);
 
             await foreach (AnomalyIncident currentIncident in client.GetIncidentsForDetectionConfigurationAsync(DetectionConfigurationId, options))
             {
@@ -324,7 +324,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var columns = new Dictionary<string, string>() { { "category", "Handmade" } };
             var options = new GetAnomalyDimensionValuesOptions(SamplingStartTime, SamplingEndTime)
             {
-                DimensionToFilter = new DimensionKey(columns)
+                SeriesGroupKey = new DimensionKey(columns)
             };
 
             var valueCount = 0;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionTests.cs
@@ -197,10 +197,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var columns = new Dictionary<string, string>() { { "name", "value" } };
+            var dimensions = new Dictionary<string, string>() { { "name", "value" } };
 
             var emptyList = new List<DimensionKey>();
-            var seriesKeys = new List<DimensionKey>() { new DimensionKey(columns) };
+            var seriesKeys = new List<DimensionKey>() { new DimensionKey(dimensions) };
 
             Assert.That(() => client.GetMetricEnrichedSeriesDataAsync(FakeGuid, null, default, default), Throws.InstanceOf<ArgumentNullException>());
             Assert.That(() => client.GetMetricEnrichedSeriesDataAsync(FakeGuid, emptyList, default, default), Throws.InstanceOf<ArgumentException>());
@@ -220,10 +220,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var columns = new Dictionary<string, string>() { { "name", "value" } };
+            var dimensions = new Dictionary<string, string>() { { "name", "value" } };
 
             var emptyList = new List<DimensionKey>();
-            var seriesKeys = new List<DimensionKey>() { new DimensionKey(columns) };
+            var seriesKeys = new List<DimensionKey>() { new DimensionKey(dimensions) };
 
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/MetricFeedbackLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/MetricFeedbackLiveTests.cs
@@ -215,9 +215,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Assert.That(feedback.CreatedOn, Is.Not.Null);
 
                 Assert.That(feedback.DimensionFilter, Is.Not.Null);
-                Assert.That(feedback.DimensionFilter.DimensionFilter, Is.Not.Null);
+                Assert.That(feedback.DimensionFilter.DimensionKey, Is.Not.Null);
 
-                ValidateGroupKey(feedback.DimensionFilter.DimensionFilter);
+                ValidateGroupKey(feedback.DimensionFilter.DimensionKey);
 
                 if (feedback.Kind == MetricFeedbackKind.Anomaly)
                 {
@@ -299,7 +299,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
                 Assert.That(feedback.DimensionFilter, Is.Not.Null);
 
-                DimensionKey dimensionKeyFilter = feedback.DimensionFilter.DimensionFilter;
+                DimensionKey dimensionKeyFilter = feedback.DimensionFilter.DimensionKey;
 
                 Assert.That(dimensionKeyFilter, Is.Not.Null);
 
@@ -336,7 +336,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(feedback.DimensionFilter, Is.Not.Null);
 
-            DimensionKey dimensionFilter = feedback.DimensionFilter.DimensionFilter;
+            DimensionKey dimensionFilter = feedback.DimensionFilter.DimensionKey;
 
             Assert.That(dimensionFilter, Is.Not.Null);
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/MetricFeedbackLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/MetricFeedbackLiveTests.cs
@@ -31,8 +31,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient(useTokenCredential);
 
-            var columns = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
+            var dimensionKey = new DimensionKey(dimensions);
 
             var feedbackToAdd = new MetricAnomalyFeedback(MetricId, dimensionKey, CreatedFeedbackStartTime, CreatedFeedbackEndTime, AnomalyValue.AutoDetect);
 
@@ -58,8 +58,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var columns = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
+            var dimensionKey = new DimensionKey(dimensions);
 
             var feedbackToAdd = new MetricAnomalyFeedback(MetricId, dimensionKey, CreatedFeedbackStartTime, CreatedFeedbackEndTime, AnomalyValue.AutoDetect)
             {
@@ -88,8 +88,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var columns = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
+            var dimensionKey = new DimensionKey(dimensions);
 
             var feedbackToAdd = new MetricChangePointFeedback(MetricId, dimensionKey, CreatedFeedbackStartTime, CreatedFeedbackEndTime, ChangePointValue.AutoDetect);
 
@@ -118,8 +118,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var columns = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
+            var dimensionKey = new DimensionKey(dimensions);
 
             var comment = "Feedback created in a .NET test.";
 
@@ -145,8 +145,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var columns = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
+            var dimensionKey = new DimensionKey(dimensions);
 
             var comment = "Feedback created in a .NET test.";
 
@@ -176,8 +176,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var columns = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "city", ExpectedCity }, { "category", ExpectedCategory } };
+            var dimensionKey = new DimensionKey(dimensions);
 
             var periodValue = 10;
 
@@ -275,10 +275,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
             DateTimeOffset feedbackSamplingStartTime = DateTimeOffset.Parse("2020-12-01T00:00:00Z");
             DateTimeOffset feedbackSamplingEndTime = DateTimeOffset.Parse("2020-12-31T00:00:00Z");
 
-            var columns = new Dictionary<string, string>() { { "city", "Delhi" } };
+            var dimensions = new Dictionary<string, string>() { { "city", "Delhi" } };
             var options = new GetAllFeedbackOptions()
             {
-                Filter = new DimensionKey(columns),
+                Filter = new DimensionKey(dimensions),
                 TimeMode = FeedbackQueryTimeMode.FeedbackCreatedOn,
                 StartTime = feedbackSamplingStartTime,
                 EndTime = feedbackSamplingEndTime,

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/TimeSeriesLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/TimeSeriesLiveTests.cs
@@ -142,11 +142,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient(useTokenCredential);
 
-            var columns = new Dictionary<string, string>() { { "city", "Delhi" }, { "category", "Handmade" } };
-            var seriesKey1 = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "city", "Delhi" }, { "category", "Handmade" } };
+            var seriesKey1 = new DimensionKey(dimensions);
 
-            columns = new Dictionary<string, string>() { { "city", "Kolkata" }, { "category", "__SUM__" } };
-            var seriesKey2 = new DimensionKey(columns);
+            dimensions = new Dictionary<string, string>() { { "city", "Kolkata" }, { "category", "__SUM__" } };
+            var seriesKey2 = new DimensionKey(dimensions);
 
             var returnedKey1 = false;
             var returnedKey2 = false;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/TimeSeriesLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/TimeSeriesLiveTests.cs
@@ -154,7 +154,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var options = new GetMetricSeriesDataOptions(SamplingStartTime, SamplingEndTime)
             {
-                SeriesToFilter = { seriesKey1, seriesKey2 }
+                SeriesKeys = { seriesKey1, seriesKey2 }
             };
 
             await foreach (MetricSeriesData seriesData in client.GetMetricSeriesDataAsync(MetricId, options))

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/TimeSeriesLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/TimeSeriesLiveTests.cs
@@ -50,7 +50,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var options = new GetMetricDimensionValuesOptions()
             {
-                DimensionValueToFilter = filter
+                DimensionValueFilter = filter
             };
 
             var valueCount = 0;
@@ -106,8 +106,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var options = new GetMetricSeriesDefinitionsOptions(SamplingStartTime);
 
-            options.DimensionCombinationsToFilter.Add("city", cityFilter);
-            options.DimensionCombinationsToFilter.Add("category", categoryFilter);
+            options.DimensionCombinationsFilter.Add("city", cityFilter);
+            options.DimensionCombinationsFilter.Add("category", categoryFilter);
 
             var definitionCount = 0;
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorLiveTestBase.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorLiveTestBase.cs
@@ -112,10 +112,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             int count = 0;
 
-            foreach (KeyValuePair<string, string> column in groupKey)
+            foreach (KeyValuePair<string, string> dimension in groupKey)
             {
-                Assert.That(column.Key, Is.EqualTo("city").Or.EqualTo("category"));
-                Assert.That(column.Value, Is.Not.Null.And.Not.Empty);
+                Assert.That(dimension.Key, Is.EqualTo("city").Or.EqualTo("category"));
+                Assert.That(dimension.Value, Is.Not.Null.And.Not.Empty);
 
                 count++;
             }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DimensionKeyTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DimensionKeyTests.cs
@@ -19,8 +19,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         [Test]
         public void TryGetValueValidatesArguments()
         {
-            var columns = new Dictionary<string, string>();
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>();
+            var dimensionKey = new DimensionKey(dimensions);
 
             Assert.That(() => dimensionKey.TryGetValue(null, out var _), Throws.ArgumentNullException);
             Assert.That(() => dimensionKey.TryGetValue("", out var _), Throws.ArgumentException);
@@ -29,8 +29,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         [Test]
         public void TryGetValueGetsValues()
         {
-            var columns = new Dictionary<string, string>() { { "name1", "value1" }, { "name2", "value2" } };
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "name1", "value1" }, { "name2", "value2" } };
+            var dimensionKey = new DimensionKey(dimensions);
 
             Assert.That(dimensionKey.TryGetValue("name1", out string value1));
             Assert.That(dimensionKey.TryGetValue("name2", out string value2));
@@ -42,8 +42,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         [Test]
         public void TryGetValueReturnsFalseForMissingValue()
         {
-            var columns = new Dictionary<string, string>() { { "name", "value" } };
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "name", "value" } };
+            var dimensionKey = new DimensionKey(dimensions);
 
             Assert.That(dimensionKey.TryGetValue("otherName", out string value), Is.False);
             Assert.That(value, Is.Null);
@@ -52,37 +52,37 @@ namespace Azure.AI.MetricsAdvisor.Tests
         [Test]
         public void ContainsValidatesArguments()
         {
-            var columns = new Dictionary<string, string>();
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>();
+            var dimensionKey = new DimensionKey(dimensions);
 
             Assert.That(() => dimensionKey.Contains(null), Throws.ArgumentNullException);
             Assert.That(() => dimensionKey.Contains(""), Throws.ArgumentException);
         }
 
         [Test]
-        public void ContainsChecksColumns()
+        public void ContainsChecksDimensions()
         {
-            var columns = new Dictionary<string, string>() { { "name", "value" } };
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "name", "value" } };
+            var dimensionKey = new DimensionKey(dimensions);
 
             Assert.That(dimensionKey.Contains("name"));
             Assert.That(dimensionKey.Contains("otherName"), Is.False);
         }
 
         [Test]
-        public void DimensionKeyEnumeratesColumns()
+        public void DimensionKeyEnumeratesDimensions()
         {
-            var columns = new Dictionary<string, string>() { { "name1", "value1" }, { "name2", "value2" } };
-            var dimensionKey = new DimensionKey(columns);
+            var dimensions = new Dictionary<string, string>() { { "name1", "value1" }, { "name2", "value2" } };
+            var dimensionKey = new DimensionKey(dimensions);
 
-            var enumeratedColumns = new Dictionary<string, string>();
+            var enumeratedDimensions = new Dictionary<string, string>();
 
             foreach (KeyValuePair<string, string> column in dimensionKey)
             {
-                enumeratedColumns.Add(column.Key, column.Value);
+                enumeratedDimensions.Add(column.Key, column.Value);
             }
 
-            Assert.That(enumeratedColumns, Is.EquivalentTo(columns));
+            Assert.That(enumeratedDimensions, Is.EquivalentTo(dimensions));
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
@@ -71,7 +71,7 @@ namespace Azure.AI.MetricsAdvisor.Samples
                 Console.WriteLine($" - {metric.Name}: {metric.Id}");
             }
 
-            Console.WriteLine($"Dimension columns:");
+            Console.WriteLine($"Dimensions:");
             foreach (DataFeedDimension dimension in createdDataFeed.Schema.DimensionColumns)
             {
                 Console.WriteLine($" - {dimension.Name}");
@@ -115,7 +115,7 @@ namespace Azure.AI.MetricsAdvisor.Samples
                 Console.WriteLine($" - {metric.Name}: {metric.Id}");
             }
 
-            Console.WriteLine($"Dimension columns:");
+            Console.WriteLine($"Dimensions:");
             foreach (DataFeedDimension dimension in dataFeed.Schema.DimensionColumns)
             {
                 Console.WriteLine($" - {dimension.Name}");

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample07_QueryDetectedAnomalies.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample07_QueryDetectedAnomalies.cs
@@ -46,9 +46,9 @@ namespace Azure.AI.MetricsAdvisor.Samples
                 Console.WriteLine($"Severity: {anomaly.Severity}");
                 Console.WriteLine("Series key:");
 
-                foreach (KeyValuePair<string, string> dimensionColumn in anomaly.SeriesKey)
+                foreach (KeyValuePair<string, string> dimension in anomaly.SeriesKey)
                 {
-                    Console.WriteLine($"  Dimension '{dimensionColumn.Key}': {dimensionColumn.Value}");
+                    Console.WriteLine($"  Dimension '{dimension.Key}': {dimension.Value}");
                 }
 
                 Console.WriteLine();
@@ -102,9 +102,9 @@ namespace Azure.AI.MetricsAdvisor.Samples
                 Console.WriteLine($"Severity: {anomaly.Severity}");
                 Console.WriteLine("Series key:");
 
-                foreach (KeyValuePair<string, string> dimensionColumn in anomaly.SeriesKey)
+                foreach (KeyValuePair<string, string> dimension in anomaly.SeriesKey)
                 {
-                    Console.WriteLine($"  Dimension '{dimensionColumn.Key}': {dimensionColumn.Value}");
+                    Console.WriteLine($"  Dimension '{dimension.Key}': {dimension.Value}");
                 }
 
                 Console.WriteLine();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample08_QueryIncidentsAndRootCauses.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample08_QueryIncidentsAndRootCauses.cs
@@ -27,18 +27,18 @@ namespace Azure.AI.MetricsAdvisor.Samples
             // Only incidents from time series that are part of one of the groups specified
             // will be returned.
 
-            var dimensionColumns = new Dictionary<string, string>()
+            var dimensions = new Dictionary<string, string>()
             {
                 { "city", "Bengaluru" }
             };
-            var groupKey1 = new DimensionKey(dimensionColumns);
+            var groupKey1 = new DimensionKey(dimensions);
 
-            dimensionColumns = new Dictionary<string, string>()
+            dimensions = new Dictionary<string, string>()
             {
                 { "city", "Hong Kong" },
                 { "category", "Industrial & Scientific" }
             };
-            var groupKey2 = new DimensionKey(dimensionColumns);
+            var groupKey2 = new DimensionKey(dimensions);
 
             var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
             var endTime = DateTimeOffset.UtcNow;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample08_QueryIncidentsAndRootCauses.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample08_QueryIncidentsAndRootCauses.cs
@@ -44,8 +44,8 @@ namespace Azure.AI.MetricsAdvisor.Samples
             var endTime = DateTimeOffset.UtcNow;
             var options = new GetIncidentsForDetectionConfigurationOptions(startTime, endTime) { MaxPageSize = 3 };
 
-            options.DimensionsToFilter.Add(groupKey1);
-            options.DimensionsToFilter.Add(groupKey2);
+            options.DimensionKeys.Add(groupKey1);
+            options.DimensionKeys.Add(groupKey2);
 
             int incidentCount = 0;
 
@@ -65,7 +65,7 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
                 Console.WriteLine("Series key of root node:");
 
-                foreach (KeyValuePair<string, string> keyValuePair in incident.RootDimensionKey)
+                foreach (KeyValuePair<string, string> keyValuePair in incident.RootSeriesKey)
                 {
                     Console.WriteLine($"  Dimension '{keyValuePair.Key}': {keyValuePair.Value}");
                 }
@@ -116,7 +116,7 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
                 Console.WriteLine("Series key of root node:");
 
-                foreach (KeyValuePair<string, string> keyValuePair in incident.RootDimensionKey)
+                foreach (KeyValuePair<string, string> keyValuePair in incident.RootSeriesKey)
                 {
                     Console.WriteLine($"  Dimension '{keyValuePair.Key}': {keyValuePair.Value}");
                 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample09_QueryTimeSeriesInformation.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample09_QueryTimeSeriesInformation.cs
@@ -167,19 +167,19 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             // Only the two time series with the keys specified below will be returned.
 
-            var dimensionColumns = new Dictionary<string, string>()
+            var dimensions = new Dictionary<string, string>()
             {
                 { "city", "Belo Horizonte" },
                 { "category", "__SUM__" }
             };
-            var seriesKey1 = new DimensionKey(dimensionColumns);
+            var seriesKey1 = new DimensionKey(dimensions);
 
-            dimensionColumns = new Dictionary<string, string>()
+            dimensions = new Dictionary<string, string>()
             {
                 { "city", "Hong Kong" },
                 { "category", "Industrial & Scientific" }
             };
-            var seriesKey2 = new DimensionKey(dimensionColumns);
+            var seriesKey2 = new DimensionKey(dimensions);
 
             options.SeriesKeys.Add(seriesKey1);
             options.SeriesKeys.Add(seriesKey2);
@@ -222,19 +222,19 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             // Only the two time series with the keys specified below will be returned.
 
-            var dimensionColumns = new Dictionary<string, string>()
+            var dimensions = new Dictionary<string, string>()
             {
                 { "city", "Belo Horizonte" },
                 { "category", "__SUM__" }
             };
-            var seriesKey1 = new DimensionKey(dimensionColumns);
+            var seriesKey1 = new DimensionKey(dimensions);
 
-            dimensionColumns = new Dictionary<string, string>()
+            dimensions = new Dictionary<string, string>()
             {
                 { "city", "Hong Kong" },
                 { "category", "Industrial & Scientific" }
             };
-            var seriesKey2 = new DimensionKey(dimensionColumns);
+            var seriesKey2 = new DimensionKey(dimensions);
 
             var seriesKeys = new List<DimensionKey>() { seriesKey1, seriesKey2 };
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample09_QueryTimeSeriesInformation.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample09_QueryTimeSeriesInformation.cs
@@ -181,8 +181,8 @@ namespace Azure.AI.MetricsAdvisor.Samples
             };
             var seriesKey2 = new DimensionKey(dimensionColumns);
 
-            options.SeriesToFilter.Add(seriesKey1);
-            options.SeriesToFilter.Add(seriesKey2);
+            options.SeriesKeys.Add(seriesKey1);
+            options.SeriesKeys.Add(seriesKey2);
 
             await foreach (MetricSeriesData seriesData in client.GetMetricSeriesDataAsync(metricId, options))
             {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample10_FeedbackCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample10_FeedbackCrudOperations.cs
@@ -24,11 +24,11 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             string metricId = MetricId;
 
-            var dimensionColumns = new Dictionary<string, string>()
+            var dimensions = new Dictionary<string, string>()
             {
                 { "city", "Belo Horizonte" }
             };
-            var dimensionKey = new DimensionKey(dimensionColumns);
+            var dimensionKey = new DimensionKey(dimensions);
 
             var startTime = DateTimeOffset.Parse("2020-02-01T00:00:00Z");
             var endTime = DateTimeOffset.Parse("2020-02-03T00:00:00Z");


### PR DESCRIPTION
Renaming `DimensionKey` properties to have consistent naming across the library.

To understand this PR, it's important to understand what a `DimensionKey` is. It's just a collection of key-value pairs (string, string) that identifies a set of time series in the service. For instance, assuming your data feed only has two dimensions ("city" and "category"):

- The key  `{ { "city", "Redmond" }, { "category", "Software" } }` points to a single time series ("Redmond", "Software") in the service.
- The key `{ { "city", "Seattle" } }` points to a set of time series in the service, including ("Seattle", "Software"), ("Seattle", "Hardware"), and more.

In general, the naming rule is:
- "SeriesKey" represents a "complete" key, with all dimensions assigned (same as our first example above). This points to a single time series in the service.
- "SeriesGroupKey" represents a "partial" key, with only a few dimensions assigned (same as our second example above). This points to a group of time series in the service.
- "DimensionKey" accepts both scenarios.