### PR TITLE
Removing Unused Snippets

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputs.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputs.cs
@@ -22,7 +22,6 @@ namespace Azure.AI.Translation.Document.Samples
 
             var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            #region Snippet:MultipleInputs
             Uri source1SasUriUri = new Uri("<source1 SAS URI>");
             Uri source2SasUri = new Uri("<source2 SAS URI>");
             Uri frenchTargetSasUri = new Uri("<french target SAS URI>");
@@ -93,7 +92,6 @@ namespace Azure.AI.Translation.Document.Samples
                 }
             }
 
-            #endregion
         }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistory.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistory.cs
@@ -20,8 +20,6 @@ namespace Azure.AI.Translation.Document.Samples
 
             var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            #region Snippet:OperationsHistory
-
             int operationsCount = 0;
             int totalDocs = 0;
             int docsCancelled = 0;
@@ -61,8 +59,6 @@ namespace Azure.AI.Translation.Document.Samples
             Console.WriteLine($"Succeeded Document: {docsSucceeded}");
             Console.WriteLine($"Failed Document: {docsFailed}");
             Console.WriteLine($"Cancelled Documents: {docsCancelled}");
-
-            #endregion
         }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocuments.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocuments.cs
@@ -21,7 +21,6 @@ namespace Azure.AI.Translation.Document.Samples
 
             var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            #region Snippet:PollIndividualDocuments
             Uri sourceUri = new Uri("<source SAS URI>");
             Uri targetUri = new Uri("<target SAS URI>");
 
@@ -61,8 +60,6 @@ namespace Azure.AI.Translation.Document.Samples
                     Console.WriteLine($"  Message: {document.Error.Message}");
                 }
             }
-
-            #endregion
         }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocumentsAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocumentsAsync.cs
@@ -21,7 +21,6 @@ namespace Azure.AI.Translation.Document.Samples
 
             var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            #region Snippet:PollIndividualDocumentsAsync
             Uri sourceUri = new Uri("<source SAS URI>");
             Uri targetUri = new Uri("<target SAS URI>");
 
@@ -62,8 +61,6 @@ namespace Azure.AI.Translation.Document.Samples
                     Console.WriteLine($"  Message: {document.Error.Message}");
                 }
             }
-
-            #endregion
         }
     }
 }


### PR DESCRIPTION
The following four unused snippets were removed from the code, as they are not referenced in any Markdown documents.

translation: Snippet:MultipleInputs
translation: Snippet:OperationsHistory
translation: Snippet:PollIndividualDocuments
translation: Snippet:StartTranslationWithAzureBlobAsync

This is PR is in reference to issue #22130 .