### PR TITLE
Improve Etag ToString performance for DefaultFormat

### DIFF
--- a/sdk/core/Azure.Core/src/ETag.cs
+++ b/sdk/core/Azure.Core/src/ETag.cs
@@ -105,11 +105,9 @@ namespace Azure
                 return string.Empty;
             }
 
-            var _needsQuoateWrap = !IsValidQuotedFormat(_value);
-
             return format switch
             {
-                HeaderFormat => _needsQuoateWrap ?  $"{QuoteString}{_value}{QuoteString}" : _value,
+                HeaderFormat => !IsValidQuotedFormat(_value) ?  $"{QuoteString}{_value}{QuoteString}" : _value,
                 DefaultFormat => _value,
                 _ => throw new ArgumentException("Invalid format string.")
             };


### PR DESCRIPTION
Noticed that ETag ToString was calculating IsValidQuotedFormat even when using default format. Moves the calculation inline to improve performance for default formatting.
The below is a benchmark of ToString() on a Etag with value "test1"

| Method |           Job |       Runtime |      Mean |     Error |    StdDev | Ratio | RatioSD |
|------- |-------------- |-------------- |----------:|----------:|----------:|------:|--------:|
|   Before |    .NET 4.7.2 |    .NET 4.7.2 | 32.601 ns | 0.7547 ns | 2.2251 ns |  1.00 |    0.00 | 
|   Before | .NET Core 5.0 | .NET Core 5.0 | 18.484 ns | 0.4553 ns | 0.8210 ns |  0.56 |    0.04 |
|        |               |               |           |           |           |       |         |      |
|  After |    .NET 4.7.2 |    .NET 4.7.2 |  7.577 ns | 0.2393 ns | 0.4723 ns |  1.00 |    0.00 |
|  After | .NET Core 5.0 | .NET Core 5.0 |  7.268 ns | 0.2279 ns | 0.5505 ns |  0.96 |    0.09 | 