### PR TITLE
Updating CODEOWNERS for ACS Identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -177,7 +177,8 @@
 #/<NotInRepo>/            @ms-premp @qiaozha
 
 # PRLabel: %Communication
-/sdk/communication/                             @acsdevx-msft
+/sdk/communication/                              @acsdevx-msft
+/sdk/communication/Azure.Communication.Identity/ @petrsvihlik @martinbarnas-ms
 
 # ServiceLabel: %Compute %Service Attention
 # PRLabel: %Compute


### PR DESCRIPTION
Reason: The ACS SDKs (including Identity) are being handed over to the respective service teams.
