### PR TITLE
[TextAnalytics] Remaining Extractive Text Summarization implementation work

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.2.0-beta.1 (Unreleased)
 
 ### Features Added
+- Added property `ExtractSummaryActions` to `TextAnalyticsActions` to support the new 'extractive text summarization' API. This action can be used to extract relevant sentences from an input document.
 
 ### Breaking Changes
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 5.2.0-beta.1 (Unreleased)
 
 ### Features Added
-- Added property `ExtractSummaryActions` to `TextAnalyticsActions` to support the new 'extractive text summarization' API. This action can be used to extract relevant sentences from an input document.
+- Added property `ExtractSummaryActions` to `TextAnalyticsActions` to support the new 'extractive text summarization' API. This action can be used to get a summary for the input document by extracting the most relevant sentences.
 
 ### Breaking Changes
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -36,6 +36,7 @@ namespace Azure.AI.TextAnalytics
         internal AnalyzeActionsResult() { }
         public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.AnalyzeSentimentActionResult> AnalyzeSentimentResults { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.ExtractKeyPhrasesActionResult> ExtractKeyPhrasesResults { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.ExtractSummaryActionResult> ExtractSummaryResults { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.RecognizeEntitiesActionResult> RecognizeEntitiesResults { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.RecognizeLinkedEntitiesActionResult> RecognizeLinkedEntitiesResults { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.RecognizePiiEntitiesActionResult> RecognizePiiEntitiesResults { get { throw null; } }
@@ -257,6 +258,22 @@ namespace Azure.AI.TextAnalytics
         public int? MaxSentenceCount { get { throw null; } set { } }
         public string ModelVersion { get { throw null; } set { } }
         public Azure.AI.TextAnalytics.SummarySentencesOrder? OrderBy { get { throw null; } set { } }
+    }
+    public partial class ExtractSummaryActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
+    {
+        internal ExtractSummaryActionResult() { }
+        public Azure.AI.TextAnalytics.ExtractSummaryResultCollection DocumentsResults { get { throw null; } }
+    }
+    public partial class ExtractSummaryResult : Azure.AI.TextAnalytics.TextAnalyticsResult
+    {
+        internal ExtractSummaryResult() { }
+        public Azure.AI.TextAnalytics.SummarySentenceCollection Sentences { get { throw null; } }
+    }
+    public partial class ExtractSummaryResultCollection : System.Collections.ObjectModel.ReadOnlyCollection<Azure.AI.TextAnalytics.ExtractSummaryResult>
+    {
+        internal ExtractSummaryResultCollection() : base (default(System.Collections.Generic.IList<Azure.AI.TextAnalytics.ExtractSummaryResult>)) { }
+        public string ModelVersion { get { throw null; } }
+        public Azure.AI.TextAnalytics.TextDocumentBatchStatistics Statistics { get { throw null; } }
     }
     public partial class HealthcareEntity
     {
@@ -718,6 +735,19 @@ namespace Azure.AI.TextAnalytics
         public double Negative { get { throw null; } }
         public double Neutral { get { throw null; } }
         public double Positive { get { throw null; } }
+    }
+    public partial class SummarySentence
+    {
+        internal SummarySentence() { }
+        public int Length { get { throw null; } }
+        public int Offset { get { throw null; } }
+        public double RankScore { get { throw null; } }
+        public string Text { get { throw null; } }
+    }
+    public partial class SummarySentenceCollection : System.Collections.ObjectModel.ReadOnlyCollection<Azure.AI.TextAnalytics.SummarySentence>
+    {
+        internal SummarySentenceCollection() : base (default(System.Collections.Generic.IList<Azure.AI.TextAnalytics.SummarySentence>)) { }
+        public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.TextAnalyticsWarning> Warnings { get { throw null; } }
     }
     public enum SummarySentencesOrder
     {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsResult.cs
@@ -15,13 +15,15 @@ namespace Azure.AI.TextAnalytics
             IReadOnlyCollection<RecognizeEntitiesActionResult> recognizeEntitiesActionResults,
             IReadOnlyCollection<RecognizePiiEntitiesActionResult> recognizePiiEntitiesActionResults,
             IReadOnlyCollection<RecognizeLinkedEntitiesActionResult> recognizeLinkedEntitiesActionsResults,
-            IReadOnlyCollection<AnalyzeSentimentActionResult> analyzeSentimentActionsResults)
+            IReadOnlyCollection<AnalyzeSentimentActionResult> analyzeSentimentActionsResults,
+            IReadOnlyCollection<ExtractSummaryActionResult> extractSummaryActionsResults)
         {
             ExtractKeyPhrasesResults = extractKeyPhrasesActionResult;
             RecognizeEntitiesResults = recognizeEntitiesActionResults;
             RecognizePiiEntitiesResults = recognizePiiEntitiesActionResults;
             RecognizeLinkedEntitiesResults = recognizeLinkedEntitiesActionsResults;
             AnalyzeSentimentResults = analyzeSentimentActionsResults;
+            ExtractSummaryResults = extractSummaryActionsResults;
         }
 
         /// <summary>
@@ -48,5 +50,10 @@ namespace Azure.AI.TextAnalytics
         /// Determines the collection of <see cref="AnalyzeSentimentActionResult"/>.
         /// </summary>
         public IReadOnlyCollection<AnalyzeSentimentActionResult> AnalyzeSentimentResults { get; }
+
+        /// <summary>
+        /// Determines the collection of <see cref="ExtractSummaryActionResult"/>.
+        /// </summary>
+        public IReadOnlyCollection<ExtractSummaryActionResult> ExtractSummaryResults { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryAction.cs
@@ -49,8 +49,8 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// If set, specifies the order in which the extracted sentences will be returned in the result. Use
         /// <see cref="SummarySentencesOrder.Offset"/> to keep the original order in which the sentences appear
-        /// in the input. Use <see cref="SummarySentencesOrder.Rank"/> to order them according to their relevance
-        /// to the document input, as decided by the service. Defaults to <see cref="SummarySentencesOrder.Offset"/>.
+        /// in the input document. Use <see cref="SummarySentencesOrder.Rank"/> to order them according to their relevance
+        /// to the input document, as decided by the service. Defaults to <see cref="SummarySentencesOrder.Offset"/>.
         /// </summary>
         public SummarySentencesOrder? OrderBy { get; set; }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryActionResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryActionResult.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.AI.TextAnalytics.Models;
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// The result of the execution of an <see cref="ExtractSummaryAction"/> on the input documents.
+    /// </summary>
+    public class ExtractSummaryActionResult : TextAnalyticsActionResult
+    {
+        private readonly ExtractSummaryResultCollection _documentsResults;
+
+        /// <summary>
+        /// Successful action.
+        /// </summary>
+        internal ExtractSummaryActionResult(ExtractSummaryResultCollection result, DateTimeOffset completedOn)
+            : base(completedOn)
+        {
+            _documentsResults = result;
+        }
+
+        /// <summary>
+        /// Action with an error.
+        /// </summary>
+        internal ExtractSummaryActionResult(DateTimeOffset completedOn, TextAnalyticsErrorInternal error)
+            : base(completedOn, error) { }
+
+        /// <summary>
+        /// Gets the result of the execution of an <see cref="ExtractSummaryAction"/> per each input document.
+        /// </summary>
+        public ExtractSummaryResultCollection DocumentsResults
+        {
+            get
+            {
+                if (HasError)
+                {
+                    throw new InvalidOperationException($"Cannot access the results of this action, due to error {Error.ErrorCode}: {Error.Message}");
+                }
+                return _documentsResults;
+            }
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryResult.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// The result of the extractive text summarization operation on a document,
+    /// containing a collection of the <see cref="SummarySentence"/> objects
+    /// identified in that document.
+    /// </summary>
+    public class ExtractSummaryResult : TextAnalyticsResult
+    {
+        private readonly SummarySentenceCollection _sentences;
+
+        internal ExtractSummaryResult(string id, TextDocumentStatistics statistics, SummarySentenceCollection sentences)
+            : base(id, statistics)
+        {
+            _sentences = sentences;
+        }
+
+        internal ExtractSummaryResult(string id, TextAnalyticsError error) : base(id, error) { }
+
+        /// <summary>
+        /// Gets the collection of summary sentences extracted from the document.
+        /// </summary>
+        public SummarySentenceCollection Sentences
+        {
+            get
+            {
+                if (HasError)
+                {
+                    throw new InvalidOperationException($"Cannot access result for document {Id}, due to error {Error.ErrorCode}: {Error.Message}");
+                }
+                return _sentences;
+            }
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryResultCollection.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryResultCollection.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Collection of <see cref="ExtractSummaryResult"/> objects corresponding
+    /// to a batch of documents, and information about the batch operation.
+    /// </summary>
+    [DebuggerTypeProxy(typeof(ExtractSummaryResultCollectionDebugView))]
+    public class ExtractSummaryResultCollection : ReadOnlyCollection<ExtractSummaryResult>
+    {
+        internal ExtractSummaryResultCollection(IList<ExtractSummaryResult> list, TextDocumentBatchStatistics statistics, string modelVersion) : base(list)
+        {
+            Statistics = statistics;
+            ModelVersion = modelVersion;
+        }
+
+        /// <summary>
+        /// Gets statistics about the documents and how it was processed
+        /// by the service.  This property will have a value when IncludeStatistics
+        /// is set to true in the client call.
+        /// </summary>
+        public TextDocumentBatchStatistics Statistics { get; }
+
+        /// <summary>
+        /// Gets the version of the Text Analytics model used by this operation
+        /// on this batch of documents.
+        /// </summary>
+        public string ModelVersion { get; }
+
+        /// <summary>
+        /// Debugger Proxy class for <see cref="ExtractSummaryResultCollection"/>.
+        /// </summary>
+        internal class ExtractSummaryResultCollectionDebugView
+        {
+            private ExtractSummaryResultCollection BaseCollection { get; }
+
+            public ExtractSummaryResultCollectionDebugView(ExtractSummaryResultCollection collection)
+            {
+                BaseCollection = collection;
+            }
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public List<ExtractSummaryResult> Items
+            {
+                get
+                {
+                    return BaseCollection.ToList();
+                }
+            }
+
+            public TextDocumentBatchStatistics Statistics
+            {
+                get
+                {
+                    return BaseCollection.Statistics;
+                }
+            }
+
+            public string ModelVersion
+            {
+                get
+                {
+                    return BaseCollection.ModelVersion;
+                }
+            }
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/AnalyzeTasks.Serialization.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/AnalyzeTasks.Serialization.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.TextAnalytics.Models
             Optional<IReadOnlyList<KeyPhraseExtractionTasksItem>> keyPhraseExtractionTasks = default;
             Optional<IReadOnlyList<EntityLinkingTasksItem>> entityLinkingTasks = default;
             Optional<IReadOnlyList<SentimentAnalysisTasksItem>> sentimentAnalysisTasks = default;
-            Optional<IReadOnlyList<TasksStateTasksExtractiveSummarizationTasksItem>> extractiveSummarizationTasks = default;
+            Optional<IReadOnlyList<ExtractiveSummarizationTasksItem>> extractiveSummarizationTasks = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("completed"))
@@ -129,10 +129,10 @@ namespace Azure.AI.TextAnalytics.Models
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    List<TasksStateTasksExtractiveSummarizationTasksItem> array = new List<TasksStateTasksExtractiveSummarizationTasksItem>();
+                    List<ExtractiveSummarizationTasksItem> array = new List<ExtractiveSummarizationTasksItem>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(TasksStateTasksExtractiveSummarizationTasksItem.DeserializeTasksStateTasksExtractiveSummarizationTasksItem(item));
+                        array.Add(ExtractiveSummarizationTasksItem.DeserializeExtractiveSummarizationTasksItem(item));
                     }
                     extractiveSummarizationTasks = array;
                     continue;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/AnalyzeTasks.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/AnalyzeTasks.cs
@@ -29,7 +29,7 @@ namespace Azure.AI.TextAnalytics.Models
             KeyPhraseExtractionTasks = new ChangeTrackingList<KeyPhraseExtractionTasksItem>();
             EntityLinkingTasks = new ChangeTrackingList<EntityLinkingTasksItem>();
             SentimentAnalysisTasks = new ChangeTrackingList<SentimentAnalysisTasksItem>();
-            ExtractiveSummarizationTasks = new ChangeTrackingList<TasksStateTasksExtractiveSummarizationTasksItem>();
+            ExtractiveSummarizationTasks = new ChangeTrackingList<ExtractiveSummarizationTasksItem>();
         }
 
         /// <summary> Initializes a new instance of AnalyzeTasks. </summary>
@@ -43,7 +43,7 @@ namespace Azure.AI.TextAnalytics.Models
         /// <param name="entityLinkingTasks"> . </param>
         /// <param name="sentimentAnalysisTasks"> . </param>
         /// <param name="extractiveSummarizationTasks"> . </param>
-        internal AnalyzeTasks(int completed, int failed, int inProgress, int total, IReadOnlyList<EntityRecognitionTasksItem> entityRecognitionTasks, IReadOnlyList<EntityRecognitionPiiTasksItem> entityRecognitionPiiTasks, IReadOnlyList<KeyPhraseExtractionTasksItem> keyPhraseExtractionTasks, IReadOnlyList<EntityLinkingTasksItem> entityLinkingTasks, IReadOnlyList<SentimentAnalysisTasksItem> sentimentAnalysisTasks, IReadOnlyList<TasksStateTasksExtractiveSummarizationTasksItem> extractiveSummarizationTasks)
+        internal AnalyzeTasks(int completed, int failed, int inProgress, int total, IReadOnlyList<EntityRecognitionTasksItem> entityRecognitionTasks, IReadOnlyList<EntityRecognitionPiiTasksItem> entityRecognitionPiiTasks, IReadOnlyList<KeyPhraseExtractionTasksItem> keyPhraseExtractionTasks, IReadOnlyList<EntityLinkingTasksItem> entityLinkingTasks, IReadOnlyList<SentimentAnalysisTasksItem> sentimentAnalysisTasks, IReadOnlyList<ExtractiveSummarizationTasksItem> extractiveSummarizationTasks)
         {
             Completed = completed;
             Failed = failed;
@@ -66,6 +66,6 @@ namespace Azure.AI.TextAnalytics.Models
         public IReadOnlyList<KeyPhraseExtractionTasksItem> KeyPhraseExtractionTasks { get; }
         public IReadOnlyList<EntityLinkingTasksItem> EntityLinkingTasks { get; }
         public IReadOnlyList<SentimentAnalysisTasksItem> SentimentAnalysisTasks { get; }
-        public IReadOnlyList<TasksStateTasksExtractiveSummarizationTasksItem> ExtractiveSummarizationTasks { get; }
+        public IReadOnlyList<ExtractiveSummarizationTasksItem> ExtractiveSummarizationTasks { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/ExtractiveSummarizationTasksItem.Serialization.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/ExtractiveSummarizationTasksItem.Serialization.cs
@@ -12,9 +12,9 @@ using Azure.Core;
 
 namespace Azure.AI.TextAnalytics.Models
 {
-    internal partial class TasksStateTasksExtractiveSummarizationTasksItem
+    internal partial class ExtractiveSummarizationTasksItem
     {
-        internal static TasksStateTasksExtractiveSummarizationTasksItem DeserializeTasksStateTasksExtractiveSummarizationTasksItem(JsonElement element)
+        internal static ExtractiveSummarizationTasksItem DeserializeExtractiveSummarizationTasksItem(JsonElement element)
         {
             Optional<ExtractiveSummarizationResult> results = default;
             DateTimeOffset lastUpdateDateTime = default;
@@ -48,7 +48,7 @@ namespace Azure.AI.TextAnalytics.Models
                     continue;
                 }
             }
-            return new TasksStateTasksExtractiveSummarizationTasksItem(lastUpdateDateTime, taskName.Value, status, results.Value);
+            return new ExtractiveSummarizationTasksItem(lastUpdateDateTime, taskName.Value, status, results.Value);
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/ExtractiveSummarizationTasksItem.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/ExtractiveSummarizationTasksItem.cs
@@ -11,21 +11,21 @@ using Azure.AI.TextAnalytics;
 namespace Azure.AI.TextAnalytics.Models
 {
     /// <summary> The TasksStateTasksExtractiveSummarizationTasksItem. </summary>
-    internal partial class TasksStateTasksExtractiveSummarizationTasksItem : TaskState
+    internal partial class ExtractiveSummarizationTasksItem : TaskState
     {
-        /// <summary> Initializes a new instance of TasksStateTasksExtractiveSummarizationTasksItem. </summary>
+        /// <summary> Initializes a new instance of ExtractiveSummarizationTasksItem. </summary>
         /// <param name="lastUpdateDateTime"> . </param>
         /// <param name="status"> . </param>
-        internal TasksStateTasksExtractiveSummarizationTasksItem(DateTimeOffset lastUpdateDateTime, TextAnalyticsOperationStatus status) : base(lastUpdateDateTime, status)
+        internal ExtractiveSummarizationTasksItem(DateTimeOffset lastUpdateDateTime, TextAnalyticsOperationStatus status) : base(lastUpdateDateTime, status)
         {
         }
 
-        /// <summary> Initializes a new instance of TasksStateTasksExtractiveSummarizationTasksItem. </summary>
+        /// <summary> Initializes a new instance of ExtractiveSummarizationTasksItem. </summary>
         /// <param name="lastUpdateDateTime"> . </param>
         /// <param name="taskName"> . </param>
         /// <param name="status"> . </param>
         /// <param name="results"> . </param>
-        internal TasksStateTasksExtractiveSummarizationTasksItem(DateTimeOffset lastUpdateDateTime, string taskName, TextAnalyticsOperationStatus status, ExtractiveSummarizationResult results) : base(lastUpdateDateTime, taskName, status)
+        internal ExtractiveSummarizationTasksItem(DateTimeOffset lastUpdateDateTime, string taskName, TextAnalyticsOperationStatus status, ExtractiveSummarizationResult results) : base(lastUpdateDateTime, taskName, status)
         {
             Results = results;
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Internal/ExtractiveSummarizationTasksItem.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Internal/ExtractiveSummarizationTasksItem.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+
+namespace Azure.AI.TextAnalytics.Models
+{
+    /// <summary>
+    /// ExtractiveSummarizationTasksItem.
+    /// </summary>
+    [CodeGenModel("TasksStateTasksExtractiveSummarizationTasksItem")]
+    internal partial class ExtractiveSummarizationTasksItem { }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/SummarySentence.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/SummarySentence.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.AI.TextAnalytics.Models;
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// A sentence extracted from an input document by an extractive text summarization
+    /// operation. The service attributes a rank score to it for measuring how relevant
+    /// the sentence is to the input document.
+    /// </summary>
+    public class SummarySentence
+    {
+        internal SummarySentence(ExtractedSummarySentence sentence)
+        {
+            Text = sentence.Text;
+            RankScore = sentence.RankScore;
+            Offset = sentence.Offset;
+            Length = sentence.Length;
+        }
+
+        /// <summary>
+        /// Gets the sentence text as it appears in the input document.
+        /// </summary>
+        public string Text { get; }
+
+        /// <summary>
+        /// Gets the rank score of the sentence, measuring how relevant the sentence is
+        /// to the input document. The value is set between [0.0, 1.0], with higher
+        /// values indicating a higher relevance.
+        /// </summary>
+        public double RankScore { get; }
+
+        /// <summary>
+        /// Gets the starting position for the matching sentence in the input document.
+        /// </summary>
+        public int Offset { get; }
+
+        /// <summary>
+        /// Gets the length of the matching sentence in the input document.
+        /// </summary>
+        public int Length { get; }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/SummarySentenceCollection.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/SummarySentenceCollection.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Collection of <see cref="SummarySentence"/> objects in a document,
+    /// and warnings encountered while processing the document.
+    /// </summary>
+    [DebuggerTypeProxy(typeof(SummarySentenceCollectionDebugView))]
+    public class SummarySentenceCollection : ReadOnlyCollection<SummarySentence>
+    {
+        internal SummarySentenceCollection(IList<SummarySentence> sentences, IList<TextAnalyticsWarning> warnings)
+            : base(sentences)
+        {
+            Warnings = new ReadOnlyCollection<TextAnalyticsWarning>(warnings);
+        }
+
+        /// <summary>
+        /// Warnings encountered while processing the document.
+        /// </summary>
+        public IReadOnlyCollection<TextAnalyticsWarning> Warnings { get; }
+
+        /// <summary>
+        /// Debugger Proxy class for <see cref="SummarySentenceCollection"/>.
+        /// </summary>
+        internal class SummarySentenceCollectionDebugView
+        {
+            private SummarySentenceCollection BaseCollection { get; }
+
+            public SummarySentenceCollectionDebugView(SummarySentenceCollection collection)
+            {
+                BaseCollection = collection;
+            }
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public List<SummarySentence> Items
+            {
+                get
+                {
+                    return BaseCollection.ToList();
+                }
+            }
+
+            public IReadOnlyCollection<TextAnalyticsWarning> Warnings
+            {
+                get
+                {
+                    return BaseCollection.Warnings;
+                }
+            }
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/SummarySentencesOrder.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/SummarySentencesOrder.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.TextAnalytics
         Offset,
 
         /// <summary>
-        /// Orders sentences according to their relevance to the document input, as decided by the service.
+        /// Orders sentences according to their relevance to the input document, as decided by the service.
         /// </summary>
         Rank
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
@@ -610,7 +610,8 @@ namespace Azure.AI.TextAnalytics
                 recognizeEntitiesActionResults.ToList(),
                 recognizePiiEntitiesActionResults.ToList(),
                 recognizeLinkedEntitiesActionsResults.ToList(),
-                analyzeSentimentActionsResults.ToList());
+                analyzeSentimentActionsResults.ToList(),
+                null); // TODO: update model factory.
         }
 
         /// <summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
@@ -611,7 +611,7 @@ namespace Azure.AI.TextAnalytics
                 recognizePiiEntitiesActionResults.ToList(),
                 recognizeLinkedEntitiesActionsResults.ToList(),
                 analyzeSentimentActionsResults.ToList(),
-                null); // TODO: update model factory.
+                null); // TODO: include extractive summarization API (https://github.com/Azure/azure-sdk-for-net/issues/22836).
         }
 
         /// <summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
@@ -519,7 +519,7 @@ namespace Azure.AI.TextAnalytics
             {
                 throw new InvalidOperationException("Expected an error with a target field referencing an action but did not get one");
             }
-            Regex _targetRegex = new Regex("#/tasks/(keyPhraseExtractionTasks|entityRecognitionPiiTasks|entityRecognitionTasks|entityLinkingTasks|sentimentAnalysisTasks)/(\\d+)", RegexOptions.Compiled, TimeSpan.FromSeconds(2));
+            Regex _targetRegex = new Regex("#/tasks/(keyPhraseExtractionTasks|entityRecognitionPiiTasks|entityRecognitionTasks|entityLinkingTasks|sentimentAnalysisTasks|extractiveSummarizationTasks)/(\\d+)", RegexOptions.Compiled, TimeSpan.FromSeconds(2));
 
             // action could be failed and the target reference is "#/tasks/keyPhraseExtractionTasks/0";
             Match targetMatch = _targetRegex.Match(targetReference);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
@@ -318,6 +318,39 @@ namespace Azure.AI.TextAnalytics
 
         #endregion
 
+        #region Extract Summary
+
+        internal static List<SummarySentence> ConvertToSummarySentenceList(List<ExtractedSummarySentence> sentences)
+            => sentences.Select((sentence) => new SummarySentence(sentence)).ToList();
+
+        internal static SummarySentenceCollection ConvertToSummarySentenceCollection(ExtractedDocumentSummary documentSummary)
+        {
+            return new SummarySentenceCollection(ConvertToSummarySentenceList(documentSummary.Sentences.ToList()), ConvertToWarnings(documentSummary.Warnings));
+        }
+
+        internal static ExtractSummaryResultCollection ConvertToExtractSummaryResultCollection(ExtractiveSummarizationResult results, IDictionary<string, int> idToIndexMap)
+        {
+            var extractedSummaries = new List<ExtractSummaryResult>();
+
+            //Read errors
+            foreach (DocumentError error in results.Errors)
+            {
+                extractedSummaries.Add(new ExtractSummaryResult(error.Id, ConvertToError(error.Error)));
+            }
+
+            //Read document summaries
+            foreach (ExtractedDocumentSummary docSummary in results.Documents)
+            {
+                extractedSummaries.Add(new ExtractSummaryResult(docSummary.Id, docSummary.Statistics ?? default, ConvertToSummarySentenceCollection(docSummary)));
+            }
+
+            extractedSummaries = SortHeterogeneousCollection(extractedSummaries, idToIndexMap);
+
+            return new ExtractSummaryResultCollection(extractedSummaries, results.Statistics, results.ModelVersion);
+        }
+
+        #endregion
+
         #region Analyze Operation
 
         internal static PiiTask ConvertToPiiTask(RecognizePiiEntitiesAction action)
@@ -508,6 +541,7 @@ namespace Azure.AI.TextAnalytics
             IDictionary<int, TextAnalyticsErrorInternal> entitiesPiiRecognitionErrors = new Dictionary<int, TextAnalyticsErrorInternal>();
             IDictionary<int, TextAnalyticsErrorInternal> entitiesLinkingRecognitionErrors = new Dictionary<int, TextAnalyticsErrorInternal>();
             IDictionary<int, TextAnalyticsErrorInternal> analyzeSentimentErrors = new Dictionary<int, TextAnalyticsErrorInternal>();
+            IDictionary<int, TextAnalyticsErrorInternal> extractSummaryErrors = new Dictionary<int, TextAnalyticsErrorInternal>();
 
             if (jobState.Errors.Any())
             {
@@ -540,6 +574,10 @@ namespace Azure.AI.TextAnalytics
                     {
                         analyzeSentimentErrors.Add(taskIndex, error);
                     }
+                    else if ("extractiveSummarizationTasks".Equals(taskName))
+                    {
+                        extractSummaryErrors.Add(taskIndex, error);
+                    }
                     else
                     {
                         throw new InvalidOperationException($"Invalid task name in target reference - {taskName}. \n Additional information: Error code: {error.Code} Error message: {error.Message}");
@@ -552,7 +590,8 @@ namespace Azure.AI.TextAnalytics
                 ConvertToRecognizeEntitiesActionsResults(jobState, map, entitiesRecognitionErrors),
                 ConvertToRecognizePiiEntitiesActionsResults(jobState, map, entitiesPiiRecognitionErrors),
                 ConvertToRecognizeLinkedEntitiesActionsResults(jobState, map, entitiesLinkingRecognitionErrors),
-                ConvertToAnalyzeSentimentActionsResults(jobState, map, analyzeSentimentErrors));
+                ConvertToAnalyzeSentimentActionsResults(jobState, map, analyzeSentimentErrors),
+                ConvertToExtractSummaryActionsResults(jobState, map, extractSummaryErrors));
         }
 
         private static IReadOnlyCollection<AnalyzeSentimentActionResult> ConvertToAnalyzeSentimentActionsResults(AnalyzeJobState jobState, IDictionary<string, int> idToIndexMap, IDictionary<int, TextAnalyticsErrorInternal> tasksErrors)
@@ -651,8 +690,6 @@ namespace Azure.AI.TextAnalytics
             {
                 tasksErrors.TryGetValue(index, out TextAnalyticsErrorInternal taskError);
 
-                tasksErrors.TryGetValue(index, out taskError);
-
                 if (taskError != null)
                 {
                     collection.Add(new RecognizeEntitiesActionResult(task.LastUpdateDateTime, taskError));
@@ -660,6 +697,28 @@ namespace Azure.AI.TextAnalytics
                 else
                 {
                     collection.Add(new RecognizeEntitiesActionResult(ConvertToRecognizeEntitiesResultCollection(task.Results, idToIndexMap), task.LastUpdateDateTime));
+                }
+                index++;
+            }
+
+            return collection;
+        }
+
+        private static IReadOnlyCollection<ExtractSummaryActionResult> ConvertToExtractSummaryActionsResults(AnalyzeJobState jobState, IDictionary<string, int> idToIndexMap, IDictionary<int, TextAnalyticsErrorInternal> tasksErrors)
+        {
+            var collection = new List<ExtractSummaryActionResult>();
+            int index = 0;
+            foreach (ExtractiveSummarizationTasksItem task in jobState.Tasks.ExtractiveSummarizationTasks)
+            {
+                tasksErrors.TryGetValue(index, out TextAnalyticsErrorInternal taskError);
+
+                if (taskError != null)
+                {
+                    collection.Add(new ExtractSummaryActionResult(task.LastUpdateDateTime, taskError));
+                }
+                else
+                {
+                    collection.Add(new ExtractSummaryActionResult(ConvertToExtractSummaryResultCollection(task.Results, idToIndexMap), task.LastUpdateDateTime));
                 }
                 index++;
             }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationMockTests.cs
@@ -810,6 +810,11 @@ namespace Azure.AI.TextAnalytics.Tests
                         ""code"": ""InvalidRequest"",
                         ""message"": ""Some error"",
                         ""target"": ""#/tasks/sentimentAnalysisTasks/0""
+                      },
+                      {
+                        ""code"": ""InvalidRequest"",
+                        ""message"": ""Some error"",
+                        ""target"": ""#/tasks/extractiveSummarizationTasks/0""
                       }
                     ],
                     ""tasks"": {
@@ -818,9 +823,9 @@ namespace Azure.AI.TextAnalytics.Tests
                         ""lastUpdateDateTime"": ""2021-03-03T22:39:37Z""
                       },
                       ""completed"": 0,
-                      ""failed"": 5,
+                      ""failed"": 6,
                       ""inProgress"": 0,
-                      ""total"": 5,
+                      ""total"": 6,
                       ""entityRecognitionTasks"": [
                         {
                           ""lastUpdateDateTime"": ""2021-03-03T22:39:37.1716697Z"",
@@ -855,6 +860,13 @@ namespace Azure.AI.TextAnalytics.Tests
                           ""taskName"": ""something"",
                           ""state"": ""failed""
                         }
+                      ],
+                      ""extractiveSummarizationTasks"": [
+                        {
+                          ""lastUpdateDateTime"": ""2021-03-03T22:39:37.1716697Z"",
+                          ""taskName"": ""something"",
+                          ""state"": ""failed""
+                        }
                       ]
                     }
                 }"));
@@ -877,16 +889,17 @@ namespace Azure.AI.TextAnalytics.Tests
                 RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
                 RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
                 AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
+                ExtractSummaryActions = new List<ExtractSummaryAction>() { new ExtractSummaryAction() },
                 DisplayName = "AnalyzeOperationBatchWithErrorTest"
             };
 
             var operation = new AnalyzeActionsOperation("75d521bc-c2aa-4d8a-aabe-713e72d53a2d", client);
             await operation.UpdateStatusAsync();
 
-            Assert.AreEqual(5, operation.ActionsFailed);
+            Assert.AreEqual(6, operation.ActionsFailed);
             Assert.AreEqual(0, operation.ActionsSucceeded);
             Assert.AreEqual(0, operation.ActionsInProgress);
-            Assert.AreEqual(5, operation.ActionsTotal);
+            Assert.AreEqual(6, operation.ActionsTotal);
 
             //Take the first page
             AnalyzeActionsResult resultCollection = operation.Value.ToEnumerableAsync().Result.FirstOrDefault();
@@ -896,6 +909,7 @@ namespace Azure.AI.TextAnalytics.Tests
             RecognizePiiEntitiesActionResult piiActionsResults = resultCollection.RecognizePiiEntitiesResults.FirstOrDefault();
             RecognizeLinkedEntitiesActionResult entityLinkingActionsResults = resultCollection.RecognizeLinkedEntitiesResults.FirstOrDefault();
             AnalyzeSentimentActionResult analyzeSentimentActionsResults = resultCollection.AnalyzeSentimentResults.FirstOrDefault();
+            ExtractSummaryActionResult extractSummaryActionsResults = resultCollection.ExtractSummaryResults.FirstOrDefault();
 
             Assert.IsTrue(entitiesActionsResults.HasError);
             Assert.Throws<InvalidOperationException>(() => entitiesActionsResults.DocumentsResults.GetType());
@@ -911,6 +925,9 @@ namespace Azure.AI.TextAnalytics.Tests
 
             Assert.IsTrue(analyzeSentimentActionsResults.HasError);
             Assert.Throws<InvalidOperationException>(() => analyzeSentimentActionsResults.DocumentsResults.GetType());
+
+            Assert.IsTrue(extractSummaryActionsResults.HasError);
+            Assert.Throws<InvalidOperationException>(() => extractSummaryActionsResults.DocumentsResults.GetType());
         }
 
         [Test]


### PR DESCRIPTION
Fixes https://github.com/azure/azure-sdk-for-net/issues/22773.

Input action already implemented. This PR adds all output models and corresponding transforms for the Extractive Test Summarization API.

There are two major issues to solve after this one:
- Update the model factory for mocking the new models. Will do it in a separate PR to avoid polluting this one. Tracked by https://github.com/Azure/azure-sdk-for-net/issues/22836.
- Add live tests for the new API. Currently we only have a few mock tests that don't cover the whole usage scenarios. We still haven't updated our endpoint to version 3.2-preview.1, and we'll have a separate PR for that. Live testing work tracked by https://github.com/Azure/azure-sdk-for-net/issues/22839.