### PR TITLE
Scope UpdateSourceOnBuild target

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -39,7 +39,7 @@
   </Target>
 
   <!--Run Aggregate Updates to Source -->
-  <Target Name="UpdateSourceOnBuild" AfterTargets="Build" Condition="'$(UpdateSourceOnBuild)' == 'true' and '$(IsShippingClientLibrary)' == 'true'" >
+  <Target Name="UpdateSourceOnBuild" AfterTargets="Build" Condition="'$(UpdateSourceOnBuild)' == 'true' and '$(IsShippingClientLibrary)' == 'true' and $(MSBuildProjectDirectory.Contains($(ServiceDirectory)))" >
     <PropertyGroup>
       <CodeChecksScriptPath Condition=" '$(CodeChecksScriptPath)'=='' ">$(MSBuildThisFileDirectory)scripts/CodeChecks.ps1</CodeChecksScriptPath>
     </PropertyGroup>


### PR DESCRIPTION
Scope UpdateSourceOnBuild target to prevent cyclic run that causes files to be locked by other process
This fixes https://github.com/Azure/azure-sdk-for-net/issues/10997