### PR TITLE
ADT e2e fix: Introduce delay in event route lifecycle test.

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/E2eTestBase.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/E2eTestBase.cs
@@ -107,5 +107,17 @@ namespace Azure.DigitalTwins.Core.Tests
                 Console.WriteLine($"{model.Id}");
             }
         }
+
+        /// <summary>
+        /// Injects delay in the process when the test mode is live.
+        /// </summary>
+        /// <param name="delayDuration">Delay duration.</param>
+        protected async Task WaitIfLiveAsync(TimeSpan delayDuration)
+        {
+            if (TestEnvironment.Mode == RecordedTestMode.Live)
+            {
+                await Task.Delay(delayDuration);
+            }
+        }
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/EventRouteTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/EventRouteTests.cs
@@ -21,6 +21,7 @@ namespace Azure.DigitalTwins.Core.Tests
 
         // Infrastructure setup script uses this hard-coded value when linking the test eventhub to the test digital twins instance
         private const string EndpointName = "someEventHubEndpoint";
+        private readonly TimeSpan _creationDelay = TimeSpan.FromSeconds(10);
 
         [Test]
         public async Task EventRoutes_Lifecycle()
@@ -37,6 +38,10 @@ namespace Azure.DigitalTwins.Core.Tests
             // Test CreateEventRoute
             Response createEventRouteResponse = await client.CreateOrReplaceEventRouteAsync(eventRouteId, eventRoute).ConfigureAwait(false);
             createEventRouteResponse.Status.Should().Be((int)HttpStatusCode.NoContent);
+
+            // Wait certain amount of time to test if the issue is with propagation.
+            // TODO: azabbasi: remove this logic once experiment is over.
+            await WaitIfLiveAsync(_creationDelay);
 
             // Test GetEventRoute
             DigitalTwinsEventRoute getEventRouteResult = await client.GetEventRouteAsync(eventRouteId);


### PR DESCRIPTION
we have resumed the conversation with the service team to get help investigating the issue specific to event routes. 
in the meanwhile, we are experimenting with a little delay between PUT and GET to see if propagation is the source of the issue.