### PR TITLE
Support event source deduplication

### DIFF
--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -35,6 +35,7 @@
     <Compile Include="Shared\AppContextSwitchHelper.cs" />
     <Compile Include="Shared\Argument.cs" />
     <Compile Include="Shared\AuthorizationChallengeParser.cs" />
+    <Compile Include="Shared\AzureEventSource.cs" />
     <Compile Include="Shared\AzureKeyCredentialPolicy.cs" />
     <Compile Include="Shared\AzureSasCredentialSynchronousPolicy.cs" />
     <Compile Include="Shared\Base64Url.cs" />

--- a/sdk/core/Azure.Core/src/Diagnostics/AzureCoreEventSource.cs
+++ b/sdk/core/Azure.Core/src/Diagnostics/AzureCoreEventSource.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Diagnostics.Tracing;
 
 namespace Azure.Core.Diagnostics
 {
     [EventSource(Name = EventSourceName)]
-    internal sealed class AzureCoreEventSource : EventSource
+    internal sealed class AzureCoreEventSource : AzureEventSource
     {
         private const string EventSourceName = "Azure-Core";
 
@@ -29,7 +28,7 @@ namespace Azure.Core.Diagnostics
         private const int RequestRetryingEvent = 10;
         private const int ExceptionResponseEvent = 18;
 
-        private AzureCoreEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue) { }
+        private AzureCoreEventSource() : base(EventSourceName) { }
 
         public static AzureCoreEventSource Singleton { get; } = new AzureCoreEventSource();
 

--- a/sdk/core/Azure.Core/src/Diagnostics/AzureEventSourceListener.cs
+++ b/sdk/core/Azure.Core/src/Diagnostics/AzureEventSourceListener.cs
@@ -23,7 +23,6 @@ namespace Azure.Core.Diagnostics
         /// The trait value that has to be present on all event sources collected by this listener.
         /// </summary>
         public const string TraitValue = "true";
-
         private readonly List<EventSource> _eventSources = new List<EventSource>();
 
         private readonly Action<EventWrittenEventArgs, string> _log;

--- a/sdk/core/Azure.Core/src/Shared/AzureEventSource.cs
+++ b/sdk/core/Azure.Core/src/Shared/AzureEventSource.cs
@@ -25,11 +25,6 @@ namespace Azure.Core.Diagnostics
             if (namesInUse == null)
             {
                 namesInUse = new HashSet<string>();
-                foreach (var source in GetSources())
-                {
-                    namesInUse.Add(source.Name);
-                }
-
                 AppDomain.CurrentDomain.SetData(SharedDataKey, namesInUse);
             }
 
@@ -56,6 +51,12 @@ namespace Azure.Core.Diagnostics
         {
             lock (NamesInUse)
             {
+                // pick up existing EventSources that might not participate in this logic
+                foreach (var source in GetSources())
+                {
+                    NamesInUse.Add(source.Name);
+                }
+
                 if (!NamesInUse.Contains(eventSourceName))
                 {
                     NamesInUse.Add(eventSourceName);

--- a/sdk/core/Azure.Core/src/Shared/AzureEventSource.cs
+++ b/sdk/core/Azure.Core/src/Shared/AzureEventSource.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace Azure.Core.Diagnostics
+{
+    internal abstract class AzureEventSource: EventSource
+    {
+        private static string[] MainEventSourceTraits =
+        {
+            AzureEventSourceListener.TraitName,
+            AzureEventSourceListener.TraitValue
+        };
+
+        protected AzureEventSource(string eventSourceName): base(
+            DeduplicateName(eventSourceName),
+            EventSourceSettings.Default,
+            MainEventSourceTraits
+        )
+        {
+        }
+
+        private static string DeduplicateName(string eventSourceName)
+        {
+            HashSet<string> namesInUse = new();
+            foreach (var source in GetSources())
+            {
+                namesInUse.Add(source.Name);
+            }
+
+            if (!namesInUse.Contains(eventSourceName))
+            {
+                return eventSourceName;
+            }
+
+            int i = 1;
+            while (true)
+            {
+                var candidate = $"{eventSourceName}-{i}";
+                if (!namesInUse.Contains(candidate))
+                {
+                    return candidate;
+                }
+                i++;
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/ArgumentTests.cs
+++ b/sdk/core/Azure.Core/tests/ArgumentTests.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests

--- a/sdk/core/Azure.Core/tests/ArgumentTests.cs
+++ b/sdk/core/Azure.Core/tests/ArgumentTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests

--- a/sdk/core/Azure.Core/tests/AzureEventSourceTests.cs
+++ b/sdk/core/Azure.Core/tests/AzureEventSourceTests.cs
@@ -52,15 +52,15 @@ namespace Azure.Core.Tests
                 LogEvent(es1);
                 LogEvent(es2);
 
-                Assert.AreEqual("Azure-Core", es0.Name);
-                Assert.AreEqual("Azure-Core-1", es1.Name);
-                Assert.AreEqual("Azure-Core-2", es2.Name);
+                Assert.AreEqual("Azure-Corez", es0.Name);
+                Assert.AreEqual("Azure-Corez-1", es1.Name);
+                Assert.AreEqual("Azure-Corez-2", es2.Name);
 
                 Assert.AreEqual(3, events.Count);
 
-                Assert.AreEqual("Azure-Core", events[0].EventSource.Name);
-                Assert.AreEqual("Azure-Core-1", events[1].EventSource.Name);
-                Assert.AreEqual("Azure-Core-2", events[2].EventSource.Name);
+                Assert.AreEqual("Azure-Corez", events[0].EventSource.Name);
+                Assert.AreEqual("Azure-Corez-1", events[1].EventSource.Name);
+                Assert.AreEqual("Azure-Corez-2", events[2].EventSource.Name);
             }
             finally
             {
@@ -85,7 +85,7 @@ namespace Azure.Core.Tests
 
         internal class TestEventSource: AzureEventSource
         {
-            public TestEventSource() : base("Azure-Core")
+            public TestEventSource() : base("Azure-Corez")
             {
             }
 

--- a/sdk/core/Azure.Core/tests/AzureEventSourceTests.cs
+++ b/sdk/core/Azure.Core/tests/AzureEventSourceTests.cs
@@ -89,10 +89,10 @@ namespace Azure.Core.Tests
             {
             }
 
-            [Event(0)]
+            [Event(1)]
             public void LogSomething()
             {
-                WriteEvent(0);
+                WriteEvent(1);
             }
         }
     }

--- a/sdk/core/Azure.Core/tests/AzureEventSourceTests.cs
+++ b/sdk/core/Azure.Core/tests/AzureEventSourceTests.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if NET5_0
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Azure.Core.Diagnostics;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class AzureEventSourceTests
+    {
+        [Test]
+        public void CanCreateMultipleEventSources()
+        {
+            EventSource GetEventSource(TestAssemblyLoadContext testAssemblyLoadContext)
+            {
+                return (EventSource)Activator.CreateInstance(testAssemblyLoadContext.Assemblies
+                    .Single()
+                    .GetType("Azure.Core.Tests.AzureEventSourceTests+TestEventSource"));
+            }
+
+            void LogEvent(EventSource azureCoreEventSource)
+            {
+                azureCoreEventSource.GetType()
+                    .GetMethod("LogSomething", BindingFlags.Public | BindingFlags.Instance)
+                    .Invoke(azureCoreEventSource, Array.Empty<object>());
+            }
+
+            var alc = new TestAssemblyLoadContext("Test 1");
+            var alc2 = new TestAssemblyLoadContext("Test 2");
+
+            try
+            {
+                List<EventWrittenEventArgs> events = new();
+                using var listener = new AzureEventSourceListener((args, s) => events.Add(args), EventLevel.Verbose);
+
+                alc.LoadFromAssemblyPath(typeof(TestEventSource).Assembly.Location);
+                alc2.LoadFromAssemblyPath(typeof(TestEventSource).Assembly.Location);
+
+                using var es0 = new TestEventSource();
+                using var es1 = GetEventSource(alc);
+                using var es2 = GetEventSource(alc2);
+
+                LogEvent(es0);
+                LogEvent(es1);
+                LogEvent(es2);
+
+                Assert.AreEqual("Azure-Core", es0.Name);
+                Assert.AreEqual("Azure-Core-1", es1.Name);
+                Assert.AreEqual("Azure-Core-2", es2.Name);
+
+                Assert.AreEqual(3, events.Count);
+
+                Assert.AreEqual("Azure-Core", events[0].EventSource.Name);
+                Assert.AreEqual("Azure-Core-1", events[1].EventSource.Name);
+                Assert.AreEqual("Azure-Core-2", events[2].EventSource.Name);
+            }
+            finally
+            {
+                alc.Unload();
+                alc2.Unload();
+            }
+        }
+
+        [Test]
+        public void SetsTraits()
+        {
+            using var es = new TestEventSource();
+            Assert.AreEqual("true", es.GetTrait("AzureEventSource"));
+        }
+
+        public class TestAssemblyLoadContext : AssemblyLoadContext
+        {
+            public TestAssemblyLoadContext(string name) : base(name, true)
+            {
+            }
+        }
+
+        internal class TestEventSource: AzureEventSource
+        {
+            public TestEventSource() : base("Azure-Core")
+            {
+            }
+
+            [Event(0)]
+            public void LogSomething()
+            {
+                WriteEvent(0);
+            }
+        }
+    }
+}
+#endif

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -39,6 +39,7 @@
   <!-- Import Azure.Core shared source -->
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)AzureEventSource.cs" LinkBase="SharedSource\Azure.Core" />
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="SharedSource\Azure.Core" />
   </ItemGroup>
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -35,7 +35,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///   outside the scope of this library.  Exposed for testing purposes only.
         /// </summary>
         ///
-        private BlobEventStoreEventSource() : base(EventSourceName)
+        protected BlobEventStoreEventSource() : base(EventSourceName)
         {
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -28,16 +28,14 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///   use for logging.
         /// </summary>
         ///
-        public static BlobEventStoreEventSource Log { get; } = new BlobEventStoreEventSource(EventSourceName);
+        public static BlobEventStoreEventSource Log { get; } = new BlobEventStoreEventSource();
 
         /// <summary>
         ///   Prevents an instance of the <see cref="BlobEventStoreEventSource" /> class from being created
         ///   outside the scope of this library.  Exposed for testing purposes only.
         /// </summary>
         ///
-        /// <param name="eventSourceName">The name to assign to the event source.</param>
-        ///
-        private BlobEventStoreEventSource(string eventSourceName) : base(eventSourceName)
+        private BlobEventStoreEventSource() : base(EventSourceName)
         {
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
     /// </remarks>
     ///
     [EventSource(Name = EventSourceName)]
-    internal class BlobEventStoreEventSource : EventSource
+    internal class BlobEventStoreEventSource : AzureEventSource
     {
         /// <summary>The name to use for the event source.</summary>
         private const string EventSourceName = "Azure-Messaging-EventHubs-Processor-BlobEventStore";
@@ -35,18 +35,9 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///   outside the scope of this library.  Exposed for testing purposes only.
         /// </summary>
         ///
-        protected BlobEventStoreEventSource()
-        {
-        }
-
-        /// <summary>
-        ///   Prevents an instance of the <see cref="BlobEventStoreEventSource" /> class from being created
-        ///   outside the scope of this library.  Exposed for testing purposes only.
-        /// </summary>
-        ///
         /// <param name="eventSourceName">The name to assign to the event source.</param>
         ///
-        private BlobEventStoreEventSource(string eventSourceName) : base(eventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
+        private BlobEventStoreEventSource(string eventSourceName) : base(eventSourceName)
         {
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
@@ -27,16 +27,14 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///   use for logging.
         /// </summary>
         ///
-        public static EventProcessorClientEventSource Log { get; } = new EventProcessorClientEventSource(EventSourceName);
+        public static EventProcessorClientEventSource Log { get; } = new EventProcessorClientEventSource();
 
         /// <summary>
         ///   Prevents an instance of the <see cref="EventProcessorClientEventSource" /> class from being created
         ///   outside the scope of this library.  Exposed for testing purposes only.
         /// </summary>
         ///
-        /// <param name="eventSourceName">The name to assign the event source.</param>
-        ///
-        private EventProcessorClientEventSource(string eventSourceName) : base(eventSourceName)
+        protected EventProcessorClientEventSource() : base(EventSourceName)
         {
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
@@ -17,7 +17,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
     /// </remarks>
     ///
     [EventSource(Name = EventSourceName)]
-    internal class EventProcessorClientEventSource : EventSource
+    internal class EventProcessorClientEventSource : AzureEventSource
     {
         /// <summary>The name to use for the event source.</summary>
         private const string EventSourceName = "Azure-Messaging-EventHubs-Processor-EventProcessorClient";
@@ -34,18 +34,9 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///   outside the scope of this library.  Exposed for testing purposes only.
         /// </summary>
         ///
-        protected EventProcessorClientEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
-        {
-        }
-
-        /// <summary>
-        ///   Prevents an instance of the <see cref="EventProcessorClientEventSource" /> class from being created
-        ///   outside the scope of this library.  Exposed for testing purposes only.
-        /// </summary>
-        ///
         /// <param name="eventSourceName">The name to assign the event source.</param>
         ///
-        private EventProcessorClientEventSource(string eventSourceName) : base(eventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
+        private EventProcessorClientEventSource(string eventSourceName) : base(eventSourceName)
         {
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Diagnostics/PartitionLoadBalancerEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Diagnostics/PartitionLoadBalancerEventSource.cs
@@ -34,7 +34,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         ///   outside the scope of this library.
         /// </summary>
         ///
-        internal PartitionLoadBalancerEventSource() : base(EventSourceName)
+        protected PartitionLoadBalancerEventSource() : base(EventSourceName)
         {
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Diagnostics/PartitionLoadBalancerEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Diagnostics/PartitionLoadBalancerEventSource.cs
@@ -17,7 +17,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
     /// </remarks>
     ///
     [EventSource(Name = EventSourceName)]
-    internal class PartitionLoadBalancerEventSource : EventSource
+    internal class PartitionLoadBalancerEventSource : AzureEventSource
     {
         /// <summary>The name to use for the event source.</summary>
         private const string EventSourceName = "Azure-Messaging-EventHubs-Processor-PartitionLoadBalancer";
@@ -34,7 +34,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         ///   outside the scope of this library.
         /// </summary>
         ///
-        internal PartitionLoadBalancerEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
+        internal PartitionLoadBalancerEventSource() : base(EventSourceName)
         {
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
@@ -42,6 +42,7 @@
   <!-- Import Azure.Core shared source -->
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)AzureEventSource.cs" LinkBase="SharedSource\Azure.Core" />
   </ItemGroup>
 
   <!--Embed the shared resources -->

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -34,6 +34,7 @@
   <!-- Import Azure.Core shared source -->
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)AzureEventSource.cs" LinkBase="SharedSource\Azure.Core" />
     <Compile Include="$(AzureCoreSharedSources)HashCodeBuilder.cs" LinkBase="SharedSource\Azure.Core" />
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="SharedSource\Azure.Core" />
     <Compile Include="$(AzureCoreSharedSources)ValueStopwatch.cs" LinkBase="SharedSource\Azure.Core" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -30,16 +30,14 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         ///   use for logging.
         /// </summary>
         ///
-        public static EventHubsEventSource Log { get; } = new EventHubsEventSource(EventSourceName);
+        public static EventHubsEventSource Log { get; } = new EventHubsEventSource();
 
         /// <summary>
         ///   Prevents an instance of the <see cref="EventHubsEventSource"/> class from being created
         ///   outside the scope of the <see cref="Log" /> instance.
         /// </summary>
         ///
-        /// <param name="eventSourceName">The name to assign to the event source.</param>
-        ///
-        private EventHubsEventSource(string eventSourceName) : base(eventSourceName)
+        protected EventHubsEventSource() : base(EventSourceName)
         {
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -20,7 +20,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
     /// </remarks>
     ///
     [EventSource(Name = EventSourceName)]
-    internal class EventHubsEventSource : EventSource
+    internal class EventHubsEventSource : AzureEventSource
     {
         /// <summary>The name to use for the event source.</summary>
         private const string EventSourceName = "Azure-Messaging-EventHubs";
@@ -37,18 +37,9 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         ///   outside the scope of the <see cref="Log" /> instance.
         /// </summary>
         ///
-        protected EventHubsEventSource()
-        {
-        }
-
-        /// <summary>
-        ///   Prevents an instance of the <see cref="EventHubsEventSource"/> class from being created
-        ///   outside the scope of the <see cref="Log" /> instance.
-        /// </summary>
-        ///
         /// <param name="eventSourceName">The name to assign to the event source.</param>
         ///
-        private EventHubsEventSource(string eventSourceName) : base(eventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
+        private EventHubsEventSource(string eventSourceName) : base(eventSourceName)
         {
         }
 

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)AzureEventSource.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared" />

--- a/sdk/identity/Azure.Identity/src/AzureIdentityEventSource.cs
+++ b/sdk/identity/Azure.Identity/src/AzureIdentityEventSource.cs
@@ -11,7 +11,7 @@ using Azure.Core.Diagnostics;
 namespace Azure.Identity
 {
     [EventSource(Name = EventSourceName)]
-    internal sealed class AzureIdentityEventSource : EventSource
+    internal sealed class AzureIdentityEventSource : AzureEventSource
     {
         private const string EventSourceName = "Azure-Identity";
 
@@ -28,7 +28,7 @@ namespace Azure.Identity
         private const int InteractiveAuthenticationThreadPoolExecutionEvent = 11;
         private const int InteractiveAuthenticationInlineExecutionEvent = 12;
 
-        private AzureIdentityEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue) { }
+        private AzureIdentityEventSource() : base(EventSourceName) { }
 
         public static AzureIdentityEventSource Singleton { get; } = new AzureIdentityEventSource();
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)AzureEventSource.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="Shared" />

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatesEventSource.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatesEventSource.cs
@@ -7,7 +7,7 @@ using Azure.Core.Diagnostics;
 namespace Azure.Security.KeyVault.Certificates
 {
     [EventSource(Name = EventSourceName)]
-    internal sealed class CertificatesEventSource : EventSource
+    internal sealed class CertificatesEventSource : AzureEventSource
     {
         internal const int BeginUpdateStatusEvent = 1;
         internal const int EndUpdateStatusEvent = 2;
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Certificates
         private const string Deleted = "(deleted)";
         private const string NoError = "(none)";
 
-        private CertificatesEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue) { }
+        private CertificatesEventSource() : base(EventSourceName) { }
 
         public static CertificatesEventSource Singleton { get; } = new CertificatesEventSource();
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)AzureEventSource.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" LinkBase="Shared" />

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeysEventSource.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeysEventSource.cs
@@ -10,7 +10,7 @@ using Azure.Core.Diagnostics;
 namespace Azure.Security.KeyVault.Keys
 {
     [EventSource(Name = EventSourceName)]
-    internal sealed class KeysEventSource : EventSource
+    internal sealed class KeysEventSource : AzureEventSource
     {
         internal const int AlgorithmNotSupportedEvent = 1;
         internal const int KeyTypeNotSupportedEvent = 2;
@@ -19,7 +19,7 @@ namespace Azure.Security.KeyVault.Keys
 
         private const string EventSourceName = "Azure-Security-KeyVault-Keys";
 
-        private KeysEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue) { }
+        private KeysEventSource() : base(EventSourceName) { }
 
         public static KeysEventSource Singleton { get; } = new KeysEventSource();
 

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/src/Azure.IoT.ModelsRepository.csproj
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/src/Azure.IoT.ModelsRepository.csproj
@@ -25,6 +25,9 @@
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs">
       <LinkBase>Shared\Azure.Core</LinkBase>
     </Compile>
+    <Compile Include="$(AzureCoreSharedSources)AzureEventSource.cs">
+      <LinkBase>Shared\Azure.Core</LinkBase>
+    </Compile>
     <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs">
       <LinkBase>Shared\Azure.Core</LinkBase>
     </Compile>

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/src/ModelsRepositoryEventSource.cs
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/src/ModelsRepositoryEventSource.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.Tracing;
 namespace Azure.IoT.ModelsRepository
 {
     [EventSource(Name = EventSourceName)]
-    internal sealed class ModelsRepositoryEventSource : EventSource
+    internal sealed class ModelsRepositoryEventSource : AzureEventSource
     {
         private const string EventSourceName = ModelsRepositoryConstants.ModelsRepositoryEventSourceName;
 
@@ -30,10 +30,7 @@ namespace Azure.IoT.ModelsRepository
         public static ModelsRepositoryEventSource Instance { get; } = new ModelsRepositoryEventSource();
 
         private ModelsRepositoryEventSource()
-            : base(EventSourceName,
-                  EventSourceSettings.Default,
-                  AzureEventSourceListener.TraitName,
-                  AzureEventSourceListener.TraitValue)
+            : base(EventSourceName)
         { }
 
         [Event(InitFetcherEventId, Level = EventLevel.Informational, Message = StandardStrings.ClientInitWithFetcher)]

--- a/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
+++ b/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
@@ -19,6 +19,7 @@
   <!-- Pull in Shared Source from Azure.Core -->
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)AzureEventSource.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AzureKeyCredentialPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared\Core" />

--- a/sdk/search/Azure.Search.Documents/src/AzureSearchDocumentsEventSource.cs
+++ b/sdk/search/Azure.Search.Documents/src/AzureSearchDocumentsEventSource.cs
@@ -8,7 +8,7 @@ using Azure.Core.Diagnostics;
 namespace Azure.Search.Documents
 {
     [EventSource(Name = EventSourceName)]
-    internal sealed class AzureSearchDocumentsEventSource : EventSource
+    internal sealed class AzureSearchDocumentsEventSource : AzureEventSource
     {
         private const string EventSourceName = "Azure-Search-Documents";
 
@@ -22,7 +22,7 @@ namespace Azure.Search.Documents
         internal const int BatchActionPayloadTooLargeEvent = 8;
 
         private AzureSearchDocumentsEventSource() :
-            base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
+            base(EventSourceName)
         { }
 
         public static AzureSearchDocumentsEventSource Instance { get; } = new AzureSearchDocumentsEventSource();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -28,18 +28,19 @@
 
   <!-- Import Azure.Core shared source -->
   <ItemGroup>
-    <Compile Include="$(AzureCoreSharedSources)Argument.cs" Link="SharedSource\Azure.Core\Argument.cs" />
-    <Compile Include="$(AzureCoreSharedSources)HashCodeBuilder.cs" Link="SharedSource\Azure.Core\HashCodeBuilder.cs" />
-    <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" Link="SharedSource\Azure.Core\DiagnosticScope.cs" />
-    <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" Link="SharedSource\Azure.Core\DiagnosticScopeFactory.cs" />
-    <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" Link="SharedSource\Azure.Core\HttpMessageSanitizer.cs" />
-    <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" Link="SharedSource\Azure.Core\ClientDiagnostics.cs" />
-    <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" Link="SharedSource\Azure.Core\ContentTypeUtilities.cs" />
-    <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" Link="SharedSource\Azure.Core\ArrayBufferWriter.cs" />
-    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" Link="SharedSource\Azure.Core\TaskExtensions.cs" />
-    <Compile Include="$(AzureCoreSharedSources)ValueStopwatch.cs" Link="SharedSource\Azure.Core\ValueStopwatch.cs" />
-    <Compile Include="$(AzureCoreSharedSources)PageResponseEnumerator.cs" Link="SharedSource\Azure.Core\PageResponseEnumerator.cs" />
-    <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" Link="SharedSource\Azure.Core\AzureResourceProviderNamespaceAttribute.cs" />
+    <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)AzureEventSource.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)HashCodeBuilder.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)ValueStopwatch.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)PageResponseEnumerator.cs" LinkBase="SharedSource\Azure.Core" />
+    <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="SharedSource\Azure.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -32,14 +32,14 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         ///   Provides a singleton instance of the event source for callers to
         ///   use for logging.
         /// </summary>
-        public static ServiceBusEventSource Log { get; } = new ServiceBusEventSource(EventSourceName);
+        public static ServiceBusEventSource Log { get; } = new ServiceBusEventSource();
 
         /// <summary>
         ///   Prevents an instance of the <see cref="ServiceBusEventSource"/> class from being
         ///   created outside the scope of the <see cref="Log" /> instance, as well as setting up the
         ///   integration with AzureEventSourceListener.
         /// </summary>
-        private ServiceBusEventSource(string eventSourceName) : base(eventSourceName)
+        protected ServiceBusEventSource() : base(EventSourceName)
         {
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -23,7 +23,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
     ///   the CompleteEvent.Id must be exactly StartEvent.Id + 1.
     /// </remarks>
     [EventSource(Name = EventSourceName)]
-    internal class ServiceBusEventSource : EventSource
+    internal class ServiceBusEventSource : AzureEventSource
     {
         /// <summary>The name to use for the event source.</summary>
         private const string EventSourceName = "Azure-Messaging-ServiceBus";
@@ -39,12 +39,9 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         ///   created outside the scope of the <see cref="Log" /> instance, as well as setting up the
         ///   integration with AzureEventSourceListener.
         /// </summary>
-        private ServiceBusEventSource(string eventSourceName) : base(eventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
+        private ServiceBusEventSource(string eventSourceName) : base(eventSourceName)
         {
         }
-
-        // Parameterless constructor for mocking
-        internal ServiceBusEventSource() { }
 
         #region event constants
         // event constants should not be changed


### PR DESCRIPTION
In some cases, applications can load multiple versions of Azure client libraries in different AssemblyLoadContexts.

The eventsource has a limitation where their names have to be unique process-wide and every AzureCoreEventSource after the first fails to initialize.

This change adds additional logic to append `-1 ,-2, etc` to event sources created in subsequent ALCs. We are working on relaxing the uniqueness requirement with the BCL team in the meantime.