### PR TITLE
[Event Hubs] Connection Idle Timeout Option

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Azure.Messaging.EventHubs.Processor.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Azure.Messaging.EventHubs.Processor.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{797FF941-76FD-45FD-AC17-A73DFE2BA621}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs", "..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj", "{87A3ED70-190D-4E6B-A568-40DF5B9F3939}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,12 +31,17 @@ Global
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87A3ED70-190D-4E6B-A568-40DF5B9F3939}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87A3ED70-190D-4E6B-A568-40DF5B9F3939}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87A3ED70-190D-4E6B-A568-40DF5B9F3939}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87A3ED70-190D-4E6B-A568-40DF5B9F3939}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
+		{87A3ED70-190D-4E6B-A568-40DF5B9F3939} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {44BD3BD5-61DF-464D-8627-E00B0BC4B3A3}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -14,7 +14,12 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="Azure.Messaging.EventHubs" />
+
+    <!-- TEMP :: Change back to package reference before releasing -->
+    <!-- <PackageReference Include="Azure.Messaging.EventHubs" /> -->
+    <ProjectReference Include="../../Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj" />
+    <!-- TEMP :: Remove project reference before releasing-->
+
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/EventHubConnectionOptionsExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/EventHubConnectionOptionsExtensions.cs
@@ -22,6 +22,7 @@ namespace Azure.Messaging.EventHubs.Core
             new EventHubConnectionOptions
             {
                 TransportType = instance.TransportType,
+                ConnectionIdleTimeout = instance.ConnectionIdleTimeout,
                 Proxy = instance.Proxy,
                 CustomEndpointAddress = instance.CustomEndpointAddress,
                 SendBufferSizeInBytes = instance.SendBufferSizeInBytes,

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/EventHubConnectionOptionsExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/EventHubConnectionOptionsExtensionsTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Security;
+using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using Azure.Messaging.EventHubs.Core;
 using Moq;
@@ -23,6 +25,37 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   Verifies functionality of the <see cref="EventHubConnectionOptions.Clone" />
         ///   method.
         /// </summary>
+        [Test]
+        public void CloneKnowsAllMembersOfEventHubConnectionOptions()
+        {
+            // This approach is inelegant and brute force, but allows us to detect
+            // additional members added to the options that we're not currently
+            // cloning and avoid drift.
+
+            var knownMembers = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "TransportType",
+                "Properties",
+                "ConnectionIdleTimeout",
+                "CustomEndpointAddress",
+                "SendBufferSizeInBytes",
+                "ReceiveBufferSizeInBytes",
+                "CertificateValidationCallback"
+            };
+
+            var getterSetterProperties = typeof(EventHubConnectionOptions)
+                .GetProperties(BindingFlags.Public | BindingFlags.GetProperty | BindingFlags.SetProperty);
+
+            foreach (var property in getterSetterProperties)
+            {
+                Assert.That(knownMembers.Contains(property.Name), $"The property: { property.Name } of { nameof(EventHubConnectionOptions) } is not being cloned.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConnectionOptions.Clone" />
+        ///   method.
+        /// </summary>
         ///
         [Test]
         public void CloneProducesACopy()
@@ -30,6 +63,7 @@ namespace Azure.Messaging.EventHubs.Tests
            var options = new EventHubConnectionOptions
             {
                 TransportType = EventHubsTransportType.AmqpWebSockets,
+                ConnectionIdleTimeout = TimeSpan.FromHours(3),
                 Proxy = Mock.Of<IWebProxy>(),
                 CustomEndpointAddress = new Uri("https://fake.servciebus.net"),
                 SendBufferSizeInBytes = 65,
@@ -40,6 +74,7 @@ namespace Azure.Messaging.EventHubs.Tests
             EventHubConnectionOptions clone = options.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
             Assert.That(clone.TransportType, Is.EqualTo(options.TransportType), "The connection type of the clone should match.");
+            Assert.That(clone.ConnectionIdleTimeout, Is.EqualTo(options.ConnectionIdleTimeout), "The connection idle timeout of the clone should match.");
             Assert.That(clone.Proxy, Is.EqualTo(options.Proxy), "The proxy of the clone should match.");
             Assert.That(clone.CustomEndpointAddress, Is.EqualTo(options.CustomEndpointAddress), "The custom endpoint address clone should match.");
             Assert.That(clone.SendBufferSizeInBytes, Is.EqualTo(options.SendBufferSizeInBytes), "The send buffer size clone should match.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- Added the ability to adjust the connection idle timeout using the `EventHubConnectionOptions` available within the options for each client type.
+
 ## 5.5.0 (2021-07-07)
 
 ### Acknowledgments

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -57,6 +57,7 @@ namespace Azure.Messaging.EventHubs
     {
         public EventHubConnectionOptions() { }
         public System.Net.Security.RemoteCertificateValidationCallback CertificateValidationCallback { get { throw null; } set { } }
+        public System.TimeSpan ConnectionIdleTimeout { get { throw null; } set { } }
         public System.Uri CustomEndpointAddress { get { throw null; } set { } }
         public System.Net.IWebProxy Proxy { get { throw null; } set { } }
         public int ReceiveBufferSizeInBytes { get { throw null; } set { } }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -182,6 +182,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                     credential,
                     clientOptions.TransportType,
                     clientOptions.Proxy,
+                    clientOptions.ConnectionIdleTimeout,
                     null,
                     clientOptions.SendBufferSizeInBytes,
                     clientOptions.ReceiveBufferSizeInBytes,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnectionOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnectionOptions.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
+using Azure.Core;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -16,6 +17,9 @@ namespace Azure.Messaging.EventHubs
     ///
     public class EventHubConnectionOptions
     {
+        // <summary>The amount of time to allow a connection to have no observed traffic before considering it idle.</summary>
+        private TimeSpan _connectionIdleTimeout = TimeSpan.FromMinutes(1);
+
         /// <summary>
         ///   The type of protocol and transport that will be used for communicating with the Event Hubs
         ///   service.
@@ -24,6 +28,32 @@ namespace Azure.Messaging.EventHubs
         /// <value>The default transport is AMQP over TCP.</value>
         ///
         public EventHubsTransportType TransportType { get; set; } = EventHubsTransportType.AmqpTcp;
+
+        /// <summary>
+        ///   The amount of time to allow a connection to have no observed traffic before considering
+        ///   it idle and eligible to close.
+        /// </summary>
+        ///
+        /// <value>The default idle timeout is 60 seconds.  The timeout must be a positive value.</value>
+        ///
+        /// <remarks>
+        ///   If a connection is closed due to being idle, the Event Hubs clients will automatically
+        ///   reopen the connection when it is needed for a network operation.  An idle connection
+        ///   being closed does not cause client errors or interfere with normal operation.
+        ///
+        ///   It is recommended to use the default value unless your application has special needs and
+        ///   you've tested the impact of changing the idle timeout.
+        /// </remarks>
+        ///
+        public TimeSpan ConnectionIdleTimeout
+        {
+            get => _connectionIdleTimeout;
+            set
+            {
+                Argument.AssertNotNegative(value, nameof(ConnectionIdleTimeout));
+                _connectionIdleTimeout = value;
+            }
+        }
 
         /// <summary>
         ///   The size of the buffer used for sending information via the active transport.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -557,7 +557,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
-            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
+            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null, TimeSpan.FromSeconds(30));
             var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, identifier, eventPosition, true, false, null, null, null, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
 
             scope.Dispose();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -246,7 +246,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
-            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
+            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null, TimeSpan.FromSeconds(30));
             scope.Dispose();
 
             var producer = new AmqpProducer(eventHub, partition, identifier, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
@@ -724,7 +724,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
-            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
+            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null, TimeSpan.FromSeconds(30));
             scope.Dispose();
 
             var producer = new AmqpProducer(eventHub, partition, identifier, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
@@ -1131,7 +1131,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
-            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
+            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null, TimeSpan.FromSeconds(30));
             var producer = new AmqpProducer(eventHub, partition, identifier, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
 
             scope.Dispose();
@@ -1490,7 +1490,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var mockCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>());
 
-            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null);
+            var scope = new AmqpConnectionScope(endpoint, endpoint, eventHub, mockCredential, EventHubsTransportType.AmqpTcp, null, TimeSpan.FromSeconds(30));
             var producer = new AmqpProducer(eventHub, partition, identifier, scope, Mock.Of<AmqpMessageConverter>(), retryPolicy);
 
             scope.Dispose();


### PR DESCRIPTION
# Summary

The focus of these changes is to allow the idle timeout applied to connections be specified as part of the options for each client.

# References and Related

- [Expose additional idle timeout configuration in ConnectionOptions (#22674)](https://github.com/Azure/azure-sdk-for-net/issues/22674)