### PR TITLE
Removed Unused Snippets from Code  [Correct PR]

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputs.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputs.cs
@@ -22,7 +22,6 @@ namespace Azure.AI.Translation.Document.Samples
 
             var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            #region Snippet:MultipleInputs
             Uri source1SasUriUri = new Uri("<source1 SAS URI>");
             Uri source2SasUri = new Uri("<source2 SAS URI>");
             Uri frenchTargetSasUri = new Uri("<french target SAS URI>");
@@ -92,8 +91,6 @@ namespace Azure.AI.Translation.Document.Samples
                     Console.WriteLine($"  Message: {document.Error.Message}");
                 }
             }
-
-            #endregion
         }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistory.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistory.cs
@@ -20,8 +20,6 @@ namespace Azure.AI.Translation.Document.Samples
 
             var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            #region Snippet:OperationsHistory
-
             int operationsCount = 0;
             int totalDocs = 0;
             int docsCancelled = 0;
@@ -61,8 +59,6 @@ namespace Azure.AI.Translation.Document.Samples
             Console.WriteLine($"Succeeded Document: {docsSucceeded}");
             Console.WriteLine($"Failed Document: {docsFailed}");
             Console.WriteLine($"Cancelled Documents: {docsCancelled}");
-
-            #endregion
         }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocuments.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocuments.cs
@@ -21,7 +21,6 @@ namespace Azure.AI.Translation.Document.Samples
 
             var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            #region Snippet:PollIndividualDocuments
             Uri sourceUri = new Uri("<source SAS URI>");
             Uri targetUri = new Uri("<target SAS URI>");
 
@@ -61,8 +60,6 @@ namespace Azure.AI.Translation.Document.Samples
                     Console.WriteLine($"  Message: {document.Error.Message}");
                 }
             }
-
-            #endregion
         }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslationWithAzureBlob.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslationWithAzureBlob.cs
@@ -50,7 +50,6 @@ namespace Azure.AI.Translation.Document.Samples
 
             var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            #region Snippet:StartTranslationWithAzureBlobAsync
             Uri storageEndpoint = new Uri(Environment.GetEnvironmentVariable("AZURE_STORAGE_SOURCE_ENDPOINT"));
             string storageAccountName = Environment.GetEnvironmentVariable("AZURE_STORAGE_ACCOUNT_NAME");
             string storageAccountKey = Environment.GetEnvironmentVariable("AZURE_STORAGE_SOURCE_KEY");
@@ -108,8 +107,6 @@ namespace Azure.AI.Translation.Document.Samples
                     Console.WriteLine($"Document ID: {document.Id}, Error Code: {document.Error.ErrorCode}, Message: {document.Error.Message}");
                 }
             }
-
-            #endregion
         }
     }
 }


### PR DESCRIPTION
Excuse the mess with the previous PR, I have closed it. The following four unused snippets were removed from the code, as they are not referenced in any Markdown documents.

translation: Snippet:MultipleInputs
translation: Snippet:OperationsHistory
translation: Snippet:PollIndividualDocuments
translation: Snippet:StartTranslationWithAzureBlobAsync

This is PR is in reference to issue #22130 .