### PR TITLE
Fix for consistently failing tests

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRepositoryLiveTests.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRepositoryLiveTests.cs
@@ -169,15 +169,9 @@ namespace Azure.Containers.ContainerRegistry.Tests
             AsyncPageable<ArtifactManifestProperties> artifacts = repository.GetManifestPropertiesCollectionAsync();
             var pages = artifacts.AsPages(pageSizeHint: pageSize);
 
-            int pageCount = 0;
-            await foreach (var page in pages)
-            {
-                Assert.GreaterOrEqual(page.Values.Count, pageSize);
-                pageCount++;
-            }
-
             // Assert
-            Assert.IsTrue(pageCount >= minExpectedPages);
+            int pageCount = await pages.CountAsync();
+            Assert.GreaterOrEqual(pageCount, minExpectedPages);
         }
 
         [RecordedTest]

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/RegistryArtifactLiveTests.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/RegistryArtifactLiveTests.cs
@@ -32,7 +32,7 @@ namespace Azure.Containers.ContainerRegistry.Tests
             // Assert
             Assert.Contains(tag, properties.Tags.ToList());
             Assert.AreEqual(_repositoryName, properties.RepositoryName);
-            Assert.GreaterOrEqual(helloWorldRelatedArtifacts, properties.RelatedArtifacts.Count);
+            Assert.GreaterOrEqual(properties.RelatedArtifacts.Count, helloWorldRelatedArtifacts);
 
             Assert.IsTrue(properties.RelatedArtifacts.Any(
                 artifact =>


### PR DESCRIPTION
Separating out a subset of functionality from https://github.com/Azure/azure-sdk-for-net/pull/22713 to fix consistently failing tests.  

This addresses:
- The multi-architecture images we were pulling from DockerHub added new architectures. Because of this, I learned I had my greater than or equals to operator in the wrong direction :-/


Fixes #22736