### PR TITLE
Fix Azure.Core dependencies for .NET 5.0

### DIFF
--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -20,12 +20,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Memory.Data" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework)!='net5.0'">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Numerics.Vectors" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Text.Encodings.Web" />
-    <PackageReference Include="System.Memory.Data" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This removes dependencies that are inbox for .NET 5.0.