### PR TITLE
Return RandomBytes instead of byte[] for GetRandomBytes

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
@@ -127,8 +127,8 @@ namespace Azure.Security.KeyVault.Keys
         public virtual Azure.AsyncPageable<Azure.Security.KeyVault.Keys.KeyProperties> GetPropertiesOfKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.Security.KeyVault.Keys.KeyProperties> GetPropertiesOfKeyVersions(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.Security.KeyVault.Keys.KeyProperties> GetPropertiesOfKeyVersionsAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<byte[]> GetRandomBytes(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<byte[]>> GetRandomBytesAsync(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Security.KeyVault.Keys.RandomBytes> GetRandomBytes(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.KeyVault.Keys.RandomBytes>> GetRandomBytesAsync(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Security.KeyVault.Keys.KeyVaultKey> ImportKey(Azure.Security.KeyVault.Keys.ImportKeyOptions importKeyOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Security.KeyVault.Keys.KeyVaultKey> ImportKey(string name, Azure.Security.KeyVault.Keys.JsonWebKey keyMaterial, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.KeyVault.Keys.KeyVaultKey>> ImportKeyAsync(Azure.Security.KeyVault.Keys.ImportKeyOptions importKeyOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -184,6 +184,7 @@ namespace Azure.Security.KeyVault.Keys
         public static Azure.Security.KeyVault.Keys.KeyProperties KeyProperties(System.Uri id, System.Uri vaultUri, string name, string version, bool managed, System.DateTimeOffset? createdOn, System.DateTimeOffset? updatedOn, string recoveryLevel) { throw null; }
         public static Azure.Security.KeyVault.Keys.KeyProperties KeyProperties(System.Uri id = null, System.Uri vaultUri = null, string name = null, string version = null, bool managed = false, System.DateTimeOffset? createdOn = default(System.DateTimeOffset?), System.DateTimeOffset? updatedOn = default(System.DateTimeOffset?), string recoveryLevel = null, int? recoverableDays = default(int?)) { throw null; }
         public static Azure.Security.KeyVault.Keys.KeyVaultKey KeyVaultKey(Azure.Security.KeyVault.Keys.KeyProperties properties, Azure.Security.KeyVault.Keys.JsonWebKey key) { throw null; }
+        public static Azure.Security.KeyVault.Keys.RandomBytes RandomBytes(byte[] value) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct KeyOperation : System.IEquatable<Azure.Security.KeyVault.Keys.KeyOperation>
@@ -275,6 +276,11 @@ namespace Azure.Security.KeyVault.Keys
         public override int GetHashCode() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
+    }
+    public partial class RandomBytes
+    {
+        internal RandomBytes() { }
+        public byte[] Value { get { throw null; } }
     }
     public partial class RecoverDeletedKeyOperation : Azure.Operation<Azure.Security.KeyVault.Keys.KeyVaultKey>
     {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
@@ -1174,9 +1174,9 @@ namespace Azure.Security.KeyVault.Keys
         /// </summary>
         /// <param name="count">The requested number of random bytes.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <returns>A byte array containing random values from a managed hardware security module (HSM).</returns>
+        /// <returns><see cref="RandomBytes"/> containing random values from a managed hardware security module (HSM).</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than 0.</exception>
-        public virtual Response<byte[]> GetRandomBytes(int count, CancellationToken cancellationToken = default)
+        public virtual Response<RandomBytes> GetRandomBytes(int count, CancellationToken cancellationToken = default)
         {
             // Service currently documents 1 to 128 inclusive but we must not tightly couple to service constraints.
             Argument.AssertInRange(count, 1, int.MaxValue, nameof(count));
@@ -1186,8 +1186,7 @@ namespace Azure.Security.KeyVault.Keys
 
             try
             {
-                Response<RandomBytes> response = _pipeline.SendRequest(RequestMethod.Post, new GetRandomBytesRequest(count), () => new RandomBytes(), cancellationToken, RngPath);
-                return Response.FromValue(response.Value.Value, response.GetRawResponse());
+                return _pipeline.SendRequest(RequestMethod.Post, new GetRandomBytesRequest(count), () => new RandomBytes(), cancellationToken, RngPath);
             }
             catch (Exception e)
             {
@@ -1201,9 +1200,9 @@ namespace Azure.Security.KeyVault.Keys
         /// </summary>
         /// <param name="count">The requested number of random bytes.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <returns>A byte array containing random values from a managed hardware security module (HSM).</returns>
+        /// <returns><see cref="RandomBytes"/> containing random values from a managed hardware security module (HSM).</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than 0.</exception>
-        public virtual async Task<Response<byte[]>> GetRandomBytesAsync(int count, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<RandomBytes>> GetRandomBytesAsync(int count, CancellationToken cancellationToken = default)
         {
             // Service currently documents 1 to 128 inclusive but we must not tightly couple to service constraints.
             Argument.AssertInRange(count, 1, int.MaxValue, nameof(count));
@@ -1213,8 +1212,7 @@ namespace Azure.Security.KeyVault.Keys
 
             try
             {
-                Response<RandomBytes> response = await _pipeline.SendRequestAsync(RequestMethod.Post, new GetRandomBytesRequest(count), () => new RandomBytes(), cancellationToken, RngPath).ConfigureAwait(false);
-                return Response.FromValue(response.Value.Value, response.GetRawResponse());
+                return await _pipeline.SendRequestAsync(RequestMethod.Post, new GetRandomBytesRequest(count), () => new RandomBytes(), cancellationToken, RngPath).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyModelFactory.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyModelFactory.cs
@@ -167,5 +167,12 @@ namespace Azure.Security.KeyVault.Keys
             DeletedOn = deletedOn,
             ScheduledPurgeDate = scheduledPurgeDate,
         };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Keys.RandomBytes"/> for mocking purposes.
+        /// </summary>
+        /// <param name="value">Sets the <see cref="Keys.RandomBytes.Value"/> property.</param>
+        /// <returns>A new instance of the <see cref="Keys.RandomBytes"/> for mocking purposes.</returns>
+        public static RandomBytes RandomBytes(byte[] value) => new RandomBytes { Value = value };
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/RandomBytes.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/RandomBytes.cs
@@ -6,11 +6,23 @@ using Azure.Core;
 
 namespace Azure.Security.KeyVault.Keys
 {
-    internal class RandomBytes : IJsonDeserializable
+    /// <summary>
+    /// Contains random bytes returned from <see cref="KeyClient.GetRandomBytes(int, System.Threading.CancellationToken)"/>
+    /// or <see cref="KeyClient.GetRandomBytesAsync(int, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    public class RandomBytes : IJsonDeserializable
     {
-        private const string s_valuePropertyName = "value";
+        private const string ValuePropertyName = "value";
 
-        public byte[] Value { get; private set; }
+        internal RandomBytes()
+        {
+        }
+
+        /// <summary>
+        /// Gets random bytes returned from <see cref="KeyClient.GetRandomBytes(int, System.Threading.CancellationToken)"/>
+        /// or <see cref="KeyClient.GetRandomBytesAsync(int, System.Threading.CancellationToken)"/>.
+        /// </summary>
+        public byte[] Value { get; internal set; }
 
         void IJsonDeserializable.ReadProperties(JsonElement json)
         {
@@ -18,7 +30,7 @@ namespace Azure.Security.KeyVault.Keys
             {
                 switch (prop.Name)
                 {
-                    case s_valuePropertyName:
+                    case ValuePropertyName:
                         string value = prop.Value.GetString();
                         Value = Base64Url.Decode(value);
                         break;

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmLiveTests.cs
@@ -82,8 +82,8 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [ServiceVersion(Min = KeyClientOptions.ServiceVersion.V7_3_Preview)]
         public async Task GetRandomBytes(int count)
         {
-            byte[] iv = await Client.GetRandomBytesAsync(count);
-            Assert.AreEqual(count, iv.Length);
+            RandomBytes rand = await Client.GetRandomBytesAsync(count);
+            Assert.AreEqual(count, rand.Value.Length);
         }
     }
 }


### PR DESCRIPTION
Resolves #22794
