### PR TITLE
Updating README in Azure.Communication.NetworkTraversal to point to latest version

### DIFF
--- a/sdk/communication/Azure.Communication.NetworkTraversal/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.NetworkTraversal/CHANGELOG.md
@@ -10,11 +10,12 @@
 
 ### Other Changes
 
-## 1.0.0-beta.2 (2021-07-13)
+## 1.0.0-beta.2 (2021-07-14)
+
+### Breaking Changes
 
 - Renamed `CommunicationTurnServer` to `CommunicationIceServer`
 - Renamed field `turnServers` to `iceServers` in `CommunicationRelayConfiguration`
-- Renamed `IssueCredentials[Async]` to `IssueRelayConfiguration[Async]`
 
 ## 1.0.0-beta.1 (2021-05-24)
 

--- a/sdk/communication/Azure.Communication.NetworkTraversal/README.md
+++ b/sdk/communication/Azure.Communication.NetworkTraversal/README.md
@@ -10,7 +10,7 @@ Azure Communication Network Traversal enables high bandwidth, low latency connec
 Install the Azure Communication Network Traversal client library for .NET with [NuGet][nuget]:
 
 ```Powershell
-dotnet add package Azure.Communication.NetworkTraversal --version 1.0.0-beta.1
+dotnet add package Azure.Communication.NetworkTraversal --version 1.0.0-beta.2
 ```
 
 ### Prerequisites


### PR DESCRIPTION
Updating readme to point to version 1.0.0-beta.2

Additional Changes
- Removed typo of "Renamed `IssueCredentials[Async]` to `IssueRelayConfiguration[Async]`"
- Updated the release date of 1.0.0-beta.2 from 2021-07-13 to 2021-07-14