### PR TITLE
update tests after base class change

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/Instrumentation/ManagementInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Instrumentation/ManagementInterceptor.cs
@@ -89,7 +89,7 @@ namespace Azure.Core.TestFramework
             if (elementType.BaseType == typeof(object))
                 return false;
 
-            if (elementType.BaseType.Name == "OperationsBase")
+            if (elementType.BaseType.Name == "ResourceOperations")
                 return true;
 
             return InheritsFromOperationBase(elementType.BaseType);

--- a/sdk/core/Azure.Core/tests/ManagementRecordedTestBaseTests.cs
+++ b/sdk/core/Azure.Core/tests/ManagementRecordedTestBaseTests.cs
@@ -90,11 +90,11 @@ namespace Azure.Core.Tests.Management
         }
 
         [Test]
-        public async Task ValidateInstrumentPhPageable()
+        public async Task ValidateInstrumentPageable()
         {
             ManagementTestClient client = InstrumentClient(new ManagementTestClient());
             var testResources = client.GetTestResourceContainer();
-            await foreach (var item in testResources.ListAsync())
+            await foreach (var item in testResources.GetAllAsync())
             {
                 Assert.AreEqual("TestResourceProxy", item.GetType().Name);
                 Assert.AreEqual("success", item.Method());

--- a/sdk/core/Azure.Core/tests/TestClients/TestResourceContainer.cs
+++ b/sdk/core/Azure.Core/tests/TestClients/TestResourceContainer.cs
@@ -7,20 +7,23 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Core;
 
 namespace Azure.Core.Tests
 {
-    public class TestResourceContainer
+    public class TestResourceContainer : ResourceContainer
     {
         private DiagnosticScopeFactory _diagnostic = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
 
-        [ForwardsClientCalls]
-        public virtual Pageable<TestResource> List(int pages = 1, CancellationToken cancellation = default)
+        protected override ResourceType ValidResourceType => "MyFake.Namespace/testResource";
+
+        public virtual Pageable<TestResource> GetAll(int pages = 1, CancellationToken cancellation = default)
         {
             Page<TestResource> pageFunc(int? pageSizeHint)
             {
                 //simulates forwarding with todays wrapper.  This should go away after codegen is finished
-                using var scope = _diagnostic.CreateScope("TestResourceContainer.GetSyncResults");
+                using var scope = _diagnostic.CreateScope("TestResourceContainer.GetAll");
                 scope.Start();
 
                 try
@@ -37,12 +40,11 @@ namespace Azure.Core.Tests
             return PageableHelpers.CreateEnumerable(pageFunc, null);
         }
 
-        [ForwardsClientCalls]
-        public virtual AsyncPageable<TestResource> ListAsync(int pages = 1, CancellationToken cancellation = default)
+        public virtual AsyncPageable<TestResource> GetAllAsync(int pages = 1, CancellationToken cancellation = default)
         {
             async Task<Page<TestResource>> pageFunc(int? pageSizeHint)
             {
-                using var scope = _diagnostic.CreateScope("TestResourceContainer.GetAsyncResults");
+                using var scope = _diagnostic.CreateScope("TestResourceContainer.GetAll");
                 scope.Start();
 
                 try

--- a/sdk/core/Azure.Core/tests/TestClients/TestResourceOperations.cs
+++ b/sdk/core/Azure.Core/tests/TestClients/TestResourceOperations.cs
@@ -11,7 +11,7 @@ using Azure.ResourceManager.Core;
 
 namespace Azure.Core.Tests
 {
-    public class TestResourceOperations : OperationsBase
+    public class TestResourceOperations : ResourceOperations
     {
         private DiagnosticScopeFactory _diagnostic = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
 


### PR DESCRIPTION
# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
