### PR TITLE
[Event Hubs] Processor Event Dispatch Cancellation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where partition processing would ignore cancellation when the processor was shutting down or partition ownership changed and continue dispatching events to the handler until the entire batch was complete.  Cancellation will now be properly respected.
+
 ### Other Changes
 
 ## 5.5.0 (2021-07-07)

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -888,6 +888,16 @@ namespace Azure.Messaging.EventHubs
 
                 foreach (var eventData in events)
                 {
+                    // If cancellation was requested, then either partition ownership was lost or the processor is
+                    // shutting down.  In either case, dispatching of events to be handled should cease.  Since this
+                    // flow is entirely internal, there's no benefit to throwing a cancellation exception; instead,
+                    // just exit the loop.
+
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
                     emptyBatch = false;
 
                     try


### PR DESCRIPTION
# Summary

The focus of these changes is to fix the loop responsible for dispatching events to the handler for processing so that it respects cancellation when the processor signals the associated token.  Currently, the loop will dispatch all events in the batch to the handler, potentially causing duplicate processing and checkpoint interleaving.