### PR TITLE
[Event Hubs] Avoid Possible Allocation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpAnnotatedMessageExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpAnnotatedMessageExtensions.cs
@@ -399,9 +399,12 @@ namespace Azure.Messaging.EventHubs.Amqp
         private static void CopyDictionary<TKey, TValue>(IDictionary<TKey, TValue> source,
                                                          IDictionary<TKey, TValue> destination)
         {
-            foreach (var key in source.Keys)
+            if (source.Count > 0)
             {
-                destination[key] = source[key];
+                foreach (var pair in source)
+                {
+                    destination[pair.Key] = pair.Value;
+                }
             }
         }
     }


### PR DESCRIPTION
# Summary

The focus of these changes is to alter the approach used for copying an AMQP message section dictionary to avoid a possible allocation of the `Keys` collection of the source dictionary when no items are present.

# References and Resources

- [AmqpAnnotatedMessageExtensions - CopyDictionary forces allocation of Keys-collection (#22622)](https://github.com/Azure/azure-sdk-for-net/issues/22622)