### PR TITLE
[Smoke Tests] Remove Explicit `Azure.Core` Reference

### DIFF
--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Add an OverrideDailyVersion attribute to prevent the Update-Dependencies script from overwriting it with a daily build version -->
-    <PackageReference Include="Azure.Core" Version="1.16.0" />
     <PackageReference Include="Azure.Identity" Version="1.5.0-beta.2" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.5.0" />
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.5.0" />


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the explicit reference to the `Azure.Core` package; these can cause the run to fail when rewritten for daily runs due to existing project references to `Azure.Core`.