### PR TITLE
Feature/storage/append check empty

### DIFF
--- a/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for Parquet as an input format in DataLakeFileClient.Query().
 - Added support for RequestConditions parameter validation.  If a request condition is set for an API that doesn't support it, and ArguementException will be thrown.
     - This feature can be disabled with the environment variable "AZURE_STORAGE_DISABLE_REQUEST_CONDITIONS_VALIDATION" or the App Context switch "Azure.Storage.DisableRequestConditionsValidation".
+- Fixed bug where DataLakeFileClient.Append() accepts an empty stream which lead to a InvalidHeaderValue error. This will now throw a ArgumentException with a clear error message.
 
 ## 12.7.0 (2021-06-08)
 - Includes all features from 12.7.0-beta.4

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeErrors.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeErrors.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Azure.Storage.Files.DataLake.Models;
 
@@ -59,5 +60,13 @@ namespace Azure.Storage.Files.DataLake
                 $"{nameof(DataLakeAclChangeFailedException.ContinuationToken)}={continuationToken} after addressing the error.",
                 exception,
                 continuationToken);
+
+        internal static void VerifyValidAppendStream(Stream stream)
+        {
+            if (stream == null || stream.Length == 0)
+            {
+                throw new ArgumentException($"Stream is null or empty.");
+            }
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -1901,6 +1901,7 @@ namespace Azure.Storage.Files.DataLake
             bool async,
             CancellationToken cancellationToken)
         {
+            DataLakeErrors.VerifyValidAppendStream(content);
             using (ClientConfiguration.Pipeline.BeginLoggingScope(nameof(DataLakeFileClient)))
             {
                 content = content?.WithNoDispose().WithProgress(progressHandler);

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -1715,19 +1715,9 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Act
             using (var stream = new MemoryStream())
             {
-                await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
+                await TestHelper.AssertExpectedExceptionAsync<ArgumentException>(
                     file.AppendAsync(stream, 0),
-                    e =>
-                    {
-                        Assert.AreEqual("InvalidHeaderValue", e.ErrorCode);
-                        Assert.IsTrue(e.Message.Contains("The value for one of the HTTP headers is not in the correct format."));
-                        if (_serviceVersion > DataLakeClientOptions.ServiceVersion.V2019_02_02)
-                        {
-                            Assert.AreEqual("Content-Length", e.Data["HeaderName"]);
-                            Assert.AreEqual("0", e.Data["HeaderValue"]);
-                        }
-                    }
-                );
+                    e => Assert.AreEqual("Stream is null or empty.", e.Message));
             }
         }
 
@@ -1872,11 +1862,11 @@ namespace Azure.Storage.Files.DataLake.Tests
             using (var stream = (MemoryStream)null)
             {
                 // Check if the correct param name that is causing the error is being returned
-                await TestHelper.AssertExpectedExceptionAsync<ArgumentNullException>(
+                await TestHelper.AssertExpectedExceptionAsync<ArgumentException>(
                     file.AppendAsync(
                         content: stream,
                         offset: 0),
-                    e => Assert.AreEqual("body", e.ParamName));
+                    e => Assert.AreEqual("Stream is null or empty.", e.Message));
             }
         }
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/AppendDataAsync_EmptyStream.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/AppendDataAsync_EmptyStream.json
@@ -1,19 +1,19 @@
-﻿{
+{
   "Entries": [
     {
-      "RequestUri": "https://seannse.blob.core.windows.net/test-filesystem-70fca5bc-ee13-fa3b-0fef-f0bc7ab27a67?restype=container",
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-70fca5bc-ee13-fa3b-0fef-f0bc7ab27a67?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-a8f42bf38d0bba488a22ff5fa9eb3d26-93c22da832c3ea47-00",
+        "traceparent": "00-8bbcbcdc33374f459bb96bca4616c8cf-af8c46ad59b93048-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "c627453a-4125-5ec1-fc0a-f9088b9e5c70",
-        "x-ms-date": "Fri, 19 Feb 2021 19:56:42 GMT",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:37 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -21,32 +21,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:56:40 GMT",
-        "ETag": "\"0x8D8D51079D6DC01\"",
-        "Last-Modified": "Fri, 19 Feb 2021 19:56:41 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:37 GMT",
+        "ETag": "\u00220x8D945861195D3C2\u0022",
+        "Last-Modified": "Mon, 12 Jul 2021 22:40:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c627453a-4125-5ec1-fc0a-f9088b9e5c70",
-        "x-ms-request-id": "46910ae8-401e-0056-74f9-068eb0000000",
+        "x-ms-request-id": "2cc3b041-101e-00d1-756e-7794ab000000",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://seannse.dfs.core.windows.net/test-filesystem-70fca5bc-ee13-fa3b-0fef-f0bc7ab27a67/test-file-666ae4db-9f01-3562-3042-fe232c09712a?resource=file",
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-70fca5bc-ee13-fa3b-0fef-f0bc7ab27a67/test-file-666ae4db-9f01-3562-3042-fe232c09712a?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9be21903990b1041aeb15217c256fed3-a62c5e2eebade44d-00",
+        "traceparent": "00-e79bba5c68e966429c06582796ef990e-95bed1e24a4b2f4a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "a4565092-747a-9b2d-e2f2-95e3429d31f2",
-        "x-ms-date": "Fri, 19 Feb 2021 19:56:42 GMT",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:37 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -54,67 +54,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:56:40 GMT",
-        "ETag": "\"0x8D8D51079E79B16\"",
-        "Last-Modified": "Fri, 19 Feb 2021 19:56:41 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:37 GMT",
+        "ETag": "\u00220x8D9458611D5A354\u0022",
+        "Last-Modified": "Mon, 12 Jul 2021 22:40:37 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a4565092-747a-9b2d-e2f2-95e3429d31f2",
-        "x-ms-request-id": "d66a6bf3-f01f-0088-22f9-069a56000000",
+        "x-ms-request-id": "711f4508-501f-008d-346e-77c1f3000000",
+        "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://seannse.dfs.core.windows.net/test-filesystem-70fca5bc-ee13-fa3b-0fef-f0bc7ab27a67/test-file-666ae4db-9f01-3562-3042-fe232c09712a?action=append&position=0",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "0",
-        "Content-Type": "application/octet-stream",
-        "traceparent": "00-9d6146fa5461ec49931f0f3d4c2150c9-2b645c60a1536341-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
-        ],
-        "x-ms-client-request-id": "db902b14-cdb3-9fb0-94e6-51981f5eba65",
-        "x-ms-date": "Fri, 19 Feb 2021 19:56:42 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-10-02"
-      },
-      "RequestBody": [],
-      "StatusCode": 400,
-      "ResponseHeaders": {
-        "Content-Length": "262",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Feb 2021 19:56:40 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "db902b14-cdb3-9fb0-94e6-51981f5eba65",
-        "x-ms-error-code": "InvalidHeaderValue",
-        "x-ms-request-id": "d66a6c0e-f01f-0088-3df9-069a56000000",
-        "x-ms-version": "2020-10-02"
-      },
-      "ResponseBody": "{\"error\":{\"code\":\"InvalidHeaderValue\",\"message\":\"The value for one of the HTTP headers is not in the correct format.\\nRequestId:d66a6c0e-f01f-0088-3df9-069a56000000\\nTime:2021-02-19T19:56:41.5276948Z\",\"detail\":{\"HeaderName\":\"Content-Length\", \"HeaderValue\":\"0\"}}}"
-    },
-    {
-      "RequestUri": "https://seannse.blob.core.windows.net/test-filesystem-70fca5bc-ee13-fa3b-0fef-f0bc7ab27a67?restype=container",
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-70fca5bc-ee13-fa3b-0fef-f0bc7ab27a67?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-2865dfd0ad0e6e478e7468e6151d40bb-cf4c281059fecd42-00",
+        "traceparent": "00-74b3f9bdd8c66f49a2c09a26a23211c9-10218dddd0b25a47-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "17ced049-550d-cb3f-1e54-3536d64c0744",
-        "x-ms-date": "Fri, 19 Feb 2021 19:56:42 GMT",
+        "x-ms-client-request-id": "db902b14-cdb3-9fb0-94e6-51981f5eba65",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:37 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -122,13 +88,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:56:40 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "17ced049-550d-cb3f-1e54-3536d64c0744",
-        "x-ms-request-id": "46910bc2-401e-0056-3bf9-068eb0000000",
+        "x-ms-client-request-id": "db902b14-cdb3-9fb0-94e6-51981f5eba65",
+        "x-ms-request-id": "2cc3b06f-101e-00d1-1a6e-7794ab000000",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
@@ -136,6 +102,6 @@
   ],
   "Variables": {
     "RandomSeed": "1082056955",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseannse\nU2FuaXRpemVk\nhttps://seannse.blob.core.windows.net\nhttps://seannse.file.core.windows.net\nhttps://seannse.queue.core.windows.net\nhttps://seannse.table.core.windows.net\n\n\n\n\nhttps://seannse-secondary.blob.core.windows.net\nhttps://seannse-secondary.file.core.windows.net\nhttps://seannse-secondary.queue.core.windows.net\nhttps://seannse-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seannse.blob.core.windows.net/;QueueEndpoint=https://seannse.queue.core.windows.net/;FileEndpoint=https://seannse.file.core.windows.net/;BlobSecondaryEndpoint=https://seannse-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seannse-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seannse-secondary.file.core.windows.net/;AccountName=seannse;AccountKey=Sanitized\n\n\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary\nU2FuaXRpemVk\nhttps://amandaadlscanary.blob.core.windows.net\nhttps://amandaadlscanary.file.core.windows.net\nhttps://amandaadlscanary.queue.core.windows.net\nhttps://amandaadlscanary.table.core.windows.net\n\n\n\n\nhttps://amandaadlscanary-secondary.blob.core.windows.net\nhttps://amandaadlscanary-secondary.file.core.windows.net\nhttps://amandaadlscanary-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://amandaadlscanary.blob.core.windows.net/;QueueEndpoint=https://amandaadlscanary.queue.core.windows.net/;FileEndpoint=https://amandaadlscanary.file.core.windows.net/;BlobSecondaryEndpoint=https://amandaadlscanary-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandaadlscanary-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandaadlscanary-secondary.file.core.windows.net/;AccountName=amandaadlscanary;AccountKey=Sanitized\n\n\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/AppendDataAsync_EmptyStreamAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/AppendDataAsync_EmptyStreamAsync.json
@@ -1,19 +1,19 @@
-﻿{
+{
   "Entries": [
     {
-      "RequestUri": "https://seannse.blob.core.windows.net/test-filesystem-3f4e7de4-c7bf-adbb-9b17-bcd15e095ff6?restype=container",
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-3f4e7de4-c7bf-adbb-9b17-bcd15e095ff6?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-5177fff336a0494eb8c8c5779bc27a5a-dea183d6ebffc043-00",
+        "traceparent": "00-d5e56d34014dbe4599ebf7b9c6d07aa6-97a7db2399121946-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "be3e407e-eb6d-a1ea-64cc-50efbbea548b",
-        "x-ms-date": "Fri, 19 Feb 2021 19:58:16 GMT",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:25 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -21,32 +21,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:58:15 GMT",
-        "ETag": "\"0x8D8D510B262722C\"",
-        "Last-Modified": "Fri, 19 Feb 2021 19:58:16 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:25 GMT",
+        "ETag": "\u00220x8D945860AD3FBC6\u0022",
+        "Last-Modified": "Mon, 12 Jul 2021 22:40:25 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "be3e407e-eb6d-a1ea-64cc-50efbbea548b",
-        "x-ms-request-id": "4691f2df-401e-0056-6ff9-068eb0000000",
+        "x-ms-request-id": "4bbcb026-b01e-0085-4c6e-77dbfc000000",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://seannse.dfs.core.windows.net/test-filesystem-3f4e7de4-c7bf-adbb-9b17-bcd15e095ff6/test-file-23e685f3-5aae-5bb1-a798-18aa2d12e589?resource=file",
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-3f4e7de4-c7bf-adbb-9b17-bcd15e095ff6/test-file-23e685f3-5aae-5bb1-a798-18aa2d12e589?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-8d042551418a254bb2e61012b54f8506-54ed7451a5aded4c-00",
+        "traceparent": "00-12a0496453b95646b8ed6a6625b3d14a-90b9b87f042d4e46-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "42b50ebf-7b2b-2326-8ee2-16d4d33f7452",
-        "x-ms-date": "Fri, 19 Feb 2021 19:58:17 GMT",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:26 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -54,67 +54,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:58:15 GMT",
-        "ETag": "\"0x8D8D510B2773D4B\"",
-        "Last-Modified": "Fri, 19 Feb 2021 19:58:16 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:26 GMT",
+        "ETag": "\u00220x8D945860B3346C1\u0022",
+        "Last-Modified": "Mon, 12 Jul 2021 22:40:26 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "42b50ebf-7b2b-2326-8ee2-16d4d33f7452",
-        "x-ms-request-id": "d66aae9f-f01f-0088-09f9-069a56000000",
+        "x-ms-request-id": "12459d34-701f-0051-156e-776bad000000",
+        "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://seannse.dfs.core.windows.net/test-filesystem-3f4e7de4-c7bf-adbb-9b17-bcd15e095ff6/test-file-23e685f3-5aae-5bb1-a798-18aa2d12e589?action=append&position=0",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "0",
-        "Content-Type": "application/octet-stream",
-        "traceparent": "00-2047fc84f2a8854cb58848f8bb9e06b9-dae8b1635da2a246-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
-        ],
-        "x-ms-client-request-id": "1eebdb9f-a25c-fd5d-c02e-8fe88ab49d04",
-        "x-ms-date": "Fri, 19 Feb 2021 19:58:17 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-10-02"
-      },
-      "RequestBody": [],
-      "StatusCode": 400,
-      "ResponseHeaders": {
-        "Content-Length": "262",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Feb 2021 19:58:15 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "1eebdb9f-a25c-fd5d-c02e-8fe88ab49d04",
-        "x-ms-error-code": "InvalidHeaderValue",
-        "x-ms-request-id": "d66aaeb6-f01f-0088-20f9-069a56000000",
-        "x-ms-version": "2020-10-02"
-      },
-      "ResponseBody": "{\"error\":{\"code\":\"InvalidHeaderValue\",\"message\":\"The value for one of the HTTP headers is not in the correct format.\\nRequestId:d66aaeb6-f01f-0088-20f9-069a56000000\\nTime:2021-02-19T19:58:16.4460689Z\",\"detail\":{\"HeaderName\":\"Content-Length\", \"HeaderValue\":\"0\"}}}"
-    },
-    {
-      "RequestUri": "https://seannse.blob.core.windows.net/test-filesystem-3f4e7de4-c7bf-adbb-9b17-bcd15e095ff6?restype=container",
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-3f4e7de4-c7bf-adbb-9b17-bcd15e095ff6?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-e6ac7fbd0a546440869d6f9b42982230-6040130f4dde484a-00",
+        "traceparent": "00-c267c9585c42754a88cdfb438e8e1c12-a28d506b0a22f643-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "f73555bd-5554-44f6-6a78-1469a6d8c747",
-        "x-ms-date": "Fri, 19 Feb 2021 19:58:17 GMT",
+        "x-ms-client-request-id": "1eebdb9f-a25c-fd5d-c02e-8fe88ab49d04",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:26 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -122,13 +88,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:58:15 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:26 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f73555bd-5554-44f6-6a78-1469a6d8c747",
-        "x-ms-request-id": "4691f389-401e-0056-03f9-068eb0000000",
+        "x-ms-client-request-id": "1eebdb9f-a25c-fd5d-c02e-8fe88ab49d04",
+        "x-ms-request-id": "4bbcb062-b01e-0085-796e-77dbfc000000",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
@@ -136,6 +102,6 @@
   ],
   "Variables": {
     "RandomSeed": "567237005",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseannse\nU2FuaXRpemVk\nhttps://seannse.blob.core.windows.net\nhttps://seannse.file.core.windows.net\nhttps://seannse.queue.core.windows.net\nhttps://seannse.table.core.windows.net\n\n\n\n\nhttps://seannse-secondary.blob.core.windows.net\nhttps://seannse-secondary.file.core.windows.net\nhttps://seannse-secondary.queue.core.windows.net\nhttps://seannse-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seannse.blob.core.windows.net/;QueueEndpoint=https://seannse.queue.core.windows.net/;FileEndpoint=https://seannse.file.core.windows.net/;BlobSecondaryEndpoint=https://seannse-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seannse-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seannse-secondary.file.core.windows.net/;AccountName=seannse;AccountKey=Sanitized\n\n\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary\nU2FuaXRpemVk\nhttps://amandaadlscanary.blob.core.windows.net\nhttps://amandaadlscanary.file.core.windows.net\nhttps://amandaadlscanary.queue.core.windows.net\nhttps://amandaadlscanary.table.core.windows.net\n\n\n\n\nhttps://amandaadlscanary-secondary.blob.core.windows.net\nhttps://amandaadlscanary-secondary.file.core.windows.net\nhttps://amandaadlscanary-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://amandaadlscanary.blob.core.windows.net/;QueueEndpoint=https://amandaadlscanary.queue.core.windows.net/;FileEndpoint=https://amandaadlscanary.file.core.windows.net/;BlobSecondaryEndpoint=https://amandaadlscanary-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandaadlscanary-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandaadlscanary-secondary.file.core.windows.net/;AccountName=amandaadlscanary;AccountKey=Sanitized\n\n\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/AppendDataAsync_NullStream_Error.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/AppendDataAsync_NullStream_Error.json
@@ -1,19 +1,19 @@
-﻿{
+{
   "Entries": [
     {
-      "RequestUri": "https://seannse.blob.core.windows.net/test-filesystem-7521670a-8b72-97ca-ac81-39fd34d90db4?restype=container",
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-7521670a-8b72-97ca-ac81-39fd34d90db4?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-2b1fc0e282c1164894729a2f61992b2b-12d2bd2b743e5e4e-00",
+        "traceparent": "00-cd37550b4219d64a96d3ecc3b5d7f9d9-7e29b25e0734044a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "d6ebf82e-99fe-d921-638b-d1f6ae81ff5e",
-        "x-ms-date": "Fri, 19 Feb 2021 19:08:50 GMT",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -21,33 +21,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:08:50 GMT",
-        "ETag": "\"0x8D8D509CA797AC1\"",
-        "Last-Modified": "Fri, 19 Feb 2021 19:08:50 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:37 GMT",
+        "ETag": "\u00220x8D9458611FA5987\u0022",
+        "Last-Modified": "Mon, 12 Jul 2021 22:40:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d6ebf82e-99fe-d921-638b-d1f6ae81ff5e",
-        "x-ms-request-id": "2e6282a3-201e-00a4-7cf2-0676f9000000",
+        "x-ms-request-id": "2cc3b078-101e-00d1-236e-7794ab000000",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://seannse.dfs.core.windows.net/test-filesystem-7521670a-8b72-97ca-ac81-39fd34d90db4/test-file-f582b198-38c7-d49a-6254-4e4775dfc54d?resource=file",
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-7521670a-8b72-97ca-ac81-39fd34d90db4/test-file-f582b198-38c7-d49a-6254-4e4775dfc54d?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "If-None-Match": "*",
-        "traceparent": "00-9a07cf964ec5764eba3621949d2c14a7-696254dda174254d-00",
+        "traceparent": "00-6ba5a60ec7472c4997af92eb151d5df8-3b88d6b7db66e046-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "2053b72c-18dc-f51c-5d17-73a94bda6484",
-        "x-ms-date": "Fri, 19 Feb 2021 19:08:50 GMT",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -55,32 +55,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:08:49 GMT",
-        "ETag": "\"0x8D8D509CA898F9F\"",
-        "Last-Modified": "Fri, 19 Feb 2021 19:08:50 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:37 GMT",
+        "ETag": "\u00220x8D945861211C92C\u0022",
+        "Last-Modified": "Mon, 12 Jul 2021 22:40:38 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "2053b72c-18dc-f51c-5d17-73a94bda6484",
-        "x-ms-request-id": "6f4af11f-e01f-004f-55f2-060e0b000000",
+        "x-ms-request-id": "711f4509-501f-008d-356e-77c1f3000000",
+        "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://seannse.blob.core.windows.net/test-filesystem-7521670a-8b72-97ca-ac81-39fd34d90db4?restype=container",
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-7521670a-8b72-97ca-ac81-39fd34d90db4?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-796e3f0b19986a42a85e3bfb3d64457d-3d95bdf245acfd4f-00",
+        "traceparent": "00-a660a7314170ec48aa5108c3f49bb05e-c103b3a20e337141-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "bd1aa936-a48c-5b71-38da-ded7c30d00fd",
-        "x-ms-date": "Fri, 19 Feb 2021 19:08:51 GMT",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -88,13 +89,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:08:50 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:38 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "bd1aa936-a48c-5b71-38da-ded7c30d00fd",
-        "x-ms-request-id": "2e6284ad-201e-00a4-6af2-0676f9000000",
+        "x-ms-request-id": "2cc3b0a6-101e-00d1-4c6e-7794ab000000",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
@@ -102,6 +103,6 @@
   ],
   "Variables": {
     "RandomSeed": "1100854221",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseannse\nU2FuaXRpemVk\nhttps://seannse.blob.core.windows.net\nhttps://seannse.file.core.windows.net\nhttps://seannse.queue.core.windows.net\nhttps://seannse.table.core.windows.net\n\n\n\n\nhttps://seannse-secondary.blob.core.windows.net\nhttps://seannse-secondary.file.core.windows.net\nhttps://seannse-secondary.queue.core.windows.net\nhttps://seannse-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seannse.blob.core.windows.net/;QueueEndpoint=https://seannse.queue.core.windows.net/;FileEndpoint=https://seannse.file.core.windows.net/;BlobSecondaryEndpoint=https://seannse-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seannse-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seannse-secondary.file.core.windows.net/;AccountName=seannse;AccountKey=Sanitized\n\n\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary\nU2FuaXRpemVk\nhttps://amandaadlscanary.blob.core.windows.net\nhttps://amandaadlscanary.file.core.windows.net\nhttps://amandaadlscanary.queue.core.windows.net\nhttps://amandaadlscanary.table.core.windows.net\n\n\n\n\nhttps://amandaadlscanary-secondary.blob.core.windows.net\nhttps://amandaadlscanary-secondary.file.core.windows.net\nhttps://amandaadlscanary-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://amandaadlscanary.blob.core.windows.net/;QueueEndpoint=https://amandaadlscanary.queue.core.windows.net/;FileEndpoint=https://amandaadlscanary.file.core.windows.net/;BlobSecondaryEndpoint=https://amandaadlscanary-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandaadlscanary-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandaadlscanary-secondary.file.core.windows.net/;AccountName=amandaadlscanary;AccountKey=Sanitized\n\n\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/AppendDataAsync_NullStream_ErrorAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/AppendDataAsync_NullStream_ErrorAsync.json
@@ -1,19 +1,19 @@
-﻿{
+{
   "Entries": [
     {
-      "RequestUri": "https://seannse.blob.core.windows.net/test-filesystem-ba538edb-0f9c-c3cc-b86b-45ae78de002e?restype=container",
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-ba538edb-0f9c-c3cc-b86b-45ae78de002e?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-099126dd45942847aa6a112cf17ff967-88cd750604440147-00",
+        "traceparent": "00-dc66505e2049684399db232925da0bfa-28061f9e0e4fbf4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "673e4e56-e72e-d3d8-1070-04a93b135afd",
-        "x-ms-date": "Fri, 19 Feb 2021 19:11:57 GMT",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:26 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -21,33 +21,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:11:56 GMT",
-        "ETag": "\"0x8D8D50A39A9214F\"",
-        "Last-Modified": "Fri, 19 Feb 2021 19:11:56 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:26 GMT",
+        "ETag": "\u00220x8D945860B5A8577\u0022",
+        "Last-Modified": "Mon, 12 Jul 2021 22:40:26 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "673e4e56-e72e-d3d8-1070-04a93b135afd",
-        "x-ms-request-id": "2e69a51d-201e-00a4-4bf3-0676f9000000",
+        "x-ms-request-id": "4bbcb072-b01e-0085-076e-77dbfc000000",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://seannse.dfs.core.windows.net/test-filesystem-ba538edb-0f9c-c3cc-b86b-45ae78de002e/test-file-e783b62a-2617-75bf-8e6e-7a6168cadc3c?resource=file",
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-ba538edb-0f9c-c3cc-b86b-45ae78de002e/test-file-e783b62a-2617-75bf-8e6e-7a6168cadc3c?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "If-None-Match": "*",
-        "traceparent": "00-a6cbb71e0738e54991de4263b82064f7-c4926ae6073abf4a-00",
+        "traceparent": "00-7b762a48f67df34c9b2e743305a3b14f-746dc13ed421004a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "31d8aae1-6cf8-2fbd-8fc8-d9c06c776b46",
-        "x-ms-date": "Fri, 19 Feb 2021 19:11:57 GMT",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:27 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -55,32 +55,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:11:56 GMT",
-        "ETag": "\"0x8D8D50A39B81D45\"",
-        "Last-Modified": "Fri, 19 Feb 2021 19:11:56 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:26 GMT",
+        "ETag": "\u00220x8D945860B6D7DDB\u0022",
+        "Last-Modified": "Mon, 12 Jul 2021 22:40:26 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "31d8aae1-6cf8-2fbd-8fc8-d9c06c776b46",
-        "x-ms-request-id": "6f4b7cc2-e01f-004f-5bf3-060e0b000000",
+        "x-ms-request-id": "12459d35-701f-0051-166e-776bad000000",
+        "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://seannse.blob.core.windows.net/test-filesystem-ba538edb-0f9c-c3cc-b86b-45ae78de002e?restype=container",
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-ba538edb-0f9c-c3cc-b86b-45ae78de002e?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-f2e61cdb7ccc6942a4a6f8201344e376-ac82958a243e3b47-00",
+        "traceparent": "00-d9c16c362e15ea479ad405d4c9614c19-2570065c6735c246-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.7.0-alpha.20210219.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19041)"
+          "azsdk-net-Storage.Files.DataLake/12.8.0-alpha.20210712.1",
+          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "bd804ec4-aaf1-ab43-b428-9ad7bf3f692c",
-        "x-ms-date": "Fri, 19 Feb 2021 19:11:57 GMT",
+        "x-ms-date": "Mon, 12 Jul 2021 22:40:27 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-10-02"
       },
@@ -88,13 +89,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 19 Feb 2021 19:11:56 GMT",
+        "Date": "Mon, 12 Jul 2021 22:40:26 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "bd804ec4-aaf1-ab43-b428-9ad7bf3f692c",
-        "x-ms-request-id": "2e69a6fd-201e-00a4-10f3-0676f9000000",
+        "x-ms-request-id": "4bbcb081-b01e-0085-126e-77dbfc000000",
         "x-ms-version": "2020-10-02"
       },
       "ResponseBody": []
@@ -102,6 +103,6 @@
   ],
   "Variables": {
     "RandomSeed": "1144567925",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseannse\nU2FuaXRpemVk\nhttps://seannse.blob.core.windows.net\nhttps://seannse.file.core.windows.net\nhttps://seannse.queue.core.windows.net\nhttps://seannse.table.core.windows.net\n\n\n\n\nhttps://seannse-secondary.blob.core.windows.net\nhttps://seannse-secondary.file.core.windows.net\nhttps://seannse-secondary.queue.core.windows.net\nhttps://seannse-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seannse.blob.core.windows.net/;QueueEndpoint=https://seannse.queue.core.windows.net/;FileEndpoint=https://seannse.file.core.windows.net/;BlobSecondaryEndpoint=https://seannse-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seannse-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seannse-secondary.file.core.windows.net/;AccountName=seannse;AccountKey=Sanitized\n\n\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary\nU2FuaXRpemVk\nhttps://amandaadlscanary.blob.core.windows.net\nhttps://amandaadlscanary.file.core.windows.net\nhttps://amandaadlscanary.queue.core.windows.net\nhttps://amandaadlscanary.table.core.windows.net\n\n\n\n\nhttps://amandaadlscanary-secondary.blob.core.windows.net\nhttps://amandaadlscanary-secondary.file.core.windows.net\nhttps://amandaadlscanary-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://amandaadlscanary.blob.core.windows.net/;QueueEndpoint=https://amandaadlscanary.queue.core.windows.net/;FileEndpoint=https://amandaadlscanary.file.core.windows.net/;BlobSecondaryEndpoint=https://amandaadlscanary-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandaadlscanary-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandaadlscanary-secondary.file.core.windows.net/;AccountName=amandaadlscanary;AccountKey=Sanitized\n\n\n"
   }
 }


### PR DESCRIPTION
Attempt at resolving https://github.com/Azure/azure-sdk-for-net/issues/9489

Currently the service will throw if the stream passed is empty. In general `Append` should not be accepting empty streams, because it's not possible to append nothing to the file.

Currently the service will throw an `InvalidHeaderValue`
