### PR TITLE
[Storage][Function] Fix visibility timeout extension in queues extension.

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.0.0-beta.5 (Unreleased)
 - QueuesOptions.MaxPollingInterval other than default is now honored in "Development" environment.
-- Fixed bug where QueueTrigger would fail to renew ownership of message if function runs longer than 20 minutes.
+- Fixed bug where QueueTrigger would fail to renew ownership of message if function runs for long period of time (i.e. 15 minutes and longer).
 
 
 ## 5.0.0-beta.4 (2021-05-18)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0-beta.5 (Unreleased)
 - QueuesOptions.MaxPollingInterval other than default is now honored in "Development" environment.
+- Fixed bug where QueueTrigger would fail to renew ownership of message if function runs longer than 20 minutes.
 
 
 ## 5.0.0-beta.4 (2021-05-18)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/UpdateQueueMessageVisibilityCommandTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/UpdateQueueMessageVisibilityCommandTests.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
+{
+    using global::Azure.Storage.Queues;
+    using global::Azure.Storage.Queues.Models;
+    using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners;
+    using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests;
+    using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Timers;
+    using Moq;
+    using NUnit.Framework;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class UpdateQueueMessageVisibilityCommandTests
+    {
+        private QueueServiceClient _queueServiceClient;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _queueServiceClient = AzuriteNUnitFixture.Instance.GetQueueServiceClient();
+        }
+
+        [Test]
+        public async Task CanExtendVisibilityTimeoutMultipleTimes()
+        {
+            // Arange
+            string queueName = Guid.NewGuid().ToString();
+            var queueClient = _queueServiceClient.GetQueueClient(queueName);
+            await queueClient.CreateIfNotExistsAsync();
+            await queueClient.SendMessageAsync("foo");
+            QueueMessage message = await queueClient.ReceiveMessageAsync(visibilityTimeout: TimeSpan.FromSeconds(60));
+            Mock<IDelayStrategy> delayStrategyMock = new Mock<IDelayStrategy>();
+            delayStrategyMock.Setup(x => x.GetNextDelay(It.IsAny<bool>())).Returns(TimeSpan.FromMilliseconds(1));
+
+            int counter = 0;
+            Action<UpdateReceipt> onUpdateReceipt = updateReceipt => { counter++; };
+
+            var command = new UpdateQueueMessageVisibilityCommand(queueClient, message, TimeSpan.FromSeconds(60), delayStrategyMock.Object, onUpdateReceipt);
+
+            // Act
+            var commandResult1 = await command.ExecuteAsync(CancellationToken.None);
+            var commandResult2 = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            // If renewal was successful then result should wait as much as IDelayStrategy decided (see mock above).
+            // Otherwise if it failed due to non-transient reason (i.e. pop recepit got lost) it would delay infinitely leading to assertion error below.
+            Assert.IsTrue(commandResult1.Wait.Wait(TimeSpan.FromSeconds(1)));
+            Assert.IsTrue(commandResult2.Wait.Wait(TimeSpan.FromSeconds(1)));
+            // Check the counter too
+            Assert.AreEqual(2, counter);
+        }
+    }
+}


### PR DESCRIPTION
Fixed bug where QueueTrigger would loose message ownership if function runs for long period of time.

I.e. QueueTrigger retrieves messages with 10 minutes visibility timeout (see [here](https://github.com/Azure/azure-sdk-for-net/blob/6b59b529e8a0949b88a503b44d2713f6dbc9fe77/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs#L107-L109) ).
Then it periodically updates the timeout (see [here](https://github.com/Azure/azure-sdk-for-net/blob/6b59b529e8a0949b88a503b44d2713f6dbc9fe77/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs#L325-L326))
The Command however would only extend the timeout once as it looses reference to latest receipt (see [here](https://github.com/Azure/azure-sdk-for-net/blob/6b59b529e8a0949b88a503b44d2713f6dbc9fe77/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/UpdateQueueMessageVisibilityCommand.cs#L53-L54)). It only propagates update to caller...