### PR TITLE
Add missing link to Monitor Query README

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/README.md
+++ b/sdk/monitor/Azure.Monitor.Query/README.md
@@ -59,6 +59,7 @@ All client instance methods are thread-safe and independent of each other ([guid
 - [Batch query](#batch-query)
 - [Query dynamic table](#query-dynamic-table)
 - [Increase query timeout](#increase-query-timeout)
+- [Query metrics](#query-metrics)
 
 ### Query logs
 


### PR DESCRIPTION
Add a missing section link to the **Examples** section of the Azure Monitor Query _README_ file.