### PR TITLE
[MetricsAdvisor] Renamed all occurrences of StartTime to StartsOn, and EndTime to EndsOn

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Split the method `GetAnomalies` into two different methods: `GetAnomaliesForAlert` and `GetAnomaliesForDetectionConfiguration`.
 - Split the method `GetIncidents` into two different methods: `GetIncidentsForAlert` and `GetIncidentsForDetectionConfiguration`.
 - Removed the property `DimensionFilter` in `MetricFeedback`. It's now a property of type `DimensionKey` (named `DimensionKey` as well). Similarly, feedback constructors now require a `dimensionKey` parameter to be passed.
-- `DataFeedIngestionSettings` constructor now takes the required `ingestionStartTime` parameter. For this reason, the property `IngestionStartTime` is not nullable anymore.
+- `DataFeedIngestionSettings` constructor now takes the required `ingestionStartsOn` parameter. For this reason, the property `IngestionStartTime`, now named `IngestionStartsOn`, is not nullable anymore.
 - `DataFeedMissingDataPointFillSettings` constructor now takes the required `fillType` parameter. For this reason, the property `FillType` is not nullable anymore.
 - `EmailNotificationHook` constructor now takes the required `name` parameter.
 - `WebNotificationHook` constructor now takes the required `name` and `endpoint` parameters.
@@ -45,6 +45,7 @@
 - `MetricSingleSeriesDetectionCondition` constructor now takes the required `seriesKey` parameter.
 - Renamed all occurrences of `CreatedTime` to `CreatedOn` and `ModifiedTime` to `LastModified`.
 - Renamed `AnomalyIncident.StartTime` to `StartedOn` and `AnomalyIncident.LastTime` to `LastDetectedOn`.
+- Renamed any other occurrences of `StartTime` to `StartsOn`, and `EndTime` to `EndsOn`, including property and parameter names.
 - Renamed `AlertQueryTimeMode.AnomalyTime` to `AnomalyDetectedOn`, and `FeedbackQueryTimeMode.FeedbackCreatedTime` to `FeedbackCreatedOn`.
 - Renamed `DataFeedRollupSettings.AlreadyRollupIdentificationValue` to `RollupIdentificationValue`.
 - In `DataFeedRollupType`, renamed `AlreadyRollup` to `AlreadyRolledUp`, `NeedRollup` to `RollupNeeded`, and `NoRollup` to `NoRollupNeeded`.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
@@ -247,9 +247,9 @@ Check the ingestion status of a previously created [`DataFeed`](#data-feed).
 ```C# Snippet:GetDataFeedIngestionStatusesAsync
 string dataFeedId = "<dataFeedId>";
 
-var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-var endTime = DateTimeOffset.Parse("2020-09-09T00:00:00Z");
-var options = new GetDataFeedIngestionStatusesOptions(startTime, endTime)
+var startsOn = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
+var endsOn = DateTimeOffset.Parse("2020-09-09T00:00:00Z");
+var options = new GetDataFeedIngestionStatusesOptions(startsOn, endsOn)
 {
     MaxPageSize = 5
 };
@@ -363,9 +363,9 @@ Look through the [alerts](#anomaly-alert) created by a given anomaly alert confi
 ```C# Snippet:GetAlertsAsync
 string anomalyAlertConfigurationId = "<anomalyAlertConfigurationId>";
 
-var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-var endTime = DateTimeOffset.UtcNow;
-var options = new GetAlertsOptions(startTime, endTime, AlertQueryTimeMode.AnomalyDetectedOn)
+var startsOn = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
+var endsOn = DateTimeOffset.UtcNow;
+var options = new GetAlertsOptions(startsOn, endsOn, AlertQueryTimeMode.AnomalyDetectedOn)
 {
     MaxPageSize = 5
 };

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -18,9 +18,9 @@ namespace Azure.AI.MetricsAdvisor
     {
         public FeedbackFilter() { }
         public Azure.AI.MetricsAdvisor.Models.DimensionKey DimensionKey { get { throw null; } set { } }
-        public System.DateTimeOffset? EndTime { get { throw null; } set { } }
+        public System.DateTimeOffset? EndsOn { get { throw null; } set { } }
         public Azure.AI.MetricsAdvisor.Models.MetricFeedbackKind? FeedbackKind { get { throw null; } set { } }
-        public System.DateTimeOffset? StartTime { get { throw null; } set { } }
+        public System.DateTimeOffset? StartsOn { get { throw null; } set { } }
         public Azure.AI.MetricsAdvisor.FeedbackQueryTimeMode TimeMode { get { throw null; } set { } }
     }
     public enum FeedbackQueryTimeMode
@@ -31,11 +31,11 @@ namespace Azure.AI.MetricsAdvisor
     }
     public partial class GetAlertsOptions
     {
-        public GetAlertsOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime, Azure.AI.MetricsAdvisor.AlertQueryTimeMode timeMode) { }
-        public System.DateTimeOffset EndTime { get { throw null; } }
+        public GetAlertsOptions(System.DateTimeOffset startsOn, System.DateTimeOffset endsOn, Azure.AI.MetricsAdvisor.AlertQueryTimeMode timeMode) { }
+        public System.DateTimeOffset EndsOn { get { throw null; } }
         public int? MaxPageSize { get { throw null; } set { } }
         public int? Skip { get { throw null; } set { } }
-        public System.DateTimeOffset StartTime { get { throw null; } }
+        public System.DateTimeOffset StartsOn { get { throw null; } }
         public Azure.AI.MetricsAdvisor.AlertQueryTimeMode TimeMode { get { throw null; } }
     }
     public partial class GetAllFeedbackOptions
@@ -53,21 +53,21 @@ namespace Azure.AI.MetricsAdvisor
     }
     public partial class GetAnomaliesForDetectionConfigurationOptions
     {
-        public GetAnomaliesForDetectionConfigurationOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
-        public System.DateTimeOffset EndTime { get { throw null; } }
+        public GetAnomaliesForDetectionConfigurationOptions(System.DateTimeOffset startsOn, System.DateTimeOffset endsOn) { }
+        public System.DateTimeOffset EndsOn { get { throw null; } }
         public Azure.AI.MetricsAdvisor.AnomalyFilter Filter { get { throw null; } set { } }
         public int? MaxPageSize { get { throw null; } set { } }
         public int? Skip { get { throw null; } set { } }
-        public System.DateTimeOffset StartTime { get { throw null; } }
+        public System.DateTimeOffset StartsOn { get { throw null; } }
     }
     public partial class GetAnomalyDimensionValuesOptions
     {
-        public GetAnomalyDimensionValuesOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
-        public System.DateTimeOffset EndTime { get { throw null; } }
+        public GetAnomalyDimensionValuesOptions(System.DateTimeOffset startsOn, System.DateTimeOffset endsOn) { }
+        public System.DateTimeOffset EndsOn { get { throw null; } }
         public int? MaxPageSize { get { throw null; } set { } }
         public Azure.AI.MetricsAdvisor.Models.DimensionKey SeriesGroupKey { get { throw null; } set { } }
         public int? Skip { get { throw null; } set { } }
-        public System.DateTimeOffset StartTime { get { throw null; } }
+        public System.DateTimeOffset StartsOn { get { throw null; } }
     }
     public partial class GetIncidentsForAlertOptions
     {
@@ -77,11 +77,11 @@ namespace Azure.AI.MetricsAdvisor
     }
     public partial class GetIncidentsForDetectionConfigurationOptions
     {
-        public GetIncidentsForDetectionConfigurationOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
+        public GetIncidentsForDetectionConfigurationOptions(System.DateTimeOffset startsOn, System.DateTimeOffset endsOn) { }
         public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DimensionKey> DimensionKeys { get { throw null; } }
-        public System.DateTimeOffset EndTime { get { throw null; } }
+        public System.DateTimeOffset EndsOn { get { throw null; } }
         public int? MaxPageSize { get { throw null; } set { } }
-        public System.DateTimeOffset StartTime { get { throw null; } }
+        public System.DateTimeOffset StartsOn { get { throw null; } }
     }
     public partial class GetMetricDimensionValuesOptions
     {
@@ -92,18 +92,18 @@ namespace Azure.AI.MetricsAdvisor
     }
     public partial class GetMetricEnrichmentStatusesOptions
     {
-        public GetMetricEnrichmentStatusesOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
-        public System.DateTimeOffset EndTime { get { throw null; } }
+        public GetMetricEnrichmentStatusesOptions(System.DateTimeOffset startsOn, System.DateTimeOffset endsOn) { }
+        public System.DateTimeOffset EndsOn { get { throw null; } }
         public int? MaxPageSize { get { throw null; } set { } }
         public int? Skip { get { throw null; } set { } }
-        public System.DateTimeOffset StartTime { get { throw null; } }
+        public System.DateTimeOffset StartsOn { get { throw null; } }
     }
     public partial class GetMetricSeriesDataOptions
     {
-        public GetMetricSeriesDataOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
-        public System.DateTimeOffset EndTime { get { throw null; } }
+        public GetMetricSeriesDataOptions(System.DateTimeOffset startsOn, System.DateTimeOffset endsOn) { }
+        public System.DateTimeOffset EndsOn { get { throw null; } }
         public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DimensionKey> SeriesKeys { get { throw null; } }
-        public System.DateTimeOffset StartTime { get { throw null; } }
+        public System.DateTimeOffset StartsOn { get { throw null; } }
     }
     public partial class GetMetricSeriesDefinitionsOptions
     {
@@ -115,26 +115,26 @@ namespace Azure.AI.MetricsAdvisor
     }
     public partial class MetricAnomalyFeedback : Azure.AI.MetricsAdvisor.MetricFeedback
     {
-        public MetricAnomalyFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.DimensionKey dimensionKey, System.DateTimeOffset startTime, System.DateTimeOffset endTime, Azure.AI.MetricsAdvisor.Models.AnomalyValue value) { }
+        public MetricAnomalyFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.DimensionKey dimensionKey, System.DateTimeOffset startsOn, System.DateTimeOffset endsOn, Azure.AI.MetricsAdvisor.Models.AnomalyValue value) { }
         public Azure.AI.MetricsAdvisor.Models.AnomalyValue AnomalyValue { get { throw null; } }
         public string DetectionConfigurationId { get { throw null; } set { } }
         public Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration DetectionConfigurationSnapshot { get { throw null; } }
-        public System.DateTimeOffset EndTime { get { throw null; } }
-        public System.DateTimeOffset StartTime { get { throw null; } }
+        public System.DateTimeOffset EndsOn { get { throw null; } }
+        public System.DateTimeOffset StartsOn { get { throw null; } }
     }
     public partial class MetricChangePointFeedback : Azure.AI.MetricsAdvisor.MetricFeedback
     {
-        public MetricChangePointFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.DimensionKey dimensionKey, System.DateTimeOffset startTime, System.DateTimeOffset endTime, Azure.AI.MetricsAdvisor.Models.ChangePointValue value) { }
+        public MetricChangePointFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.DimensionKey dimensionKey, System.DateTimeOffset startsOn, System.DateTimeOffset endsOn, Azure.AI.MetricsAdvisor.Models.ChangePointValue value) { }
         public Azure.AI.MetricsAdvisor.Models.ChangePointValue ChangePointValue { get { throw null; } }
-        public System.DateTimeOffset EndTime { get { throw null; } }
-        public System.DateTimeOffset StartTime { get { throw null; } }
+        public System.DateTimeOffset EndsOn { get { throw null; } }
+        public System.DateTimeOffset StartsOn { get { throw null; } }
     }
     public partial class MetricCommentFeedback : Azure.AI.MetricsAdvisor.MetricFeedback
     {
         public MetricCommentFeedback(string metricId, Azure.AI.MetricsAdvisor.Models.DimensionKey dimensionKey, string comment) { }
         public string Comment { get { throw null; } }
-        public System.DateTimeOffset? EndTime { get { throw null; } set { } }
-        public System.DateTimeOffset? StartTime { get { throw null; } set { } }
+        public System.DateTimeOffset? EndsOn { get { throw null; } set { } }
+        public System.DateTimeOffset? StartsOn { get { throw null; } set { } }
     }
     public abstract partial class MetricFeedback
     {
@@ -183,8 +183,8 @@ namespace Azure.AI.MetricsAdvisor
         public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.AnomalyIncident> GetIncidentsForDetectionConfigurationAsync(string detectionConfigurationId, Azure.AI.MetricsAdvisor.GetIncidentsForDetectionConfigurationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<string> GetMetricDimensionValues(string metricId, string dimensionName, Azure.AI.MetricsAdvisor.GetMetricDimensionValuesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<string> GetMetricDimensionValuesAsync(string metricId, string dimensionName, Azure.AI.MetricsAdvisor.GetMetricDimensionValuesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.MetricEnrichedSeriesData> GetMetricEnrichedSeriesData(string detectionConfigurationId, System.Collections.Generic.IEnumerable<Azure.AI.MetricsAdvisor.Models.DimensionKey> seriesKeys, System.DateTimeOffset startTime, System.DateTimeOffset endTime, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.MetricEnrichedSeriesData> GetMetricEnrichedSeriesDataAsync(string detectionConfigurationId, System.Collections.Generic.IEnumerable<Azure.AI.MetricsAdvisor.Models.DimensionKey> seriesKeys, System.DateTimeOffset startTime, System.DateTimeOffset endTime, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.MetricEnrichedSeriesData> GetMetricEnrichedSeriesData(string detectionConfigurationId, System.Collections.Generic.IEnumerable<Azure.AI.MetricsAdvisor.Models.DimensionKey> seriesKeys, System.DateTimeOffset startsOn, System.DateTimeOffset endsOn, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.MetricEnrichedSeriesData> GetMetricEnrichedSeriesDataAsync(string detectionConfigurationId, System.Collections.Generic.IEnumerable<Azure.AI.MetricsAdvisor.Models.DimensionKey> seriesKeys, System.DateTimeOffset startsOn, System.DateTimeOffset endsOn, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.EnrichmentStatus> GetMetricEnrichmentStatuses(string metricId, Azure.AI.MetricsAdvisor.GetMetricEnrichmentStatusesOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.EnrichmentStatus> GetMetricEnrichmentStatusesAsync(string metricId, Azure.AI.MetricsAdvisor.GetMetricEnrichmentStatusesOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.MetricSeriesData> GetMetricSeriesData(string metricId, Azure.AI.MetricsAdvisor.GetMetricSeriesDataOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -360,11 +360,11 @@ namespace Azure.AI.MetricsAdvisor.Administration
     }
     public partial class GetDataFeedIngestionStatusesOptions
     {
-        public GetDataFeedIngestionStatusesOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
-        public System.DateTimeOffset EndTime { get { throw null; } }
+        public GetDataFeedIngestionStatusesOptions(System.DateTimeOffset startsOn, System.DateTimeOffset endsOn) { }
+        public System.DateTimeOffset EndsOn { get { throw null; } }
         public int? MaxPageSize { get { throw null; } set { } }
         public int? Skip { get { throw null; } set { } }
-        public System.DateTimeOffset StartTime { get { throw null; } }
+        public System.DateTimeOffset StartsOn { get { throw null; } }
     }
     public partial class GetDataFeedsOptions
     {
@@ -462,8 +462,8 @@ namespace Azure.AI.MetricsAdvisor.Administration
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Administration.NotificationHook>> GetHookAsync(string hookId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Administration.NotificationHook> GetHooks(Azure.AI.MetricsAdvisor.Administration.GetHooksOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Administration.NotificationHook> GetHooksAsync(Azure.AI.MetricsAdvisor.Administration.GetHooksOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response RefreshDataFeedIngestion(string dataFeedId, System.DateTimeOffset startTime, System.DateTimeOffset endTime, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response> RefreshDataFeedIngestionAsync(string dataFeedId, System.DateTimeOffset startTime, System.DateTimeOffset endTime, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response RefreshDataFeedIngestion(string dataFeedId, System.DateTimeOffset startsOn, System.DateTimeOffset endsOn, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> RefreshDataFeedIngestionAsync(string dataFeedId, System.DateTimeOffset startsOn, System.DateTimeOffset endsOn, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration> UpdateAlertConfiguration(Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration alertConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration>> UpdateAlertConfigurationAsync(Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration alertConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeed> UpdateDataFeed(Azure.AI.MetricsAdvisor.Models.DataFeed dataFeed, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -875,11 +875,11 @@ namespace Azure.AI.MetricsAdvisor.Models
     }
     public partial class DataFeedIngestionSettings
     {
-        public DataFeedIngestionSettings(System.DateTimeOffset ingestionStartTime) { }
+        public DataFeedIngestionSettings(System.DateTimeOffset ingestionStartsOn) { }
         public int? DataSourceRequestConcurrency { get { throw null; } set { } }
         public System.TimeSpan? IngestionRetryDelay { get { throw null; } set { } }
         public System.TimeSpan? IngestionStartOffset { get { throw null; } set { } }
-        public System.DateTimeOffset IngestionStartTime { get { throw null; } set { } }
+        public System.DateTimeOffset IngestionStartsOn { get { throw null; } set { } }
         public System.TimeSpan? StopRetryAfter { get { throw null; } set { } }
     }
     public partial class DataFeedIngestionStatus

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/FeedbackFilter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/FeedbackFilter.cs
@@ -52,18 +52,18 @@ namespace Azure.AI.MetricsAdvisor
         /// in UTC, will be returned. In order to filter by time, you also need to set the property
         /// <see cref="TimeMode"/>.
         /// </summary>
-        public DateTimeOffset? StartTime { get; set; }
+        public DateTimeOffset? StartsOn { get; set; }
 
         /// <summary>
         /// Filters the result under the chosen <see cref="TimeMode"/>. Only results up to this point in time,
         /// in UTC, will be returned. In order to filter by time, you also need to set the property
         /// <see cref="TimeMode"/>.
         /// </summary>
-        public DateTimeOffset? EndTime { get; set; }
+        public DateTimeOffset? EndsOn { get; set; }
 
         /// <summary>
-        /// Specifies to which time property of a <see cref="MetricFeedback"/> the filters <see cref="StartTime"/>
-        /// and <see cref="EndTime"/> will be applied.
+        /// Specifies to which time property of a <see cref="MetricFeedback"/> the filters <see cref="StartsOn"/>
+        /// and <see cref="EndsOn"/> will be applied.
         /// </summary>
         public FeedbackQueryTimeMode TimeMode { get; set; }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricAnomalyFeedback.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricAnomalyFeedback.Serialization.cs
@@ -18,9 +18,9 @@ namespace Azure.AI.MetricsAdvisor
         {
             writer.WriteStartObject();
             writer.WritePropertyName("startTime");
-            writer.WriteStringValue(StartTime, "O");
+            writer.WriteStringValue(StartsOn, "O");
             writer.WritePropertyName("endTime");
-            writer.WriteStringValue(EndTime, "O");
+            writer.WriteStringValue(EndsOn, "O");
             writer.WritePropertyName("value");
             writer.WriteObjectValue(ValueInternal);
             if (Optional.IsDefined(DetectionConfigurationId))

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricAnomalyFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricAnomalyFeedback.cs
@@ -21,15 +21,15 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="userPrincipal"> user who gives this feedback. </param>
         /// <param name="metricId"> metric unique id. </param>
         /// <param name="dimensionFilter"> . </param>
-        /// <param name="startTime"> the start timestamp of feedback time range. </param>
-        /// <param name="endTime"> the end timestamp of feedback time range, when equals to startTime means only one timestamp. </param>
+        /// <param name="startsOn"> the start timestamp of feedback time range. </param>
+        /// <param name="endsOn"> the end timestamp of feedback time range, when equals to startTime means only one timestamp. </param>
         /// <param name="valueInternal"> . </param>
         /// <param name="detectionConfigurationId"> the corresponding anomaly detection configuration of this feedback. </param>
         /// <param name="detectionConfigurationSnapshot"> . </param>
-        internal MetricAnomalyFeedback(MetricFeedbackKind feedbackKind, string id, DateTimeOffset? createdOn, string userPrincipal, string metricId, FeedbackFilter dimensionFilter, DateTimeOffset startTime, DateTimeOffset endTime, AnomalyFeedbackValue valueInternal, string detectionConfigurationId, AnomalyDetectionConfiguration detectionConfigurationSnapshot) : base(feedbackKind, id, createdOn, userPrincipal, metricId, dimensionFilter)
+        internal MetricAnomalyFeedback(MetricFeedbackKind feedbackKind, string id, DateTimeOffset? createdOn, string userPrincipal, string metricId, FeedbackFilter dimensionFilter, DateTimeOffset startsOn, DateTimeOffset endsOn, AnomalyFeedbackValue valueInternal, string detectionConfigurationId, AnomalyDetectionConfiguration detectionConfigurationSnapshot) : base(feedbackKind, id, createdOn, userPrincipal, metricId, dimensionFilter)
         {
-            StartsOn = startTime;
-            EndsOn = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
             ValueInternal = valueInternal;
             DetectionConfigurationId = detectionConfigurationId;
             DetectionConfigurationSnapshot = detectionConfigurationSnapshot;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricAnomalyFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricAnomalyFeedback.cs
@@ -28,8 +28,8 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="detectionConfigurationSnapshot"> . </param>
         internal MetricAnomalyFeedback(MetricFeedbackKind feedbackKind, string id, DateTimeOffset? createdOn, string userPrincipal, string metricId, FeedbackFilter dimensionFilter, DateTimeOffset startTime, DateTimeOffset endTime, AnomalyFeedbackValue valueInternal, string detectionConfigurationId, AnomalyDetectionConfiguration detectionConfigurationSnapshot) : base(feedbackKind, id, createdOn, userPrincipal, metricId, dimensionFilter)
         {
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startTime;
+            EndsOn = endTime;
             ValueInternal = valueInternal;
             DetectionConfigurationId = detectionConfigurationId;
             DetectionConfigurationSnapshot = detectionConfigurationSnapshot;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricChangePointFeedback.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricChangePointFeedback.Serialization.cs
@@ -18,9 +18,9 @@ namespace Azure.AI.MetricsAdvisor
         {
             writer.WriteStartObject();
             writer.WritePropertyName("startTime");
-            writer.WriteStringValue(StartTime, "O");
+            writer.WriteStringValue(StartsOn, "O");
             writer.WritePropertyName("endTime");
-            writer.WriteStringValue(EndTime, "O");
+            writer.WriteStringValue(EndsOn, "O");
             writer.WritePropertyName("value");
             writer.WriteObjectValue(ValueInternal);
             writer.WritePropertyName("feedbackType");

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricChangePointFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricChangePointFeedback.cs
@@ -21,13 +21,13 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="userPrincipal"> user who gives this feedback. </param>
         /// <param name="metricId"> metric unique id. </param>
         /// <param name="dimensionFilter"> . </param>
-        /// <param name="startTime"> the start timestamp of feedback time range. </param>
-        /// <param name="endTime"> the end timestamp of feedback time range, when equals to startTime means only one timestamp. </param>
+        /// <param name="startsOn"> the start timestamp of feedback time range. </param>
+        /// <param name="endsOn"> the end timestamp of feedback time range, when equals to startTime means only one timestamp. </param>
         /// <param name="valueInternal"> . </param>
-        internal MetricChangePointFeedback(MetricFeedbackKind feedbackKind, string id, DateTimeOffset? createdOn, string userPrincipal, string metricId, FeedbackFilter dimensionFilter, DateTimeOffset startTime, DateTimeOffset endTime, ChangePointFeedbackValue valueInternal) : base(feedbackKind, id, createdOn, userPrincipal, metricId, dimensionFilter)
+        internal MetricChangePointFeedback(MetricFeedbackKind feedbackKind, string id, DateTimeOffset? createdOn, string userPrincipal, string metricId, FeedbackFilter dimensionFilter, DateTimeOffset startsOn, DateTimeOffset endsOn, ChangePointFeedbackValue valueInternal) : base(feedbackKind, id, createdOn, userPrincipal, metricId, dimensionFilter)
         {
-            StartsOn = startTime;
-            EndsOn = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
             ValueInternal = valueInternal;
             FeedbackKind = feedbackKind;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricChangePointFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricChangePointFeedback.cs
@@ -26,8 +26,8 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="valueInternal"> . </param>
         internal MetricChangePointFeedback(MetricFeedbackKind feedbackKind, string id, DateTimeOffset? createdOn, string userPrincipal, string metricId, FeedbackFilter dimensionFilter, DateTimeOffset startTime, DateTimeOffset endTime, ChangePointFeedbackValue valueInternal) : base(feedbackKind, id, createdOn, userPrincipal, metricId, dimensionFilter)
         {
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startTime;
+            EndsOn = endTime;
             ValueInternal = valueInternal;
             FeedbackKind = feedbackKind;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricCommentFeedback.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricCommentFeedback.Serialization.cs
@@ -17,24 +17,24 @@ namespace Azure.AI.MetricsAdvisor
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            if (Optional.IsDefined(StartTime))
+            if (Optional.IsDefined(StartsOn))
             {
-                if (StartTime != null)
+                if (StartsOn != null)
                 {
                     writer.WritePropertyName("startTime");
-                    writer.WriteStringValue(StartTime.Value, "O");
+                    writer.WriteStringValue(StartsOn.Value, "O");
                 }
                 else
                 {
                     writer.WriteNull("startTime");
                 }
             }
-            if (Optional.IsDefined(EndTime))
+            if (Optional.IsDefined(EndsOn))
             {
-                if (EndTime != null)
+                if (EndsOn != null)
                 {
                     writer.WritePropertyName("endTime");
-                    writer.WriteStringValue(EndTime.Value, "O");
+                    writer.WriteStringValue(EndsOn.Value, "O");
                 }
                 else
                 {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricCommentFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricCommentFeedback.cs
@@ -21,13 +21,13 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="userPrincipal"> user who gives this feedback. </param>
         /// <param name="metricId"> metric unique id. </param>
         /// <param name="dimensionFilter"> . </param>
-        /// <param name="startTime"> the start timestamp of feedback time range. </param>
-        /// <param name="endTime"> the end timestamp of feedback time range, when equals to startTime means only one timestamp. </param>
+        /// <param name="startsOn"> the start timestamp of feedback time range. </param>
+        /// <param name="endsOn"> the end timestamp of feedback time range, when equals to startTime means only one timestamp. </param>
         /// <param name="valueInternal"> . </param>
-        internal MetricCommentFeedback(MetricFeedbackKind feedbackKind, string id, DateTimeOffset? createdOn, string userPrincipal, string metricId, FeedbackFilter dimensionFilter, DateTimeOffset? startTime, DateTimeOffset? endTime, CommentFeedbackValue valueInternal) : base(feedbackKind, id, createdOn, userPrincipal, metricId, dimensionFilter)
+        internal MetricCommentFeedback(MetricFeedbackKind feedbackKind, string id, DateTimeOffset? createdOn, string userPrincipal, string metricId, FeedbackFilter dimensionFilter, DateTimeOffset? startsOn, DateTimeOffset? endsOn, CommentFeedbackValue valueInternal) : base(feedbackKind, id, createdOn, userPrincipal, metricId, dimensionFilter)
         {
-            StartsOn = startTime;
-            EndsOn = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
             ValueInternal = valueInternal;
             FeedbackKind = feedbackKind;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricCommentFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MetricCommentFeedback.cs
@@ -26,8 +26,8 @@ namespace Azure.AI.MetricsAdvisor
         /// <param name="valueInternal"> . </param>
         internal MetricCommentFeedback(MetricFeedbackKind feedbackKind, string id, DateTimeOffset? createdOn, string userPrincipal, string metricId, FeedbackFilter dimensionFilter, DateTimeOffset? startTime, DateTimeOffset? endTime, CommentFeedbackValue valueInternal) : base(feedbackKind, id, createdOn, userPrincipal, metricId, dimensionFilter)
         {
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startTime;
+            EndsOn = endTime;
             ValueInternal = valueInternal;
             FeedbackKind = feedbackKind;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAlertsOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAlertsOptions.cs
@@ -15,29 +15,29 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// Initializes a new instance of the <see cref="GetAlertsOptions"/> class.
         /// </summary>
-        /// <param name="startTime">Filters the result. Only alerts triggered from this point in time, in UTC, will be returned.</param>
-        /// <param name="endTime">Filters the result. Only alerts triggered up to this point in time, in UTC, will be returned.</param>
-        /// <param name="timeMode">Specifies to which time property of an <see cref="AnomalyAlert"/> the filters <paramref name="startTime"/> and <paramref name="endTime"/> will be applied.</param>
-        public GetAlertsOptions(DateTimeOffset startTime, DateTimeOffset endTime, AlertQueryTimeMode timeMode)
+        /// <param name="startsOn">Filters the result. Only alerts triggered from this point in time, in UTC, will be returned.</param>
+        /// <param name="endsOn">Filters the result. Only alerts triggered up to this point in time, in UTC, will be returned.</param>
+        /// <param name="timeMode">Specifies to which time property of an <see cref="AnomalyAlert"/> the filters <paramref name="startsOn"/> and <paramref name="endsOn"/> will be applied.</param>
+        public GetAlertsOptions(DateTimeOffset startsOn, DateTimeOffset endsOn, AlertQueryTimeMode timeMode)
         {
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
             TimeMode = timeMode;
         }
 
         /// <summary>
         /// Filters the result. Only alerts triggered from this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset StartTime { get; }
+        public DateTimeOffset StartsOn { get; }
 
         /// <summary>
         /// Filters the result. Only alerts triggered up to this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset EndTime { get; }
+        public DateTimeOffset EndsOn { get; }
 
         /// <summary>
-        /// Specifies to which time property of an <see cref="AnomalyAlert"/> the filters <see cref="StartTime"/>
-        /// and <see cref="EndTime"/> will be applied.
+        /// Specifies to which time property of an <see cref="AnomalyAlert"/> the filters <see cref="StartsOn"/>
+        /// and <see cref="EndsOn"/> will be applied.
         /// </summary>
         public AlertQueryTimeMode TimeMode { get; }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAnomaliesForDetectionConfigurationOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAnomaliesForDetectionConfigurationOptions.cs
@@ -16,23 +16,23 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// Initializes a new instance of the <see cref="GetAnomaliesForDetectionConfigurationOptions"/> class.
         /// </summary>
-        /// <param name="startTime">Filters the result. Only anomalies created from this point in time, in UTC, will be returned.</param>
-        /// <param name="endTime">Filters the result. Only anomalies created up to this point in time, in UTC, will be returned.</param>
-        public GetAnomaliesForDetectionConfigurationOptions(DateTimeOffset startTime, DateTimeOffset endTime)
+        /// <param name="startsOn">Filters the result. Only anomalies created from this point in time, in UTC, will be returned.</param>
+        /// <param name="endsOn">Filters the result. Only anomalies created up to this point in time, in UTC, will be returned.</param>
+        public GetAnomaliesForDetectionConfigurationOptions(DateTimeOffset startsOn, DateTimeOffset endsOn)
         {
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
         }
 
         /// <summary>
         /// Filters the result. Only anomalies created from this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset StartTime { get; }
+        public DateTimeOffset StartsOn { get; }
 
         /// <summary>
         /// Filters the result. Only anomalies created up to this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset EndTime { get; }
+        public DateTimeOffset EndsOn { get; }
 
         /// <summary>
         /// Optional filters, such as filtering by time series or by severity level.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAnomalyDimensionValuesOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAnomalyDimensionValuesOptions.cs
@@ -15,23 +15,23 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// Initializes a new instance of the <see cref="GetAnomalyDimensionValuesOptions"/> class.
         /// </summary>
-        /// <param name="startTime">Filters the result. Only dimension values for anomalies created from this point in time, in UTC, will be returned.</param>
-        /// <param name="endTime">Filters the result. Only dimension values for anomalies created up to this point in time, in UTC, will be returned.</param>
-        public GetAnomalyDimensionValuesOptions(DateTimeOffset startTime, DateTimeOffset endTime)
+        /// <param name="startsOn">Filters the result. Only dimension values for anomalies created from this point in time, in UTC, will be returned.</param>
+        /// <param name="endsOn">Filters the result. Only dimension values for anomalies created up to this point in time, in UTC, will be returned.</param>
+        public GetAnomalyDimensionValuesOptions(DateTimeOffset startsOn, DateTimeOffset endsOn)
         {
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
         }
 
         /// <summary>
         /// Filters the result. Only dimension values for anomalies created from this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset StartTime { get; }
+        public DateTimeOffset StartsOn { get; }
 
         /// <summary>
         /// Filters the result. Only dimension values for anomalies created up to this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset EndTime { get; }
+        public DateTimeOffset EndsOn { get; }
 
         /// <summary>
         /// Filters the result by time series. Only dimension values for anomalies detected in the time series

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetDataFeedIngestionStatusesOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetDataFeedIngestionStatusesOptions.cs
@@ -12,23 +12,23 @@ namespace Azure.AI.MetricsAdvisor.Administration
     public class GetDataFeedIngestionStatusesOptions
     {
         /// <summary> Initializes a new instance of the <see cref="GetDataFeedIngestionStatusesOptions"/> class. </summary>
-        /// <param name="startTime"> The start point of time range to query data ingestion status. </param>
-        /// <param name="endTime"> The end point of time range to query data ingestion status. </param>
-        public GetDataFeedIngestionStatusesOptions(DateTimeOffset startTime, DateTimeOffset endTime)
+        /// <param name="startsOn"> The start point of time range to query data ingestion status. </param>
+        /// <param name="endsOn"> The end point of time range to query data ingestion status. </param>
+        public GetDataFeedIngestionStatusesOptions(DateTimeOffset startsOn, DateTimeOffset endsOn)
         {
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
         }
 
         /// <summary>
         /// Filters the result. Only status of data being ingested from this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset StartTime { get; }
+        public DateTimeOffset StartsOn { get; }
 
         /// <summary>
         /// Filters the result. Only status of data being ingested up to this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset EndTime { get; }
+        public DateTimeOffset EndsOn { get; }
 
         /// <summary>
         /// If set, skips the first set of items returned. This property specifies the count of items to be skipped.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetIncidentsForDetectionConfigurationOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetIncidentsForDetectionConfigurationOptions.cs
@@ -19,24 +19,24 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// Initializes a new instance of the <see cref="GetIncidentsForDetectionConfigurationOptions"/> class.
         /// </summary>
-        /// <param name="startTime">Filters the result. Only incidents detected from this point in time, in UTC, will be returned.</param>
-        /// <param name="endTime">Filters the result. Only incidents detected up to this point in time, in UTC, will be returned.</param>
-        public GetIncidentsForDetectionConfigurationOptions(DateTimeOffset startTime, DateTimeOffset endTime)
+        /// <param name="startsOn">Filters the result. Only incidents detected from this point in time, in UTC, will be returned.</param>
+        /// <param name="endsOn">Filters the result. Only incidents detected up to this point in time, in UTC, will be returned.</param>
+        public GetIncidentsForDetectionConfigurationOptions(DateTimeOffset startsOn, DateTimeOffset endsOn)
         {
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
             DimensionKeys = new ChangeTrackingList<DimensionKey>();
         }
 
         /// <summary>
         /// Filters the result. Only incidents detected from this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset StartTime { get; }
+        public DateTimeOffset StartsOn { get; }
 
         /// <summary>
         /// Filters the result. Only incidents detected up to this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset EndTime { get; }
+        public DateTimeOffset EndsOn { get; }
 
         /// <summary>
         /// Filters the result by time series. Each element in this list represents a set of time series, and only

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricEnrichmentStatusesOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricEnrichmentStatusesOptions.cs
@@ -9,19 +9,19 @@ namespace Azure.AI.MetricsAdvisor
     public class GetMetricEnrichmentStatusesOptions
     {
         /// <summary> Initializes a new instance of <see cref="GetMetricEnrichmentStatusesOptions"/>. </summary>
-        /// <param name="startTime"> the start point of time range to query anomaly detection status. </param>
-        /// <param name="endTime"> the end point of time range to query anomaly detection status. </param>
-        public GetMetricEnrichmentStatusesOptions(DateTimeOffset startTime, DateTimeOffset endTime)
+        /// <param name="startsOn"> the start point of time range to query anomaly detection status. </param>
+        /// <param name="endsOn"> the end point of time range to query anomaly detection status. </param>
+        public GetMetricEnrichmentStatusesOptions(DateTimeOffset startsOn, DateTimeOffset endsOn)
         {
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
         }
 
         /// <summary> the start point of time range to query anomaly detection status. </summary>
-        public DateTimeOffset StartTime { get; }
+        public DateTimeOffset StartsOn { get; }
 
         /// <summary> the end point of time range to query anomaly detection status. </summary>
-        public DateTimeOffset EndTime { get; }
+        public DateTimeOffset EndsOn { get; }
 
         /// <summary>
         /// If set, skips the first set of items returned. This property specifies the amount of items to

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricSeriesDataOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricSeriesDataOptions.cs
@@ -17,13 +17,13 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// Initializes a new instance of the <see cref="GetMetricSeriesDataOptions"/> class.
         /// </summary>
-        /// <param name="startTime">Filters the result. Only data points ingested from this point in time, in UTC, will be returned.</param>
-        /// <param name="endTime">Filters the result. Only data points ingested up to this point in time, in UTC, will be returned.</param>
-        public GetMetricSeriesDataOptions(DateTimeOffset startTime, DateTimeOffset endTime)
+        /// <param name="startsOn">Filters the result. Only data points ingested from this point in time, in UTC, will be returned.</param>
+        /// <param name="endsOn">Filters the result. Only data points ingested up to this point in time, in UTC, will be returned.</param>
+        public GetMetricSeriesDataOptions(DateTimeOffset startsOn, DateTimeOffset endsOn)
         {
             SeriesKeys = new ChangeTrackingList<DimensionKey>();
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
         }
 
         /// <summary>
@@ -36,11 +36,11 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// Filters the result. Only data points ingested from this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset StartTime { get; }
+        public DateTimeOffset StartsOn { get; }
 
         /// <summary>
         /// Filters the result. Only data points ingested up to this point in time, in UTC, will be returned.
         /// </summary>
-        public DateTimeOffset EndTime { get; }
+        public DateTimeOffset EndsOn { get; }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
@@ -534,14 +534,14 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// </summary>
         /// <param name="dataFeedId">The unique identifier of the <see cref="DataFeed"/>.</param>
         /// <param name="startsOn">The inclusive data back-fill time range.</param>
-        /// <param name="endTime">The exclusive data back-fill time range.</param>
+        /// <param name="endsOn">The exclusive data back-fill time range.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>
         /// A <see cref="Response"/> containing the result of the operation.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="dataFeedId"/> is empty or not a valid GUID.</exception>
-        public virtual async Task<Response> RefreshDataFeedIngestionAsync(string dataFeedId, DateTimeOffset startsOn, DateTimeOffset endTime, CancellationToken cancellationToken = default)
+        public virtual async Task<Response> RefreshDataFeedIngestionAsync(string dataFeedId, DateTimeOffset startsOn, DateTimeOffset endsOn, CancellationToken cancellationToken = default)
         {
             Guid dataFeedGuid = ClientCommon.ValidateGuid(dataFeedId, nameof(dataFeedId));
 
@@ -549,7 +549,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             scope.Start();
             try
             {
-                IngestionProgressResetOptions options = new IngestionProgressResetOptions(ClientCommon.NormalizeDateTimeOffset(startsOn), ClientCommon.NormalizeDateTimeOffset(endTime));
+                IngestionProgressResetOptions options = new IngestionProgressResetOptions(ClientCommon.NormalizeDateTimeOffset(startsOn), ClientCommon.NormalizeDateTimeOffset(endsOn));
 
                 return await _serviceRestClient.ResetDataFeedIngestionStatusAsync(dataFeedGuid, options, cancellationToken).ConfigureAwait(false);
             }
@@ -566,14 +566,14 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// </summary>
         /// <param name="dataFeedId">The unique identifier of the <see cref="DataFeed"/>.</param>
         /// <param name="startsOn">The inclusive data back-fill time range.</param>
-        /// <param name="endTime">The exclusive data back-fill time range.</param>
+        /// <param name="endsOn">The exclusive data back-fill time range.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>
         /// A <see cref="Response"/> containing the result of the operation.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="dataFeedId"/> is empty or not a valid GUID.</exception>
-        public virtual Response RefreshDataFeedIngestion(string dataFeedId, DateTimeOffset startsOn, DateTimeOffset endTime, CancellationToken cancellationToken = default)
+        public virtual Response RefreshDataFeedIngestion(string dataFeedId, DateTimeOffset startsOn, DateTimeOffset endsOn, CancellationToken cancellationToken = default)
         {
             Guid dataFeedGuid = ClientCommon.ValidateGuid(dataFeedId, nameof(dataFeedId));
 
@@ -581,7 +581,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             scope.Start();
             try
             {
-                IngestionProgressResetOptions options = new IngestionProgressResetOptions(ClientCommon.NormalizeDateTimeOffset(startsOn), ClientCommon.NormalizeDateTimeOffset(endTime));
+                IngestionProgressResetOptions options = new IngestionProgressResetOptions(ClientCommon.NormalizeDateTimeOffset(startsOn), ClientCommon.NormalizeDateTimeOffset(endsOn));
 
                 return _serviceRestClient.ResetDataFeedIngestionStatus(dataFeedGuid, options, cancellationToken);
             }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
@@ -533,7 +533,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// Anomaly detection is re-triggered on selected range only.
         /// </summary>
         /// <param name="dataFeedId">The unique identifier of the <see cref="DataFeed"/>.</param>
-        /// <param name="startTime">The inclusive data back-fill time range.</param>
+        /// <param name="startsOn">The inclusive data back-fill time range.</param>
         /// <param name="endTime">The exclusive data back-fill time range.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>
@@ -541,7 +541,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="dataFeedId"/> is empty or not a valid GUID.</exception>
-        public virtual async Task<Response> RefreshDataFeedIngestionAsync(string dataFeedId, DateTimeOffset startTime, DateTimeOffset endTime, CancellationToken cancellationToken = default)
+        public virtual async Task<Response> RefreshDataFeedIngestionAsync(string dataFeedId, DateTimeOffset startsOn, DateTimeOffset endTime, CancellationToken cancellationToken = default)
         {
             Guid dataFeedGuid = ClientCommon.ValidateGuid(dataFeedId, nameof(dataFeedId));
 
@@ -549,7 +549,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             scope.Start();
             try
             {
-                IngestionProgressResetOptions options = new IngestionProgressResetOptions(ClientCommon.NormalizeDateTimeOffset(startTime), ClientCommon.NormalizeDateTimeOffset(endTime));
+                IngestionProgressResetOptions options = new IngestionProgressResetOptions(ClientCommon.NormalizeDateTimeOffset(startsOn), ClientCommon.NormalizeDateTimeOffset(endTime));
 
                 return await _serviceRestClient.ResetDataFeedIngestionStatusAsync(dataFeedGuid, options, cancellationToken).ConfigureAwait(false);
             }
@@ -565,7 +565,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// Anomaly detection is re-triggered on selected range only.
         /// </summary>
         /// <param name="dataFeedId">The unique identifier of the <see cref="DataFeed"/>.</param>
-        /// <param name="startTime">The inclusive data back-fill time range.</param>
+        /// <param name="startsOn">The inclusive data back-fill time range.</param>
         /// <param name="endTime">The exclusive data back-fill time range.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>
@@ -573,7 +573,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="dataFeedId"/> is empty or not a valid GUID.</exception>
-        public virtual Response RefreshDataFeedIngestion(string dataFeedId, DateTimeOffset startTime, DateTimeOffset endTime, CancellationToken cancellationToken = default)
+        public virtual Response RefreshDataFeedIngestion(string dataFeedId, DateTimeOffset startsOn, DateTimeOffset endTime, CancellationToken cancellationToken = default)
         {
             Guid dataFeedGuid = ClientCommon.ValidateGuid(dataFeedId, nameof(dataFeedId));
 
@@ -581,7 +581,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             scope.Start();
             try
             {
-                IngestionProgressResetOptions options = new IngestionProgressResetOptions(ClientCommon.NormalizeDateTimeOffset(startTime), ClientCommon.NormalizeDateTimeOffset(endTime));
+                IngestionProgressResetOptions options = new IngestionProgressResetOptions(ClientCommon.NormalizeDateTimeOffset(startsOn), ClientCommon.NormalizeDateTimeOffset(endTime));
 
                 return _serviceRestClient.ResetDataFeedIngestionStatus(dataFeedGuid, options, cancellationToken);
             }
@@ -606,7 +606,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             Guid dataFeedGuid = ClientCommon.ValidateGuid(dataFeedId, nameof(dataFeedId));
             Argument.AssertNotNull(options, nameof(options));
 
-            IngestionStatusQueryOptions queryOptions = new IngestionStatusQueryOptions(options.StartTime, options.EndTime);
+            IngestionStatusQueryOptions queryOptions = new IngestionStatusQueryOptions(options.StartsOn, options.EndsOn);
             int? skip = options.Skip;
             int? maxPageSize = options.MaxPageSize;
 
@@ -661,7 +661,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             Guid dataFeedGuid = ClientCommon.ValidateGuid(dataFeedId, nameof(dataFeedId));
             Argument.AssertNotNull(options, nameof(options));
 
-            IngestionStatusQueryOptions queryOptions = new IngestionStatusQueryOptions(options.StartTime, options.EndTime);
+            IngestionStatusQueryOptions queryOptions = new IngestionStatusQueryOptions(options.StartsOn, options.EndsOn);
             int? skip = options.Skip;
             int? maxPageSize = options.MaxPageSize;
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorClient.cs
@@ -356,7 +356,7 @@ namespace Azure.AI.MetricsAdvisor
 
             Guid metricGuid = ClientCommon.ValidateGuid(metricId, nameof(metricId));
             IEnumerable<IDictionary<string, string>> series = options.SeriesKeys.Select(key => key.Dimension);
-            MetricDataQueryOptions queryOptions = new MetricDataQueryOptions(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime), series);
+            MetricDataQueryOptions queryOptions = new MetricDataQueryOptions(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn), series);
 
             async Task<Page<MetricSeriesData>> FirstPageFunc(int? pageSizeHint)
             {
@@ -394,7 +394,7 @@ namespace Azure.AI.MetricsAdvisor
 
             Guid metricGuid = ClientCommon.ValidateGuid(metricId, nameof(metricId));
             IEnumerable<IDictionary<string, string>> series = options.SeriesKeys.Select(key => key.Dimension);
-            MetricDataQueryOptions queryOptions = new MetricDataQueryOptions(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime), series);
+            MetricDataQueryOptions queryOptions = new MetricDataQueryOptions(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn), series);
 
             Page<MetricSeriesData> FirstPageFunc(int? pageSizeHint)
             {
@@ -428,7 +428,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options));
 
             Guid metricGuid = ClientCommon.ValidateGuid(metricId, nameof(metricId));
-            EnrichmentStatusQueryOption queryOptions = new EnrichmentStatusQueryOption(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime));
+            EnrichmentStatusQueryOption queryOptions = new EnrichmentStatusQueryOption(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn));
             int? skip = options.Skip;
             int? maxPageSize = options.MaxPageSize;
 
@@ -481,7 +481,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options));
 
             Guid metricGuid = ClientCommon.ValidateGuid(metricId, nameof(metricId));
-            EnrichmentStatusQueryOption queryOptions = new EnrichmentStatusQueryOption(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime));
+            EnrichmentStatusQueryOption queryOptions = new EnrichmentStatusQueryOption(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn));
             int? skip = options.Skip;
             int? maxPageSize = options.MaxPageSize;
 
@@ -549,9 +549,9 @@ namespace Azure.AI.MetricsAdvisor
 
             if (filter != null)
             {
-                queryOptions.EndTime = filter.EndTime;
+                queryOptions.EndTime = filter.EndsOn;
                 queryOptions.FeedbackType = filter.FeedbackKind;
-                queryOptions.StartTime = filter.StartTime;
+                queryOptions.StartTime = filter.StartsOn;
                 queryOptions.TimeMode = filter.TimeMode;
             }
 
@@ -618,9 +618,9 @@ namespace Azure.AI.MetricsAdvisor
 
             if (filter != null)
             {
-                queryOptions.EndTime = filter.EndTime;
+                queryOptions.EndTime = filter.EndsOn;
                 queryOptions.FeedbackType = filter.FeedbackKind;
-                queryOptions.StartTime = filter.StartTime;
+                queryOptions.StartTime = filter.StartsOn;
                 queryOptions.TimeMode = filter.TimeMode;
             }
 
@@ -818,7 +818,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options));
 
             Guid detectionConfigurationGuid = ClientCommon.ValidateGuid(detectionConfigurationId, nameof(detectionConfigurationId));
-            DetectionAnomalyResultQuery queryOptions = new DetectionAnomalyResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime))
+            DetectionAnomalyResultQuery queryOptions = new DetectionAnomalyResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn))
             {
                 Filter = options.Filter?.GetDetectionAnomalyFilterCondition()
             };
@@ -876,7 +876,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options));
 
             Guid detectionConfigurationGuid = ClientCommon.ValidateGuid(detectionConfigurationId, nameof(detectionConfigurationId));
-            DetectionAnomalyResultQuery queryOptions = new DetectionAnomalyResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime))
+            DetectionAnomalyResultQuery queryOptions = new DetectionAnomalyResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn))
             {
                 Filter = options.Filter?.GetDetectionAnomalyFilterCondition()
             };
@@ -934,7 +934,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options));
 
             Guid detectionConfigurationGuid = ClientCommon.ValidateGuid(detectionConfigurationId, nameof(detectionConfigurationId));
-            DetectionIncidentResultQuery queryOptions = new DetectionIncidentResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime))
+            DetectionIncidentResultQuery queryOptions = new DetectionIncidentResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn))
             {
                 Filter = options.GetDetectionIncidentFilterCondition()
             };
@@ -993,7 +993,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options));
 
             Guid detectionConfigurationGuid = ClientCommon.ValidateGuid(detectionConfigurationId, nameof(detectionConfigurationId));
-            DetectionIncidentResultQuery queryOptions = new DetectionIncidentResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime))
+            DetectionIncidentResultQuery queryOptions = new DetectionIncidentResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn))
             {
                 Filter = options.GetDetectionIncidentFilterCondition()
             };
@@ -1153,7 +1153,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options));
 
             Guid detectionConfigurationGuid = ClientCommon.ValidateGuid(detectionConfigurationId, nameof(detectionConfigurationId));
-            AnomalyDimensionQuery queryOptions = new AnomalyDimensionQuery(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime), dimensionName)
+            AnomalyDimensionQuery queryOptions = new AnomalyDimensionQuery(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn), dimensionName)
             {
                 DimensionFilter = options.SeriesGroupKey?.Clone()
             };
@@ -1214,7 +1214,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options));
 
             Guid detectionConfigurationGuid = ClientCommon.ValidateGuid(detectionConfigurationId, nameof(detectionConfigurationId));
-            AnomalyDimensionQuery queryOptions = new AnomalyDimensionQuery(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime), dimensionName)
+            AnomalyDimensionQuery queryOptions = new AnomalyDimensionQuery(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn), dimensionName)
             {
                 DimensionFilter = options.SeriesGroupKey?.Clone()
             };
@@ -1267,19 +1267,19 @@ namespace Azure.AI.MetricsAdvisor
         /// anomalies detected in one of these series will be returned. For every element, all possible dimensions must
         /// be set.
         /// </param>
-        /// <param name="startTime">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
-        /// <param name="endTime">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
+        /// <param name="startsOn">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
+        /// <param name="endsOn">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>An <see cref="AsyncPageable{T}"/> containing the collection of <see cref="MetricEnrichedSeriesData"/>s.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="detectionConfigurationId"/> or <paramref name="seriesKeys"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="detectionConfigurationId"/> is empty or not a valid GUID.</exception>
-        public virtual AsyncPageable<MetricEnrichedSeriesData> GetMetricEnrichedSeriesDataAsync(string detectionConfigurationId, IEnumerable<DimensionKey> seriesKeys, DateTimeOffset startTime, DateTimeOffset endTime, CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<MetricEnrichedSeriesData> GetMetricEnrichedSeriesDataAsync(string detectionConfigurationId, IEnumerable<DimensionKey> seriesKeys, DateTimeOffset startsOn, DateTimeOffset endsOn, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(seriesKeys, nameof(seriesKeys));
 
             Guid detectionConfigurationGuid = ClientCommon.ValidateGuid(detectionConfigurationId, nameof(detectionConfigurationId));
             IEnumerable<SeriesIdentity> seriesIdentities = seriesKeys.Select(key => key?.ConvertToSeriesIdentity());
-            DetectionSeriesQuery queryOptions = new DetectionSeriesQuery(ClientCommon.NormalizeDateTimeOffset(startTime), ClientCommon.NormalizeDateTimeOffset(endTime), seriesIdentities);
+            DetectionSeriesQuery queryOptions = new DetectionSeriesQuery(ClientCommon.NormalizeDateTimeOffset(startsOn), ClientCommon.NormalizeDateTimeOffset(endsOn), seriesIdentities);
 
             async Task<Page<MetricEnrichedSeriesData>> FirstPageFunc(int? pageSizeHint)
             {
@@ -1310,19 +1310,19 @@ namespace Azure.AI.MetricsAdvisor
         /// anomalies detected in one of these series will be returned. For every element, all possible dimensions must
         /// be set.
         /// </param>
-        /// <param name="startTime">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
-        /// <param name="endTime">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
+        /// <param name="startsOn">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
+        /// <param name="endsOn">Filters the result. Only data points after this point in time, in UTC, will be returned.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>An <see cref="Pageable{T}"/> containing the collection of <see cref="MetricEnrichedSeriesData"/>s.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="detectionConfigurationId"/> or <paramref name="seriesKeys"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="detectionConfigurationId"/> is empty or not a valid GUID.</exception>
-        public virtual Pageable<MetricEnrichedSeriesData> GetMetricEnrichedSeriesData(string detectionConfigurationId, IEnumerable<DimensionKey> seriesKeys, DateTimeOffset startTime, DateTimeOffset endTime, CancellationToken cancellationToken = default)
+        public virtual Pageable<MetricEnrichedSeriesData> GetMetricEnrichedSeriesData(string detectionConfigurationId, IEnumerable<DimensionKey> seriesKeys, DateTimeOffset startsOn, DateTimeOffset endsOn, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(seriesKeys, nameof(seriesKeys));
 
             Guid detectionConfigurationGuid = ClientCommon.ValidateGuid(detectionConfigurationId, nameof(detectionConfigurationId));
             IEnumerable<SeriesIdentity> seriesIdentities = seriesKeys.Select(key => key?.ConvertToSeriesIdentity());
-            DetectionSeriesQuery queryOptions = new DetectionSeriesQuery(ClientCommon.NormalizeDateTimeOffset(startTime), ClientCommon.NormalizeDateTimeOffset(endTime), seriesIdentities);
+            DetectionSeriesQuery queryOptions = new DetectionSeriesQuery(ClientCommon.NormalizeDateTimeOffset(startsOn), ClientCommon.NormalizeDateTimeOffset(endsOn), seriesIdentities);
 
             Page<MetricEnrichedSeriesData> FirstPageFunc(int? pageSizeHint)
             {
@@ -1370,7 +1370,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options));
 
             Guid alertConfigurationGuid = ClientCommon.ValidateGuid(alertConfigurationId, nameof(alertConfigurationId));
-            AlertingResultQuery queryOptions = new AlertingResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime), options.TimeMode);
+            AlertingResultQuery queryOptions = new AlertingResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn), options.TimeMode);
             int? skip = options.Skip;
             int? maxPageSize = options.MaxPageSize;
 
@@ -1425,7 +1425,7 @@ namespace Azure.AI.MetricsAdvisor
             Argument.AssertNotNull(options, nameof(options));
 
             Guid alertConfigurationGuid = ClientCommon.ValidateGuid(alertConfigurationId, nameof(alertConfigurationId));
-            AlertingResultQuery queryOptions = new AlertingResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartTime), ClientCommon.NormalizeDateTimeOffset(options.EndTime), options.TimeMode);
+            AlertingResultQuery queryOptions = new AlertingResultQuery(ClientCommon.NormalizeDateTimeOffset(options.StartsOn), ClientCommon.NormalizeDateTimeOffset(options.EndsOn), options.TimeMode);
             int? skip = options.Skip;
             int? maxPageSize = options.MaxPageSize;
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -159,7 +159,7 @@ namespace Azure.AI.MetricsAdvisor.Models
 
         internal DataFeedDetail GetDataFeedDetail()
         {
-            DataFeedDetail detail = DataSource.InstantiateDataFeedDetail(Name, Granularity.GranularityType, Schema.MetricColumns, IngestionSettings.IngestionStartTime);
+            DataFeedDetail detail = DataSource.InstantiateDataFeedDetail(Name, Granularity.GranularityType, Schema.MetricColumns, IngestionSettings.IngestionStartsOn);
 
             foreach (var column in Schema.DimensionColumns)
             {
@@ -228,7 +228,7 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             if (IngestionSettings != null)
             {
-                patch.DataStartFrom = ClientCommon.NormalizeDateTimeOffset(IngestionSettings.IngestionStartTime);
+                patch.DataStartFrom = ClientCommon.NormalizeDateTimeOffset(IngestionSettings.IngestionStartsOn);
                 patch.MaxConcurrency = IngestionSettings.DataSourceRequestConcurrency;
                 patch.MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds;
                 patch.StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedIngestionSettings.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedIngestionSettings.cs
@@ -13,15 +13,15 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="DataFeedIngestionSettings"/> class.
         /// </summary>
-        /// <param name="ingestionStartTime">The starting point in time from which data will be ingested from the data source. Subsequent ingestions happen periodically according to the data feed's granularity.</param>
-        public DataFeedIngestionSettings(DateTimeOffset ingestionStartTime)
+        /// <param name="ingestionStartsOn">The starting point in time from which data will be ingested from the data source. Subsequent ingestions happen periodically according to the data feed's granularity.</param>
+        public DataFeedIngestionSettings(DateTimeOffset ingestionStartsOn)
         {
-            IngestionStartTime = ingestionStartTime;
+            IngestionStartsOn = ingestionStartsOn;
         }
 
         internal DataFeedIngestionSettings(DataFeedDetail dataFeedDetail)
         {
-            IngestionStartTime = dataFeedDetail.DataStartFrom;
+            IngestionStartsOn = dataFeedDetail.DataStartFrom;
             DataSourceRequestConcurrency = dataFeedDetail.MaxConcurrency;
             IngestionRetryDelay = dataFeedDetail.MinRetryIntervalInSeconds.HasValue
                 ? TimeSpan.FromSeconds(dataFeedDetail.MinRetryIntervalInSeconds.Value) as TimeSpan?
@@ -38,7 +38,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// The starting point in time from which data will be ingested from the data source. Subsequent
         /// ingestions happen periodically according to the data feed's granularity.
         /// </summary>
-        public DateTimeOffset IngestionStartTime { get; set; }
+        public DateTimeOffset IngestionStartsOn { get; set; }
 
         /// <summary>
         /// If the specified data source supports limited concurrency, this can be set to specify the

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricAnomalyFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricAnomalyFeedback.cs
@@ -63,11 +63,13 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// The start timestamp of feedback time range.
         /// </summary>
+        [CodeGenMember("StartTime")]
         public DateTimeOffset StartsOn { get; }
 
         /// <summary>
         /// The end timestamp of feedback timerange. When this is equal to <see cref="StartsOn"/> it indicates a single timestamp.
         /// </summary>
+        [CodeGenMember("EndTime")]
         public DateTimeOffset EndsOn { get; }
 
         /// <summary>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricAnomalyFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricAnomalyFeedback.cs
@@ -25,16 +25,16 @@ namespace Azure.AI.MetricsAdvisor
         /// for the specified <paramref name="metricId"/>. If only a subset of dimensions are set, this
         /// key uniquely identifies a group of time series.
         /// </param>
-        /// <param name="startTime">The start timestamp of feedback time range.</param>
-        /// <param name="endTime">The end timestamp of feedback time range. When this is equal to <paramref name="startTime"/> it indicates a single timestamp.</param>
+        /// <param name="startsOn">The start timestamp of feedback time range.</param>
+        /// <param name="endsOn">The end timestamp of feedback time range. When this is equal to <paramref name="startsOn"/> it indicates a single timestamp.</param>
         /// <param name="value">The <see cref="Models.AnomalyValue"/> for the feedback.</param>
         /// <exception cref="ArgumentNullException"><paramref name="metricId"/> or <paramref name="dimensionKey"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException"><paramref name="metricId"/> is empty.</exception>
-        public MetricAnomalyFeedback(string metricId, DimensionKey dimensionKey, DateTimeOffset startTime, DateTimeOffset endTime, AnomalyValue value)
+        public MetricAnomalyFeedback(string metricId, DimensionKey dimensionKey, DateTimeOffset startsOn, DateTimeOffset endsOn, AnomalyValue value)
             : base(metricId, dimensionKey)
         {
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
             ValueInternal = new AnomalyFeedbackValue(value);
             FeedbackKind = MetricFeedbackKind.Anomaly;
         }
@@ -42,11 +42,11 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary> Initializes a new instance of <see cref="MetricAnomalyFeedback"/>. </summary>
         /// <param name="metricId"> The metric unique id. </param>
         /// <param name="feedbackFilter"> The dimension filter. </param>
-        /// <param name="startTime"> The start timestamp of feedback timerange. </param>
-        /// <param name="endTime"> The end timestamp of feedback timerange. When this is equal to <paramref name="startTime"/> it indicates a single timestamp. </param>
+        /// <param name="startsOn"> The start timestamp of feedback timerange. </param>
+        /// <param name="endsOn"> The end timestamp of feedback timerange. When this is equal to <paramref name="startsOn"/> it indicates a single timestamp. </param>
         /// <param name="value"> The <see cref="AnomalyFeedbackValue"/> for the feedback. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="feedbackFilter"/> or <paramref name="value"/> is null. </exception>
-        internal MetricAnomalyFeedback(string metricId, FeedbackFilter feedbackFilter, DateTimeOffset startTime, DateTimeOffset endTime, AnomalyFeedbackValue value)
+        internal MetricAnomalyFeedback(string metricId, FeedbackFilter feedbackFilter, DateTimeOffset startsOn, DateTimeOffset endsOn, AnomalyFeedbackValue value)
             : base(metricId, feedbackFilter.DimensionKey)
         {
             if (value == null)
@@ -54,8 +54,8 @@ namespace Azure.AI.MetricsAdvisor
                 throw new ArgumentNullException(nameof(value));
             }
 
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
             ValueInternal = value;
             FeedbackKind = MetricFeedbackKind.Anomaly;
         }
@@ -63,17 +63,17 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// The start timestamp of feedback time range.
         /// </summary>
-        public DateTimeOffset StartTime { get; }
+        public DateTimeOffset StartsOn { get; }
 
         /// <summary>
-        /// The end timestamp of feedback timerange. When this is equal to <see cref="StartTime"/> it indicates a single timestamp.
+        /// The end timestamp of feedback timerange. When this is equal to <see cref="StartsOn"/> it indicates a single timestamp.
         /// </summary>
-        public DateTimeOffset EndTime { get; }
+        public DateTimeOffset EndsOn { get; }
 
         /// <summary>
         /// The ID of the <see cref="AnomalyDetectionConfiguration"/> to which this feedback applies. If
         /// <c>null</c>, this feedback applies to all anomalies within the specified time range, defined
-        /// by <see cref="StartTime"/> and <see cref="EndTime"/>, without regard for the configuration used
+        /// by <see cref="StartsOn"/> and <see cref="EndsOn"/>, without regard for the configuration used
         /// to detect them.
         /// </summary>
         [CodeGenMember("AnomalyDetectionConfigurationId")]

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricChangePointFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricChangePointFeedback.cs
@@ -24,16 +24,16 @@ namespace Azure.AI.MetricsAdvisor
         /// for the specified <paramref name="metricId"/>. If only a subset of dimensions are set, this
         /// key uniquely identifies a group of time series.
         /// </param>
-        /// <param name="startTime">The start timestamp of feedback time range.</param>
-        /// <param name="endTime">The end timestamp of feedback time range. When this is equal to <paramref name="startTime"/> it indicates a single timestamp.</param>
+        /// <param name="startsOn">The start timestamp of feedback time range.</param>
+        /// <param name="endsOn">The end timestamp of feedback time range. When this is equal to <paramref name="startsOn"/> it indicates a single timestamp.</param>
         /// <param name="value">The <see cref="Models.ChangePointValue"/> for the feedback.</param>
         /// <exception cref="ArgumentNullException"><paramref name="metricId"/> or <paramref name="dimensionKey"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException"><paramref name="metricId"/> is empty.</exception>
-        public MetricChangePointFeedback(string metricId, DimensionKey dimensionKey, DateTimeOffset startTime, DateTimeOffset endTime, ChangePointValue value)
+        public MetricChangePointFeedback(string metricId, DimensionKey dimensionKey, DateTimeOffset startsOn, DateTimeOffset endsOn, ChangePointValue value)
             : base(metricId, dimensionKey)
         {
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
             ValueInternal = new ChangePointFeedbackValue(value);
             FeedbackKind = MetricFeedbackKind.ChangePoint;
         }
@@ -41,16 +41,16 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary> Initializes a new <see cref="MetricChangePointFeedback"/> instance. </summary>
         /// <param name="metricId"> The metric unique id. </param>
         /// <param name="feedbackFilter"> The dimension filter. </param>
-        /// <param name="startTime"> The start timestamp of feedback timerange. </param>
-        /// <param name="endTime"> The end timestamp of feedback timerange. When this is equal to <paramref name="startTime"/> it indicates a single timestamp. </param>
+        /// <param name="startsOn"> The start timestamp of feedback timerange. </param>
+        /// <param name="endsOn"> The end timestamp of feedback timerange. When this is equal to <paramref name="startsOn"/> it indicates a single timestamp. </param>
         /// <param name="value"> The <see cref="Models.ChangePointFeedbackValue"/> for the feedback. </param>
-        internal MetricChangePointFeedback(string metricId, FeedbackFilter feedbackFilter, DateTimeOffset startTime, DateTimeOffset endTime, ChangePointFeedbackValue value)
+        internal MetricChangePointFeedback(string metricId, FeedbackFilter feedbackFilter, DateTimeOffset startsOn, DateTimeOffset endsOn, ChangePointFeedbackValue value)
             : base(metricId, feedbackFilter.DimensionKey)
         {
             Argument.AssertNotNull(value, nameof(value));
 
-            StartTime = startTime;
-            EndTime = endTime;
+            StartsOn = startsOn;
+            EndsOn = endsOn;
             ValueInternal = value;
             FeedbackKind = MetricFeedbackKind.ChangePoint;
         }
@@ -58,12 +58,12 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// The start timestamp of feedback time range.
         /// </summary>
-        public DateTimeOffset StartTime { get; }
+        public DateTimeOffset StartsOn { get; }
 
         /// <summary>
-        /// The end timestamp of feedback timerange. When this is equal to <see cref="StartTime"/> it indicates a single timestamp.
+        /// The end timestamp of feedback timerange. When this is equal to <see cref="StartsOn"/> it indicates a single timestamp.
         /// </summary>
-        public DateTimeOffset EndTime { get; }
+        public DateTimeOffset EndsOn { get; }
 
         /// <summary>
         /// The <see cref="Models.ChangePointValue"/> for the feedback.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricChangePointFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricChangePointFeedback.cs
@@ -58,11 +58,13 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// The start timestamp of feedback time range.
         /// </summary>
+        [CodeGenMember("StartTime")]
         public DateTimeOffset StartsOn { get; }
 
         /// <summary>
         /// The end timestamp of feedback timerange. When this is equal to <see cref="StartsOn"/> it indicates a single timestamp.
         /// </summary>
+        [CodeGenMember("EndTime")]
         public DateTimeOffset EndsOn { get; }
 
         /// <summary>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricCommentFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricCommentFeedback.cs
@@ -51,12 +51,12 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// The start timestamp of feedback time range.
         /// </summary>
-        public DateTimeOffset? StartTime { get; set; }
+        public DateTimeOffset? StartsOn { get; set; }
 
         /// <summary>
-        /// The end timestamp of feedback timerange. When this is equal to <see cref="StartTime"/> it indicates a single timestamp.
+        /// The end timestamp of feedback timerange. When this is equal to <see cref="StartsOn"/> it indicates a single timestamp.
         /// </summary>
-        public DateTimeOffset? EndTime { get; set; }
+        public DateTimeOffset? EndsOn { get; set; }
 
         /// <summary>
         /// The comment content for the feedback.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricCommentFeedback.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/MetricCommentFeedback.cs
@@ -51,11 +51,13 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// The start timestamp of feedback time range.
         /// </summary>
+        [CodeGenMember("StartTime")]
         public DateTimeOffset? StartsOn { get; set; }
 
         /// <summary>
         /// The end timestamp of feedback timerange. When this is equal to <see cref="StartsOn"/> it indicates a single timestamp.
         /// </summary>
+        [CodeGenMember("EndTime")]
         public DateTimeOffset? EndsOn { get; set; }
 
         /// <summary>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -1735,7 +1735,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Assert.That(dataFeed.Schema.TimestampColumn, Is.Not.Null);
 
                 Assert.That(dataFeed.IngestionSettings, Is.Not.Null);
-                Assert.That(dataFeed.IngestionSettings.IngestionStartTime, Is.Not.EqualTo(default(DateTimeOffset)));
+                Assert.That(dataFeed.IngestionSettings.IngestionStartsOn, Is.Not.EqualTo(default(DateTimeOffset)));
                 Assert.That(dataFeed.IngestionSettings.IngestionStartOffset, Is.Not.Null);
                 Assert.That(dataFeed.IngestionSettings.IngestionRetryDelay, Is.Not.Null);
                 Assert.That(dataFeed.IngestionSettings.StopRetryAfter, Is.Not.Null);
@@ -1919,7 +1919,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.Schema.TimestampColumn, Is.Empty);
 
             Assert.That(dataFeed.IngestionSettings, Is.Not.Null);
-            Assert.That(dataFeed.IngestionSettings.IngestionStartTime, Is.EqualTo(ingestionStartTime));
+            Assert.That(dataFeed.IngestionSettings.IngestionStartsOn, Is.EqualTo(ingestionStartTime));
             Assert.That(dataFeed.IngestionSettings.IngestionStartOffset, Is.EqualTo(TimeSpan.Zero));
             Assert.That(dataFeed.IngestionSettings.IngestionRetryDelay, Is.EqualTo(TimeSpan.FromSeconds(-1)));
             Assert.That(dataFeed.IngestionSettings.StopRetryAfter, Is.EqualTo(TimeSpan.FromSeconds(-1)));
@@ -1990,7 +1990,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.Schema.TimestampColumn, Is.EqualTo("timestamp"));
 
             Assert.That(dataFeed.IngestionSettings, Is.Not.Null);
-            Assert.That(dataFeed.IngestionSettings.IngestionStartTime, Is.EqualTo(ingestionStartTime));
+            Assert.That(dataFeed.IngestionSettings.IngestionStartsOn, Is.EqualTo(ingestionStartTime));
             Assert.That(dataFeed.IngestionSettings.IngestionStartOffset, Is.EqualTo(TimeSpan.FromMinutes(30)));
             Assert.That(dataFeed.IngestionSettings.IngestionRetryDelay, Is.EqualTo(TimeSpan.FromSeconds(80)));
             Assert.That(dataFeed.IngestionSettings.StopRetryAfter, Is.EqualTo(TimeSpan.FromMinutes(10)));
@@ -2053,7 +2053,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.Schema.TimestampColumn, Is.EqualTo("updatedTimestampColumn"));
 
             Assert.That(dataFeed.IngestionSettings, Is.Not.Null);
-            Assert.That(dataFeed.IngestionSettings.IngestionStartTime, Is.EqualTo(ingestionStartTime));
+            Assert.That(dataFeed.IngestionSettings.IngestionStartsOn, Is.EqualTo(ingestionStartTime));
             Assert.That(dataFeed.IngestionSettings.IngestionStartOffset, Is.EqualTo(TimeSpan.FromMinutes(40)));
             Assert.That(dataFeed.IngestionSettings.IngestionRetryDelay, Is.EqualTo(TimeSpan.FromSeconds(90)));
             Assert.That(dataFeed.IngestionSettings.StopRetryAfter, Is.EqualTo(TimeSpan.FromMinutes(20)));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/MetricFeedbackLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/MetricFeedbackLiveTests.cs
@@ -46,8 +46,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(anomalyFeedback, Is.Not.Null);
             Assert.That(anomalyFeedback.AnomalyValue, Is.EqualTo(AnomalyValue.AutoDetect));
-            Assert.That(anomalyFeedback.StartTime, Is.EqualTo(CreatedFeedbackStartTime));
-            Assert.That(anomalyFeedback.EndTime, Is.EqualTo(CreatedFeedbackEndTime));
+            Assert.That(anomalyFeedback.StartsOn, Is.EqualTo(CreatedFeedbackStartTime));
+            Assert.That(anomalyFeedback.EndsOn, Is.EqualTo(CreatedFeedbackEndTime));
             Assert.That(anomalyFeedback.UserPrincipal, Is.Not.Null.And.Not.Empty);
             Assert.That(anomalyFeedback.DetectionConfigurationId, Is.Null);
             Assert.That(anomalyFeedback.DetectionConfigurationSnapshot, Is.Null);
@@ -76,8 +76,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(anomalyFeedback, Is.Not.Null);
             Assert.That(anomalyFeedback.AnomalyValue, Is.EqualTo(AnomalyValue.AutoDetect));
-            Assert.That(anomalyFeedback.StartTime, Is.EqualTo(CreatedFeedbackStartTime));
-            Assert.That(anomalyFeedback.EndTime, Is.EqualTo(CreatedFeedbackEndTime));
+            Assert.That(anomalyFeedback.StartsOn, Is.EqualTo(CreatedFeedbackStartTime));
+            Assert.That(anomalyFeedback.EndsOn, Is.EqualTo(CreatedFeedbackEndTime));
             Assert.That(anomalyFeedback.UserPrincipal, Is.Not.Null.And.Not.Empty);
             Assert.That(anomalyFeedback.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
             // TODO: Add snapshot validation (https://github.com/azure/azure-sdk-for-net/issues/15915)
@@ -103,8 +103,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(changePointFeedback, Is.Not.Null);
             Assert.That(changePointFeedback.ChangePointValue, Is.EqualTo(ChangePointValue.AutoDetect));
-            Assert.That(changePointFeedback.StartTime, Is.EqualTo(CreatedFeedbackStartTime));
-            Assert.That(changePointFeedback.EndTime, Is.EqualTo(CreatedFeedbackEndTime));
+            Assert.That(changePointFeedback.StartsOn, Is.EqualTo(CreatedFeedbackStartTime));
+            Assert.That(changePointFeedback.EndsOn, Is.EqualTo(CreatedFeedbackEndTime));
             Assert.That(changePointFeedback.UserPrincipal, Is.Not.Null.And.Not.Empty);
         }
 
@@ -135,8 +135,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(commentFeedback, Is.Not.Null);
             Assert.That(commentFeedback.Comment, Is.EqualTo(comment));
-            Assert.That(commentFeedback.StartTime, Is.Null);
-            Assert.That(commentFeedback.EndTime, Is.Null);
+            Assert.That(commentFeedback.StartsOn, Is.Null);
+            Assert.That(commentFeedback.EndsOn, Is.Null);
             Assert.That(commentFeedback.UserPrincipal, Is.Not.Null.And.Not.Empty);
         }
 
@@ -152,8 +152,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var feedbackToAdd = new MetricCommentFeedback(MetricId, dimensionKey, comment)
             {
-                StartTime = CreatedFeedbackStartTime,
-                EndTime = CreatedFeedbackEndTime
+                StartsOn = CreatedFeedbackStartTime,
+                EndsOn = CreatedFeedbackEndTime
             };
 
             MetricFeedback addedFeedback = await client.AddFeedbackAsync(feedbackToAdd);
@@ -166,8 +166,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(commentFeedback, Is.Not.Null);
             Assert.That(commentFeedback.Comment, Is.EqualTo(comment));
-            Assert.That(commentFeedback.StartTime, Is.EqualTo(CreatedFeedbackStartTime));
-            Assert.That(commentFeedback.EndTime, Is.EqualTo(CreatedFeedbackEndTime));
+            Assert.That(commentFeedback.StartsOn, Is.EqualTo(CreatedFeedbackStartTime));
+            Assert.That(commentFeedback.EndsOn, Is.EqualTo(CreatedFeedbackEndTime));
             Assert.That(commentFeedback.UserPrincipal, Is.Not.Null.And.Not.Empty);
         }
 
@@ -282,8 +282,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 {
                     DimensionKey = new DimensionKey(dimensions),
                     TimeMode = FeedbackQueryTimeMode.FeedbackCreatedOn,
-                    StartTime = feedbackSamplingStartTime,
-                    EndTime = feedbackSamplingEndTime,
+                    StartsOn = feedbackSamplingStartTime,
+                    EndsOn = feedbackSamplingEndTime,
                     FeedbackKind = MetricFeedbackKind.Comment,
                 }
             };

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample02_DataFeedIngestionOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample02_DataFeedIngestionOperations.cs
@@ -29,9 +29,9 @@ namespace Azure.AI.MetricsAdvisor.Samples
             string dataFeedId = DataFeedId;
 #endif
 
-            var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-            var endTime = DateTimeOffset.Parse("2020-09-09T00:00:00Z");
-            var options = new GetDataFeedIngestionStatusesOptions(startTime, endTime)
+            var startsOn = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
+            var endsOn = DateTimeOffset.Parse("2020-09-09T00:00:00Z");
+            var options = new GetDataFeedIngestionStatusesOptions(startsOn, endsOn)
             {
                 MaxPageSize = 5
             };
@@ -89,10 +89,10 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             string dataFeedId = DataFeedId;
 
-            var startTime = DateTimeOffset.Parse("2020-08-01T00:00:00Z");
-            var endTime = DateTimeOffset.Parse("2020-08-03T00:00:00Z");
+            var startsOn = DateTimeOffset.Parse("2020-08-01T00:00:00Z");
+            var endsOn = DateTimeOffset.Parse("2020-08-03T00:00:00Z");
 
-            await adminClient.RefreshDataFeedIngestionAsync(dataFeedId, startTime, endTime);
+            await adminClient.RefreshDataFeedIngestionAsync(dataFeedId, startsOn, endsOn);
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample06_QueryTriggeredAlerts.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample06_QueryTriggeredAlerts.cs
@@ -28,9 +28,9 @@ namespace Azure.AI.MetricsAdvisor.Samples
             string anomalyAlertConfigurationId = AlertConfigurationId;
 #endif
 
-            var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-            var endTime = DateTimeOffset.UtcNow;
-            var options = new GetAlertsOptions(startTime, endTime, AlertQueryTimeMode.AnomalyDetectedOn)
+            var startsOn = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
+            var endsOn = DateTimeOffset.UtcNow;
+            var options = new GetAlertsOptions(startsOn, endsOn, AlertQueryTimeMode.AnomalyDetectedOn)
             {
                 MaxPageSize = 5
             };

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample07_QueryDetectedAnomalies.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample07_QueryDetectedAnomalies.cs
@@ -24,9 +24,9 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             string detectionConfigurationId = DetectionConfigurationId;
 
-            var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-            var endTime = DateTimeOffset.UtcNow;
-            var options = new GetAnomaliesForDetectionConfigurationOptions(startTime, endTime)
+            var startsOn = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
+            var endsOn = DateTimeOffset.UtcNow;
+            var options = new GetAnomaliesForDetectionConfigurationOptions(startsOn, endsOn)
             {
                 MaxPageSize = 3
             };

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample08_QueryIncidentsAndRootCauses.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample08_QueryIncidentsAndRootCauses.cs
@@ -40,9 +40,9 @@ namespace Azure.AI.MetricsAdvisor.Samples
             };
             var groupKey2 = new DimensionKey(dimensions);
 
-            var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-            var endTime = DateTimeOffset.UtcNow;
-            var options = new GetIncidentsForDetectionConfigurationOptions(startTime, endTime) { MaxPageSize = 3 };
+            var startsOn = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
+            var endsOn = DateTimeOffset.UtcNow;
+            var options = new GetIncidentsForDetectionConfigurationOptions(startsOn, endsOn) { MaxPageSize = 3 };
 
             options.DimensionKeys.Add(groupKey1);
             options.DimensionKeys.Add(groupKey2);

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample09_QueryTimeSeriesInformation.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample09_QueryTimeSeriesInformation.cs
@@ -57,9 +57,9 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             string dimensionName = "city";
 
-            var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-            var endTime = DateTimeOffset.UtcNow;
-            var options = new GetAnomalyDimensionValuesOptions(startTime, endTime)
+            var startsOn = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
+            var endsOn = DateTimeOffset.UtcNow;
+            var options = new GetAnomalyDimensionValuesOptions(startsOn, endsOn)
             {
                 MaxPageSize = 10
             };
@@ -92,9 +92,9 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             string metricId = MetricId;
 
-            var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-            var endTime = DateTimeOffset.UtcNow;
-            var options = new GetMetricEnrichmentStatusesOptions(startTime, endTime) { MaxPageSize = 5 };
+            var startsOn = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
+            var endsOn = DateTimeOffset.UtcNow;
+            var options = new GetMetricEnrichmentStatusesOptions(startsOn, endsOn) { MaxPageSize = 5 };
 
             int statusCount = 0;
 
@@ -161,9 +161,9 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             string metricId = MetricId;
 
-            var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-            var endTime = DateTimeOffset.UtcNow;
-            var options = new GetMetricSeriesDataOptions(startTime, endTime);
+            var startsOn = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
+            var endsOn = DateTimeOffset.UtcNow;
+            var options = new GetMetricSeriesDataOptions(startsOn, endsOn);
 
             // Only the two time series with the keys specified below will be returned.
 
@@ -238,10 +238,10 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             var seriesKeys = new List<DimensionKey>() { seriesKey1, seriesKey2 };
 
-            var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-            var endTime = DateTimeOffset.UtcNow;
+            var startsOn = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
+            var endsOn = DateTimeOffset.UtcNow;
 
-            await foreach (MetricEnrichedSeriesData seriesData in client.GetMetricEnrichedSeriesDataAsync(detectionConfigurationId, seriesKeys, startTime, endTime))
+            await foreach (MetricEnrichedSeriesData seriesData in client.GetMetricEnrichedSeriesDataAsync(detectionConfigurationId, seriesKeys, startsOn, endsOn))
             {
                 Console.WriteLine("Time series key:");
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample10_FeedbackCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample10_FeedbackCrudOperations.cs
@@ -30,13 +30,13 @@ namespace Azure.AI.MetricsAdvisor.Samples
             };
             var dimensionKey = new DimensionKey(dimensions);
 
-            var startTime = DateTimeOffset.Parse("2020-02-01T00:00:00Z");
-            var endTime = DateTimeOffset.Parse("2020-02-03T00:00:00Z");
+            var startsOn = DateTimeOffset.Parse("2020-02-01T00:00:00Z");
+            var endsOn = DateTimeOffset.Parse("2020-02-03T00:00:00Z");
 
             // Other types of feedback, such as MetricCommentFeedback, MetricChangePointFeedback,
             // and MetricPeriodFeedback are supported as well.
 
-            var anomalyFeedback = new MetricAnomalyFeedback(metricId, dimensionKey, startTime, endTime, AnomalyValue.NotAnomaly);
+            var anomalyFeedback = new MetricAnomalyFeedback(metricId, dimensionKey, startsOn, endsOn, AnomalyValue.NotAnomaly);
 
             Response<MetricFeedback> response = await client.AddFeedbackAsync(anomalyFeedback);
 
@@ -110,8 +110,8 @@ namespace Azure.AI.MetricsAdvisor.Samples
             {
                 Filter = new FeedbackFilter()
                 {
-                    StartTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z"),
-                    EndTime = DateTimeOffset.Parse("2020-09-09T00:00:00Z"),
+                    StartsOn = DateTimeOffset.Parse("2020-01-01T00:00:00Z"),
+                    EndsOn = DateTimeOffset.Parse("2020-09-09T00:00:00Z"),
                     TimeMode = FeedbackQueryTimeMode.MetricTimestamp
                 },
                 MaxPageSize = 5


### PR DESCRIPTION
Architect feedback.