### PR TITLE
Add readme.md to all nuget packages

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -49,7 +49,7 @@
   <PropertyGroup>
     <OriginalReadmeMdPath>$([MSBuild]::NormalizeDirectory($(MSBuildProjectDirectory)/../))README.md</OriginalReadmeMdPath>
     <ProcessedReadmeMdPath>$(IntermediateOutputPath)README.md</ProcessedReadmeMdPath>
-    <EnableNuGetReadmeMd Condition="'$(HasReleaseVersion)' == 'false' and Exists('$(OriginalReadmeMdPath)')">true</EnableNuGetReadmeMd>
+    <EnableNuGetReadmeMd Condition="'$(IsDesignTimeBuild)' == 'false' and Exists('$(OriginalReadmeMdPath)')">true</EnableNuGetReadmeMd>
     <PackageReadmeFile Condition="'$(EnableNuGetReadmeMd)' == 'true'">README.md</PackageReadmeFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Things seemed to have gone well this release.

The `IsDesignTimeBuild` fixes https://github.com/Azure/azure-sdk-for-net/issues/22098