### PR TITLE
[MetricsAdvisor] Handling unknown MetricFeedback and DataFeed scenarios

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSource.cs
@@ -12,9 +12,9 @@ namespace Azure.AI.MetricsAdvisor.Administration
     /// </summary>
     public abstract class DataFeedSource
     {
-        internal DataFeedSource(DataFeedSourceKind dataFeedSourceType)
+        internal DataFeedSource(DataFeedSourceKind dataFeedSourceKind)
         {
-            DataSourceKind = dataFeedSourceType;
+            DataSourceKind = dataFeedSourceKind;
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
                 MySqlDataFeed d => new MySqlDataFeedSource(d.DataSourceParameter),
                 PostgreSqlDataFeed d => new PostgreSqlDataFeedSource(d.DataSourceParameter),
                 SQLServerDataFeed d => new SqlServerDataFeedSource(d.DataSourceParameter, d.AuthenticationType, d.CredentialId),
-                _ => throw new InvalidOperationException("Invalid DataFeedDetail type")
+                _ => new UnknownDataFeedSource(dataFeedDetail.DataSourceType)
             };
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
                     new SqlSourceParameter(d.Query) { ConnectionString = d.ConnectionString }),
                 SqlServerDataFeedSource d => new SQLServerDataFeed(name, granularityType, metricColumns, ingestionStartTime,
                     new SqlSourceParameter(d.Query) { ConnectionString = d.ConnectionString }),
-                _ => throw new InvalidOperationException("Invalid DataFeedDetail type")
+                _ => new DataFeedDetail(name, granularityType, metricColumns, ingestionStartTime) { DataSourceType = DataSourceKind }
             };
         }
 
@@ -111,7 +111,15 @@ namespace Azure.AI.MetricsAdvisor.Administration
                 { DataSourceParameter = new() { Query = d.Query, ConnectionString = d.ConnectionString } },
             SqlServerDataFeedSource d => new SQLServerDataFeedPatch()
                 { DataSourceParameter = new() { Query = d.Query, ConnectionString = d.ConnectionString } },
-            _ => throw new InvalidOperationException("Invalid DataFeedDetailPatch type")
+            _ => new DataFeedDetailPatch() { DataSourceType = DataSourceKind }
         };
+
+        private class UnknownDataFeedSource : DataFeedSource
+        {
+            public UnknownDataFeedSource(DataFeedSourceKind dataFeedSourceKind)
+                : base(dataFeedSourceKind)
+            {
+            }
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
@@ -69,7 +69,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             ""dataFeedName"": ""unknownDataFeedName"",
             ""dataSourceType"": ""unknownType"",
             ""fillMissingPointType"": ""NoFilling"",
-            ""description"": ""unknown data feed description"",
+            ""dataFeedDescription"": ""unknown data feed description"",
             ""metrics"": [
                 {{
                     ""metricId"": ""{FakeGuid}"",
@@ -186,7 +186,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(content, ContainsJsonString("dataFeedName", "newDataFeedName"));
             Assert.That(content, ContainsJsonString("dataSourceType", "unknownType"));
             Assert.That(content, ContainsJsonString("fillMissingPointType", "PreviousValue"));
-            Assert.That(content, ContainsJsonString("description", "new description"));
+            Assert.That(content, ContainsJsonString("dataFeedDescription", "new description"));
         }
 
         private void UpdateSecret(DataFeedSource dataSource, string secretPropertyName)

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/DataFeedSourcesTests.cs
@@ -63,6 +63,22 @@ namespace Azure.AI.MetricsAdvisor.Tests
         }
         ";
 
+        private string UnknownDataFeedContent => $@"
+        {{
+            ""dataFeedId"": ""{FakeGuid}"",
+            ""dataFeedName"": ""unknownDataFeedName"",
+            ""dataSourceType"": ""unknownType"",
+            ""fillMissingPointType"": ""NoFilling"",
+            ""description"": ""unknown data feed description"",
+            ""metrics"": [
+                {{
+                    ""metricId"": ""{FakeGuid}"",
+                    ""metricName"": ""cost""
+                }}
+            ]
+        }}
+        ";
+
         [Test]
         [TestCaseSource(nameof(CreateDataSourceTestCases))]
         public async Task DataFeedSourceSendsSecretDuringCreation(DataFeedSource dataSource, string secretPropertyName)
@@ -122,6 +138,55 @@ namespace Azure.AI.MetricsAdvisor.Tests
             string content = ReadContent(request);
 
             Assert.That(content, ContainsJsonString(secretPropertyName, "new_secret"));
+        }
+
+        [Test]
+        public async Task DataFeedSourceGetsUnknownDataFeed()
+        {
+            MockResponse getResponse = new MockResponse(200);
+            getResponse.SetContent(UnknownDataFeedContent);
+
+            MetricsAdvisorAdministrationClient adminClient = CreateInstrumentedAdministrationClient(getResponse);
+            DataFeed dataFeed = await adminClient.GetDataFeedAsync(FakeGuid);
+
+            Assert.That(dataFeed.Id, Is.EqualTo(FakeGuid));
+            Assert.That(dataFeed.Name, Is.EqualTo("unknownDataFeedName"));
+            Assert.That(dataFeed.MissingDataPointFillSettings.FillType, Is.EqualTo(DataFeedMissingDataPointFillType.NoFilling));
+            Assert.That(dataFeed.Description, Is.EqualTo("unknown data feed description"));
+
+            DataFeedMetric metric = dataFeed.Schema.MetricColumns.Single();
+
+            Assert.That(metric.Id, Is.EqualTo(FakeGuid));
+            Assert.That(metric.Name, Is.EqualTo("cost"));
+        }
+
+        [Test]
+        public async Task DataFeedSourceUpdatesUnknownDataFeed()
+        {
+            MockResponse getResponse = new MockResponse(200);
+            getResponse.SetContent(UnknownDataFeedContent);
+
+            MockResponse updateResponse = new MockResponse(200);
+            updateResponse.SetContent(UnknownDataFeedContent);
+
+            MockTransport mockTransport = new MockTransport(getResponse, updateResponse);
+            MetricsAdvisorAdministrationClient adminClient = CreateInstrumentedAdministrationClient(mockTransport);
+            DataFeed dataFeed = await adminClient.GetDataFeedAsync(FakeGuid);
+
+            dataFeed.Name = "newDataFeedName";
+            dataFeed.MissingDataPointFillSettings = new DataFeedMissingDataPointFillSettings(DataFeedMissingDataPointFillType.PreviousValue);
+            dataFeed.Description = "new description";
+
+            await adminClient.UpdateDataFeedAsync(dataFeed);
+
+            MockRequest request = mockTransport.Requests.Last();
+            string content = ReadContent(request);
+
+            Assert.That(request.Uri.Path, Contains.Substring(FakeGuid));
+            Assert.That(content, ContainsJsonString("dataFeedName", "newDataFeedName"));
+            Assert.That(content, ContainsJsonString("dataSourceType", "unknownType"));
+            Assert.That(content, ContainsJsonString("fillMissingPointType", "PreviousValue"));
+            Assert.That(content, ContainsJsonString("description", "new description"));
         }
 
         private void UpdateSecret(DataFeedSource dataSource, string secretPropertyName)

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/MetricFeedbackModelTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Models/MetricFeedbackModelTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.AI.MetricsAdvisor.Tests
+{
+    public class MetricFeedbackModelTests : MockClientTestBase
+    {
+        public MetricFeedbackModelTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        private string UnknownFeedbackContent => $@"
+        {{
+            ""feedbackId"": ""{FakeGuid}"",
+            ""createdTime"": ""2021-01-01T00:00:00.000Z"",
+            ""userPrincipal"": ""fake@email.com"",
+            ""metricId"": ""{FakeGuid}"",
+            ""dimensionFilter"": {{
+                ""dimension"": {{
+                    ""city"": ""Delhi""
+                }}
+            }},
+            ""feedbackType"": ""unknownType""
+        }}
+        ";
+
+        [Test]
+        public async Task MetricFeedbackGetsUnknownFeedback()
+        {
+            MockResponse getResponse = new MockResponse(200);
+            getResponse.SetContent(UnknownFeedbackContent);
+
+            MetricsAdvisorClient client = CreateInstrumentedClient(getResponse);
+            MetricFeedback feedback = await client.GetFeedbackAsync(FakeGuid);
+
+            Assert.That(feedback.Id, Is.EqualTo(FakeGuid));
+            Assert.That(feedback.CreatedOn, Is.EqualTo(DateTimeOffset.Parse("2021-01-01T00:00:00.000Z")));
+            Assert.That(feedback.UserPrincipal, Is.EqualTo("fake@email.com"));
+            Assert.That(feedback.MetricId, Is.EqualTo(FakeGuid));
+            Assert.That(feedback.DimensionKey.TryGetValue("city", out string city));
+            Assert.That(city, Is.EqualTo("Delhi"));
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/azure/azure-sdk-for-net/issues/16333.

As we did for `NotificationHook` and `DataSourceCredentialEntity`, we're updating the other two abstract classes from our API to be able to handle round-trip scenarios in case the service adds a new "kind" for these types.

Tests added as well.