### PR TITLE
[Translation] Reducing flaky tests

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 
@@ -32,11 +33,12 @@ namespace Azure.AI.Translation.Document.Tests
 
         protected override async ValueTask<bool> IsEnvironmentReadyAsync()
         {
-            string endpoint = Environment.GetEnvironmentVariable(EndpointEnvironmentVariableName);
+            string endpoint = GetOptionalVariable(EndpointEnvironmentVariableName);
             var client = new DocumentTranslationClient(new Uri(endpoint), Credential);
             try
             {
                 await client.GetSupportedDocumentFormatsAsync();
+                client.GetAllTranslationStatuses().Take(2);
             }
             catch (RequestFailedException e) when (e.Status == 401)
             {

--- a/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/Infrastructure/DocumentTranslationTestEnvironment.cs
@@ -38,6 +38,7 @@ namespace Azure.AI.Translation.Document.Tests
             try
             {
                 await client.GetSupportedDocumentFormatsAsync();
+                await client.GetSupportedGlossaryFormatsAsync();
                 client.GetAllTranslationStatuses().Take(2);
             }
             catch (RequestFailedException e) when (e.Status == 401)

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTarget.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTarget.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source698049479?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1450818626?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-eb10404cd7faca4bbff43c1cb5b01a17-164cac8981089746-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-24ae4ea3da9881469203af0c8e94a50e-2a2b952df4747249-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "251d52a14369df430fc579df7ccffe74",
-        "x-ms-date": "Mon, 29 Mar 2021 22:05:29 GMT",
+        "x-ms-client-request-id": "c50dd19d9b0315e9682778429f918236",
+        "x-ms-date": "Thu, 22 Jul 2021 17:05:36 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:05:28 GMT",
-        "ETag": "\u00220x8D8F2FEC38F50C4\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 22:05:28 GMT",
+        "Date": "Thu, 22 Jul 2021 17:05:39 GMT",
+        "ETag": "\u00220x8D94D32EE6BB7B9\u0022",
+        "Last-Modified": "Thu, 22 Jul 2021 17:05:39 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "251d52a14369df430fc579df7ccffe74",
-        "x-ms-request-id": "07f4ed91-501e-0035-2be7-248446000000",
+        "x-ms-client-request-id": "c50dd19d9b0315e9682778429f918236",
+        "x-ms-request-id": "f387f4a2-e01e-007d-741b-7f9971000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source698049479/Document1.txt",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source1450818626/Document1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "27",
         "If-None-Match": "*",
-        "traceparent": "00-4be022584c123f4eb230f2bd4288aec3-e8b7b1765ed25746-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-088ff8aab0ede844893ca0dd84114810-355436a858d1f64b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "ea41cd2ed3cabcea600064179df2d013",
-        "x-ms-date": "Mon, 29 Mar 2021 22:05:29 GMT",
+        "x-ms-client-request-id": "562b85fc052c86a1dcfd65bb715252b8",
+        "x-ms-date": "Thu, 22 Jul 2021 17:05:37 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,29 +47,29 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
-        "Date": "Mon, 29 Mar 2021 22:05:28 GMT",
-        "ETag": "\u00220x8D8F2FEC3DBF27C\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 22:05:29 GMT",
+        "Date": "Thu, 22 Jul 2021 17:05:39 GMT",
+        "ETag": "\u00220x8D94D32EEA017C3\u0022",
+        "Last-Modified": "Thu, 22 Jul 2021 17:05:39 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "ea41cd2ed3cabcea600064179df2d013",
+        "x-ms-client-request-id": "562b85fc052c86a1dcfd65bb715252b8",
         "x-ms-content-crc64": "V7knc5S52gk=",
-        "x-ms-request-id": "07f4edf9-501e-0035-06e7-248446000000",
+        "x-ms-request-id": "f387f534-e01e-007d-741b-7f9971000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d829add4f1de5744a033d6184cc3b1ad-e13be3aae1dc184b-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "fceeecd3913cdc5e25d62bdb6421cc62",
+        "traceparent": "00-87c1ea889041d24f87abe0a6c7c3cc86-67bb85af5f7d4144-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210722.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "47a5a3a92a647747ef12fd43cb36373e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -89,65 +89,65 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "aab09a36-deb3-4aac-b6b6-7ae2aa7eb57a",
+        "apim-request-id": "f48a0c8a-5018-44ef-8b73-9470e4b8de31",
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:05:29 GMT",
-        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/f4bee4d9-1607-4d25-b930-d0cb95c363a6",
+        "Date": "Thu, 22 Jul 2021 17:05:39 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1115a862-5a14-40b8-a979-e9b040207535",
         "Set-Cookie": [
-          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "aab09a36-deb3-4aac-b6b6-7ae2aa7eb57a"
+        "X-RequestId": "f48a0c8a-5018-44ef-8b73-9470e4b8de31"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/f4bee4d9-1607-4d25-b930-d0cb95c363a6",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1115a862-5a14-40b8-a979-e9b040207535",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "c18e721e6127cefd6760c568df2c421c",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210722.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "956475deb9d697153087e905352da416",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "115739aa-158e-49f5-9f64-2d4e77045476",
+        "apim-request-id": "0eb20a31-a056-4f80-8f4f-d06bf7b2bd1d",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 29 Mar 2021 22:05:30 GMT",
-        "ETag": "\u0022249CE59B2C5F40050766B1F37F6A5A8B127F3EA66A951DC9D1762AA3E970BAD1\u0022",
+        "Date": "Thu, 22 Jul 2021 17:05:42 GMT",
+        "ETag": "\u00227B13BAC529F101B4635EEFA8C54AA7DD2FB01F35469E88C62AD5CA8FD288AAFD\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "115739aa-158e-49f5-9f64-2d4e77045476"
+        "X-RequestId": "0eb20a31-a056-4f80-8f4f-d06bf7b2bd1d"
       },
       "ResponseBody": {
-        "id": "f4bee4d9-1607-4d25-b930-d0cb95c363a6",
-        "createdDateTimeUtc": "2021-03-29T22:05:29.9357334Z",
-        "lastActionDateTimeUtc": "2021-03-29T22:05:30.1071124Z",
+        "id": "1115a862-5a14-40b8-a979-e9b040207535",
+        "createdDateTimeUtc": "2021-07-22T17:05:40.1923014Z",
+        "lastActionDateTimeUtc": "2021-07-22T17:05:40.3774034Z",
         "status": "ValidationFailed",
         "error": {
           "code": "InvalidRequest",
-          "message": "Cannot access source document location with the current permissions.",
+          "message": "Cannot access target document location with the current permissions.",
           "target": "Operation",
           "innerError": {
-            "code": "InvalidDocumentAccessLevel",
-            "message": "Cannot access source document location with the current permissions."
+            "code": "InvalidTargetDocumentAccessLevel",
+            "message": "Cannot access target document location with the current permissions."
           }
         },
         "summary": {
@@ -166,6 +166,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
-    "RandomSeed": "50827542"
+    "RandomSeed": "1262242246"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTargetAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/RightSourceWrongTargetAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source18224896?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source442290765?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-f3a6f6ef0c104a438b2439d00250a773-d6f090e267e17c44-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-598bb9cf74664b408e3e55fd39f373df-beb4d7ff19051c48-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "3f10d19745857fc61c122af6c3d72724",
-        "x-ms-date": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "x-ms-client-request-id": "b75dedfd7284b188e20039d92f75d116",
+        "x-ms-date": "Thu, 22 Jul 2021 17:05:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:03:32 GMT",
-        "ETag": "\u00220x8D8F2FE7E222549\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "Date": "Thu, 22 Jul 2021 17:05:42 GMT",
+        "ETag": "\u00220x8D94D32F09CE155\u0022",
+        "Last-Modified": "Thu, 22 Jul 2021 17:05:43 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "3f10d19745857fc61c122af6c3d72724",
-        "x-ms-request-id": "edb702e0-f01e-002c-49e7-2404fd000000",
+        "x-ms-client-request-id": "b75dedfd7284b188e20039d92f75d116",
+        "x-ms-request-id": "f387fec9-e01e-007d-801b-7f9971000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source18224896/Document1.txt",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/source442290765/Document1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "27",
         "If-None-Match": "*",
-        "traceparent": "00-024be1d22e24a6408e44f64cf72ac5d4-c881574e9730eb42-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-27ba32dca2971e48bf7f67bb48a3e44c-d5fb7266f3f29449-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "28c5fa18444d725ba99cbba42b4d8792",
-        "x-ms-date": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "x-ms-client-request-id": "d53e4ad954cad69b84b738eb2fcdc0bb",
+        "x-ms-date": "Thu, 22 Jul 2021 17:05:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,29 +47,29 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "zc6asiLoUz/caxlJ6YwKxA==",
-        "Date": "Mon, 29 Mar 2021 22:03:32 GMT",
-        "ETag": "\u00220x8D8F2FE7E585DC6\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 22:03:32 GMT",
+        "Date": "Thu, 22 Jul 2021 17:05:43 GMT",
+        "ETag": "\u00220x8D94D32F0C41FA8\u0022",
+        "Last-Modified": "Thu, 22 Jul 2021 17:05:43 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "28c5fa18444d725ba99cbba42b4d8792",
+        "x-ms-client-request-id": "d53e4ad954cad69b84b738eb2fcdc0bb",
         "x-ms-content-crc64": "V7knc5S52gk=",
-        "x-ms-request-id": "edb70314-f01e-002c-77e7-2404fd000000",
+        "x-ms-request-id": "f387ff51-e01e-007d-801b-7f9971000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c28db55da4b91445bad5e446cab15fc4-c3da274c414ccb4b-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "9e0739f09d606a72731fd80ea4475968",
+        "traceparent": "00-fd8111b5bd8fe14a94a2c4d6470014a6-2b10d411e32c5a46-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210722.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7eaf9cc13cada6d445e9ba6c02f49090",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -89,65 +89,65 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1ab77998-6570-4d29-adc9-2f751df5ea41",
+        "apim-request-id": "c8db2edb-7acd-489d-8f4f-ff2f31fa38d7",
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:03:32 GMT",
-        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/9bee1b87-044a-4945-a9df-2e875e2e3fe1",
+        "Date": "Thu, 22 Jul 2021 17:05:42 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/68b42427-e27e-469b-bec4-357c70656fb8",
         "Set-Cookie": [
-          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "1ab77998-6570-4d29-adc9-2f751df5ea41"
+        "X-RequestId": "c8db2edb-7acd-489d-8f4f-ff2f31fa38d7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/9bee1b87-044a-4945-a9df-2e875e2e3fe1",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/68b42427-e27e-469b-bec4-357c70656fb8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "7e9d14f44a0e52b2769d96e8892254ce",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210722.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "59654bb1d069a883528732cd399c8115",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "18e380b0-258b-4331-af5f-9e5b8c740fec",
+        "apim-request-id": "18eb08da-8199-48d0-ae0d-6174a882a23f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 29 Mar 2021 22:03:33 GMT",
-        "ETag": "\u002263A575F29138241B6067A5A0552DCE7593A83CDB926B6B5C2252BA4E15C72314\u0022",
+        "Date": "Thu, 22 Jul 2021 17:05:44 GMT",
+        "ETag": "\u0022819828B86F1DAA2642B2904C6BA5C7428CE7B8814B8447E44D6122E7548D8312\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "18e380b0-258b-4331-af5f-9e5b8c740fec"
+        "X-RequestId": "18eb08da-8199-48d0-ae0d-6174a882a23f"
       },
       "ResponseBody": {
-        "id": "9bee1b87-044a-4945-a9df-2e875e2e3fe1",
-        "createdDateTimeUtc": "2021-03-29T22:03:33.3975576Z",
-        "lastActionDateTimeUtc": "2021-03-29T22:03:33.5123233Z",
+        "id": "68b42427-e27e-469b-bec4-357c70656fb8",
+        "createdDateTimeUtc": "2021-07-22T17:05:43.4831071Z",
+        "lastActionDateTimeUtc": "2021-07-22T17:05:43.6225504Z",
         "status": "ValidationFailed",
         "error": {
           "code": "InvalidRequest",
-          "message": "Cannot access source document location with the current permissions.",
+          "message": "Cannot access target document location with the current permissions.",
           "target": "Operation",
           "innerError": {
-            "code": "InvalidDocumentAccessLevel",
-            "message": "Cannot access source document location with the current permissions."
+            "code": "InvalidTargetDocumentAccessLevel",
+            "message": "Cannot access target document location with the current permissions."
           }
         },
         "summary": {
@@ -166,6 +166,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
-    "RandomSeed": "248593475"
+    "RandomSeed": "1309257932"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTarget.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTarget.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1975097330?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1082937542?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8fdaac7f320bec4cabb24c00bfe95ce1-ea9b7014b4144740-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fdd55495a6364c4995e1740d174a1237-488dc86829d04840-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "39813578d6bc9900ae5eeaa526bb6c41",
-        "x-ms-date": "Mon, 29 Mar 2021 20:02:37 GMT",
+        "x-ms-client-request-id": "37d4b5deb867b605c40fa8d225689d54",
+        "x-ms-date": "Thu, 22 Jul 2021 17:01:02 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,27 +17,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 20:02:37 GMT",
-        "ETag": "\u00220x8D8F2ED9A29DBE7\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 20:02:38 GMT",
+        "Date": "Thu, 22 Jul 2021 17:01:04 GMT",
+        "ETag": "\u00220x8D94D324AE3A80B\u0022",
+        "Last-Modified": "Thu, 22 Jul 2021 17:01:04 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "39813578d6bc9900ae5eeaa526bb6c41",
-        "x-ms-request-id": "963bd64b-701e-009b-74d6-242957000000",
+        "x-ms-client-request-id": "37d4b5deb867b605c40fa8d225689d54",
+        "x-ms-request-id": "b449e059-c01e-0018-511b-7f3735000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e2acc8f745078845977852b480d8ccbc-c62fa90c51bc7b45-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "8e55a27be348b38b411bf91a17ebe28b",
+        "traceparent": "00-53ef8c6a08f97e4d8c0f90f091a51dff-1eaa93b94bc76e44-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210722.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b71a7c5c71040fb941c6320ddf67fd77",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -57,57 +57,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "35c0b636-033c-41ae-971e-b91ab83f22f7",
+        "apim-request-id": "ab911f7e-b722-454e-a7be-698d1747f6da",
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 20:02:38 GMT",
-        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/5fae77cb-59cd-4021-bae7-5fcc4fb6cd2c",
+        "Date": "Thu, 22 Jul 2021 17:01:05 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2d8caaab-61c9-4cff-83ef-c2b704826d8a",
         "Set-Cookie": [
-          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "35c0b636-033c-41ae-971e-b91ab83f22f7"
+        "X-RequestId": "ab911f7e-b722-454e-a7be-698d1747f6da"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/5fae77cb-59cd-4021-bae7-5fcc4fb6cd2c",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2d8caaab-61c9-4cff-83ef-c2b704826d8a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "495abe4052c5dbe59a303ed4e45da222",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210722.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "be5855ac53e91238e010b0c612862043",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "53971b6a-d8d4-411e-ae00-8ca19014c2ed",
+        "apim-request-id": "fdfda13c-ac34-409f-89b8-1585154b2165",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 29 Mar 2021 20:02:38 GMT",
-        "ETag": "\u00221896FC34685EE237390A421959D24389AF788E84405256DFBB9BA149CAFC8E40\u0022",
+        "Date": "Thu, 22 Jul 2021 17:01:07 GMT",
+        "ETag": "\u0022F33F9FA552451AE6D2CE46808A29E96C53320156FF03B146C76BC9283EBC84F3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "53971b6a-d8d4-411e-ae00-8ca19014c2ed"
+        "X-RequestId": "fdfda13c-ac34-409f-89b8-1585154b2165"
       },
       "ResponseBody": {
-        "id": "5fae77cb-59cd-4021-bae7-5fcc4fb6cd2c",
-        "createdDateTimeUtc": "2021-03-29T20:02:38.6637111",
-        "lastActionDateTimeUtc": "2021-03-29T20:02:38.8240231",
+        "id": "2d8caaab-61c9-4cff-83ef-c2b704826d8a",
+        "createdDateTimeUtc": "2021-07-22T17:01:05.8729996Z",
+        "lastActionDateTimeUtc": "2021-07-22T17:01:06.0091401Z",
         "status": "ValidationFailed",
         "error": {
           "code": "InvalidRequest",
@@ -134,6 +134,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
-    "RandomSeed": "1304523582"
+    "RandomSeed": "1876683507"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTargetAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/TranslationOperationLiveTests/WrongSourceRightTargetAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target1191210950?restype=container",
+      "RequestUri": "https://mariaridoctrans29prim.blob.core.windows.net/target404828805?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-a2cb45d0a5e7b84aa8aae7da508d72b3-e18eac37575b8d4a-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ee2f3d466be06e4c9cc4423d18c7a9be-b72cba58aea6e64c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "f5d48f90a78e5b44a791fc59ae8a9b77",
-        "x-ms-date": "Mon, 29 Mar 2021 22:04:07 GMT",
+        "x-ms-client-request-id": "dc273dae1e0109e8d35b9ea3e52d693b",
+        "x-ms-date": "Thu, 22 Jul 2021 17:01:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,27 +17,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:04:07 GMT",
-        "ETag": "\u00220x8D8F2FE92F16DAC\u0022",
-        "Last-Modified": "Mon, 29 Mar 2021 22:04:07 GMT",
+        "Date": "Thu, 22 Jul 2021 17:01:08 GMT",
+        "ETag": "\u00220x8D94D324D46BE47\u0022",
+        "Last-Modified": "Thu, 22 Jul 2021 17:01:08 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "f5d48f90a78e5b44a791fc59ae8a9b77",
-        "x-ms-request-id": "edb75c2f-f01e-002c-04e7-2404fd000000",
+        "x-ms-client-request-id": "dc273dae1e0109e8d35b9ea3e52d693b",
+        "x-ms-request-id": "b449e994-c01e-0018-281b-7f3735000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9ef8394e8a59e24894651e885d4231bd-7af6e745a8352f4b-00",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "278b37e4c1330177a6d9cc86e292a3c2",
+        "traceparent": "00-7e8aafa89771d542b61ea18035ae77b1-01f41e5113438346-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210722.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c046b6d2f98561ed6cfb0424042d7ed3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -57,57 +57,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "386b9e79-779e-4fc1-8289-d4d320ba37f9",
+        "apim-request-id": "f3547e11-a077-48f7-bf0c-a41bad672126",
         "Content-Length": "0",
-        "Date": "Mon, 29 Mar 2021 22:04:07 GMT",
-        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/e23a6b30-7872-4e7d-9375-b925b7f56a93",
+        "Date": "Thu, 22 Jul 2021 17:01:08 GMT",
+        "Operation-Location": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1c67df93-cb00-458f-8c43-77d55be9a403",
         "Set-Cookie": [
-          "ARRAffinity=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=5dd610bbbfcdcce1e8b7e036dad4b7c92b91df5adc2f4b536e67d2a5eff0940e;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "386b9e79-779e-4fc1-8289-d4d320ba37f9"
+        "X-RequestId": "f3547e11-a077-48f7-bf0c-a41bad672126"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0-preview.1/batches/e23a6b30-7872-4e7d-9375-b925b7f56a93",
+      "RequestUri": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1c67df93-cb00-458f-8c43-77d55be9a403",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.DocumentTranslation/1.0.0-alpha.20210329.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "c89cd07360e4d120015f5965b1179f2e",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210722.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "180315f4c2d9376ecf6638109bbaace5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e7151610-a5c3-400c-bbdd-43a796e6eba8",
+        "apim-request-id": "11104c5d-46ee-4561-9431-79c4c746be8a",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 29 Mar 2021 22:04:08 GMT",
-        "ETag": "\u00220BF9587DDA3BEF711909560197A9B84EC427FBA2A5A1558629A6302C182D2953\u0022",
+        "Date": "Thu, 22 Jul 2021 17:01:10 GMT",
+        "ETag": "\u002264693739D980D0D9A8B8A642FF5E0192333056EC8EAE795117D7F0B9D92DF2C2\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;Secure;Domain=doctrans.westus.microsofttranslator.com",
-          "ARRAffinitySameSite=19727efd86700e5294e01d3d9816fda18b4016b330aceb2a79043575a77e402c;Path=/;HttpOnly;SameSite=None;Secure;Domain=doctrans.westus.microsofttranslator.com"
+          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e7151610-a5c3-400c-bbdd-43a796e6eba8"
+        "X-RequestId": "11104c5d-46ee-4561-9431-79c4c746be8a"
       },
       "ResponseBody": {
-        "id": "e23a6b30-7872-4e7d-9375-b925b7f56a93",
-        "createdDateTimeUtc": "2021-03-29T22:04:07.7752119Z",
-        "lastActionDateTimeUtc": "2021-03-29T22:04:08.0995268Z",
+        "id": "1c67df93-cb00-458f-8c43-77d55be9a403",
+        "createdDateTimeUtc": "2021-07-22T17:01:09.3074625Z",
+        "lastActionDateTimeUtc": "2021-07-22T17:01:09.500841Z",
         "status": "ValidationFailed",
         "error": {
           "code": "InvalidRequest",
@@ -134,6 +134,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=mariaridoctrans29prim;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://mariaridoctrans29-doctranslation.cognitiveservices.azure.com",
-    "RandomSeed": "422929117"
+    "RandomSeed": "345289854"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/TranslationOperationLiveTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/TranslationOperationLiveTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -248,7 +249,6 @@ namespace Azure.AI.Translation.Document.Tests
         }
 
         [RecordedTest]
-        [Ignore("Flaky test. Enable once service provides fix/information")]
         public async Task WrongSourceRightTarget()
         {
             Uri source = new("https://idont.ex.ist");
@@ -258,6 +258,7 @@ namespace Azure.AI.Translation.Document.Tests
 
             var input = new DocumentTranslationInput(source, target, "fr");
             DocumentTranslationOperation operation = await client.StartTranslationAsync(input);
+            Thread.Sleep(2000);
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.UpdateStatusAsync());
 
@@ -269,7 +270,6 @@ namespace Azure.AI.Translation.Document.Tests
         }
 
         [RecordedTest]
-        [Ignore("Flaky test. Enable once service provides fix/information")]
         public async Task RightSourceWrongTarget()
         {
             Uri source = await CreateSourceContainerAsync(oneTestDocuments);
@@ -279,10 +279,11 @@ namespace Azure.AI.Translation.Document.Tests
 
             var input = new DocumentTranslationInput(source, target, "fr");
             DocumentTranslationOperation operation = await client.StartTranslationAsync(input);
+            Thread.Sleep(2000);
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.UpdateStatusAsync());
 
-            Assert.AreEqual("InvalidDocumentAccessLevel", ex.ErrorCode);
+            Assert.AreEqual("InvalidTargetDocumentAccessLevel", ex.ErrorCode);
 
             Assert.IsTrue(operation.HasCompleted);
             Assert.IsFalse(operation.HasValue);


### PR DESCRIPTION
- Fixes: #22035 Adding another method to the waiting period time to see if the propagation of security access has reached out to all endpoints.
- After talking to the service, adding a sleep time in between the POST and the GET. As for our users, we are looking into a short LRO proposal that will cover this.

I have run the pipeline around 4 times and it is passing. Hopefully, this will mean that we can go back to constant green builds
