### PR TITLE
Switch from AppendFormat to Append

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpExceptionHelper.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpExceptionHelper.cs
@@ -184,10 +184,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
         public static Exception TranslateException(Exception exception, string referenceId = null, Exception innerException = null, bool connectionError = false)
         {
             var stringBuilder = new StringBuilder();
-            stringBuilder.AppendFormat(CultureInfo.InvariantCulture, exception.Message);
+            stringBuilder.Append(exception.Message);
             if (referenceId != null)
             {
-                stringBuilder.AppendFormat(CultureInfo.InvariantCulture, $"Reference: {referenceId}, {DateTime.UtcNow}");
+                stringBuilder.Append($"Reference: {referenceId}, {DateTime.UtcNow}");
             }
 
             var message = stringBuilder.ToString();
@@ -196,13 +196,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
             switch (exception)
             {
                 case SocketException _:
-                    message = stringBuilder.AppendFormat(CultureInfo.InvariantCulture, $" ErrorCode: {((SocketException)exception).SocketErrorCode}").ToString();
+                    message = stringBuilder.Append($" ErrorCode: {((SocketException)exception).SocketErrorCode}").ToString();
                     return new ServiceBusException(message, ServiceBusFailureReason.ServiceCommunicationProblem, innerException: aggregateException);
 
                 case IOException _:
                     if (exception.InnerException is SocketException socketException)
                     {
-                        message = stringBuilder.AppendFormat(CultureInfo.InvariantCulture, $" ErrorCode: {socketException.SocketErrorCode}").ToString();
+                        message = stringBuilder.Append($" ErrorCode: {socketException.SocketErrorCode}").ToString();
                     }
                     return new ServiceBusException(message, ServiceBusFailureReason.ServiceCommunicationProblem, innerException: aggregateException);
 


### PR DESCRIPTION
If underlying exception message had an unescaped brace it could cause FormatExceptions.