### PR TITLE
Fixed bug where 'Segment doesn't have any more events exception' was …

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Release History
 
 ## 12.0.0-preview.14 (Unreleased)
-
 - TenantId can now be discovered through the service challenge response, when using a TokenCredential for authorization.
     - A new property is now available on the ClientOptions called `EnableTenantDiscovery`. If set to true, the client will attempt an initial unauthorized request to the service to prompt a challenge containing the tenantId hint.
-
-- This release contains bug fixes to improve quality.
+- Fixed bug where "Segment doesn't have any more events" exception was throw when attempting to resume from a cusor pointed at a segment that had no more events, and newer segments exist in the Change Feed.
 
 ## 12.0.0-preview.13 (2021-06-08)
 - This release contains bug fixes to improve quality.

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/Segment.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/Segment.cs
@@ -75,7 +75,7 @@ namespace Azure.Storage.Blobs.ChangeFeed
 
             if (!HasNext())
             {
-                throw new InvalidOperationException("Segment doesn't have any more events");
+                return new List<BlobChangeFeedEvent>(capacity: 0);
             }
 
             int i = 0;


### PR DESCRIPTION
…throw when attempting to resume from a cusor pointed at a segment that had no more events, and newer segments exist in the Change Feed.

Resolves https://github.com/Azure/azure-sdk-for-net/issues/15831