### PR TITLE
[MetricsAdvisor] Updated DataFeedSource constructors

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Added property `CredentialKind` to `DataSourceCredentialEntity`.
 - Added value `None` to `FeedbackQueryTimeMode` to indicate that no time mode is set.
 - Some properties can now be set to their default value if set to null during an Update operation. For example, `DataFeedIngestionSettings.IngestionStartOffset`, or `MetricWholeSeriesDetectionCondition.SmartDetectionCondition`.
+- Added new constructor to `AzureDataLakeStorageDataFeedSource` to be used with authentication types that are not `Basic`.
+- Added new constructor to `SqlServerDataFeedSource` to be used with the `SqlConnectionString` authentication type.
 
 ### Breaking Changes
 - Removed methods `AddDimensionColumn` and `RemoveDimensionColumn` from `DimensionKey`. In order to access elements, the new method `TryGetValue` must be used. Once the instance has been created, the columns can't be modified anymore.
@@ -80,6 +82,7 @@
 - The class `DatasourceCredential` (now called `DataSourceCredentialEntity`) is now abstract.
 - `AlertQueryTimeMode` and `FeedbackQueryTimeMode` are now regular enums.
 - The enum `AuthenticationType` present in some `DataFeedSource` subtypes is now an extensible enum.
+- Removed constructor `(string workspaceId, string query)` from the `LogAnalyticsDataFeedSource`.
 
 ## 1.0.0-beta.4 (2021-06-07)
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -279,6 +279,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
     }
     public partial class AzureDataLakeStorageDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
     {
+        public AzureDataLakeStorageDataFeedSource(string accountName, string fileSystemName, string directoryTemplate, string fileTemplate) { }
         public AzureDataLakeStorageDataFeedSource(string accountName, string accountKey, string fileSystemName, string directoryTemplate, string fileTemplate) { }
         public string AccountName { get { throw null; } set { } }
         public Azure.AI.MetricsAdvisor.Administration.AzureDataLakeStorageDataFeedSource.AuthenticationType? Authentication { get { throw null; } set { } }
@@ -403,7 +404,6 @@ namespace Azure.AI.MetricsAdvisor.Administration
     }
     public partial class LogAnalyticsDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
     {
-        public LogAnalyticsDataFeedSource(string workspaceId, string query) { }
         public LogAnalyticsDataFeedSource(string workspaceId, string query, string clientId, string clientSecret, string tenantId) { }
         public string ClientId { get { throw null; } set { } }
         public string Query { get { throw null; } set { } }
@@ -528,6 +528,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
     }
     public partial class SqlServerDataFeedSource : Azure.AI.MetricsAdvisor.Administration.DataFeedSource
     {
+        public SqlServerDataFeedSource(string query) { }
         public SqlServerDataFeedSource(string connectionString, string query) { }
         public Azure.AI.MetricsAdvisor.Administration.SqlServerDataFeedSource.AuthenticationType? Authentication { get { throw null; } set { } }
         public string DataSourceCredentialId { get { throw null; } set { } }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataLakeStorageDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/AzureDataLakeStorageDataFeedSource.cs
@@ -17,7 +17,60 @@ namespace Azure.AI.MetricsAdvisor.Administration
         private string _accountKey;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AzureDataLakeStorageDataFeedSource"/> class.
+        /// Initializes a new instance of the <see cref="AzureDataLakeStorageDataFeedSource"/> class. This constructor does not
+        /// set an <see cref="AccountKey"/>, so you must assign an <see cref="AuthenticationType"/> to the <see cref="Authentication"/>
+        /// property. If you intend to use the default authentication type, <see cref="AuthenticationType.Basic"/>, see
+        /// <see cref="AzureDataLakeStorageDataFeedSource(string, string, string, string, string)"/>.
+        /// </summary>
+        /// <param name="accountName">The name of the Storage Account.</param>
+        /// <param name="fileSystemName">The name of the file system.</param>
+        /// <param name="directoryTemplate">The directory template.</param>
+        /// <param name="fileTemplate">
+        /// This is the file template of the Blob file. For example: X_%Y-%m-%d-%h-%M.json. The following parameters are supported:
+        /// <list type="bullet">
+        /// <item>
+        /// <term>%Y</term>
+        /// <description>The year formatted as yyyy</description>
+        /// </item>
+        /// <item>
+        /// <term>%m</term>
+        /// <description>The month formatted as MM</description>
+        /// </item>
+        /// <item>
+        /// <term>%d</term>
+        /// <description>The day formatted as dd</description>
+        /// </item>
+        /// <item>
+        /// <term>%h</term>
+        /// <description>The hour formatted as HH</description>
+        /// </item>
+        /// <item>
+        /// <term>%M</term>
+        /// <description>The minute formatted as mm</description>
+        /// </item>
+        /// </list>
+        /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="accountName"/>, <paramref name="fileSystemName"/>, <paramref name="directoryTemplate"/>, or <paramref name="fileTemplate"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="accountName"/>, <paramref name="fileSystemName"/>, <paramref name="directoryTemplate"/>, or <paramref name="fileTemplate"/> is empty.</exception>
+        public AzureDataLakeStorageDataFeedSource(string accountName, string fileSystemName, string directoryTemplate, string fileTemplate)
+            : base(DataFeedSourceKind.AzureDataLakeStorage)
+        {
+            Argument.AssertNotNullOrEmpty(accountName, nameof(accountName));
+            Argument.AssertNotNullOrEmpty(fileSystemName, nameof(fileSystemName));
+            Argument.AssertNotNullOrEmpty(directoryTemplate, nameof(directoryTemplate));
+            Argument.AssertNotNullOrEmpty(fileTemplate, nameof(fileTemplate));
+
+            AccountName = accountName;
+            FileSystemName = fileSystemName;
+            DirectoryTemplate = directoryTemplate;
+            FileTemplate = fileTemplate;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureDataLakeStorageDataFeedSource"/> class. This constructor
+        /// requires an <paramref name="accountKey"/> and is intended to be used with the default authentication type,
+        /// <see cref="AuthenticationType.Basic"/>. If you intend to use another type of authentication, see
+        /// <see cref="AzureDataLakeStorageDataFeedSource(string, string, string, string)"/>.
         /// </summary>
         /// <param name="accountName">The name of the Storage Account.</param>
         /// <param name="accountKey">The Storage Account key.</param>
@@ -48,22 +101,14 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// </item>
         /// </list>
         /// </param>
-        /// <exception cref="ArgumentNullException"><paramref name="accountName"/>, <paramref name="accountKey"/>, <paramref name="fileSystemName"/>, <paramref name="directoryTemplate"/>, or <paramref name="fileTemplate"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="accountName"/>, <paramref name="accountKey"/>, <paramref name="fileSystemName"/>, <paramref name="directoryTemplate"/>, or <paramref name="fileTemplate"/> is empty.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="accountName"/>, <paramref name="fileSystemName"/>, <paramref name="directoryTemplate"/>, <paramref name="fileTemplate"/>, or <paramref name="accountKey"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="accountName"/>, <paramref name="fileSystemName"/>, <paramref name="directoryTemplate"/>, <paramref name="fileTemplate"/>, or <paramref name="accountKey"/> is empty.</exception>
         public AzureDataLakeStorageDataFeedSource(string accountName, string accountKey, string fileSystemName, string directoryTemplate, string fileTemplate)
-            : base(DataFeedSourceKind.AzureDataLakeStorage)
+            : this(accountName, fileSystemName, directoryTemplate, fileTemplate)
         {
-            Argument.AssertNotNullOrEmpty(accountName, nameof(accountName));
             Argument.AssertNotNullOrEmpty(accountKey, nameof(accountKey));
-            Argument.AssertNotNullOrEmpty(fileSystemName, nameof(fileSystemName));
-            Argument.AssertNotNullOrEmpty(directoryTemplate, nameof(directoryTemplate));
-            Argument.AssertNotNullOrEmpty(fileTemplate, nameof(fileTemplate));
 
-            AccountName = accountName;
             AccountKey = accountKey;
-            FileSystemName = fileSystemName;
-            DirectoryTemplate = directoryTemplate;
-            FileTemplate = fileTemplate;
         }
 
         internal AzureDataLakeStorageDataFeedSource(AzureDataLakeStorageGen2Parameter parameter, AuthenticationTypeEnum? authentication, string credentialId)

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/LogAnalyticsDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/LogAnalyticsDataFeedSource.cs
@@ -20,23 +20,6 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// </summary>
         /// <param name="workspaceId">The workspace ID of the Log Analytics resource.</param>
         /// <param name="query">The query to retrieve the data to be ingested.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="workspaceId"/> or <paramref name="query"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="workspaceId"/> or <paramref name="query"/> is empty.</exception>
-        public LogAnalyticsDataFeedSource(string workspaceId, string query)
-            : base(DataFeedSourceKind.LogAnalytics)
-        {
-            Argument.AssertNotNullOrEmpty(workspaceId, nameof(workspaceId));
-            Argument.AssertNotNullOrEmpty(query, nameof(query));
-
-            WorkspaceId = workspaceId;
-            Query = query;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LogAnalyticsDataFeedSource"/> class.
-        /// </summary>
-        /// <param name="workspaceId">The workspace ID of the Log Analytics resource.</param>
-        /// <param name="query">The query to retrieve the data to be ingested.</param>
         /// <param name="clientId">The client ID used for AAD authentication.</param>
         /// <param name="clientSecret">The client secret used for AAD authentication.</param>
         /// <param name="tenantId">The tenant ID used for AAD authentication.</param>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/SqlServerDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/SqlServerDataFeedSource.cs
@@ -17,14 +17,37 @@ namespace Azure.AI.MetricsAdvisor.Administration
         private string _connectionString;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SqlServerDataFeedSource"/> class.
+        /// Initializes a new instance of the <see cref="SqlServerDataFeedSource"/> class. This constructor does not
+        /// set a <see cref="ConnectionString"/>, so you must assign an <see cref="AuthenticationType"/> to the
+        /// <see cref="Authentication"/> property. Currently, only the <see cref="AuthenticationType.SqlConnectionString"/>
+        /// authentication is supported without a connection string. If you intend to use another type of authentication,
+        /// see <see cref="SqlServerDataFeedSource(string, string)"/>.
+        /// </summary>
+        /// <param name="query">The query to retrieve the data to be ingested.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="query"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="query"/> is empty.</exception>
+        public SqlServerDataFeedSource(string query)
+            : base(DataFeedSourceKind.SqlServer)
+        {
+            Argument.AssertNotNullOrEmpty(query, nameof(query));
+
+            Query = query;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlServerDataFeedSource"/> class. This constructor requires a
+        /// <paramref name="connectionString"/> and is intended to be used with the authentication types
+        /// <see cref="AuthenticationType.Basic"/> (default), <see cref="AuthenticationType.ManagedIdentity"/>,
+        /// <see cref="AuthenticationType.ServicePrincipal"/>, or <see cref="AuthenticationType.ServicePrincipalInKeyVault"/>.
+        /// If you intend to use <see cref="AuthenticationType.SqlConnectionString"/> authentication, see
+        /// <see cref="SqlServerDataFeedSource(string)"/>.
         /// </summary>
         /// <param name="connectionString">The connection string.</param>
         /// <param name="query">The query to retrieve the data to be ingested.</param>
         /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> or <paramref name="query"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="connectionString"/> or <paramref name="query"/> is empty.</exception>
         public SqlServerDataFeedSource(string connectionString, string query)
-            : base(DataFeedSourceKind.SqlServer)
+            : this(query)
         {
             Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
             Argument.AssertNotNullOrEmpty(query, nameof(query));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
@@ -80,6 +80,42 @@ namespace Azure.AI.MetricsAdvisor.Tests
         ";
 
         [Test]
+        public void AzureDataLakeStorageDataFeedSourceConstructorValidatesArguments()
+        {
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource(null, "mock", "mock", "mock"), Throws.ArgumentNullException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("", "mock", "mock", "mock"), Throws.ArgumentException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", null, "mock", "mock"), Throws.ArgumentNullException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "", "mock", "mock"), Throws.ArgumentException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "mock", null, "mock"), Throws.ArgumentNullException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "mock", "", "mock"), Throws.ArgumentException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "mock", "mock", null), Throws.ArgumentNullException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "mock", "mock", ""), Throws.ArgumentException);
+
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource(null, "mock", "mock", "mock", "mock"), Throws.ArgumentNullException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("", "mock", "mock", "mock", "mock"), Throws.ArgumentException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", null, "mock", "mock", "mock"), Throws.ArgumentNullException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "", "mock", "mock", "mock"), Throws.ArgumentException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "mock", null, "mock", "mock"), Throws.ArgumentNullException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "mock", "", "mock", "mock"), Throws.ArgumentException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "mock", "mock", null, "mock"), Throws.ArgumentNullException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "mock", "mock", "", "mock"), Throws.ArgumentException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "mock", "mock", "mock", null), Throws.ArgumentNullException);
+            Assert.That(() => new AzureDataLakeStorageDataFeedSource("mock", "mock", "mock", "mock", ""), Throws.ArgumentException);
+        }
+
+        [Test]
+        public void SqlServerDataFeedSourceConstructorValidatesArguments()
+        {
+            Assert.That(() => new SqlServerDataFeedSource(null), Throws.ArgumentNullException);
+            Assert.That(() => new SqlServerDataFeedSource(""), Throws.ArgumentException);
+
+            Assert.That(() => new SqlServerDataFeedSource(null, "mock"), Throws.ArgumentNullException);
+            Assert.That(() => new SqlServerDataFeedSource("", "mock"), Throws.ArgumentException);
+            Assert.That(() => new SqlServerDataFeedSource("mock", null), Throws.ArgumentNullException);
+            Assert.That(() => new SqlServerDataFeedSource("mock", ""), Throws.ArgumentException);
+        }
+
+        [Test]
         [TestCaseSource(nameof(CreateDataSourceTestCases))]
         public async Task DataFeedSourceSendsSecretDuringCreation(DataFeedSource dataSource, string secretPropertyName)
         {


### PR DESCRIPTION
Adding/removing data source constructors based on what parameters are currently required by the service (fixes https://github.com/azure/azure-sdk-for-net/issues/21616).