### PR TITLE
Revert "Use sparse checkout for Create Release Tag release job"

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -56,10 +56,7 @@ stages:
               runOnce:
                 deploy:
                   steps:
-                    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-                      parameters:
-                        Paths:
-                          - '${{ parameters.ServiceDirectory }}'
+                    - checkout: self
                     - template: /eng/common/pipelines/templates/steps/retain-run.yml
                     - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
                       parameters:


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-net#21789

This sparse-checkout doesn't play well with https://github.com/Azure/azure-sdk-for-net/pull/22352 which requires running msbuild commands which requires files in the root of the repo. We can revisit this sparse checkout command after releases are done.

We might be able to use this pattern:
```
    Paths:
      - "/*"
      - "!/*/"
      - "/eng"
      - '/sdk/${{ parameters.ServiceDirectory }}'
```
but more testing would need to be done and potentially some changes to our sparse-checkout template are in order.                          