### PR TITLE
[Search] Update a broken link in README

### DIFF
--- a/sdk/search/Azure.Search.Documents/README.md
+++ b/sdk/search/Azure.Search.Documents/README.md
@@ -189,7 +189,7 @@ We guarantee that all client instance methods are thread-safe and independent of
 
 ## Examples
 
-The following examples all use a simple [Hotel data set](https://docs.microsoft.com/samples/azure-samples/azure-search-sample-data/azure-search-sample-data/)
+The following examples all use a simple [Hotel data set](https://github.com/Azure-Samples/azure-search-sample-data)
 that you can [import into your own index from the Azure portal.](https://docs.microsoft.com/azure/search/search-get-started-portal#step-1---start-the-import-data-wizard-and-create-a-data-source)
 These are just a few of the basics - please [check out our Samples][samples] for
 much more.


### PR DESCRIPTION
This is a temporary change to unblock the SDK release.
Doc team is aware of the issue and are looking at options.