### PR TITLE
[digitaltwins] Ensure Bicep CLI is installed on MacOS

### DIFF
--- a/sdk/digitaltwins/tests.yml
+++ b/sdk/digitaltwins/tests.yml
@@ -14,3 +14,12 @@ extends:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
         Location: eastus2euap
     Clouds: Public,Canary
+    PreSteps:
+      # Remove when https://github.com/actions/virtual-environments/pull/3655 is deployed to our macOS agents
+      - pwsh: |
+          if (!(Get-Command bicep -ErrorAction Ignore)) {
+            brew tap azure/bicep
+            brew install bicep
+          }
+        condition: contains(variables['OSVmImage'], 'mac')
+        displayName: Ensure Bicep CLI is installed on macOS

--- a/sdk/digitaltwins/tests.yml
+++ b/sdk/digitaltwins/tests.yml
@@ -22,4 +22,4 @@ extends:
             brew install bicep
           }
         condition: contains(variables['OSVmImage'], 'mac')
-        displayName: Ensure Bicep CLI is installed on macOS
+        displayName: (MacOS) Ensure Bicep CLI

--- a/sdk/digitaltwins/tests.yml
+++ b/sdk/digitaltwins/tests.yml
@@ -15,7 +15,7 @@ extends:
         Location: eastus2euap
     Clouds: Public,Canary
     PreSteps:
-      # Remove when https://github.com/actions/virtual-environments/pull/3655 is deployed to our macOS agents
+      # Remove when https://github.com/actions/virtual-environments/pull/3655 is deployed to our MacOS agents
       - pwsh: |
           if (!(Get-Command bicep -ErrorAction Ignore)) {
             brew tap azure/bicep


### PR DESCRIPTION
* This change is scoped to just .NET digitaltwins.
* If we want this change for all services and languages I can make a PR to `eng/common` instead, but I expect our mac agents will be updated to include `bicep` in the next few weeks, so I'd prefer to avoid updating `eng/common` if we can wait.
* If we want this change for digitaltwins in all languages, I would just copy this PR to each language repo.

Verification Build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=999305&view=results