### PR TITLE
Support Timeout.Zero in ReceiveMessagesAsync

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -11,7 +11,7 @@
     Dependency versions for Track 1 libraries.
   -->
   <ItemGroup Condition="'$(IsClientLibrary)' != 'true'">
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.5.1" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.4.13" />
     <PackageReference Update="Microsoft.Azure.Batch" Version="11.0.0" />
     <PackageReference Update="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Update="Microsoft.Azure.Devices" Version="1.19.0" />
@@ -90,7 +90,7 @@
     <PackageReference Update="Azure.Storage.Blobs" Version="12.8.0" />
     
     <!-- Other approved packages -->
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.4.13" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.5.1" />
     <PackageReference Update="Microsoft.Identity.Client" Version="4.30.1" />
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.4" />
 

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -11,7 +11,7 @@
     Dependency versions for Track 1 libraries.
   -->
   <ItemGroup Condition="'$(IsClientLibrary)' != 'true'">
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.4.11" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.5.1" />
     <PackageReference Update="Microsoft.Azure.Batch" Version="11.0.0" />
     <PackageReference Update="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Update="Microsoft.Azure.Devices" Version="1.19.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -11,7 +11,7 @@
     Dependency versions for Track 1 libraries.
   -->
   <ItemGroup Condition="'$(IsClientLibrary)' != 'true'">
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.4.13" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.4.11" />
     <PackageReference Update="Microsoft.Azure.Batch" Version="11.0.0" />
     <PackageReference Update="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Update="Microsoft.Azure.Devices" Version="1.19.0" />

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Core.Amqp" />
-    <PackageReference Include="Microsoft.Azure.Amqp" />
+    <PackageReference Include="Microsoft.Azure.Amqp" VersionOverride="2.5.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Memory.Data" />
   </ItemGroup>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Core.Amqp" />
-    <PackageReference Include="Microsoft.Azure.Amqp" VersionOverride="2.5.1" />
+    <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Memory.Data" />
   </ItemGroup>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -260,7 +260,15 @@ namespace Azure.Messaging.ServiceBus
 
             if (maxWaitTime.HasValue)
             {
-                Argument.AssertNotNegative(maxWaitTime.Value, nameof(maxWaitTime));
+                // maxWaitTime could be zero only when prefetch enabled
+                if (PrefetchCount > 0)
+                {
+                    Argument.AssertNotNegative(maxWaitTime.Value, nameof(maxWaitTime));
+                }
+                else
+                {
+                    Argument.AssertPositive(maxWaitTime.Value, nameof(maxWaitTime));
+                }
             }
             if (PrefetchCount > 0 && maxMessages > PrefetchCount)
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -260,7 +260,7 @@ namespace Azure.Messaging.ServiceBus
 
             if (maxWaitTime.HasValue)
             {
-                Argument.AssertPositive(maxWaitTime.Value, nameof(maxWaitTime));
+                Argument.AssertNotNegative(maxWaitTime.Value, nameof(maxWaitTime));
             }
             if (PrefetchCount > 0 && maxMessages > PrefetchCount)
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -56,30 +56,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 await using var receiverWithPrefetch = client.CreateReceiver(scope.QueueName,
                     options: new ServiceBusReceiverOptions() {PrefetchCount = 10});
-                await using var receiver = client.CreateReceiver(scope.QueueName);
 
-                // Test without prefetch
                 var stopwatch = new Stopwatch();
-                stopwatch.Start();
-                await receiver.ReceiveMessagesAsync(10, TimeSpan.Zero).ConfigureAwait(false);
-
-                stopwatch.Stop();
-                var durationInSecs = stopwatch.Elapsed.TotalSeconds;
-
-                // Test with prefetch
-                stopwatch.Reset();
                 stopwatch.Start();
                 await receiverWithPrefetch.ReceiveMessagesAsync(10, TimeSpan.Zero).ConfigureAwait(false);
                 stopwatch.Stop();
                 var durationWithPrefetchModeInSecs = stopwatch.Elapsed.TotalSeconds;
 
-                // Asserts:
-                Assert.IsTrue(durationWithPrefetchModeInSecs < durationInSecs);
-
-                // If prefetch isn't enabled, timeout 0 secs will be replaced with 10 seconds.
-                Assert.IsTrue(durationInSecs > 10);
-
-                // If prefetch is enabled, timeout 0 secs will not be replaced with 10 seconds.
+                // If prefetch is enabled, timeout 0 secs will not be replaced with default timeout.
                 // In such case, only prefetched messages will be returned and no call to server will be made and call will be very fast.
                 Assert.IsTrue(durationWithPrefetchModeInSecs < 1);
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -43,6 +44,44 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     }
                 }
                 Assert.AreEqual(messageCt, ct);
+            }
+        }
+
+        [Test]
+        public async Task PeekWithZeroTimeout()
+        {
+            await using (var scope =
+                await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var receiverWithPrefetch = client.CreateReceiver(scope.QueueName,
+                    options: new ServiceBusReceiverOptions() {PrefetchCount = 10});
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+
+                // Test without prefetch
+                var stopwatch = new Stopwatch();
+                stopwatch.Start();
+                await receiver.ReceiveMessagesAsync(10, TimeSpan.Zero).ConfigureAwait(false);
+
+                stopwatch.Stop();
+                var durationInSecs = stopwatch.Elapsed.TotalSeconds;
+
+                // Test with prefetch
+                stopwatch.Reset();
+                stopwatch.Start();
+                await receiverWithPrefetch.ReceiveMessagesAsync(10, TimeSpan.Zero).ConfigureAwait(false);
+                stopwatch.Stop();
+                var durationWithPrefetchModeInSecs = stopwatch.Elapsed.TotalSeconds;
+
+                // Asserts:
+                Assert.IsTrue(durationWithPrefetchModeInSecs < durationInSecs);
+
+                // If prefetch isn't enabled, timeout 0 secs will be replaced with 10 seconds.
+                Assert.IsTrue(durationInSecs > 10);
+
+                // If prefetch is enabled, timeout 0 secs will not be replaced with 10 seconds.
+                // In such case, only prefetched messages will be returned and no call to server will be made and call will be very fast.
+                Assert.IsTrue(durationWithPrefetchModeInSecs < 1);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -114,9 +114,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             var client = new ServiceBusClient(connString);
             var receiver = client.CreateReceiver("queue");
             Assert.That(
-                async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(0)),
-                Throws.InstanceOf<ArgumentOutOfRangeException>());
-            Assert.That(
                 async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(-1)),
                 Throws.InstanceOf<ArgumentOutOfRangeException>());
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -114,6 +114,25 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             var client = new ServiceBusClient(connString);
             var receiver = client.CreateReceiver("queue");
             Assert.That(
+                async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(0)),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(-1)),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void ReceiveValidatesMaxWaitTimePrefetchMode()
+        {
+            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
+            var client = new ServiceBusClient(connString);
+            var receiver = client.CreateReceiver("queue", options: new ServiceBusReceiverOptions { PrefetchCount = 10 });
+            Assert.That(
+                async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(0)),
+                Throws.InstanceOf<ServiceBusException>());
+            Assert.That(
                 async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(-1)),
                 Throws.InstanceOf<ArgumentOutOfRangeException>());
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Messaging.ServiceBus.Amqp;
 using Azure.Messaging.ServiceBus.Core;
 using Moq;
 using NUnit.Framework;
@@ -122,19 +122,45 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         }
 
         [Test]
-        public void ReceiveValidatesMaxWaitTimePrefetchMode()
+        public async Task ReceiveValidatesMaxWaitTimePrefetchMode()
         {
-            var account = Encoding.Default.GetString(GetRandomBuffer(12));
-            var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
-            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
-            var client = new ServiceBusClient(connString);
-            var receiver = client.CreateReceiver("queue", options: new ServiceBusReceiverOptions { PrefetchCount = 10 });
+            var mockTransportReceiver = new Mock<TransportReceiver>();
+            var mockConnection = CreateMockConnection();
+            mockConnection.Setup(
+                    connection => connection.CreateTransportReceiver(
+                        It.IsAny<string>(),
+                        It.IsAny<ServiceBusRetryPolicy>(),
+                        It.IsAny<ServiceBusReceiveMode>(),
+                        It.IsAny<uint>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<CancellationToken>()))
+                .Returns(mockTransportReceiver.Object);
+            IReadOnlyList<ServiceBusReceivedMessage> receivedMessages = new[]
+            {
+                ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: Guid.NewGuid().ToString())
+            };
+            mockTransportReceiver.Setup(transportReceiver =>
+                    transportReceiver.ReceiveMessagesAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(),
+                        It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(receivedMessages));
+
+            var receiver = new ServiceBusReceiver(mockConnection.Object, "queue", default,
+                new ServiceBusReceiverOptions {PrefetchCount = 10});
+
             Assert.That(
-                async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(0)),
-                Throws.InstanceOf<ServiceBusException>());
+                async () => await receiver.ReceiveMessagesAsync(10, TimeSpan.FromSeconds(-1)),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(
                 async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(-1)),
                 Throws.InstanceOf<ArgumentOutOfRangeException>());
+
+            var actuallyReceivedMessages =
+                await receiver.ReceiveMessagesAsync(10, TimeSpan.FromSeconds(0)).ConfigureAwait(false);
+            Assert.AreEqual(receivedMessages.Count, actuallyReceivedMessages.Count);
+            Assert.AreEqual(receivedMessages[0].MessageId, actuallyReceivedMessages[0].MessageId);
         }
 
         [Test]


### PR DESCRIPTION
Goal: Performance optimization when prefetch is enabled and queue is empty.
Used version of AMQP was updated to not override TimeSpan.Zero for prefetch mode: https://github.com/Azure/azure-amqp/commit/ba792e8a515f49d6df55c3b8b18b5c0990e26b7f

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ x ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ x ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ x  ] Title of the pull request is clear and informative.
- [ x ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ x ] Pull request includes test coverage for the included changes.