### PR TITLE
Properly initialize options for EnvironmentCredential sub credentials

### DIFF
--- a/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
+++ b/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
@@ -39,9 +39,8 @@ namespace Azure.Identity
         /// If the expected environment variables are not found at this time, the GetToken method will return the default <see cref="AccessToken"/> when invoked.
         /// </summary>
         public EnvironmentCredential()
-            : this(CredentialPipeline.GetInstance(null))
-        {
-        }
+            : this(CredentialPipeline.GetInstance(null), new TokenCredentialOptions())
+        { }
 
         /// <summary>
         /// Creates an instance of the EnvironmentCredential class and reads client secret details from environment variables.
@@ -49,14 +48,13 @@ namespace Azure.Identity
         /// </summary>
         /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
         public EnvironmentCredential(TokenCredentialOptions options)
-            : this(CredentialPipeline.GetInstance(options))
-        {
-            _options = options;
-        }
+            : this(CredentialPipeline.GetInstance(options), options)
+        { }
 
-        internal EnvironmentCredential(CredentialPipeline pipeline)
+        internal EnvironmentCredential(CredentialPipeline pipeline, TokenCredentialOptions options)
         {
             _pipeline = pipeline;
+            _options = options;
 
             string tenantId = EnvironmentVariables.TenantId;
             string clientId = EnvironmentVariables.ClientId;

--- a/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
+++ b/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
@@ -39,7 +39,7 @@ namespace Azure.Identity
         /// If the expected environment variables are not found at this time, the GetToken method will return the default <see cref="AccessToken"/> when invoked.
         /// </summary>
         public EnvironmentCredential()
-            : this(CredentialPipeline.GetInstance(null), new TokenCredentialOptions())
+            : this(CredentialPipeline.GetInstance(null))
         { }
 
         /// <summary>
@@ -51,10 +51,10 @@ namespace Azure.Identity
             : this(CredentialPipeline.GetInstance(options), options)
         { }
 
-        internal EnvironmentCredential(CredentialPipeline pipeline, TokenCredentialOptions options)
+        internal EnvironmentCredential(CredentialPipeline pipeline, TokenCredentialOptions options = null)
         {
             _pipeline = pipeline;
-            _options = options;
+            _options = options ?? new TokenCredentialOptions();
 
             string tenantId = EnvironmentVariables.TenantId;
             string clientId = EnvironmentVariables.ClientId;

--- a/sdk/identity/Azure.Identity/tests/EnvironmentCredentialProviderTests.cs
+++ b/sdk/identity/Azure.Identity/tests/EnvironmentCredentialProviderTests.cs
@@ -79,7 +79,7 @@ namespace Azure.Identity.Tests
         [Test]
         public void EnvironmentCredentialUnavailableException()
         {
-            var credential = InstrumentClient(new EnvironmentCredential(CredentialPipeline.GetInstance(null), null));
+            var credential = InstrumentClient(new EnvironmentCredential(CredentialPipeline.GetInstance(null)));
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
         }
 


### PR DESCRIPTION
fixes #22787