### PR TITLE
[Event Hubs] Client Identifier Option

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Each Event Hubs client type now offers an option to set an Identifier. The identifier is informational and is associated with the AMQP links used, allowing the service to provide additional context in error messages and the SDK logs to provide an additional point of correlation.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -204,6 +204,7 @@ namespace Azure.Messaging.EventHubs.Consumer
         public string ConsumerGroup { get { throw null; } }
         public string EventHubName { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
         public bool IsClosed { get { throw null; } protected set { } }
         public virtual System.Threading.Tasks.Task CloseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
@@ -226,6 +227,7 @@ namespace Azure.Messaging.EventHubs.Consumer
     {
         public EventHubConsumerClientOptions() { }
         public Azure.Messaging.EventHubs.EventHubConnectionOptions ConnectionOptions { get { throw null; } set { } }
+        public string Identifier { get { throw null; } set { } }
         public Azure.Messaging.EventHubs.EventHubsRetryOptions RetryOptions { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
@@ -400,6 +402,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         public string ConsumerGroup { get { throw null; } }
         public string EventHubName { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
         public Azure.Messaging.EventHubs.Consumer.EventPosition InitialPosition { get { throw null; } }
         public bool IsClosed { get { throw null; } protected set { } }
         public string PartitionId { get { throw null; } }
@@ -421,6 +424,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         public PartitionReceiverOptions() { }
         public Azure.Messaging.EventHubs.EventHubConnectionOptions ConnectionOptions { get { throw null; } set { } }
         public System.TimeSpan? DefaultMaximumReceiveWaitTime { get { throw null; } set { } }
+        public string Identifier { get { throw null; } set { } }
         public long? OwnerLevel { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
         public long? PrefetchSizeInBytes { get { throw null; } set { } }
@@ -519,6 +523,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public EventHubProducerClient(string connectionString, string eventHubName, Azure.Messaging.EventHubs.Producer.EventHubProducerClientOptions clientOptions) { }
         public string EventHubName { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
         public bool IsClosed { get { throw null; } protected set { } }
         public virtual System.Threading.Tasks.Task CloseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.ValueTask<Azure.Messaging.EventHubs.Producer.EventDataBatch> CreateBatchAsync(Azure.Messaging.EventHubs.Producer.CreateBatchOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -541,6 +546,7 @@ namespace Azure.Messaging.EventHubs.Producer
     {
         public EventHubProducerClientOptions() { }
         public Azure.Messaging.EventHubs.EventHubConnectionOptions ConnectionOptions { get { throw null; } set { } }
+        public string Identifier { get { throw null; } set { } }
         public Azure.Messaging.EventHubs.EventHubsRetryOptions RetryOptions { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -403,6 +403,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
+        /// <param name="producerIdentifier">The identifier to associate with the consumer; if <c>null</c> or <see cref="string.Empty" />, a random identifier will be generated.</param>
         /// <param name="requestedFeatures">The flags specifying the set of special transport features that should be opted-into.</param>
         /// <param name="partitionOptions">The set of options, if any, that should be considered when initializing the producer.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
@@ -410,6 +411,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
         public override TransportProducer CreateProducer(string partitionId,
+                                                         string producerIdentifier,
                                                          TransportProducerFeatures requestedFeatures,
                                                          PartitionPublishingOptions partitionOptions,
                                                          EventHubsRetryPolicy retryPolicy)
@@ -420,6 +422,7 @@ namespace Azure.Messaging.EventHubs.Amqp
             (
                 EventHubName,
                 partitionId,
+                producerIdentifier,
                 ConnectionScope,
                 MessageConverter,
                 retryPolicy,
@@ -447,6 +450,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
+        /// <param name="consumerIdentifier">The identifier to associate with the consumer; if <c>null</c> or <see cref="string.Empty" />, a random identifier will be generated.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
@@ -459,6 +463,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         public override TransportConsumer CreateConsumer(string consumerGroup,
                                                          string partitionId,
+                                                         string consumerIdentifier,
                                                          EventPosition eventPosition,
                                                          EventHubsRetryPolicy retryPolicy,
                                                          bool trackLastEnqueuedEventProperties,
@@ -474,6 +479,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 EventHubName,
                 consumerGroup,
                 partitionId,
+                consumerIdentifier,
                 eventPosition,
                 trackLastEnqueuedEventProperties,
                 invalidateConsumerWhenPartitionStolen,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
@@ -20,6 +20,12 @@ namespace Azure.Messaging.EventHubs
         public static AmqpSymbol ConsumerOwnerLevel { get; } = AmqpConstants.Vendor + ":epoch";
 
         /// <summary>
+        ///   The consumer identifier to associate with a receiver link.
+        /// </summary>
+        ///
+        public static AmqpSymbol ConsumerIdentifier { get; } = AmqpConstants.Vendor + ":receiver-name";
+
+        /// <summary>
         ///   The owner level (a.k.a. epoch) to associate with a sending link.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -75,6 +75,12 @@ namespace Azure.Messaging.EventHubs.Consumer
         public string ConsumerGroup { get; }
 
         /// <summary>
+        ///   A unique name used to identify this consumer.
+        /// </summary>
+        ///
+        public string Identifier { get; }
+
+        /// <summary>
         ///   Indicates whether or not this <see cref="EventHubConsumerClient"/> has been closed.
         /// </summary>
         ///
@@ -216,6 +222,10 @@ namespace Azure.Messaging.EventHubs.Consumer
             Connection = new EventHubConnection(connectionString, eventHubName, clientOptions.ConnectionOptions);
             ConsumerGroup = consumerGroup;
             RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
+
+            Identifier = string.IsNullOrEmpty(clientOptions.Identifier)
+                ? Guid.NewGuid().ToString()
+                : clientOptions.Identifier;
         }
 
         /// <summary>
@@ -293,6 +303,10 @@ namespace Azure.Messaging.EventHubs.Consumer
             Connection = connection;
             ConsumerGroup = consumerGroup;
             RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
+
+            Identifier = string.IsNullOrEmpty(clientOptions.Identifier)
+                ? Guid.NewGuid().ToString()
+                : clientOptions.Identifier;
         }
 
         /// <summary>
@@ -331,6 +345,10 @@ namespace Azure.Messaging.EventHubs.Consumer
             Connection = EventHubConnection.CreateWithCredential(fullyQualifiedNamespace, eventHubName, credential, clientOptions.ConnectionOptions);
             ConsumerGroup = consumerGroup;
             RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
+
+            Identifier = string.IsNullOrEmpty(clientOptions.Identifier)
+                ? Guid.NewGuid().ToString()
+                : clientOptions.Identifier;
         }
 
         /// <summary>
@@ -458,7 +476,7 @@ namespace Azure.Messaging.EventHubs.Consumer
 
                 try
                 {
-                    transportConsumer = Connection.CreateTransportConsumer(ConsumerGroup, partitionId, startingPosition, RetryPolicy, readOptions.TrackLastEnqueuedEventProperties, InvalidateConsumerWhenPartitionIsStolen, readOptions.OwnerLevel, (uint)readOptions.PrefetchCount);
+                    transportConsumer = Connection.CreateTransportConsumer(ConsumerGroup, partitionId, Identifier, startingPosition, RetryPolicy, readOptions.TrackLastEnqueuedEventProperties, InvalidateConsumerWhenPartitionIsStolen, readOptions.OwnerLevel, (uint)readOptions.PrefetchCount);
                     partitionContext = new PartitionContext(partitionId, transportConsumer);
                     emptyPartitionEvent = new PartitionEvent(partitionContext, null);
                 }
@@ -731,9 +749,7 @@ namespace Azure.Messaging.EventHubs.Consumer
             }
 
             IsClosed = true;
-
-            var clientHash = GetHashCode().ToString(CultureInfo.InvariantCulture);
-            EventHubsEventSource.Log.ClientCloseStart(nameof(EventHubConsumerClient), EventHubName, clientHash);
+            EventHubsEventSource.Log.ClientCloseStart(nameof(EventHubConsumerClient), EventHubName, Identifier);
 
             // Attempt to close the active transport consumers.  In the event that an exception is encountered,
             // it should not impact the attempt to close the connection, assuming ownership.
@@ -754,7 +770,7 @@ namespace Azure.Messaging.EventHubs.Consumer
             }
             catch (Exception ex)
             {
-                EventHubsEventSource.Log.ClientCloseError(nameof(EventHubConsumerClient), EventHubName, clientHash, ex.Message);
+                EventHubsEventSource.Log.ClientCloseError(nameof(EventHubConsumerClient), EventHubName, Identifier, ex.Message);
                 transportConsumerException = ex;
             }
 
@@ -770,13 +786,13 @@ namespace Azure.Messaging.EventHubs.Consumer
             }
             catch (Exception ex)
             {
-                EventHubsEventSource.Log.ClientCloseError(nameof(EventHubConsumerClient), EventHubName, clientHash, ex.Message);
+                EventHubsEventSource.Log.ClientCloseError(nameof(EventHubConsumerClient), EventHubName, Identifier, ex.Message);
                 transportConsumerException = null;
                 throw;
             }
             finally
             {
-                EventHubsEventSource.Log.ClientCloseComplete(nameof(EventHubConsumerClient), EventHubName, clientHash);
+                EventHubsEventSource.Log.ClientCloseComplete(nameof(EventHubConsumerClient), EventHubName, Identifier);
             }
 
             // If there was an active exception pending from closing the individual
@@ -920,7 +936,7 @@ namespace Azure.Messaging.EventHubs.Consumer
 
             try
             {
-                transportConsumer = Connection.CreateTransportConsumer(ConsumerGroup, partitionId, startingPosition, RetryPolicy, trackLastEnqueuedEventProperties, InvalidateConsumerWhenPartitionIsStolen, ownerLevel, prefetchCount);
+                transportConsumer = Connection.CreateTransportConsumer(ConsumerGroup, partitionId, Identifier, startingPosition, RetryPolicy, trackLastEnqueuedEventProperties, InvalidateConsumerWhenPartitionIsStolen, ownerLevel, prefetchCount);
 
                 if (!ActiveConsumers.TryAdd(publisherId, transportConsumer))
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClientOptions.cs
@@ -21,6 +21,13 @@ namespace Azure.Messaging.EventHubs.Consumer
         private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
 
         /// <summary>
+        ///   A unique name used to identify the consumer.  If <c>null</c> or empty, a GUID will be used as the
+        ///   identifier.
+        /// </summary>
+        ///
+        public string Identifier { get; set; }
+
+        /// <summary>
         ///   The options used for configuring the connection to the Event Hubs service.
         /// </summary>
         ///
@@ -88,6 +95,7 @@ namespace Azure.Messaging.EventHubs.Consumer
         internal EventHubConsumerClientOptions Clone() =>
             new EventHubConsumerClientOptions
             {
+                Identifier = Identifier,
                 _connectionOptions = ConnectionOptions.Clone(),
                 _retryOptions = RetryOptions.Clone()
             };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
@@ -68,13 +68,16 @@ namespace Azure.Messaging.EventHubs.Core
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
+        /// <param name="producerIdentifier">The identifier to associate with the consumer; if <c>null</c> or <see cref="string.Empty" />, a random identifier will be generated.</param>
         /// <param name="requestedFeatures">The flags specifying the set of special transport features that should be opted-into.</param>
         /// <param name="partitionOptions">The set of options, if any, that should be considered when initializing the producer.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
+
         ///
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
         public abstract TransportProducer CreateProducer(string partitionId,
+                                                         string producerIdentifier,
                                                          TransportProducerFeatures requestedFeatures,
                                                          PartitionPublishingOptions partitionOptions,
                                                          EventHubsRetryPolicy retryPolicy);
@@ -98,6 +101,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
+        /// <param name="consumerIdentifier">The identifier to associate with the consumer; if <c>null</c> or <see cref="string.Empty" />, a random identifier will be generated.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
@@ -110,6 +114,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         public abstract TransportConsumer CreateConsumer(string consumerGroup,
                                                          string partitionId,
+                                                         string consumerIdentifier,
                                                          EventPosition eventPosition,
                                                          EventHubsRetryPolicy retryPolicy,
                                                          bool trackLastEnqueuedEventProperties,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
@@ -394,6 +394,7 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
+        /// <param name="producerIdentifier">The identifier to associate with the consumer; if <c>null</c> or <see cref="string.Empty" />, a random identifier will be generated.</param>
         /// <param name="requestedFeatures">The flags specifying the set of special transport features that should be opted-into.</param>
         /// <param name="partitionOptions">The set of options, if any, that should be considered when initializing the producer.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
@@ -401,12 +402,13 @@ namespace Azure.Messaging.EventHubs
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
         internal virtual TransportProducer CreateTransportProducer(string partitionId,
+                                                                   string producerIdentifier,
                                                                    TransportProducerFeatures requestedFeatures,
                                                                    PartitionPublishingOptions partitionOptions,
                                                                    EventHubsRetryPolicy retryPolicy)
         {
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
-            return InnerClient.CreateProducer(partitionId, requestedFeatures, partitionOptions, retryPolicy);
+            return InnerClient.CreateProducer(partitionId, producerIdentifier, requestedFeatures, partitionOptions, retryPolicy);
         }
 
         /// <summary>
@@ -428,6 +430,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
+        /// <param name="consumerIdentifier">The identifier to associate with the consumer; if <c>null</c> or <see cref="string.Empty" />, a random identifier will be generated.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
@@ -440,6 +443,7 @@ namespace Azure.Messaging.EventHubs
         ///
         internal virtual TransportConsumer CreateTransportConsumer(string consumerGroup,
                                                                    string partitionId,
+                                                                   string consumerIdentifier,
                                                                    EventPosition eventPosition,
                                                                    EventHubsRetryPolicy retryPolicy,
                                                                    bool trackLastEnqueuedEventProperties = true,
@@ -452,7 +456,7 @@ namespace Azure.Messaging.EventHubs
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
 
-            return InnerClient.CreateConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, invalidateConsumerWhenPartitionStolen, ownerLevel, prefetchCount, prefetchSizeInBytes);
+            return InnerClient.CreateConsumer(consumerGroup, partitionId, consumerIdentifier, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, invalidateConsumerWhenPartitionStolen, ownerLevel, prefetchCount, prefetchSizeInBytes);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -516,6 +516,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         /// <param name="consumerGroup">The consumer group to associate with the consumer.</param>
         /// <param name="partitionId">The partition to associated with the consumer.</param>
+        /// <param name="consumerIdentifier">The identifier to associate with the consumer; if <c>null</c> or <see cref="string.Empty" />, a random identifier will be generated.</param>
         /// <param name="eventPosition">The position in the event stream where the consumer should begin reading.</param>
         /// <param name="connection">The connection to use for the consumer.</param>
         /// <param name="options">The options to use for configuring the consumer.</param>
@@ -524,10 +525,11 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         internal virtual TransportConsumer CreateConsumer(string consumerGroup,
                                                           string partitionId,
+                                                          string consumerIdentifier,
                                                           EventPosition eventPosition,
                                                           EventHubConnection connection,
                                                           EventProcessorOptions options) =>
-            connection.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, options.RetryOptions.ToRetryPolicy(), options.TrackLastEnqueuedEventProperties, InvalidateConsumerWhenPartitionIsStolen, prefetchCount: (uint?)options.PrefetchCount, prefetchSizeInBytes: options.PrefetchSizeInBytes, ownerLevel: 0);
+            connection.CreateTransportConsumer(consumerGroup, partitionId, consumerIdentifier, eventPosition, options.RetryOptions.ToRetryPolicy(), options.TrackLastEnqueuedEventProperties, InvalidateConsumerWhenPartitionIsStolen, prefetchCount: (uint?)options.PrefetchCount, prefetchSizeInBytes: options.PrefetchSizeInBytes, ownerLevel: 0);
 
         /// <summary>
         ///   Performs the tasks needed to process a batch of events.
@@ -686,7 +688,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                 {
                     try
                     {
-                        consumer = CreateConsumer(ConsumerGroup, partition.PartitionId, startingPosition, connection, Options);
+                        consumer = CreateConsumer(ConsumerGroup, partition.PartitionId, $"P{ partition.PartitionId }-{ Identifier }", startingPosition, connection, Options);
 
                         // Register for notification when the cancellation token is triggered.  Attempt to close the consumer
                         // in response to force-close the link and short-circuit any receive operation that is blocked and

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -73,6 +73,12 @@ namespace Azure.Messaging.EventHubs.Primitives
         public string PartitionId { get; }
 
         /// <summary>
+        ///   A unique name used to identify this receiver.
+        /// </summary>
+        ///
+        public string Identifier { get; }
+
+        /// <summary>
         ///   The position within the partition where the client begins reading events.
         /// </summary>
         ///
@@ -199,10 +205,21 @@ namespace Azure.Messaging.EventHubs.Primitives
             DefaultMaximumWaitTime = options.DefaultMaximumReceiveWaitTime;
             RetryPolicy = options.RetryOptions.ToRetryPolicy();
 
-#pragma warning disable CA2214 // Do not call overridable methods in constructors. This internal method is virtual for testing purposes.
-            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options);
-#pragma warning restore CA2214 // Do not call overridable methods in constructors.
+            Identifier = string.IsNullOrEmpty(options.Identifier)
+                ? Guid.NewGuid().ToString()
+                : options.Identifier;
 
+            InnerConsumer = Connection.CreateTransportConsumer(
+                consumerGroup,
+                partitionId,
+                Identifier,
+                eventPosition,
+                RetryPolicy,
+                options.TrackLastEnqueuedEventProperties,
+                InvalidateConsumerWhenPartitionIsStolen,
+                options.OwnerLevel,
+                (uint?)options.PrefetchCount,
+                options.PrefetchSizeInBytes);
         }
 
         /// <summary>
@@ -301,9 +318,21 @@ namespace Azure.Messaging.EventHubs.Primitives
             DefaultMaximumWaitTime = options.DefaultMaximumReceiveWaitTime;
             RetryPolicy = options.RetryOptions.ToRetryPolicy();
 
-#pragma warning disable CA2214 // Do not call overridable methods in constructors. This internal method is virtual for testing purposes.
-            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options);
-#pragma warning restore CA2214 // Do not call overridable methods in constructors.
+            Identifier = string.IsNullOrEmpty(options.Identifier)
+                ? Guid.NewGuid().ToString()
+                : options.Identifier;
+
+            InnerConsumer = Connection.CreateTransportConsumer(
+                consumerGroup,
+                partitionId,
+                Identifier,
+                eventPosition,
+                RetryPolicy,
+                options.TrackLastEnqueuedEventProperties,
+                InvalidateConsumerWhenPartitionIsStolen,
+                options.OwnerLevel,
+                (uint?)options.PrefetchCount,
+                options.PrefetchSizeInBytes);
         }
 
         /// <summary>
@@ -341,9 +370,21 @@ namespace Azure.Messaging.EventHubs.Primitives
             DefaultMaximumWaitTime = options.DefaultMaximumReceiveWaitTime;
             RetryPolicy = options.RetryOptions.ToRetryPolicy();
 
-#pragma warning disable CA2214 // Do not call overridable methods in constructors. This internal method is virtual for testing purposes.
-            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options);
-#pragma warning restore CA2214 // Do not call overridable methods in constructors.
+            Identifier = string.IsNullOrEmpty(options.Identifier)
+                ? Guid.NewGuid().ToString()
+                : options.Identifier;
+
+            InnerConsumer = Connection.CreateTransportConsumer(
+                consumerGroup,
+                partitionId,
+                Identifier,
+                eventPosition,
+                RetryPolicy,
+                options.TrackLastEnqueuedEventProperties,
+                InvalidateConsumerWhenPartitionIsStolen,
+                options.OwnerLevel,
+                (uint?)options.PrefetchCount,
+                options.PrefetchSizeInBytes);
         }
 
         /// <summary>
@@ -452,9 +493,7 @@ namespace Azure.Messaging.EventHubs.Primitives
             }
 
             IsClosed = true;
-
-            var clientHash = GetHashCode().ToString(CultureInfo.InvariantCulture);
-            Logger.ClientCloseStart(nameof(PartitionReceiver), EventHubName, clientHash);
+            Logger.ClientCloseStart(nameof(PartitionReceiver), EventHubName, Identifier);
 
             // Attempt to close the transport consumer.  In the event that an exception is encountered,
             // it should not impact the attempt to close the connection, assuming ownership.
@@ -467,7 +506,7 @@ namespace Azure.Messaging.EventHubs.Primitives
             }
             catch (Exception ex)
             {
-                Logger.ClientCloseError(nameof(PartitionReceiver), EventHubName, clientHash, ex.Message);
+                Logger.ClientCloseError(nameof(PartitionReceiver), EventHubName, Identifier, ex.Message);
                 transportConsumerException = ex;
             }
 
@@ -483,12 +522,12 @@ namespace Azure.Messaging.EventHubs.Primitives
             }
             catch (Exception ex)
             {
-                Logger.ClientCloseError(nameof(PartitionReceiver), EventHubName, clientHash, ex.Message);
+                Logger.ClientCloseError(nameof(PartitionReceiver), EventHubName, Identifier, ex.Message);
                 throw;
             }
             finally
             {
-                Logger.ClientCloseComplete(nameof(PartitionReceiver), EventHubName, clientHash);
+                Logger.ClientCloseComplete(nameof(PartitionReceiver), EventHubName, Identifier);
             }
 
             // If there was an active exception pending from closing the transport
@@ -539,25 +578,6 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
-
-        /// <summary>
-        ///   Creates an <see cref="TransportConsumer" /> to use for reading events.
-        /// </summary>
-        ///
-        /// <param name="consumerGroup">The name of the consumer group the consumer will be associated with.  Events will be read in the context of this group.</param>
-        /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
-        /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
-        /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
-        /// <param name="options">A set of options to apply when configuring the consumer.</param>
-        ///
-        /// <returns>A <see cref="TransportConsumer" /> configured in the requested manner.</returns>
-        ///
-        internal virtual TransportConsumer CreateTransportConsumer(string consumerGroup,
-                                                                   string partitionId,
-                                                                   EventPosition eventPosition,
-                                                                   EventHubsRetryPolicy retryPolicy,
-                                                                   PartitionReceiverOptions options) =>
-            Connection.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, options.TrackLastEnqueuedEventProperties, InvalidateConsumerWhenPartitionIsStolen, options.OwnerLevel, (uint?)options.PrefetchCount, options.PrefetchSizeInBytes);
 
         /// <summary>
         ///   Receives a batch of <see cref="EventData" /> from the Event Hub partition this client is associated with.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
@@ -82,6 +82,13 @@ namespace Azure.Messaging.EventHubs.Primitives
         }
 
         /// <summary>
+        ///   A unique name used to identify the receiver.  If <c>null</c> or empty, a GUID will be used as the
+        ///   identifier.
+        /// </summary>
+        ///
+        public string Identifier { get; set; }
+
+        /// <summary>
         ///   When populated, the owner level indicates that a reading is intended to be performed exclusively for events in the
         ///   requested partition and for the associated consumer group.  To do so, reading will attempt to assert ownership
         ///   over the partition; in the case where more than one exclusive reader attempts to assert ownership for the same
@@ -219,6 +226,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                 _defaultMaximumReceiveWaitTime = DefaultMaximumReceiveWaitTime,
                 _prefetchCount = PrefetchCount,
                 _prefetchSizeInBytes = PrefetchSizeInBytes,
+                Identifier = Identifier,
                 OwnerLevel = OwnerLevel,
                 TrackLastEnqueuedEventProperties = TrackLastEnqueuedEventProperties
             };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClientOptions.cs
@@ -22,6 +22,13 @@ namespace Azure.Messaging.EventHubs.Producer
         private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
 
         /// <summary>
+        ///   A unique name used to identify the consumer.  If <c>null</c> or empty, a GUID will be used as the
+        ///   identifier.
+        /// </summary>
+        ///
+        public string Identifier { get; set; }
+
+        /// <summary>
         ///   Indicates whether or not the producer should enable idempotent publishing to the Event Hub partitions.  If
         ///   enabled, the producer will only be able to publish directly to partitions; it will not be able to publish to
         ///   the Event Hubs gateway for automatic partition routing nor using a partition key.
@@ -115,6 +122,7 @@ namespace Azure.Messaging.EventHubs.Producer
         {
             var copiedOptions = new EventHubProducerClientOptions
             {
+                Identifier = Identifier,
                 EnableIdempotentPartitions = EnableIdempotentPartitions,
                 _connectionOptions = ConnectionOptions.Clone(),
                 _retryOptions = RetryOptions.Clone()

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
@@ -732,7 +732,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var client = new AmqpClient("my.eventhub.com", "somePath", credential.Object, new EventHubConnectionOptions());
             await client.CloseAsync(cancellationSource.Token);
 
-            Assert.That(() => client.CreateConsumer("group", "0", EventPosition.Earliest, Mock.Of<EventHubsRetryPolicy>(), false, false, null, null, null), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+            Assert.That(() => client.CreateConsumer("group", "0", "id", EventPosition.Earliest, Mock.Of<EventHubsRetryPolicy>(), false, false, null, null, null), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
         }
 
         /// <summary>
@@ -749,7 +749,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var client = new AmqpClient("my.eventhub.com", "somePath", credential.Object, new EventHubConnectionOptions());
             await client.CloseAsync(cancellationSource.Token);
 
-            Assert.That(() => client.CreateProducer(null, TransportProducerFeatures.None, null, Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+            Assert.That(() => client.CreateProducer(null, "", TransportProducerFeatures.None, null, Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -59,7 +59,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheEventHubName(string eventHub)
         {
-            Assert.That(() => new AmqpConsumer(eventHub, "$DEFAULT", "0", EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpConsumer(eventHub, "$DEFAULT", "0", null, EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheConsumerGroup(string group)
         {
-            Assert.That(() => new AmqpConsumer("myHub", group, "0", EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpConsumer("myHub", group, "0", "", EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresThePartition(string partition)
         {
-            Assert.That(() => new AmqpConsumer("aHub", "$DEFAULT", partition, EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpConsumer("aHub", "$DEFAULT", partition, "te5t-z", EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheConnectionScope()
         {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), true, false, null, null, null, null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", null, EventPosition.FromSequenceNumber(123), true, false, null, null, null, null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheMessageConverter()
         {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), null, Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", "", EventPosition.FromSequenceNumber(123), true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), null, Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheRetryPolicy()
         {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.Latest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), null), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", "fake", EventPosition.Latest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), null), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CloseMarksTheConsumerAsClosed()
         {
-            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
+            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", "dummy", EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(consumer.IsClosed, Is.False, "The consumer should not be closed on creation");
 
             await consumer.CloseAsync(CancellationToken.None);
@@ -139,7 +139,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CloseRespectsTheCancellationToken()
         {
-            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
+            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", null, EventPosition.Earliest, true, false, null, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             using var cancellationSource = new CancellationTokenSource();
 
             cancellationSource.Cancel();
@@ -161,6 +161,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "eventHubName";
             var consumerGroup = "$DEFAULT";
             var partition = "3";
+            var identifier = "cusTOM-1D";
             var eventPosition = EventPosition.FromOffset(123);
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var retriableException = new EventHubsException(true, "Test");
@@ -170,7 +171,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using var cancellationSource = new CancellationTokenSource();
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, true, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, identifier, eventPosition, true, true, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(count, null, cancellationSource.Token), Throws.InstanceOf<ArgumentException>());
         }
 
@@ -185,6 +186,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "eventHubName";
             var consumerGroup = "$DEFAULT";
             var partition = "3";
+            var identifier = "cusTOM-1D";
             var eventPosition = EventPosition.FromOffset(123);
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var retriableException = new EventHubsException(true, "Test");
@@ -195,7 +197,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, true, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, identifier, eventPosition, true, true, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
@@ -212,6 +214,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "eventHubName";
             var consumerGroup = "$DEFAULT";
             var partition = "3";
+            var identifier = "cusTOM-1D";
             var eventPosition = EventPosition.FromOffset(123);
             var trackLastEnqueued = false;
             var invalidateOnSteal = true;
@@ -239,10 +242,11 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<long?>(),
                    It.IsAny<long?>(),
                    It.IsAny<bool>(),
+                   It.IsAny<string>(),
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, identifier, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
 
             mockScope
@@ -255,6 +259,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<long?>(),
                     It.Is<long?>(value => value == ownerLevel),
                     It.Is<bool>(value => value == trackLastEnqueued),
+                    It.Is<string>(value => value == identifier),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(1 + retryOptions.MaximumRetries));
         }
@@ -271,6 +276,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "eventHubName";
             var consumerGroup = "$DEFAULT";
             var partition = "3";
+            var identifier = "cusTOM-1D";
             var eventPosition = EventPosition.FromOffset(123);
             var trackLastEnqueued = false;
             var invalidateOnSteal = true;
@@ -298,10 +304,11 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<long?>(),
                    It.IsAny<long?>(),
                    It.IsAny<bool>(),
+                   It.IsAny<string>(),
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, identifier, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
 
             mockScope
@@ -314,6 +321,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<long?>(),
                     It.Is<long?>(value => value == ownerLevel),
                     It.Is<bool>(value => value == trackLastEnqueued),
+                    It.Is<string>(value => value == identifier),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(1 + retryOptions.MaximumRetries));
         }
@@ -331,6 +339,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "eventHubName";
             var consumerGroup = "$DEFAULT";
             var partition = "3";
+            var identifier = "cusTOM-1D";
             var eventPosition = EventPosition.FromOffset(123);
             var trackLastEnqueued = false;
             var invalidateOnSteal = true;
@@ -358,10 +367,11 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<long?>(),
                    It.IsAny<long?>(),
                    It.IsAny<bool>(),
+                   It.IsAny<string>(),
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, identifier, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
 
             mockScope
@@ -374,6 +384,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<long?>(),
                     It.Is<long?>(value => value == ownerLevel),
                     It.Is<bool>(value => value == trackLastEnqueued),
+                    It.Is<string>(value => value == identifier),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(1 + retryOptions.MaximumRetries));
         }
@@ -389,6 +400,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "eventHubName";
             var consumerGroup = "$DEFAULT";
             var partition = "3";
+            var identifier = "cusTOM-1D";
             var eventPosition = EventPosition.FromOffset(123);
             var trackLastEnqueued = false;
             var invalidateOnSteal = true;
@@ -416,10 +428,11 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<long?>(),
                    It.IsAny<long?>(),
                    It.IsAny<bool>(),
+                   It.IsAny<string>(),
                    It.IsAny<CancellationToken>()))
                .Throws(embeddedException);
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, identifier, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<OperationCanceledException>());
 
             mockScope
@@ -432,6 +445,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<long?>(),
                     It.Is<long?>(value => value == ownerLevel),
                     It.Is<bool>(value => value == trackLastEnqueued),
+                    It.Is<string>(value => value == identifier),
                     It.IsAny<CancellationToken>()),
                 Times.Once());
         }
@@ -447,6 +461,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "eventHubName";
             var consumerGroup = "$DEFAULT";
             var partition = "3";
+            var identifier = "cusTOM-1D";
             var eventPosition = EventPosition.FromOffset(123);
             var trackLastEnqueued = false;
             var invalidateOnSteal = true;
@@ -474,10 +489,11 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<long?>(),
                    It.IsAny<long?>(),
                    It.IsAny<bool>(),
+                   It.IsAny<string>(),
                    It.IsAny<CancellationToken>()))
                .Throws(embeddedException);
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, identifier, eventPosition, trackLastEnqueued, invalidateOnSteal, ownerLevel, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<OperationCanceledException>());
 
             mockScope
@@ -490,6 +506,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<long?>(),
                     It.Is<long?>(value => value == ownerLevel),
                     It.Is<bool>(value => value == trackLastEnqueued),
+                    It.Is<string>(value => value == identifier),
                     It.IsAny<CancellationToken>()),
                 Times.Once());
         }
@@ -505,6 +522,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "eventHubName";
             var consumerGroup = "$DEFAULT";
             var partition = "3";
+            var identifier = "cusTOM-1D";
             var eventPosition = EventPosition.FromOffset(123);
             var options = new EventHubConsumerClientOptions();
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
@@ -515,7 +533,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using var cancellationSource = new CancellationTokenSource();
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, false, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, identifier, eventPosition, true, false, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             await consumer.CloseAsync(cancellationSource.Token);
 
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
@@ -533,13 +551,14 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "eventHubName";
             var consumerGroup = "$DEFAULT";
             var partition = "3";
+            var identifier = "cusTOM-1D";
             var eventPosition = EventPosition.FromOffset(123);
             var options = new EventHubConsumerClientOptions();
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
             var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, false, null, null, null, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, identifier, eventPosition, true, false, null, null, null, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
 
             scope.Dispose();
 
@@ -612,7 +631,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             try
             {
-                await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None);
+                await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", "", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None);
             }
             catch (Exception ex)
             {
@@ -665,6 +684,7 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<long?>(),
                    It.IsAny<long?>(),
                    It.IsAny<bool>(),
+                   It.IsAny<string>(),
                    It.IsAny<CancellationToken>()),
                Times.Never);
         }
@@ -682,9 +702,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockConsumer = new MockAmqpConsumer(eventHub, false, terminalException);
 
             SetActivePartitionStolenException(mockConsumer, terminalException);
-            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the first call.");
-            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.Nothing, "The second call should not throw.");
-            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.Nothing, "The third call should not throw.");
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", null, EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the first call.");
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", "", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.Nothing, "The second call should not throw.");
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", "fake-id", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.Nothing, "The third call should not throw.");
 
             var capturedException = GetActivePartitionStolenException(mockConsumer);
             Assert.That(capturedException, Is.Null, "The active exception should have been cleared after it was surfaced.");
@@ -703,9 +723,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockConsumer = new MockAmqpConsumer(eventHub, true, terminalException);
 
             SetActivePartitionStolenException(mockConsumer, terminalException);
-            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the first call.");
-            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the second call.");
-            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the third call.");
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", "fake-id", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the first call.");
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", "", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the second call.");
+            Assert.That(async () => await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", null, EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None), Throws.InstanceOf(terminalException.GetType()), "The exception should have been surfaced on the third call.");
 
             var capturedException = GetActivePartitionStolenException(mockConsumer);
             Assert.That(capturedException, Is.SameAs(terminalException), "The active exception should have been preserved after the calls were completed.");
@@ -735,6 +755,7 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<long?>(),
                    It.IsAny<long?>(),
                    It.IsAny<bool>(),
+                   It.IsAny<string>(),
                    It.IsAny<CancellationToken>()))
                .Throws(terminalException);
 
@@ -808,7 +829,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public MockAmqpConsumer(string eventHubName,
                                     bool invalidateConsumerWhenPartitionIsStolen,
                                     Mock<AmqpConnectionScope> mockConnectionScope,
-                                    Exception transformedTerminalException) : base(eventHubName, "fake", "0", EventPosition.Earliest, true, invalidateConsumerWhenPartitionIsStolen, null, null, null, mockConnectionScope.Object, new(), new BasicRetryPolicy(new()))
+                                    Exception transformedTerminalException) : base(eventHubName, "fake", "0", "mock-1", EventPosition.Earliest, true, invalidateConsumerWhenPartitionIsStolen, null, null, null, mockConnectionScope.Object, new(), new BasicRetryPolicy(new()))
             {
                 MockConnectionScope = mockConnectionScope;
                 TransformedTerminalException = transformedTerminalException;
@@ -816,13 +837,14 @@ namespace Azure.Messaging.EventHubs.Tests
 
             public Task<ReceivingAmqpLink> InvokeCreateConsumerLinkAsync(string consumerGroup,
                                                                          string partitionId,
+                                                                         string consumerIdentifier,
                                                                          EventPosition eventStartingPosition,
                                                                          uint prefetchCount,
                                                                          long? prefetchSizeInBytes,
                                                                          long? ownerLevel,
                                                                          bool trackLastEnqueuedEventProperties,
                                                                          TimeSpan timeout,
-                                                                         CancellationToken cancellationToken) => CreateConsumerLinkAsync(consumerGroup, partitionId, eventStartingPosition, prefetchCount, prefetchSizeInBytes, ownerLevel, trackLastEnqueuedEventProperties, timeout, cancellationToken);
+                                                                         CancellationToken cancellationToken) => CreateConsumerLinkAsync(consumerGroup, partitionId, consumerIdentifier, eventStartingPosition, prefetchCount, prefetchSizeInBytes, ownerLevel, trackLastEnqueuedEventProperties, timeout, cancellationToken);
 
             public void InvokeCloseConsumerLink(ReceivingAmqpLink link) => CloseConsumerLink(link);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheEventHubName(string eventHub)
         {
-            Assert.That(() => new AmqpProducer(eventHub, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpProducer(eventHub, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheConnectionScope()
         {
-            Assert.That(() => new AmqpProducer("theMostAwesomeHubEvar", "0", null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>(), TransportProducerFeatures.IdempotentPublishing), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpProducer("theMostAwesomeHubEvar", "0", "", null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>(), TransportProducerFeatures.IdempotentPublishing), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheRetryPolicy()
         {
-            Assert.That(() => new AmqpProducer("theMostAwesomeHubEvar", null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), null, TransportProducerFeatures.IdempotentPublishing, new PartitionPublishingOptions()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpProducer("theMostAwesomeHubEvar", null, "fake-id", Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), null, TransportProducerFeatures.IdempotentPublishing, new PartitionPublishingOptions()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CloseMarksTheProducerAsClosed()
         {
-            var producer = new AmqpProducer("aHub", "0", Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
+            var producer = new AmqpProducer("aHub", "0", "fake-", Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(producer.IsClosed, Is.False, "The producer should not be closed on creation");
 
             await producer.CloseAsync(CancellationToken.None);
@@ -93,7 +93,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CloseRespectsTheCancellationToken()
         {
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
+            var producer = new AmqpProducer("aHub", null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             using var cancellationSource = new CancellationTokenSource();
 
             cancellationSource.Cancel();
@@ -111,7 +111,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedOptions = new PartitionPublishingOptions { ProducerGroupId = 1, OwnerLevel = 4, StartingSequenceNumber = 88 };
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.IdempotentPublishing, expectedOptions)
+            var producer = new Mock<AmqpProducer>("aHub", null, null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.IdempotentPublishing, expectedOptions)
             {
                 CallBase = true
             };
@@ -119,6 +119,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -135,6 +136,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Verify<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync", Times.Once(),
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.Is<PartitionPublishingOptions>(options => areOptionsEqual(options, expectedOptions)),
                     ItExpr.IsAny<TimeSpan>(),
@@ -153,7 +155,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
             var mockConnectionScope = new Mock<AmqpConnectionScope>();
 
-            var producer = new Mock<AmqpProducer>("aHub", null, mockConnectionScope.Object, new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.IdempotentPublishing, expectedOptions)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", mockConnectionScope.Object, new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.IdempotentPublishing, expectedOptions)
             {
                 CallBase = true
             };
@@ -164,6 +166,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<TransportProducerFeatures>(),
                     It.Is<PartitionPublishingOptions>(options => options.StartingSequenceNumber == expectedOptions.StartingSequenceNumber),
                     It.IsAny<TimeSpan>(),
+                    It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings { MaxMessageSize = 512 })))
                .Verifiable();
@@ -184,7 +187,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CreateBatchAsyncValidatesTheOptions()
         {
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
+            var producer = new AmqpProducer("aHub", null, "", Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(async () => await producer.CreateBatchAsync(null, CancellationToken.None), Throws.ArgumentNullException);
         }
 
@@ -200,7 +203,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -210,6 +213,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 producer
                     .Protected()
                     .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                        ItExpr.IsAny<string>(),
                         ItExpr.IsAny<string>(),
                         ItExpr.IsAny<PartitionPublishingOptions>(),
                         ItExpr.IsAny<TimeSpan>(),
@@ -237,6 +241,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqps://not.real.com");
             var eventHub = "eventHubName";
             var partition = "3";
+            var identifier = "cusTOM-1D";
             var options = new EventHubProducerClientOptions();
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
@@ -244,7 +249,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
             scope.Dispose();
 
-            var producer = new AmqpProducer(eventHub, partition, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var producer = new AmqpProducer(eventHub, partition, identifier, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             await producer.CloseAsync(CancellationToken.None);
 
             Assert.That(async () => await producer.CreateBatchAsync(new CreateBatchOptions(), CancellationToken.None),
@@ -260,7 +265,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CreateBatchAsyncEnsuresMaximumMessageSizeIsPopulated()
         {
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -268,6 +273,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -292,7 +298,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { MaximumSizeInBytes = null };
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -300,6 +306,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -324,7 +331,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { MaximumSizeInBytes = expectedMaximumSize };
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -332,6 +339,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -356,7 +364,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { MaximumSizeInBytes = 1024 };
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -364,6 +372,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -386,7 +395,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { MaximumSizeInBytes = 512 };
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -394,6 +403,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -421,7 +431,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -429,6 +439,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -459,10 +470,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateBatchAsyncAppliesTheRetryPolicy(EventHubsRetryOptions retryOptions)
         {
             var partitionId = "testMe";
+            var identifier = "customIDE34";
             var retriableException = new EventHubsException(true, "Test");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
 
-            var producer = new Mock<AmqpProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", partitionId, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -470,6 +482,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -483,6 +496,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == partitionId),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -498,10 +512,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateBatchAsyncConsidersOperationCanceledExceptionAsRetriable(EventHubsRetryOptions retryOptions)
         {
             var partitionId = "testMe";
+            var identifier = "testIDEntif13r";
             var retriableException = new OperationCanceledException();
             var retryPolicy = new BasicRetryPolicy(retryOptions);
 
-            var producer = new Mock<AmqpProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", partitionId, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -509,6 +524,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -522,6 +538,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == partitionId),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -537,10 +554,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateBatchAsyncAppliesTheRetryPolicyForAmqpErrors(EventHubsRetryOptions retryOptions)
         {
             var partitionId = "testMe";
+            var identifier = "testIDEntif13r";
             var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
 
-            var producer = new Mock<AmqpProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", partitionId, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -548,6 +566,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -561,6 +580,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == partitionId),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -575,9 +595,10 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateBatchAsyncDetectsAnEmbeddedErrorForOperationCanceled()
         {
             var embeddedException = new OperationCanceledException("", new ArgumentNullException());
+            var identifier = "testIDEntif13r";
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -585,6 +606,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -598,6 +620,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Once(),
                     ItExpr.Is<string>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -612,9 +635,10 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateBatchAsyncDetectsAnEmbeddedAmqpErrorForOperationCanceled()
         {
             var embeddedException = new OperationCanceledException("", new AmqpException(new Error { Condition = AmqpError.ArgumentError }));
+            var identifier = "testIDEntif13r";
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -622,6 +646,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -635,6 +660,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Once(),
                     ItExpr.Is<string>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -652,7 +678,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -662,6 +688,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 producer
                     .Protected()
                     .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                        ItExpr.IsAny<string>(),
                         ItExpr.IsAny<string>(),
                         ItExpr.IsAny<PartitionPublishingOptions>(),
                         ItExpr.IsAny<TimeSpan>(),
@@ -692,6 +719,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqps://not.real.com");
             var eventHub = "eventHubName";
             var partition = "3";
+            var identifier = "testIDEntif13r";
             var options = new EventHubProducerClientOptions();
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
@@ -699,7 +727,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
             scope.Dispose();
 
-            var producer = new AmqpProducer(eventHub, partition, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var producer = new AmqpProducer(eventHub, partition, identifier, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             await producer.CloseAsync(CancellationToken.None);
 
             Assert.That(async () => await producer.ReadInitializationPublishingPropertiesAsync(CancellationToken.None),
@@ -716,7 +744,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedProperties = new PartitionPublishingProperties(false, null, null, null);
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -724,6 +752,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -746,7 +775,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedProperties = new PartitionPublishingProperties(true, 3, 17, 32768);
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -754,6 +783,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -779,7 +809,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedProperties = new PartitionPublishingProperties(true, 3, 17, 32768);
             var callbackProperties = expectedProperties;
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -787,6 +817,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -815,6 +846,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync", Times.Once(),
                     ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -830,7 +862,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -838,6 +870,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -862,10 +895,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ReadInitializationPublishingPropertiesAsyncAppliesTheRetryPolicy(EventHubsRetryOptions retryOptions)
         {
             var partitionId = "testMe";
+            var identifier = "customID234";
             var retriableException = new EventHubsException(true, "Test");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
 
-            var producer = new Mock<AmqpProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", partitionId, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -873,6 +907,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -886,6 +921,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == partitionId),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -904,7 +940,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var retriableException = new OperationCanceledException();
             var retryPolicy = new BasicRetryPolicy(retryOptions);
 
-            var producer = new Mock<AmqpProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", partitionId, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -912,6 +948,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -925,6 +962,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == partitionId),
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -940,10 +978,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ReadInitializationPublishingPropertiesAsyncAppliesTheRetryPolicyForAmqpErrors(EventHubsRetryOptions retryOptions)
         {
             var partitionId = "testMe";
+            var identifier = "123~~";
             var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
 
-            var producer = new Mock<AmqpProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", partitionId, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -951,6 +990,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -964,6 +1004,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == partitionId),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -978,9 +1019,10 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ReadInitializationPublishingPropertiesAsyncDetectsAnEmbeddedErrorForOperationCanceled()
         {
             var embeddedException = new OperationCanceledException("", new ArgumentNullException());
+            var identifier = "!!!!";
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -988,6 +1030,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1001,6 +1044,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Once(),
                     ItExpr.Is<string>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -1017,7 +1061,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var embeddedException = new OperationCanceledException("", new AmqpException(new Error { Condition = AmqpError.ArgumentError }));
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1025,6 +1069,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1038,6 +1083,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Once(),
                     ItExpr.Is<string>(value => value == null),
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -1051,7 +1097,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void SendEnumerableValidatesTheEvents()
         {
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>(), TransportProducerFeatures.None);
+            var producer = new AmqpProducer("aHub", null, null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>(), TransportProducerFeatures.None);
             Assert.That(async () => await producer.SendAsync(null, new SendEventOptions(), CancellationToken.None), Throws.ArgumentNullException);
         }
 
@@ -1063,7 +1109,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task SendEnumerableEnsuresNotClosed()
         {
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>(), TransportProducerFeatures.IdempotentPublishing);
+            var producer = new AmqpProducer("aHub", null, null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>(), TransportProducerFeatures.IdempotentPublishing);
             await producer.CloseAsync(CancellationToken.None);
 
             Assert.That(async () => await producer.SendAsync(Enumerable.Empty<EventData>(), new SendEventOptions(), CancellationToken.None), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
@@ -1080,12 +1126,13 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqps://not.real.com");
             var eventHub = "eventHubName";
             var partition = "3";
+            var identifier = "testIDEntif13r";
             var options = new EventHubProducerClientOptions();
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
             var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
-            var producer = new AmqpProducer(eventHub, partition, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var producer = new AmqpProducer(eventHub, partition, identifier, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
 
             scope.Dispose();
 
@@ -1105,7 +1152,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new SendEventOptions { PartitionKey = expectedPartitionKey };
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1137,7 +1184,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var messageFactory = default(Func<AmqpMessage>);
             var events = new[] { new EventData(new byte[] { 0x15 }) };
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>(), TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>(), TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1171,7 +1218,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using CancellationTokenSource cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>());
+            var producer = new AmqpProducer("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(async () => await producer.SendAsync(new[] { new EventData(new byte[] { 0x15 }) }, new SendEventOptions(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
@@ -1185,10 +1232,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendEnumerableAppliesTheRetryPolicy(EventHubsRetryOptions retryOptions)
         {
             var partitionId = "testMe";
+            var identifier = "customID3234";
             var retriableException = new EventHubsException(true, "Test");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
 
-            var producer = new Mock<AmqpProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", partitionId, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1196,6 +1244,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1209,6 +1258,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == partitionId),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -1224,10 +1274,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendEnumerableConsidersOperationCanceledExceptionAsRetriable(EventHubsRetryOptions retryOptions)
         {
             var partitionId = "testMe";
+            var identifier = "customID3234";
             var retriableException = new OperationCanceledException();
             var retryPolicy = new BasicRetryPolicy(retryOptions);
 
-            var producer = new Mock<AmqpProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", partitionId, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1235,6 +1286,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1248,6 +1300,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == partitionId),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -1263,10 +1316,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendEnumerableAppliesTheRetryPolicyForAmqpErrors(EventHubsRetryOptions retryOptions)
         {
             var partitionId = "testMe";
+            var identifier = "customID3234";
             var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
 
-            var producer = new Mock<AmqpProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", partitionId, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1274,6 +1328,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1287,6 +1342,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == partitionId),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -1301,9 +1357,10 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendEnumerableDetectsAnEmbeddedErrorForOperationCanceled()
         {
             var embeddedException = new OperationCanceledException("", new ArgumentNullException());
+            var identifier = "customID3234";
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1311,6 +1368,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1324,6 +1382,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Once(),
                     ItExpr.Is<string>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -1338,9 +1397,10 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendEnumerableDetectsAnEmbeddedAmqpErrorForOperationCanceled()
         {
             var embeddedException = new OperationCanceledException("", new AmqpException(new Error { Condition = AmqpError.ArgumentError }));
+            var identifier = "customID3234";
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1348,6 +1408,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1361,6 +1422,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Once(),
                     ItExpr.Is<string>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -1374,7 +1436,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void SendBatchValidatesTheBatch()
         {
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>());
+            var producer = new AmqpProducer("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(async () => await producer.SendAsync(null, CancellationToken.None), Throws.ArgumentNullException);
         }
 
@@ -1390,7 +1452,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { MaximumSizeInBytes = null };
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1398,6 +1460,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1422,12 +1485,13 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqps://not.real.com");
             var eventHub = "eventHubName";
             var partition = "3";
+            var identifier = "customID3234";
             var options = new EventHubProducerClientOptions();
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
             var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
-            var producer = new AmqpProducer(eventHub, partition, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var producer = new AmqpProducer(eventHub, partition, identifier, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
 
             scope.Dispose();
 
@@ -1448,7 +1512,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = expectedPartitionKey };
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1456,6 +1520,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1494,7 +1559,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitonKey };
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1502,6 +1567,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1544,7 +1610,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { MaximumSizeInBytes = null };
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1552,6 +1618,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1590,7 +1657,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions();
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1598,6 +1665,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1622,12 +1690,13 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendBatchAppliesTheRetryPolicy(EventHubsRetryOptions retryOptions)
         {
             var partitionKey = "testMe";
+            var identifier = "customID3234";
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = new EventHubsException(true, "Test");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
             var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1635,6 +1704,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1648,6 +1718,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -1663,12 +1734,13 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendBatchConsidersOperationCanceledExceptionAsRetriable(EventHubsRetryOptions retryOptions)
         {
             var partitionKey = "testMe";
+            var identifier = "customID3234";
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = new OperationCanceledException();
             var retryPolicy = new BasicRetryPolicy(retryOptions);
             var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1676,6 +1748,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1689,6 +1762,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -1704,12 +1778,13 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendBatchAppliesTheRetryPolicyForAmqpErrors(EventHubsRetryOptions retryOptions)
         {
             var partitionKey = "testMe";
+            var identifier = "customID3234";
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
             var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1717,6 +1792,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1730,6 +1806,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
                     ItExpr.Is<string>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -1744,12 +1821,13 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendBatchDetectsAnEmbeddedErrorForOperationCanceled()
         {
             var partitionKey = "testMe";
+            var identifier = "customID3234";
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var embeddedException = new OperationCanceledException("", new ArgumentNullException());
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1757,6 +1835,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1770,6 +1849,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Once(),
                     ItExpr.Is<string>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -1784,12 +1864,13 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendBatchDetectsAnEmbeddedAmqpErrorForOperationCanceled()
         {
             var partitionKey = "testMe";
+            var identifier = "customID3234";
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var embeddedException = new OperationCanceledException("", new AmqpException(new Error { Condition = AmqpError.ArgumentError }));
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
+            var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
                 CallBase = true
             };
@@ -1797,6 +1878,7 @@ namespace Azure.Messaging.EventHubs.Tests
             producer
                 .Protected()
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
@@ -1810,6 +1892,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Protected()
                 .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Once(),
                     ItExpr.Is<string>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<PartitionPublishingOptions>(),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>());

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
@@ -604,7 +604,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateConsumerRequiresConsumerGroup(string consumerGroup)
         {
             var connection = new EventHubConnection("Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real]", "fake", new EventHubConnectionOptions());
-            Assert.That(() => connection.CreateTransportConsumer(consumerGroup, "partition1", EventPosition.Earliest, Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => connection.CreateTransportConsumer(consumerGroup, "partition1", "", EventPosition.Earliest, Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -618,7 +618,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateConsumerRequiresPartition(string partition)
         {
             var connection = new EventHubConnection("Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real]", "fake", new EventHubConnectionOptions());
-            Assert.That(() => connection.CreateTransportConsumer("someGroup", partition, EventPosition.Earliest, Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => connection.CreateTransportConsumer("someGroup", partition, null, EventPosition.Earliest, Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -630,7 +630,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateConsumerRequiresRetryPolicy()
         {
             var connection = new EventHubConnection("Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real]", "fake", new EventHubConnectionOptions());
-            Assert.That(() => connection.CreateTransportConsumer("someGroup", "0", EventPosition.Earliest, null), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => connection.CreateTransportConsumer("someGroup", "0", "someId", EventPosition.Earliest, null), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -722,15 +722,17 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var transportClient = new ObservableTransportClientMock();
             var connection = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
-            var options = new EventHubProducerClientOptions { EnableIdempotentPartitions = true, RetryOptions = new EventHubsRetryOptions { MaximumRetries = 6, TryTimeout = TimeSpan.FromMinutes(4) } };
+            var options = new EventHubProducerClientOptions { Identifier = "test-id", EnableIdempotentPartitions = true, RetryOptions = new EventHubsRetryOptions { MaximumRetries = 6, TryTimeout = TimeSpan.FromMinutes(4) } };
+            var expectedIdentifier = options.Identifier;
             var expectedFeatures = options.CreateFeatureFlags();
             var expectedPartitionOptions = new PartitionPublishingOptions { ProducerGroupId = 123 };
             var expectedRetry = options.RetryOptions.ToRetryPolicy();
 
-            connection.CreateTransportProducer(null, expectedFeatures, expectedPartitionOptions, expectedRetry);
+            connection.CreateTransportProducer(null, expectedIdentifier, expectedFeatures, expectedPartitionOptions, expectedRetry);
 
             Assert.That(transportClient.CreateProducerCalledWith, Is.Not.Null, "The producer options should have been set.");
             Assert.That(transportClient.CreateProducerCalledWith.PartitionId, Is.Null, "There should have been no partition specified.");
+            Assert.That(transportClient.CreateProducerCalledWith.Identifier, Is.EqualTo(expectedIdentifier), "The identifier should match.");
             Assert.That(transportClient.CreateProducerCalledWith.Features, Is.EqualTo(expectedFeatures), "The features should match.");
             Assert.That(transportClient.CreateProducerCalledWith.PartitionOptions, Is.Not.Null, "The partition options should have been specified.");
             Assert.That(transportClient.CreateProducerCalledWith.PartitionOptions, Is.SameAs(expectedPartitionOptions), "The partition options should match.");
@@ -750,6 +752,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var connection = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
             var expectedPosition = EventPosition.FromOffset(65);
             var expectedPartition = "2123";
+            var expectedIdentifier = "OMG-ID";
             var expectedConsumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
             var expectedRetryPolicy = new EventHubsRetryOptions { MaximumRetries = 67 }.ToRetryPolicy();
             var expectedTrackLastEnqueued = false;
@@ -757,11 +760,12 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedPrefetch = 99U;
             var expectedOwnerLevel = 123L;
 
-            connection.CreateTransportConsumer(expectedConsumerGroup, expectedPartition, expectedPosition, expectedRetryPolicy, expectedTrackLastEnqueued, expectedInvalidateConsumerWhenPartitionIsStolen, expectedOwnerLevel, expectedPrefetch);
-            (var actualConsumerGroup, var actualPartition, EventPosition actualPosition, var actualRetry, var actualTrackLastEnqueued, var actualInvalidateConsumerWhenPartitionIsStolen, var actualOwnerLevel, var actualPrefetch) = transportClient.CreateConsumerCalledWith;
+            connection.CreateTransportConsumer(expectedConsumerGroup, expectedPartition, expectedIdentifier, expectedPosition, expectedRetryPolicy, expectedTrackLastEnqueued, expectedInvalidateConsumerWhenPartitionIsStolen, expectedOwnerLevel, expectedPrefetch);
+            (var actualConsumerGroup, var actualPartition, var actualIdentifier, EventPosition actualPosition, var actualRetry, var actualTrackLastEnqueued, var actualInvalidateConsumerWhenPartitionIsStolen, var actualOwnerLevel, var actualPrefetch) = transportClient.CreateConsumerCalledWith;
 
             Assert.That(actualPartition, Is.EqualTo(expectedPartition), "The partition should have been passed.");
-            Assert.That(actualConsumerGroup, Is.EqualTo(expectedConsumerGroup), "The consumer groups should match.");
+            Assert.That(actualConsumerGroup, Is.EqualTo(expectedConsumerGroup), "The consumer group should match.");
+            Assert.That(actualIdentifier, Is.EqualTo(expectedIdentifier), "The identifier should match.");
             Assert.That(actualPosition.Offset, Is.EqualTo(expectedPosition.Offset), "The event position to receive should match.");
             Assert.That(actualRetry, Is.SameAs(expectedRetryPolicy), "The retryPolicy should match.");
             Assert.That(actualOwnerLevel, Is.EqualTo(expectedOwnerLevel), "The owner levels should match.");
@@ -1033,8 +1037,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private class ObservableTransportClientMock : TransportClient
         {
-            public (string ConsumerGroup, string Partition, EventPosition Position, EventHubsRetryPolicy RetryPolicy, bool TrackLastEnqueued, bool InvalidateOnSteal, long? OwnerLevel, uint? Prefetch) CreateConsumerCalledWith;
-            public (string PartitionId, TransportProducerFeatures Features, PartitionPublishingOptions PartitionOptions, EventHubsRetryPolicy RetryPolicy) CreateProducerCalledWith;
+            public (string ConsumerGroup, string Partition, string Identifier, EventPosition Position, EventHubsRetryPolicy RetryPolicy, bool TrackLastEnqueued, bool InvalidateOnSteal, long? OwnerLevel, uint? Prefetch) CreateConsumerCalledWith;
+            public (string PartitionId, string Identifier, TransportProducerFeatures Features, PartitionPublishingOptions PartitionOptions, EventHubsRetryPolicy RetryPolicy) CreateProducerCalledWith;
             public string GetPartitionPropertiesCalledForId;
             public bool WasGetPropertiesCalled;
             public bool WasCloseCalled;
@@ -1055,16 +1059,18 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             public override TransportProducer CreateProducer(string partitionId,
+                                                             string producerIdentifier,
                                                              TransportProducerFeatures requestedFeatures,
                                                              PartitionPublishingOptions partitionOptions,
                                                              EventHubsRetryPolicy retryPolicy)
             {
-                CreateProducerCalledWith = (partitionId, requestedFeatures, partitionOptions, retryPolicy);
+                CreateProducerCalledWith = (partitionId, producerIdentifier, requestedFeatures, partitionOptions, retryPolicy);
                 return default;
             }
 
             public override TransportConsumer CreateConsumer(string consumerGroup,
                                                              string partitionId,
+                                                             string consumerIdentifier,
                                                              EventPosition eventPosition,
                                                              EventHubsRetryPolicy retryPolicy,
                                                              bool trackLastEnqueuedEventProperties = true,
@@ -1073,7 +1079,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                              uint? prefetchCount = default,
                                                              long? prefechSize = default)
             {
-                CreateConsumerCalledWith = (consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, invalidateConsumerWhenPartitionIsStolen, ownerLevel, prefetchCount);
+                CreateConsumerCalledWith = (consumerGroup, partitionId, consumerIdentifier, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, invalidateConsumerWhenPartitionIsStolen, ownerLevel, prefetchCount);
                 return default;
             }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -40,6 +40,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>A set of options for reading using a small prefetch buffer.</summary>
         private readonly ReadEventOptions LowPrefetchReadOptions = new ReadEventOptions { PrefetchCount = LowPrefetchCount };
+
         /// <summary>
         ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
         ///   connect to the Event Hubs service and perform operations.
@@ -298,6 +299,44 @@ namespace Azure.Messaging.EventHubs.Tests
                 var sourceEvents = EventGenerator.CreateEvents(200).ToList();
 
                 await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Read the events and validate the resulting state.
+
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, sourceEvents.Count, cancellationSource.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    foreach (var sourceEvent in sourceEvents)
+                    {
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed.");
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+                    }
+                }
+
+                cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerWithAnIdentifierCanReadEvents()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+                var connectionString = EventHubsTestEnvironment.Instance.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(200).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, new EventHubConsumerClientOptions { Identifier = "BobTheConsumer" }))
                 {
                     var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
                     await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
@@ -864,6 +903,60 @@ namespace Azure.Messaging.EventHubs.Tests
                 }
 
                 cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCanReadConcurrentlyFromMultiplePartitions()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+                var connectionString = EventHubsTestEnvironment.Instance.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(200).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, new EventHubConsumerClientOptions { Identifier = "BobTheConsumer" }))
+                {
+                    var partitions = await consumer.GetPartitionIdsAsync(cancellationSource.Token);
+
+                    await Task.WhenAll
+                    (
+                        SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partitions[0] }, cancellationSource.Token),
+                        SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partitions[1] }, cancellationSource.Token)
+                    );
+
+                    // Read the events and validate the resulting state.
+
+                    var firstMonitor = MonitorReadingEventsFromPartition(consumer, partitions[0], sourceEvents.Count, cancellationSource.Token);
+                    var secondMonitor = MonitorReadingEventsFromPartition(consumer, partitions[1], sourceEvents.Count, cancellationSource.Token);
+
+                    await Task.WhenAny(firstMonitor.EndCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    await Task.WhenAny(secondMonitor.EndCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    var firstState = await firstMonitor.ReadTask;
+                    var secondState = await secondMonitor.ReadTask;
+                    cancellationSource.Cancel();
+
+                    foreach (var sourceEvent in sourceEvents)
+                    {
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(firstState.Events.TryGetValue(sourceId, out var firstReadEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed by the first iterator.");
+                        Assert.That(sourceEvent.IsEquivalentTo(firstReadEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event for the first iterator.");
+
+                        Assert.That(secondState.Events.TryGetValue(sourceId, out var secondReadEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed by the second iterator.");
+                        Assert.That(sourceEvent.IsEquivalentTo(secondReadEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event for the second iterator.");
+                    }
+                }
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientOptionsTests.cs
@@ -26,7 +26,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubConsumerClientOptions
             {
                 RetryOptions = new EventHubsRetryOptions { Mode = EventHubsRetryMode.Fixed },
-                ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets }
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets },
+                Identifier = "Test"
             };
 
             EventHubConsumerClientOptions clone = options.Clone();
@@ -36,6 +37,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(clone.ConnectionOptions, Is.Not.SameAs(options.ConnectionOptions), "The connection options of the clone should be a copy, not the same instance.");
             Assert.That(clone.RetryOptions.IsEquivalentTo(options.RetryOptions), Is.True, "The retry options of the clone should be considered equal.");
             Assert.That(clone.RetryOptions, Is.Not.SameAs(options.RetryOptions), "The retry options of the clone should be a copy, not the same instance.");
+            Assert.That(clone.Identifier, Is.EqualTo(options.Identifier), "The identifier should match.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -260,11 +260,88 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public void ConnectionStringConstructorSetsTheIdentifier()
+        {
+            var expected = "Test-Identifier";
+            var options = new EventHubConsumerClientOptions { Identifier = expected };
+            var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, options);
+
+            Assert.That(consumer.Identifier, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void TokenCredentialConstructorSetsTheIdentifier()
+        {
+            var expected = "Test-Identifier";
+            var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>());
+            var options = new EventHubConsumerClientOptions { Identifier = expected };
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "namespace", "hub", credential.Object, options);
+
+            Assert.That(consumer.Identifier, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void SharedKeyCredentialConstructorSetsTheIdentifier()
+        {
+            var expected = "Test-Identifier";
+            var credential = new AzureNamedKeyCredential("key", "value");
+            var options = new EventHubConsumerClientOptions { Identifier = expected };
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "namespace", "hub", credential, options);
+
+            Assert.That(consumer.Identifier, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void SasCredentialConstructorSetsTheIdentifier()
+        {
+            var expected = "Test-Identifier";
+            var credential = new AzureSasCredential(new SharedAccessSignature("sb://this.is.Fake/blah", "key", "value").Value);
+            var options = new EventHubConsumerClientOptions { Identifier = expected };
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "namespace", "hub", credential, options);
+
+            Assert.That(consumer.Identifier, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConnectionConstructorSetsTheIdentifier()
+        {
+            var expected = "Test-Identifier";
+            var options = new EventHubConsumerClientOptions { Identifier = expected };
+            var mockConnection = new MockConnection();
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
+
+            Assert.That(consumer.Identifier, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
         public void ConnectionStringConstructorCreatesDefaultOptions()
         {
             var expected = new EventHubConsumerClientOptions().RetryOptions;
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
+
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
+            Assert.That(consumer.Identifier, Is.Not.Null.And.Not.Empty, "A default identifier should have been generated.");
 
             var policy = GetRetryPolicy(consumer);
             Assert.That(policy, Is.Not.Null, "There should have been a retry policy set.");
@@ -283,7 +360,9 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>());
             var expected = new EventHubConsumerClientOptions().RetryOptions;
+
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "some-namespace", "hubName", credential.Object);
+            Assert.That(consumer.Identifier, Is.Not.Null.And.Not.Empty, "A default identifier should have been generated.");
 
             var policy = GetRetryPolicy(consumer);
             Assert.That(policy, Is.Not.Null, "There should have been a retry policy set.");
@@ -302,7 +381,9 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var credential = new AzureNamedKeyCredential("key", "value");
             var expected = new EventHubConsumerClientOptions().RetryOptions;
+
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "some-namespace", "hubName", credential);
+            Assert.That(consumer.Identifier, Is.Not.Null.And.Not.Empty, "A default identifier should have been generated.");
 
             var policy = GetRetryPolicy(consumer);
             Assert.That(policy, Is.Not.Null, "There should have been a retry policy set.");
@@ -321,7 +402,9 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var credential = new AzureSasCredential(new SharedAccessSignature("sb://this.is.Fake/blah", "key", "value").Value);
             var expected = new EventHubConsumerClientOptions().RetryOptions;
+
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "some-namespace", "hubName", credential);
+            Assert.That(consumer.Identifier, Is.Not.Null.And.Not.Empty, "A default identifier should have been generated.");
 
             var policy = GetRetryPolicy(consumer);
             Assert.That(policy, Is.Not.Null, "There should have been a retry policy set.");
@@ -340,7 +423,9 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expected = new EventHubConsumerClientOptions().RetryOptions;
             var mockConnection = new MockConnection();
+
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
+            Assert.That(consumer.Identifier, Is.Not.Null.And.Not.Empty, "A default identifier should have been generated.");
 
             var policy = GetRetryPolicy(consumer);
             Assert.That(policy, Is.Not.Null, "There should have been a retry policy set.");
@@ -632,7 +717,17 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Task.FromResult(new[] { "0", "1" }));
 
             mockConnection
-                .Setup(conn => conn.CreateTransportConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<long?>(), It.IsAny<uint?>(), It.IsAny<long?>()))
+                .Setup(conn => conn.CreateTransportConsumer(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<EventPosition>(),
+                    It.IsAny<EventHubsRetryPolicy>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<long?>(),
+                    It.IsAny<uint?>(),
+                    It.IsAny<long?>()))
                 .Returns(transportConsumer);
 
             await using var enumerator = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), options).GetAsyncEnumerator();
@@ -640,6 +735,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Verify(conn => conn.CreateTransportConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -1368,7 +1464,17 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Task.FromResult(new[] { "0", "1" }));
 
             mockConnection
-                .Setup(conn => conn.CreateTransportConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<long?>(), It.IsAny<uint?>(), It.IsAny<long?>()))
+                .Setup(conn => conn.CreateTransportConsumer(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<EventPosition>(),
+                    It.IsAny<EventHubsRetryPolicy>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<long?>(),
+                    It.IsAny<uint?>(),
+                    It.IsAny<long?>()))
                 .Returns(transportConsumer);
 
             await using var enumerator = consumer.ReadEventsAsync(options).GetAsyncEnumerator();
@@ -1376,6 +1482,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Verify(conn => conn.CreateTransportConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -2557,7 +2664,9 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             internal override TransportConsumer CreateTransportConsumer(string consumerGroup,
-                                                                        string partitionId, EventPosition eventPosition,
+                                                                        string partitionId,
+                                                                        string consumerIdentifier,
+                                                                        EventPosition eventPosition,
                                                                         EventHubsRetryPolicy retryPolicy,
                                                                         bool trackLastEnqueuedEventProperties = true,
                                                                         bool invalidateConsumerWhenPartitionIsStolen = false,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
@@ -75,7 +75,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(Mock.Of<SettableTransportConsumer>());
 
              mockProcessor
@@ -132,7 +132,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(Mock.Of<SettableTransportConsumer>());
 
             mockProcessor

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
@@ -536,7 +536,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
@@ -642,7 +642,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(Mock.Of<TransportConsumer>());
 
             await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
@@ -739,7 +739,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Callback(() => startCompletionSource.TrySetResult(true))
                 .Returns(Mock.Of<TransportConsumer>());
 
@@ -858,7 +858,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
@@ -933,7 +933,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             mockProcessor
@@ -1006,7 +1006,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(Mock.Of<TransportConsumer>())
                 .Callback(() => completionSource.TrySetResult(true));
 
@@ -1022,7 +1022,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             mockProcessor
-                .Verify(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), expectedStartingPosition, mockConnection.Object, It.IsAny<EventProcessorOptions>()),
+                .Verify(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), expectedStartingPosition, mockConnection.Object, It.IsAny<EventProcessorOptions>()),
                 Times.Once);
 
             await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
@@ -1068,7 +1068,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(Mock.Of<TransportConsumer>())
                 .Callback(() => completionSource.TrySetResult(true));
 
@@ -1151,7 +1151,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
@@ -1234,7 +1234,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(Mock.Of<TransportConsumer>());
 
             mockProcessor
@@ -1327,7 +1327,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(Mock.Of<TransportConsumer>());
 
             mockProcessor
@@ -1422,7 +1422,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(Mock.Of<TransportConsumer>())
                 .Callback(() => startCompletionSource.TrySetResult(true));
 
@@ -1506,7 +1506,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(Mock.Of<TransportConsumer>())
                 .Callback(() => startCompletionSource.TrySetResult(true));
 
@@ -1603,7 +1603,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
@@ -1688,7 +1688,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
@@ -1780,7 +1780,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection.Object);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -176,7 +176,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer);
 
             var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
@@ -218,7 +218,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
@@ -256,7 +256,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Callback(() => completionSource.TrySetResult(true))
                 .Returns(mockConsumer.Object);
 
@@ -303,7 +303,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
@@ -361,7 +361,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(badMockConsumer.Object)
                 .Returns(mockConsumer.Object);
 
@@ -377,6 +377,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockProcessor
                 .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -398,7 +399,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var partition = new EventProcessorPartition { PartitionId = "99" };
             var position = EventPosition.FromOffset(12);
-            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, PrefetchCount = 37, PrefetchSizeInBytes = 44, LoadBalancingUpdateInterval = TimeSpan.FromMinutes(1) };
+            var options = new EventProcessorOptions { Identifier = "fake", TrackLastEnqueuedEventProperties = false, PrefetchCount = 37, PrefetchSizeInBytes = 44, LoadBalancingUpdateInterval = TimeSpan.FromMinutes(1) };
             var expectedOwnerLevel = 0;
             var expectedInvalidationOnSteal = true;
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -420,7 +421,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Task.CompletedTask);
 
             mockConnection
-                .Setup(connection => connection.CreateTransportConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<uint?>(), It.IsAny<long?>()))
+                .Setup(connection => connection.CreateTransportConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<uint?>(), It.IsAny<long?>()))
                 .Returns(mockConsumer.Object);
 
             var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
@@ -432,6 +433,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(connection => connection.CreateTransportConsumer(
                     mockProcessor.Object.ConsumerGroup,
                     partition.PartitionId,
+                    It.Is<string>(value => value.Contains(options.Identifier)),
                     position,
                     It.IsAny<EventHubsRetryPolicy>(),
                     options.TrackLastEnqueuedEventProperties,
@@ -473,7 +475,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             mockProcessor
@@ -527,7 +529,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             mockProcessor
@@ -601,7 +603,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             mockProcessor
@@ -711,7 +713,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             mockProcessor
@@ -777,7 +779,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             mockProcessor
@@ -880,7 +882,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object)
                 .Returns(Mock.Of<TransportConsumer>());
 
@@ -946,7 +948,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object)
                 .Returns(Mock.Of<TransportConsumer>());
 
@@ -1008,7 +1010,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object)
                 .Returns(Mock.Of<TransportConsumer>());
 
@@ -1062,7 +1064,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             mockProcessor
@@ -1123,7 +1125,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             mockProcessor
@@ -1183,7 +1185,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             mockProcessor
@@ -1230,7 +1232,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object)
                 .Returns(() =>
                 {
@@ -1290,7 +1292,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(badMockConsumer.Object)
                 .Returns(mockConsumer.Object);
 
@@ -1302,6 +1304,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockProcessor
                 .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -1338,7 +1341,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
@@ -1349,6 +1352,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockProcessor
                 .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -1385,7 +1389,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
@@ -1435,7 +1439,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
@@ -1487,7 +1491,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(badMockConsumer.Object)
                 .Returns(() =>
                 {
@@ -1505,6 +1509,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(processor => processor.CreateConsumer(
                     mockProcessor.Object.ConsumerGroup,
                     partition.PartitionId,
+                    It.IsAny<string>(),
                     initialStartingPosition,
                     mockConnection,
                     It.IsAny<EventProcessorOptions>()),
@@ -1514,6 +1519,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(processor => processor.CreateConsumer(
                     mockProcessor.Object.ConsumerGroup,
                     partition.PartitionId,
+                    It.IsAny<string>(),
                     EventPosition.FromOffset(lastEventBatch.Last().Offset, false),
                     mockConnection,
                     It.IsAny<EventProcessorOptions>()),
@@ -1549,7 +1555,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
@@ -1562,6 +1568,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockProcessor
                 .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -1599,7 +1606,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
@@ -1612,6 +1619,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockProcessor
                 .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -1648,7 +1656,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(mockConsumer.Object);
 
             var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), cancellationSource, EventPosition.Earliest);
@@ -1661,6 +1669,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockProcessor
                 .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -1708,7 +1717,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(badMockConsumer.Object)
                 .Returns(() =>
                 {
@@ -1724,6 +1733,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockProcessor
                 .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -1777,7 +1787,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConnection);
 
             mockProcessor
-                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
                 .Returns(badMockConsumer.Object)
                 .Returns(() =>
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverOptionsTests.cs
@@ -29,6 +29,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets },
                 RetryOptions = new EventHubsRetryOptions { Mode = EventHubsRetryMode.Fixed },
                 DefaultMaximumReceiveWaitTime = TimeSpan.FromMilliseconds(9994),
+                Identifier = "Test-34",
                 OwnerLevel = 99,
                 PrefetchCount = 65,
                 TrackLastEnqueuedEventProperties = false
@@ -43,6 +44,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(clone.RetryOptions.IsEquivalentTo(options.RetryOptions), Is.True, "The retry options of the clone should be considered equal.");
             Assert.That(clone.RetryOptions, Is.Not.SameAs(options.RetryOptions), "The retry options of the clone should be a copy, not the same instance.");
             Assert.That(clone.DefaultMaximumReceiveWaitTime, Is.EqualTo(options.DefaultMaximumReceiveWaitTime), "The maximum wait time should match.");
+            Assert.That(clone.Identifier, Is.EqualTo(options.Identifier), "The identifier should match.");
             Assert.That(clone.OwnerLevel, Is.EqualTo(options.OwnerLevel), "The owner level of the clone should match.");
             Assert.That(clone.PrefetchCount, Is.EqualTo(options.PrefetchCount), "The prefetch count should match.");
             Assert.That(clone.PrefetchSizeInBytes, Is.EqualTo(options.PrefetchSizeInBytes), "The prefetch size should match.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
@@ -199,6 +199,77 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public void ConnectionStringConstructorSetsTheIdentifier()
+        {
+            var expected = "Test-Identifier";
+            var options = new PartitionReceiverOptions { Identifier = expected };
+            var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, connectionString, options);
+
+            Assert.That(receiver.Identifier, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void TokenCredentialConstructorSetsTheIdentifier()
+        {
+            var expected = "Test-Identifier";
+            var options = new PartitionReceiverOptions { Identifier = expected };
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", Mock.Of<TokenCredential>(), options);
+
+            Assert.That(receiver.Identifier, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void SharedKeyCredentialConstructorSetsTheIdentifier()
+        {
+            var expected = "Test-Identifier";
+            var options = new PartitionReceiverOptions { Identifier = expected };
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", new AzureNamedKeyCredential("key", "value"), options);
+
+            Assert.That(receiver.Identifier, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void SasCredentialConstructorSetsTheIdentifier()
+        {
+            var expected = "Test-Identifier";
+            var options = new PartitionReceiverOptions { Identifier = expected };
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", new AzureSasCredential(new SharedAccessSignature("sb://this.is.Fake/blah", "key", "value").Value), options);
+
+            Assert.That(receiver.Identifier, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConnectionConstructorSetsTheIdentifier()
+        {
+            var expected = "Test-Identifier";
+            var options = new PartitionReceiverOptions { Identifier = expected };
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, Mock.Of<EventHubConnection>(), options);
+
+            Assert.That(receiver.Identifier, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
         public void ConnectionStringConstructorSetsTheDefaultMaximumWaitTime()
         {
             var expected = TimeSpan.FromMinutes(1);
@@ -270,156 +341,19 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void ConnectionStringConstructorCreatesTheTransportConsumer()
-        {
-            var expectedRetryPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var expectedOptions = new PartitionReceiverOptions
-            {
-                RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expectedRetryPolicy },
-                OwnerLevel = 99,
-                PrefetchCount = 42,
-                TrackLastEnqueuedEventProperties = false
-            };
-            var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, connectionString, expectedOptions);
-
-            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup), "The constructor should have used the correct consumer group.");
-            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId), "The constructor should have used the correct partition id.");
-            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition), "The constructor should have used the correct initial position.");
-            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy), "The constructor should have used the correct retry policy.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions, Is.Not.SameAs(expectedOptions), "The constructor should have cloned the options.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.TrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties), "The constructor should have used the correct track last enqueued event properties.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The constructor should have used the correct owner level.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The constructor should have used the correct prefetch count.");
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        public void TokenCredentialConstructorCreatesTheTransportConsumer()
-        {
-            var expectedRetryPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var expectedOptions = new PartitionReceiverOptions
-            {
-                RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expectedRetryPolicy },
-                OwnerLevel = 99,
-                PrefetchCount = 42,
-                TrackLastEnqueuedEventProperties = false
-            };
-            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", Mock.Of<TokenCredential>(), expectedOptions);
-
-            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup), "The constructor should have used the correct consumer group.");
-            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId), "The constructor should have used the correct partition id.");
-            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition), "The constructor should have used the correct initial position.");
-            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy), "The constructor should have used the correct retry policy.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions, Is.Not.SameAs(expectedOptions), "The constructor should have cloned the options.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.TrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties), "The constructor should have used the correct track last enqueued event properties.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The constructor should have used the correct owner level.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The constructor should have used the correct prefetch count.");
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        public void SharedKeyCredentialConstructorCreatesTheTransportConsumer()
-        {
-            var expectedRetryPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var expectedOptions = new PartitionReceiverOptions
-            {
-                RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expectedRetryPolicy },
-                OwnerLevel = 99,
-                PrefetchCount = 42,
-                TrackLastEnqueuedEventProperties = false
-            };
-            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", new AzureNamedKeyCredential("key", "value"), expectedOptions);
-
-            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup), "The constructor should have used the correct consumer group.");
-            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId), "The constructor should have used the correct partition id.");
-            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition), "The constructor should have used the correct initial position.");
-            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy), "The constructor should have used the correct retry policy.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions, Is.Not.SameAs(expectedOptions), "The constructor should have cloned the options.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.TrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties), "The constructor should have used the correct track last enqueued event properties.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The constructor should have used the correct owner level.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The constructor should have used the correct prefetch count.");
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        public void SasCredentialConstructorCreatesTheTransportConsumer()
-        {
-            var expectedRetryPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var expectedOptions = new PartitionReceiverOptions
-            {
-                RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expectedRetryPolicy },
-                OwnerLevel = 99,
-                PrefetchCount = 42,
-                TrackLastEnqueuedEventProperties = false
-            };
-            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", new AzureSasCredential(new SharedAccessSignature("sb://this.is.Fake/blah", "key", "value").Value), expectedOptions);
-
-            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup), "The constructor should have used the correct consumer group.");
-            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId), "The constructor should have used the correct partition id.");
-            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition), "The constructor should have used the correct initial position.");
-            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy), "The constructor should have used the correct retry policy.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions, Is.Not.SameAs(expectedOptions), "The constructor should have cloned the options.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.TrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties), "The constructor should have used the correct track last enqueued event properties.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The constructor should have used the correct owner level.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The constructor should have used the correct prefetch count.");
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        public void ConnectionConstructorCreatesTheTransportConsumer()
-        {
-            var expectedRetryPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var expectedOptions = new PartitionReceiverOptions
-            {
-                RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expectedRetryPolicy },
-                OwnerLevel = 99,
-                PrefetchCount = 42,
-                TrackLastEnqueuedEventProperties = false
-            };
-            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, Mock.Of<EventHubConnection>(), expectedOptions);
-
-            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup), "The constructor should have used the correct consumer group.");
-            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId), "The constructor should have used the correct partition id.");
-            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition), "The constructor should have used the correct initial position.");
-            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy), "The constructor should have used the correct retry policy.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions, Is.Not.SameAs(expectedOptions), "The constructor should have cloned the options.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.TrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties), "The constructor should have used the correct track last enqueued event properties.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The constructor should have used the correct owner level.");
-            Assert.That(receiver.TransportConsumerCreatedWithOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The constructor should have used the correct prefetch count.");
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
         public void ConnectionStringConstructorCreatesDefaultOptions()
         {
             var defaultOptions = new PartitionReceiverOptions();
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, connectionString);
-            var options = receiver.TransportConsumerCreatedWithOptions;
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, connectionString);
 
-            Assert.That(options.ConnectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
-            Assert.That(options.ConnectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
-            Assert.That(options.RetryOptions.IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
-            Assert.That(options.DefaultMaximumReceiveWaitTime, Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
-            Assert.That(options.OwnerLevel, Is.EqualTo(defaultOptions.OwnerLevel), "The constructor should have set the correct owner level.");
-            Assert.That(options.PrefetchCount, Is.EqualTo(defaultOptions.PrefetchCount), "The constructor should have set the correct prefetch count.");
-            Assert.That(options.TrackLastEnqueuedEventProperties, Is.EqualTo(defaultOptions.TrackLastEnqueuedEventProperties), "The constructor should have set the correct track last enqueued event properties.");
+            Assert.That(receiver.Identifier, Is.Not.Null.And.Not.Empty, "A default identifier should have been generated.");
+            Assert.That(GetDefaultMaximumWaitTime(receiver), Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
+            Assert.That(GetRetryOptions(receiver).IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
+
+            var connectionOptions = GetConnectionOptions(receiver);
+            Assert.That(connectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
+            Assert.That(connectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
         }
 
         /// <summary>
@@ -430,16 +364,15 @@ namespace Azure.Messaging.EventHubs.Tests
         public void TokenCredentialConstructorCreatesDefaultOptions()
         {
             var defaultOptions = new PartitionReceiverOptions();
-            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", Mock.Of<TokenCredential>());
-            var options = receiver.TransportConsumerCreatedWithOptions;
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", Mock.Of<TokenCredential>());
 
-            Assert.That(options.ConnectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
-            Assert.That(options.ConnectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
-            Assert.That(options.RetryOptions.IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
-            Assert.That(options.DefaultMaximumReceiveWaitTime, Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
-            Assert.That(options.OwnerLevel, Is.EqualTo(defaultOptions.OwnerLevel), "The constructor should have set the correct owner level.");
-            Assert.That(options.PrefetchCount, Is.EqualTo(defaultOptions.PrefetchCount), "The constructor should have set the correct prefetch count.");
-            Assert.That(options.TrackLastEnqueuedEventProperties, Is.EqualTo(defaultOptions.TrackLastEnqueuedEventProperties), "The constructor should have set the correct track last enqueued event properties.");
+            Assert.That(receiver.Identifier, Is.Not.Null.And.Not.Empty, "A default identifier should have been generated.");
+            Assert.That(GetDefaultMaximumWaitTime(receiver), Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
+            Assert.That(GetRetryOptions(receiver).IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
+
+            var connectionOptions = GetConnectionOptions(receiver);
+            Assert.That(connectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
+            Assert.That(connectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
         }
 
         /// <summary>
@@ -450,16 +383,15 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SharedKeyCredentialConstructorCreatesDefaultOptions()
         {
             var defaultOptions = new PartitionReceiverOptions();
-            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", new AzureNamedKeyCredential("key", "value"));
-            var options = receiver.TransportConsumerCreatedWithOptions;
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", new AzureNamedKeyCredential("key", "value"));
 
-            Assert.That(options.ConnectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
-            Assert.That(options.ConnectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
-            Assert.That(options.RetryOptions.IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
-            Assert.That(options.DefaultMaximumReceiveWaitTime, Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
-            Assert.That(options.OwnerLevel, Is.EqualTo(defaultOptions.OwnerLevel), "The constructor should have set the correct owner level.");
-            Assert.That(options.PrefetchCount, Is.EqualTo(defaultOptions.PrefetchCount), "The constructor should have set the correct prefetch count.");
-            Assert.That(options.TrackLastEnqueuedEventProperties, Is.EqualTo(defaultOptions.TrackLastEnqueuedEventProperties), "The constructor should have set the correct track last enqueued event properties.");
+            Assert.That(receiver.Identifier, Is.Not.Null.And.Not.Empty, "A default identifier should have been generated.");
+            Assert.That(GetDefaultMaximumWaitTime(receiver), Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
+            Assert.That(GetRetryOptions(receiver).IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
+
+            var connectionOptions = GetConnectionOptions(receiver);
+            Assert.That(connectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
+            Assert.That(connectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
         }
 
         /// <summary>
@@ -470,16 +402,15 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SasCredentialConstructorCreatesDefaultOptions()
         {
             var defaultOptions = new PartitionReceiverOptions();
-            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", new AzureSasCredential(new SharedAccessSignature("sb://this.is.Fake/blah", "key", "value").Value));
-            var options = receiver.TransportConsumerCreatedWithOptions;
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", new AzureSasCredential(new SharedAccessSignature("sb://this.is.Fake/blah", "key", "value").Value));
 
-            Assert.That(options.ConnectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
-            Assert.That(options.ConnectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
-            Assert.That(options.RetryOptions.IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
-            Assert.That(options.DefaultMaximumReceiveWaitTime, Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
-            Assert.That(options.OwnerLevel, Is.EqualTo(defaultOptions.OwnerLevel), "The constructor should have set the correct owner level.");
-            Assert.That(options.PrefetchCount, Is.EqualTo(defaultOptions.PrefetchCount), "The constructor should have set the correct prefetch count.");
-            Assert.That(options.TrackLastEnqueuedEventProperties, Is.EqualTo(defaultOptions.TrackLastEnqueuedEventProperties), "The constructor should have set the correct track last enqueued event properties.");
+            Assert.That(receiver.Identifier, Is.Not.Null.And.Not.Empty, "A default identifier should have been generated.");
+            Assert.That(GetDefaultMaximumWaitTime(receiver), Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
+            Assert.That(GetRetryOptions(receiver).IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
+
+            var connectionOptions = GetConnectionOptions(receiver);
+            Assert.That(connectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
+            Assert.That(connectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
         }
 
         /// <summary>
@@ -490,16 +421,26 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConnectionConstructorCreatesDefaultOptions()
         {
             var defaultOptions = new PartitionReceiverOptions();
-            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, Mock.Of<EventHubConnection>());
-            var options = receiver.TransportConsumerCreatedWithOptions;
+            var mockConnection = new Mock<EventHubConnection>();
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, mockConnection.Object);
 
-            Assert.That(options.ConnectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
-            Assert.That(options.ConnectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
-            Assert.That(options.RetryOptions.IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
-            Assert.That(options.DefaultMaximumReceiveWaitTime, Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
-            Assert.That(options.OwnerLevel, Is.EqualTo(defaultOptions.OwnerLevel), "The constructor should have set the correct owner level.");
-            Assert.That(options.PrefetchCount, Is.EqualTo(defaultOptions.PrefetchCount), "The constructor should have set the correct prefetch count.");
-            Assert.That(options.TrackLastEnqueuedEventProperties, Is.EqualTo(defaultOptions.TrackLastEnqueuedEventProperties), "The constructor should have set the correct track last enqueued event properties.");
+            Assert.That(receiver.Identifier, Is.Not.Null.And.Not.Empty, "A default identifier should have been generated.");
+            Assert.That(GetDefaultMaximumWaitTime(receiver), Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
+            Assert.That(GetRetryOptions(receiver).IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
+
+            mockConnection
+                .Verify(connection => connection.CreateTransportConsumer(
+                    receiver.ConsumerGroup,
+                    receiver.PartitionId,
+                    It.Is<string>(value => !string.IsNullOrEmpty(value)),
+                    receiver.InitialPosition,
+                    GetRetryPolicy(receiver),
+                    defaultOptions.TrackLastEnqueuedEventProperties,
+                    It.IsAny<bool>(),
+                    defaultOptions.OwnerLevel,
+                    (uint?)defaultOptions.PrefetchCount,
+                    defaultOptions.PrefetchSizeInBytes),
+                Times.Once);
         }
 
         /// <summary>
@@ -740,29 +681,31 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
             var mockConnection = new Mock<EventHubConnection>(connectionString);
-            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, mockConnection.Object);
 
             var expectedConsumerGroup = "consumerGroup";
             var expectedPartitionId = "partitionId";
+            var expectedIdentifier = "customIdent!fi3r!";
             var expectedPosition = EventPosition.FromOffset(55);
-            var expectedRetryPolicy = Mock.Of<EventHubsRetryPolicy>();
             var expectedInvalidateOnSteal = false;
+
             var expectedOptions = new PartitionReceiverOptions
             {
+                Identifier = expectedIdentifier,
                 OwnerLevel = 99,
                 PrefetchCount = 42,
                 PrefetchSizeInBytes = 43,
                 TrackLastEnqueuedEventProperties = false
             };
 
-            receiver.CreateTransportConsumer(expectedConsumerGroup, expectedPartitionId, expectedPosition, expectedRetryPolicy, expectedOptions);
+            var receiver = new PartitionReceiver(expectedConsumerGroup, expectedPartitionId, expectedPosition, mockConnection.Object, expectedOptions);
 
             mockConnection
                 .Verify(connection => connection.CreateTransportConsumer(
                     expectedConsumerGroup,
                     expectedPartitionId,
+                    expectedIdentifier,
                     expectedPosition,
-                    expectedRetryPolicy,
+                    GetRetryPolicy(receiver),
                     expectedOptions.TrackLastEnqueuedEventProperties,
                     expectedInvalidateOnSteal,
                     expectedOptions.OwnerLevel,
@@ -794,6 +737,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.CreateTransportConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -829,6 +773,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.CreateTransportConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -1049,6 +994,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(connection => connection.CreateTransportConsumer(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
                     It.IsAny<bool>(),
@@ -1096,6 +1042,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(connection => connection.CreateTransportConsumer(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
                     It.IsAny<bool>(),
@@ -1140,6 +1087,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.CreateTransportConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -1210,6 +1158,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(connection => connection.CreateTransportConsumer(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
                     It.IsAny<bool>(),
@@ -1254,6 +1203,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.CreateTransportConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -1354,6 +1304,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(connection => connection.CreateTransportConsumer(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
                     It.IsAny<EventHubsRetryPolicy>(),
                     It.IsAny<bool>(),
@@ -1411,6 +1362,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConnection
                 .Setup(connection => connection.CreateTransportConsumer(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<EventPosition>(),
@@ -1490,6 +1442,16 @@ namespace Azure.Messaging.EventHubs.Tests
                     .GetValue(partitionReceiver);
 
         /// <summary>
+        ///   Retrieves the options for the connection of the partition receiver using its private accessor.
+        /// </summary>
+        ///
+        private static EventHubConnectionOptions GetConnectionOptions(PartitionReceiver partitionReceiver) =>
+            (EventHubConnectionOptions)
+                typeof(EventHubConnection)
+                    .GetProperty("Options", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(GetConnection(partitionReceiver));
+
+        /// <summary>
         ///   Retrieves the RetryPolicy for the partition receiver using its private accessor.
         /// </summary>
         ///
@@ -1500,6 +1462,13 @@ namespace Azure.Messaging.EventHubs.Tests
                     .GetValue(partitionReceiver);
 
         /// <summary>
+        ///   Retrieves the retry options for the partition receiver using its private accessor.
+        /// </summary>
+        ///
+        private static EventHubsRetryOptions GetRetryOptions(PartitionReceiver partitionReceiver) =>
+            (GetRetryPolicy(partitionReceiver) as BasicRetryPolicy)?.Options;
+
+        /// <summary>
         ///   Retrieves the DefaultMaximumWaitTime for the partition receiver using its private accessor.
         /// </summary>
         ///
@@ -1508,95 +1477,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 typeof(PartitionReceiver)
                     .GetProperty("DefaultMaximumWaitTime", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(partitionReceiver);
-
-        /// <summary>
-        ///   Allows the observation of the creation of a <see cref="TransportConsumer"/>
-        ///   for testing purposes.
-        /// </summary>
-        ///
-        private class ObservableConsumerPartitionReceiver : PartitionReceiver
-        {
-            public string TransportConsumerCreatedWithConsumerGroup { get; private set; }
-            public string TransportConsumerCreatedWithPartitionId { get; private set; }
-            public EventPosition TransportConsumerCreatedWithEventPosition { get; private set; }
-            public EventHubsRetryPolicy TransportConsumerCreatedWithRetryPolicy { get; private set; }
-            public PartitionReceiverOptions TransportConsumerCreatedWithOptions { get; private set; }
-
-            public ObservableConsumerPartitionReceiver(string consumerGroup,
-                                                       string partitionId,
-                                                       EventPosition eventPosition,
-                                                       string connectionString) : base(consumerGroup, partitionId, eventPosition, connectionString)
-            {
-            }
-
-            public ObservableConsumerPartitionReceiver(string consumerGroup,
-                                                       string partitionId,
-                                                       EventPosition eventPosition,
-                                                       string connectionString,
-                                                       PartitionReceiverOptions options) : base(consumerGroup, partitionId, eventPosition, connectionString, options)
-            {
-            }
-
-            public ObservableConsumerPartitionReceiver(string consumerGroup,
-                                                       string partitionId,
-                                                       EventPosition eventPosition,
-                                                       string fullyQualifiedNamespace,
-                                                       string eventHubName,
-                                                       AzureNamedKeyCredential credential,
-                                                       PartitionReceiverOptions options = default) : base(consumerGroup, partitionId, eventPosition, fullyQualifiedNamespace, eventHubName, credential, options)
-            {
-            }
-
-            public ObservableConsumerPartitionReceiver(string consumerGroup,
-                                                       string partitionId,
-                                                       EventPosition eventPosition,
-                                                       string fullyQualifiedNamespace,
-                                                       string eventHubName,
-                                                       AzureSasCredential credential,
-                                                       PartitionReceiverOptions options = default) : base(consumerGroup, partitionId, eventPosition, fullyQualifiedNamespace, eventHubName, credential, options)
-            {
-            }
-
-            public ObservableConsumerPartitionReceiver(string consumerGroup,
-                                                       string partitionId,
-                                                       EventPosition eventPosition,
-                                                       string fullyQualifiedNamespace,
-                                                       string eventHubName,
-                                                       TokenCredential credential,
-                                                       PartitionReceiverOptions options = default) : base(consumerGroup, partitionId, eventPosition, fullyQualifiedNamespace, eventHubName, credential, options)
-            {
-            }
-
-            public ObservableConsumerPartitionReceiver(string consumerGroup,
-                                                       string partitionId,
-                                                       EventPosition eventPosition,
-                                                       EventHubConnection connection) : base(consumerGroup, partitionId, eventPosition, connection)
-            {
-            }
-
-            public ObservableConsumerPartitionReceiver(string consumerGroup,
-                                                       string partitionId,
-                                                       EventPosition eventPosition,
-                                                       EventHubConnection connection,
-                                                       PartitionReceiverOptions options) : base(consumerGroup, partitionId, eventPosition, connection, options)
-            {
-            }
-
-            internal override TransportConsumer CreateTransportConsumer(string consumerGroup,
-                                                                        string partitionId,
-                                                                        EventPosition eventPosition,
-                                                                        EventHubsRetryPolicy retryPolicy,
-                                                                        PartitionReceiverOptions options)
-            {
-                TransportConsumerCreatedWithConsumerGroup = consumerGroup;
-                TransportConsumerCreatedWithPartitionId = partitionId;
-                TransportConsumerCreatedWithEventPosition = eventPosition;
-                TransportConsumerCreatedWithRetryPolicy = retryPolicy;
-                TransportConsumerCreatedWithOptions = options;
-
-                return base.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, options);
-            }
-        }
 
         /// <summary>
         ///   Allows for setting the last received event by the consumer

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
@@ -127,6 +127,26 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public async Task ProducerWithIdentifierCanSend()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                var connectionString = EventHubsTestEnvironment.Instance.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { Identifier = "CustomIdentif13r!" }))
+                {
+                    var events = new[] { new EventData(Encoding.UTF8.GetBytes("AWord")) };
+                    Assert.That(async () => await producer.SendAsync(events), Throws.Nothing);
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubProducerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
         public async Task ProducerCanSendToASpecificPartition()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientOptionsTests.cs
@@ -27,6 +27,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubProducerClientOptions
             {
+                Identifier = "Test-123",
                 EnableIdempotentPartitions = true,
                 ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets },
                 RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(36) }
@@ -42,6 +43,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var clone = options.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
 
+            Assert.That(clone.Identifier, Is.EqualTo(options.Identifier), "The identifier should match.");
             Assert.That(clone.EnableIdempotentPartitions, Is.EqualTo(options.EnableIdempotentPartitions), "The flag to enable idempotent publishing should have been copied.");
             Assert.That(clone.ConnectionOptions.TransportType, Is.EqualTo(options.ConnectionOptions.TransportType), "The connection options of the clone should copy properties.");
             Assert.That(clone.ConnectionOptions, Is.Not.SameAs(options.ConnectionOptions), "The connection options of the clone should be a copy, not the same instance.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
@@ -41,7 +41,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 ["1"] = new TransportProducerPool.PoolItem("0", transportProducer),
                 ["2"] = new TransportProducerPool.PoolItem("0", transportProducer),
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), startingPool);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, null, TransportProducerFeatures.None, null, retryPolicy), startingPool);
 
             GetExpirationCallBack(transportProducerPool).Invoke(null);
 
@@ -68,7 +68,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 // An expired item in the pool
                 ["0"] = new TransportProducerPool.PoolItem("0", transportProducer, removeAfter: oneMinuteAgo)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), startingPool);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, null, TransportProducerFeatures.None, null, retryPolicy), startingPool);
 
             // This call should refresh the timespan associated to the item
             _ = transportProducerPool.GetPooledProducer("0");
@@ -94,7 +94,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
             var connection = new MockConnection(() => transportProducer);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
-            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy));
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, null, TransportProducerFeatures.None, null, retryPolicy));
             var expectedTime = DateTimeOffset.UtcNow.AddMinutes(10);
 
             await using var pooledProducer = transportProducerPool.GetPooledProducer("0");
@@ -121,7 +121,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 // An expired item in the pool
                 ["0"] = new TransportProducerPool.PoolItem("0", transportProducer, removeAfter: oneMinuteAgo)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), startingPool);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, null, TransportProducerFeatures.None, null, retryPolicy), startingPool);
 
             var pooledProducer = transportProducerPool.GetPooledProducer("0");
             startingPool.TryGetValue("0", out var poolItem);
@@ -148,7 +148,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 ["0"] = new TransportProducerPool.PoolItem("0", transportProducer)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), startingPool);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, null, TransportProducerFeatures.None, null, retryPolicy), startingPool);
 
             var pooledProducer = transportProducerPool.GetPooledProducer("0", TimeSpan.FromMinutes(-1));
 
@@ -179,7 +179,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 ["0"] = new TransportProducerPool.PoolItem("0", partitionProducer)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), eventHubProducer: transportProducer);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, null, TransportProducerFeatures.None, null, retryPolicy), eventHubProducer: transportProducer);
 
             var returnedProducer = transportProducerPool.GetPooledProducer(partitionId).TransportProducer as ObservableTransportProducerMock;
 
@@ -202,7 +202,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 ["0"] = new TransportProducerPool.PoolItem("0", partitionProducer.Object)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), eventHubProducer: transportProducer.Object);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, null, TransportProducerFeatures.None, null, retryPolicy), eventHubProducer: transportProducer.Object);
 
             transportProducer
                 .Setup(producer => producer.CloseAsync(It.IsAny<CancellationToken>()))
@@ -229,7 +229,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 ["0"] = new TransportProducerPool.PoolItem("0", partitionProducer.Object)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), eventHubProducer: transportProducer.Object);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, null, TransportProducerFeatures.None, null, retryPolicy), eventHubProducer: transportProducer.Object);
 
             partitionProducer
                 .Setup(producer => producer.CloseAsync(It.IsAny<CancellationToken>()))
@@ -302,6 +302,7 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             internal override TransportProducer CreateTransportProducer(string partitionId,
+                                                                        string producerIdentifier,
                                                                         TransportProducerFeatures requestedFeatures,
                                                                         PartitionPublishingOptions partitionOptions,
                                                                         EventHubsRetryPolicy retryPolicy) => TransportProducerFactory();


### PR DESCRIPTION
# Summary

The focus of these changes is to add an option for setting an Identifier for each Event Hubs client type.  The identifier is informational and is associated with the 
AMQP links used, allowing the service to provide additional context in error messages and the SDK logs to provide an additional point of correlation.

# References and Resources

- [Event Hubs: Client Type Identifier Support (#20101)](https://github.com/Azure/azure-sdk-for-net/issues/20101)