### PR TITLE
[MetricsAdvisor] Fix tests: making ingestion start time relative

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -58,6 +58,15 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
         }
 
+        private DateTimeOffset IngestionStartsOnForCustom
+        {
+            get
+            {
+                DateTimeOffset startsOn = Recording.UtcNow.Subtract(TimeSpan.FromDays(2));
+                return new DateTimeOffset(startsOn.Year, startsOn.Month, startsOn.Day, startsOn.Hour, startsOn.Minute, 0, TimeSpan.Zero);
+            }
+        }
+
         [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
@@ -84,13 +93,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureApplicationInsightsDataFeedSource(DataSourceAppId, DataSourceKey, DataSourceCloud, DataSourceQuery);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateAzureApplicationInsightsDataSource(createdDataFeed.DataSource as AzureApplicationInsightsDataFeedSource);
         }
 
@@ -118,13 +128,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureBlobDataFeedSource(DataSourceConnectionString, DataSourceContainer, DataSourceTemplate);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateAzureBlobDataSource(createdDataFeed.DataSource as AzureBlobDataFeedSource);
         }
 
@@ -152,13 +163,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureCosmosDbDataFeedSource(DataSourceConnectionString, DataSourceQuery, DataSourceDatabase, DataSourceCollectionId);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateAzureCosmosDbDataSource(createdDataFeed.DataSource as AzureCosmosDbDataFeedSource);
         }
 
@@ -186,13 +198,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureDataExplorerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateAzureDataExplorerDataSource(createdDataFeed.DataSource as AzureDataExplorerDataFeedSource);
         }
 
@@ -220,13 +233,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureDataLakeStorageDataFeedSource(DataSourceAccount, DataSourceKey, DataSourceFileSystem, DataSourceDirectory, DataSourceFile);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateAzureDataLakeStorageDataSource(createdDataFeed.DataSource as AzureDataLakeStorageDataFeedSource);
         }
 
@@ -256,13 +270,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureEventHubsDataFeedSource(DataSourceConnectionString, DataSourceConsumerGroup);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateAzureEventHubsDataSource(createdDataFeed.DataSource as AzureEventHubsDataFeedSource);
         }
 
@@ -290,13 +305,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureTableDataFeedSource(DataSourceConnectionString, DataSourceTable, DataSourceQuery);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateAzureTableDataSource(createdDataFeed.DataSource as AzureTableDataFeedSource);
         }
 
@@ -324,13 +340,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new InfluxDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceUsername, DataSourcePassword, DataSourceQuery);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateInfluxDbDataSource(createdDataFeed.DataSource as InfluxDbDataFeedSource);
         }
 
@@ -358,13 +375,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new LogAnalyticsDataFeedSource(DataSourceWorkspaceId, DataSourceQuery, DataSourceClientId, DataSourceClientSecret, DataSourceTenantId);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateLogAnalyticsDataSource(createdDataFeed.DataSource as LogAnalyticsDataFeedSource);
         }
 
@@ -392,13 +410,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new MongoDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceCommand);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateMongoDbDataSource(createdDataFeed.DataSource as MongoDbDataFeedSource);
         }
 
@@ -426,13 +445,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new MySqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateMySqlDataSource(createdDataFeed.DataSource as MySqlDataFeedSource);
         }
 
@@ -460,13 +480,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new PostgreSqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidatePostgreSqlDataSource(createdDataFeed.DataSource as PostgreSqlDataFeedSource);
         }
 
@@ -494,13 +515,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new SqlServerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
+            var ingestionStartsOn = IngestionStartsOnForCustom;
+            DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource, ingestionStartsOn);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
             DataFeed createdDataFeed = disposableDataFeed.DataFeed;
 
-            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName);
+            ValidateDataFeedWithOptionalMembersSet(createdDataFeed, dataFeedName, ingestionStartsOn);
             ValidateSqlServerDataSource(createdDataFeed.DataSource as SqlServerDataFeedSource);
         }
 
@@ -1798,11 +1820,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
             };
         }
 
-        private DataFeed GetDataFeedWithOptionalMembersSet(string name, DataFeedSource dataSource)
+        private DataFeed GetDataFeedWithOptionalMembersSet(string name, DataFeedSource dataSource, DateTimeOffset ingestionStartsOn)
         {
-            var ingestionStartTime = DateTimeOffset.Parse("2020-08-01T00:00:00Z");
-
-            var ingestionSettings = new DataFeedIngestionSettings(ingestionStartTime)
+            var ingestionSettings = new DataFeedIngestionSettings(ingestionStartsOn)
             {
                 IngestionStartOffset = TimeSpan.FromMinutes(30),
                 IngestionRetryDelay = TimeSpan.FromSeconds(80),
@@ -1926,10 +1946,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.IngestionSettings.DataSourceRequestConcurrency, Is.EqualTo(-1));
         }
 
-        private void ValidateDataFeedWithOptionalMembersSet(DataFeed dataFeed, string expectedName)
+        private void ValidateDataFeedWithOptionalMembersSet(DataFeed dataFeed, string expectedName, DateTimeOffset expectedIngestionStartsOn)
         {
-            var ingestionStartTime = DateTimeOffset.Parse("2020-08-01T00:00:00Z");
-
             Assert.That(dataFeed, Is.Not.Null);
             Assert.That(dataFeed.Id, Is.Not.Null.And.Not.Empty);
             Assert.That(dataFeed.Name, Is.EqualTo(expectedName));
@@ -1990,7 +2008,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.Schema.TimestampColumn, Is.EqualTo("timestamp"));
 
             Assert.That(dataFeed.IngestionSettings, Is.Not.Null);
-            Assert.That(dataFeed.IngestionSettings.IngestionStartsOn, Is.EqualTo(ingestionStartTime));
+            Assert.That(dataFeed.IngestionSettings.IngestionStartsOn, Is.EqualTo(expectedIngestionStartsOn));
             Assert.That(dataFeed.IngestionSettings.IngestionStartOffset, Is.EqualTo(TimeSpan.FromMinutes(30)));
             Assert.That(dataFeed.IngestionSettings.IngestionRetryDelay, Is.EqualTo(TimeSpan.FromSeconds(80)));
             Assert.That(dataFeed.IngestionSettings.StopRetryAfter, Is.EqualTo(TimeSpan.FromMinutes(10)));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureApplicationInsightsDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureApplicationInsightsDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "1023",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-edf917a8e9863a4db1508c5d2d68f064-c2277e13d88fb144-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-7adaa276aa107149a667c0f74bbbfa54-2ce5c74ffd066c48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "62512a71a5bf9987e92de8b666087143",
         "x-ms-return-client-request-id": "true"
@@ -48,7 +48,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:55:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -66,25 +66,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c1498d26-af8e-48d0-9e3b-0adcbfd2036e",
+        "apim-request-id": "012363dd-bd5b-475b-bd8c-7a04f5e30459",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:35:59 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/75896c06-bf67-4aef-9a2e-694ff4decd81",
+        "Date": "Wed, 28 Jul 2021 19:55:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3ea8068e-4a8f-420a-aff0-9aa92e232d86",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "2402",
-        "x-request-id": "c1498d26-af8e-48d0-9e3b-0adcbfd2036e"
+        "x-envoy-upstream-service-time": "1664",
+        "x-request-id": "012363dd-bd5b-475b-bd8c-7a04f5e30459"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/75896c06-bf67-4aef-9a2e-694ff4decd81",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3ea8068e-4a8f-420a-aff0-9aa92e232d86",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-edf917a8e9863a4db1508c5d2d68f064-5e70448681b62147-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-7adaa276aa107149a667c0f74bbbfa54-5e35861029999b46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5c77a5558ae8596b20c3b205f031b707",
         "x-ms-return-client-request-id": "true"
@@ -92,27 +92,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "93d3e503-efe5-42ab-82d7-d493bef1b8c0",
+        "apim-request-id": "a5fef306-0d46-4f2c-a51c-06f0a6e0ea48",
         "Content-Length": "1402",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:36:00 GMT",
+        "Date": "Wed, 28 Jul 2021 19:55:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "691",
-        "x-request-id": "93d3e503-efe5-42ab-82d7-d493bef1b8c0"
+        "x-envoy-upstream-service-time": "566",
+        "x-request-id": "a5fef306-0d46-4f2c-a51c-06f0a6e0ea48"
       },
       "ResponseBody": {
-        "dataFeedId": "75896c06-bf67-4aef-9a2e-694ff4decd81",
+        "dataFeedId": "3ea8068e-4a8f-420a-aff0-9aa92e232d86",
         "dataFeedName": "dataFeedbwkJ4tg1",
         "metrics": [
           {
-            "metricId": "aad0a73c-33fa-479c-b423-67513f323da6",
+            "metricId": "f4e582fa-2194-4ee6-81e3-d2738bc7f672",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "57eb9c2d-7d0b-45ba-9b3e-92a59c6e52ab",
+            "metricId": "9bcafcc1-e2aa-465a-8d4d-1e96d25efbd2",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -128,7 +128,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:55:00Z",
         "dataSourceType": "AzureApplicationInsights",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -153,7 +153,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:35:59Z",
+        "createdTime": "2021-07-28T19:55:35Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -165,13 +165,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/75896c06-bf67-4aef-9a2e-694ff4decd81",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3ea8068e-4a8f-420a-aff0-9aa92e232d86",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-be503d60d3d8e74eb3fefa33d3d7b3f1-7c2df11a59847c48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-362b09f9bbf7784cb8aed4ed55056e91-e820ebf532cf1b47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bf4feeea1b7ec90c1dae84484ccea6e0",
         "x-ms-return-client-request-id": "true"
@@ -179,19 +179,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "88cbfbda-8327-4a62-bf67-7c9941225d21",
+        "apim-request-id": "366a3fc6-0d83-4949-b28c-a6587e412041",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:36:02 GMT",
+        "Date": "Wed, 28 Jul 2021 19:55:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1175",
-        "x-request-id": "88cbfbda-8327-4a62-bf67-7c9941225d21"
+        "x-envoy-upstream-service-time": "1133",
+        "x-request-id": "366a3fc6-0d83-4949-b28c-a6587e412041"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:36:01.3476100-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:55:34.1516831-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureApplicationInsightsDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureApplicationInsightsDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "1023",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-63153396d491ac4bb0528b768eb96f6e-cca029e945107746-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6d38add51520244b8d5eb018ce08f086-0f6421342ebfde47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9acf4e3e24b889cdab8a8ea2f2a102cd",
         "x-ms-return-client-request-id": "true"
@@ -48,7 +48,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:57:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -66,25 +66,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "fc6c8a98-42af-4210-b967-a3c7195c127d",
+        "apim-request-id": "f4f8f7b9-5e0a-4dd6-927e-e1b722591f17",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:32:34 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/56607bc8-38da-48d5-997c-33c3f32f7387",
+        "Date": "Wed, 28 Jul 2021 19:57:53 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/65daad0b-00a8-4f0d-b7cd-e38102a58dd9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7224",
-        "x-request-id": "fc6c8a98-42af-4210-b967-a3c7195c127d"
+        "x-envoy-upstream-service-time": "2398",
+        "x-request-id": "f4f8f7b9-5e0a-4dd6-927e-e1b722591f17"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/56607bc8-38da-48d5-997c-33c3f32f7387",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/65daad0b-00a8-4f0d-b7cd-e38102a58dd9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-63153396d491ac4bb0528b768eb96f6e-a454189a849c2a49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6d38add51520244b8d5eb018ce08f086-b46ba7718d1b4246-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f28d7b8b1f4f020bd4899c2737fd3420",
         "x-ms-return-client-request-id": "true"
@@ -92,27 +92,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dbd4ca2a-cba8-4926-8c50-a7fbc0b4f239",
+        "apim-request-id": "b61ac40f-0197-4ca1-8b2a-6421c0b23e83",
         "Content-Length": "1402",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:32:35 GMT",
+        "Date": "Wed, 28 Jul 2021 19:57:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "803",
-        "x-request-id": "dbd4ca2a-cba8-4926-8c50-a7fbc0b4f239"
+        "x-envoy-upstream-service-time": "5631",
+        "x-request-id": "b61ac40f-0197-4ca1-8b2a-6421c0b23e83"
       },
       "ResponseBody": {
-        "dataFeedId": "56607bc8-38da-48d5-997c-33c3f32f7387",
+        "dataFeedId": "65daad0b-00a8-4f0d-b7cd-e38102a58dd9",
         "dataFeedName": "dataFeedshoTrmTc",
         "metrics": [
           {
-            "metricId": "3bc3d1c3-317d-4dde-b051-53dfdea2f17b",
+            "metricId": "57bacfa7-645a-49ad-9422-de881ef238e2",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "c1f3cb8d-986a-4b91-b55e-f322ab88569d",
+            "metricId": "3570bc38-1cd2-4fc4-b756-414c30ba96d0",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -128,7 +128,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:57:00Z",
         "dataSourceType": "AzureApplicationInsights",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -153,7 +153,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:32:33Z",
+        "createdTime": "2021-07-28T19:57:52Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -165,13 +165,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/56607bc8-38da-48d5-997c-33c3f32f7387",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/65daad0b-00a8-4f0d-b7cd-e38102a58dd9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7a75d59848b3d346bb7f71977ecd1640-79c4e4b8d1bcd74e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6d4f159c5b965644b86105ba404c9dd1-e1f2f09dd0b6d04b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d7989347317ca8ab129a1157b6164b56",
         "x-ms-return-client-request-id": "true"
@@ -179,19 +179,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c1d3f3a1-b194-4fd8-9a56-6319c00b0190",
+        "apim-request-id": "31bc9407-aebd-4d8c-b99b-e9d959e9b4bd",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:32:36 GMT",
+        "Date": "Wed, 28 Jul 2021 19:58:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1452",
-        "x-request-id": "c1d3f3a1-b194-4fd8-9a56-6319c00b0190"
+        "x-envoy-upstream-service-time": "6255",
+        "x-request-id": "31bc9407-aebd-4d8c-b99b-e9d959e9b4bd"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:32:35.7426274-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:57:51.1706567-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureBlobDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureBlobDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "1007",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b4b912c6b520d04382bffbf4d5b0ce53-485b39e134a8804a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-38b5836ebaf7f44ea086ca22798173a6-926604664002074a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f73179f69dbf3d5a5eb4c053afba517d",
         "x-ms-return-client-request-id": "true"
@@ -47,7 +47,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:55:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -65,25 +65,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c528823e-a923-45e3-a5e7-f85d881a34e0",
+        "apim-request-id": "e9f86c47-0b38-4a67-9c51-91e5393729a5",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:30:48 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d8676f7e-a780-497c-a464-7e2263843c12",
+        "Date": "Wed, 28 Jul 2021 19:55:40 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f5899b8e-9dd2-424d-91ab-7a9e4bd4a092",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6944",
-        "x-request-id": "c528823e-a923-45e3-a5e7-f85d881a34e0"
+        "x-envoy-upstream-service-time": "1522",
+        "x-request-id": "e9f86c47-0b38-4a67-9c51-91e5393729a5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d8676f7e-a780-497c-a464-7e2263843c12",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f5899b8e-9dd2-424d-91ab-7a9e4bd4a092",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b4b912c6b520d04382bffbf4d5b0ce53-dadfa51c811d244d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-38b5836ebaf7f44ea086ca22798173a6-c8e76ae7af8a974f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c4d2fcfe5267a3f57b05762bb1fd1df7",
         "x-ms-return-client-request-id": "true"
@@ -91,27 +91,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "14bfc31a-6c51-4fb4-bb49-40e9f2e6d2ec",
+        "apim-request-id": "89333ed7-2cbe-44d9-96f3-077eb31665bd",
         "Content-Length": "1376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:30:48 GMT",
+        "Date": "Wed, 28 Jul 2021 19:55:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "690",
-        "x-request-id": "14bfc31a-6c51-4fb4-bb49-40e9f2e6d2ec"
+        "x-envoy-upstream-service-time": "563",
+        "x-request-id": "89333ed7-2cbe-44d9-96f3-077eb31665bd"
       },
       "ResponseBody": {
-        "dataFeedId": "d8676f7e-a780-497c-a464-7e2263843c12",
+        "dataFeedId": "f5899b8e-9dd2-424d-91ab-7a9e4bd4a092",
         "dataFeedName": "dataFeed1UfEswJZ",
         "metrics": [
           {
-            "metricId": "38b09838-ba98-47f3-ba31-4cd6a475ba2a",
+            "metricId": "2a77b235-d5c9-4c20-8e19-a97dc8ec0526",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "f100ba5d-e24d-4ba6-bfe2-ecbf1c860c20",
+            "metricId": "eefff35c-6fa1-4642-8889-98a107d7ff62",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -127,7 +127,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:55:00Z",
         "dataSourceType": "AzureBlob",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -152,7 +152,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:30:47Z",
+        "createdTime": "2021-07-28T19:55:39Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -163,13 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d8676f7e-a780-497c-a464-7e2263843c12",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f5899b8e-9dd2-424d-91ab-7a9e4bd4a092",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fa303215b2ed524d8df5d95d4299a0e5-0b7a61e6e39ba144-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-d7466e0c0350494c8ea00bf5cb3decaf-8bb23486b8ec0245-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ed3931fc093326669636a505dbfd23e8",
         "x-ms-return-client-request-id": "true"
@@ -177,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5e5e6c8f-d46b-4151-8cb6-41f99787adf4",
+        "apim-request-id": "441f4c8b-77bf-459a-ab94-1428f85b3773",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:30:49 GMT",
+        "Date": "Wed, 28 Jul 2021 19:55:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1278",
-        "x-request-id": "5e5e6c8f-d46b-4151-8cb6-41f99787adf4"
+        "x-envoy-upstream-service-time": "1256",
+        "x-request-id": "441f4c8b-77bf-459a-ab94-1428f85b3773"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:30:49.3292332-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:55:38.6463473-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureBlobDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureBlobDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "1007",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a893354b5408394dbac00996edeecfee-d0c212e81ebf7349-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b6747037f6ea2741a257526ec7478eba-d1f692306921d040-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "59c734a90281eda0a7f7c4cc27af8d8b",
         "x-ms-return-client-request-id": "true"
@@ -47,7 +47,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:58:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -65,25 +65,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "90f85790-f2b4-4860-a22b-28297e4cc8e2",
+        "apim-request-id": "63ceee3d-ad69-4d12-a230-bc179800e006",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:32:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cbc18690-c9c6-4cc4-a6c8-69bf2fa1e404",
+        "Date": "Wed, 28 Jul 2021 19:58:07 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/feaf010e-7b22-4ebf-a291-9830a76bd5b2",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "2093",
-        "x-request-id": "90f85790-f2b4-4860-a22b-28297e4cc8e2"
+        "x-envoy-upstream-service-time": "1973",
+        "x-request-id": "63ceee3d-ad69-4d12-a230-bc179800e006"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cbc18690-c9c6-4cc4-a6c8-69bf2fa1e404",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/feaf010e-7b22-4ebf-a291-9830a76bd5b2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a893354b5408394dbac00996edeecfee-26191623c858924c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b6747037f6ea2741a257526ec7478eba-3ce904e46d227840-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b6c6bb3b979a14821337bac1a3d3a4b5",
         "x-ms-return-client-request-id": "true"
@@ -91,27 +91,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "58e3ea42-6c7f-4c8f-b056-56bc1cdce2e0",
+        "apim-request-id": "f8bcfa27-0af2-4f47-9624-1393524cb757",
         "Content-Length": "1376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:32:44 GMT",
+        "Date": "Wed, 28 Jul 2021 19:58:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5615",
-        "x-request-id": "58e3ea42-6c7f-4c8f-b056-56bc1cdce2e0"
+        "x-envoy-upstream-service-time": "5637",
+        "x-request-id": "f8bcfa27-0af2-4f47-9624-1393524cb757"
       },
       "ResponseBody": {
-        "dataFeedId": "cbc18690-c9c6-4cc4-a6c8-69bf2fa1e404",
+        "dataFeedId": "feaf010e-7b22-4ebf-a291-9830a76bd5b2",
         "dataFeedName": "dataFeedB0kvnc8e",
         "metrics": [
           {
-            "metricId": "ac22e1f1-45da-45a5-a4e3-ea625e0ac5a0",
+            "metricId": "974e0bbb-e654-4169-8ba4-dbc3db671a6c",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "d962caa1-9064-436b-b6c1-309c372fddaf",
+            "metricId": "2331d09d-7580-4a12-aef0-dda04ff320fb",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -127,7 +127,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:58:00Z",
         "dataSourceType": "AzureBlob",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -152,7 +152,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:32:38Z",
+        "createdTime": "2021-07-28T19:58:06Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -163,13 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cbc18690-c9c6-4cc4-a6c8-69bf2fa1e404",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/feaf010e-7b22-4ebf-a291-9830a76bd5b2",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5e66e6c7ebf0074b813af0cfe73faa88-29b767ac00b39d41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b9300b18134dff40ae62db505c9a0bc6-5ee32be3fdd6e945-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a74c58d39cc45c48069d663e86fb42cb",
         "x-ms-return-client-request-id": "true"
@@ -177,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f995cff7-0524-43a4-99ef-6ee9fb6ec669",
+        "apim-request-id": "476db564-39e5-4c5a-ad53-5b7ad5b121f9",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:32:50 GMT",
+        "Date": "Wed, 28 Jul 2021 19:58:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6170",
-        "x-request-id": "f995cff7-0524-43a4-99ef-6ee9fb6ec669"
+        "x-envoy-upstream-service-time": "6335",
+        "x-request-id": "476db564-39e5-4c5a-ad53-5b7ad5b121f9"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:32:45.0013444-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:58:05.7218869-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureCosmosDbDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureCosmosDbDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "1029",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e23ae4a0754f1d44b4dfbb6bb94c7aaa-a2847da102da834a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-5f091fcb5fc3a442a28910e45e652cfc-22fc650aafc7a941-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5d93cfe15d8f08b80fa08a606ba98f41",
         "x-ms-return-client-request-id": "true"
@@ -48,7 +48,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:55:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -66,25 +66,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "3c80aea7-2f5a-4345-b4ae-ff0ce791f64d",
+        "apim-request-id": "a65d6d47-62e6-4b89-adf4-4b3026832d54",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:30:51 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1cb2d1c2-42a0-4abb-8817-31b22b17c60f",
+        "Date": "Wed, 28 Jul 2021 19:55:43 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3b569f89-45f4-4024-95e5-795ea777f7d9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "2019",
-        "x-request-id": "3c80aea7-2f5a-4345-b4ae-ff0ce791f64d"
+        "x-envoy-upstream-service-time": "1574",
+        "x-request-id": "a65d6d47-62e6-4b89-adf4-4b3026832d54"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1cb2d1c2-42a0-4abb-8817-31b22b17c60f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3b569f89-45f4-4024-95e5-795ea777f7d9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e23ae4a0754f1d44b4dfbb6bb94c7aaa-77468752e8599c4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-5f091fcb5fc3a442a28910e45e652cfc-3e92b4b460e94f4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7c55837cfb14e9e0869972e95154e801",
         "x-ms-return-client-request-id": "true"
@@ -92,27 +92,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7e8422c7-c0a3-4fda-89f7-3584f65c511b",
+        "apim-request-id": "c62a1aba-8102-41dd-bffc-e6e55bc52ef4",
         "Content-Length": "1398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:30:52 GMT",
+        "Date": "Wed, 28 Jul 2021 19:55:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "609",
-        "x-request-id": "7e8422c7-c0a3-4fda-89f7-3584f65c511b"
+        "x-envoy-upstream-service-time": "565",
+        "x-request-id": "c62a1aba-8102-41dd-bffc-e6e55bc52ef4"
       },
       "ResponseBody": {
-        "dataFeedId": "1cb2d1c2-42a0-4abb-8817-31b22b17c60f",
+        "dataFeedId": "3b569f89-45f4-4024-95e5-795ea777f7d9",
         "dataFeedName": "dataFeedbDb3DlWr",
         "metrics": [
           {
-            "metricId": "ac995fe2-ba6d-40ee-8b3a-77886cb18f9d",
+            "metricId": "4eb3803b-73d4-4348-ae4d-ce3697771b78",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "51573ab5-75cb-4f46-a140-8c24c54bb3c9",
+            "metricId": "4eee5ccc-e73d-483a-ad40-a46261e81dae",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -128,7 +128,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:55:00Z",
         "dataSourceType": "AzureCosmosDB",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -153,7 +153,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:30:52Z",
+        "createdTime": "2021-07-28T19:55:43Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -165,13 +165,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1cb2d1c2-42a0-4abb-8817-31b22b17c60f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3b569f89-45f4-4024-95e5-795ea777f7d9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-aeea9e0b71d30b4998ae8f326048bf04-daf900fd1cbd154a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-4e434fffdb24234b83df18d761913638-398926b5667d1841-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "67370370dcd72058523cb609f739e552",
         "x-ms-return-client-request-id": "true"
@@ -179,19 +179,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "83e9bac3-3900-4e42-9e84-18c27243ab51",
+        "apim-request-id": "9e864c49-546c-41a2-b581-30804da018f2",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:30:53 GMT",
+        "Date": "Wed, 28 Jul 2021 19:55:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1349",
-        "x-request-id": "83e9bac3-3900-4e42-9e84-18c27243ab51"
+        "x-envoy-upstream-service-time": "1671",
+        "x-request-id": "9e864c49-546c-41a2-b581-30804da018f2"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:30:53.4694538-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:55:42.4666925-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureCosmosDbDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureCosmosDbDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "1029",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-010f55b216efdc46a5d05cfd576fb511-bd1161af7a775448-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-337ad9d43c8dbf4ca765ae97872a1570-6f0caaeebbbed546-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1db4a731d83ef4e0de60626b59ddb018",
         "x-ms-return-client-request-id": "true"
@@ -48,7 +48,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:58:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -66,25 +66,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "9d372130-0a56-470f-8f22-2f1b1a9b3893",
+        "apim-request-id": "1a114b09-324c-4a93-b636-afac3124240f",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:32:52 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5d869469-b628-49e6-b266-d2b617b6608f",
+        "Date": "Wed, 28 Jul 2021 19:58:21 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/149da38e-b3a9-4ee8-b507-a9b50823e9f7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1852",
-        "x-request-id": "9d372130-0a56-470f-8f22-2f1b1a9b3893"
+        "x-envoy-upstream-service-time": "2122",
+        "x-request-id": "1a114b09-324c-4a93-b636-afac3124240f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5d869469-b628-49e6-b266-d2b617b6608f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/149da38e-b3a9-4ee8-b507-a9b50823e9f7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-010f55b216efdc46a5d05cfd576fb511-b339e4f29eda7d40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-337ad9d43c8dbf4ca765ae97872a1570-76a9b8f34c59f842-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c8afadc15bfa34a75c7fd9941bdcd610",
         "x-ms-return-client-request-id": "true"
@@ -92,27 +92,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "23d12e14-7c5a-4c50-8c0b-26e1da246b0c",
+        "apim-request-id": "8db3f77b-f550-4eeb-af06-9cce1e115ec4",
         "Content-Length": "1398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:32:58 GMT",
+        "Date": "Wed, 28 Jul 2021 19:58:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5673",
-        "x-request-id": "23d12e14-7c5a-4c50-8c0b-26e1da246b0c"
+        "x-envoy-upstream-service-time": "658",
+        "x-request-id": "8db3f77b-f550-4eeb-af06-9cce1e115ec4"
       },
       "ResponseBody": {
-        "dataFeedId": "5d869469-b628-49e6-b266-d2b617b6608f",
+        "dataFeedId": "149da38e-b3a9-4ee8-b507-a9b50823e9f7",
         "dataFeedName": "dataFeedpGfHCqUn",
         "metrics": [
           {
-            "metricId": "14599fec-7d70-4c74-98de-043287ecd4f5",
+            "metricId": "d9c14a4e-f318-434a-af8a-05581193fc1c",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "31d9526b-3510-4632-a71b-ac88bf4e19ab",
+            "metricId": "edfc2f0e-3f8b-4d61-8bfb-182866917eea",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -128,7 +128,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:58:00Z",
         "dataSourceType": "AzureCosmosDB",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -153,7 +153,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:32:52Z",
+        "createdTime": "2021-07-28T19:58:21Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -165,13 +165,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5d869469-b628-49e6-b266-d2b617b6608f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/149da38e-b3a9-4ee8-b507-a9b50823e9f7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-115c1869cb51744aac8acd388b342437-460e34191a371d41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-c1a93a328cc83545918b4b7fa645d430-9500f2755c25e24a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9d9145c93e1cd7078d3ce4a911e26d74",
         "x-ms-return-client-request-id": "true"
@@ -179,19 +179,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7a832288-1bfc-48d6-b0a2-b8fe3d5fc55a",
+        "apim-request-id": "fd936a53-6fd7-4f09-92cc-5169d858d4e5",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:32:59 GMT",
+        "Date": "Wed, 28 Jul 2021 19:58:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1332",
-        "x-request-id": "7a832288-1bfc-48d6-b0a2-b8fe3d5fc55a"
+        "x-envoy-upstream-service-time": "1407",
+        "x-request-id": "fd936a53-6fd7-4f09-92cc-5169d858d4e5"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:32:58.9183357-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:58:19.7804185-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataExplorerDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataExplorerDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "981",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7bf6bf2759923642b3785b6e11fd0953-6d75436a01bff94a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-cd4c6835347d8b4f9bc23cab8c52f82f-a42541734849f24c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8ff259ac478ccc3cafac26cf42fbf4ec",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:55:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -64,25 +64,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "81f5dda1-d37b-4295-9759-2863215b77c2",
+        "apim-request-id": "bbe298e1-cecf-41bd-8bad-1943d37fd097",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:30:56 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0e0f2f2d-0490-482f-9952-f140707823f4",
+        "Date": "Wed, 28 Jul 2021 19:55:47 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3acaf5fa-e4cc-4662-a7ec-f0f2bb124e34",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1911",
-        "x-request-id": "81f5dda1-d37b-4295-9759-2863215b77c2"
+        "x-envoy-upstream-service-time": "1802",
+        "x-request-id": "bbe298e1-cecf-41bd-8bad-1943d37fd097"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0e0f2f2d-0490-482f-9952-f140707823f4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3acaf5fa-e4cc-4662-a7ec-f0f2bb124e34",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7bf6bf2759923642b3785b6e11fd0953-4f0469d4efebe84f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-cd4c6835347d8b4f9bc23cab8c52f82f-6ba68cca1af87244-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3ca2bc475fcb4b8299b214c0373c25df",
         "x-ms-return-client-request-id": "true"
@@ -90,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b6aa696c-3a52-4812-81c5-8b8f435708a2",
+        "apim-request-id": "858d7581-b419-4b83-83cb-f070d5161f28",
         "Content-Length": "1350",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:30:57 GMT",
+        "Date": "Wed, 28 Jul 2021 19:55:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "559",
-        "x-request-id": "b6aa696c-3a52-4812-81c5-8b8f435708a2"
+        "x-envoy-upstream-service-time": "5855",
+        "x-request-id": "858d7581-b419-4b83-83cb-f070d5161f28"
       },
       "ResponseBody": {
-        "dataFeedId": "0e0f2f2d-0490-482f-9952-f140707823f4",
+        "dataFeedId": "3acaf5fa-e4cc-4662-a7ec-f0f2bb124e34",
         "dataFeedName": "dataFeedeKXWW1HR",
         "metrics": [
           {
-            "metricId": "28afaf35-8014-41c6-b7b3-808b292f4754",
+            "metricId": "65eb05c5-e91d-4380-8ba6-bc14ee8cda36",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "8a175a00-9f8a-4483-9af2-abc90577cad1",
+            "metricId": "42a0d7f7-0a36-4472-8d21-a7397d87bf7e",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -126,7 +126,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:55:00Z",
         "dataSourceType": "AzureDataExplorer",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:30:56Z",
+        "createdTime": "2021-07-28T19:55:47Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -161,13 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0e0f2f2d-0490-482f-9952-f140707823f4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3acaf5fa-e4cc-4662-a7ec-f0f2bb124e34",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-864f00e40c311b408d7ec331adb637db-89d2867da26d184f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e79c2266a2c69047b0c35efa7ee706c3-b288202fe2043d49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0b4805bcc2c934e36e8e50dd5ee4c2e7",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "9c85bbdd-0f7a-437c-b967-c76f4fd6d03c",
+        "apim-request-id": "4424a34f-897c-41dd-8a8e-6cae30d43434",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:03 GMT",
+        "Date": "Wed, 28 Jul 2021 19:56:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6317",
-        "x-request-id": "9c85bbdd-0f7a-437c-b967-c76f4fd6d03c"
+        "x-envoy-upstream-service-time": "11372",
+        "x-request-id": "4424a34f-897c-41dd-8a8e-6cae30d43434"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:30:57.4073492-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:55:46.3914672-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataExplorerDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataExplorerDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "981",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fbf3c941801518469db05f364ec36052-5a310c792d5fa54d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b3a0ebf1aa88b948bfd3eafb36d70ebb-a121991bb6192b43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e80e9cbd169ba9b340aea27e67f86572",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:58:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -64,25 +64,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "97e93bfe-e771-4ad4-9a62-ea987fb3d687",
+        "apim-request-id": "66b2c6a6-3e94-4af9-a976-68727b56909b",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:33:07 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d6c1bd9c-08df-490f-881f-659c223e468e",
+        "Date": "Wed, 28 Jul 2021 19:58:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a7ddad41-7d2c-437e-94fd-57e41bbc0b80",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7187",
-        "x-request-id": "97e93bfe-e771-4ad4-9a62-ea987fb3d687"
+        "x-envoy-upstream-service-time": "12107",
+        "x-request-id": "66b2c6a6-3e94-4af9-a976-68727b56909b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d6c1bd9c-08df-490f-881f-659c223e468e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a7ddad41-7d2c-437e-94fd-57e41bbc0b80",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fbf3c941801518469db05f364ec36052-32cfac45296f0846-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b3a0ebf1aa88b948bfd3eafb36d70ebb-772aeba41a969843-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "995a4a2935c6ccb57e97c69c71e6fa94",
         "x-ms-return-client-request-id": "true"
@@ -90,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "46392e63-3580-41c8-8b89-97f26a4a838b",
+        "apim-request-id": "7bf3178d-b3cf-4e51-8705-929c27c48082",
         "Content-Length": "1350",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:33:12 GMT",
+        "Date": "Wed, 28 Jul 2021 19:58:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5612",
-        "x-request-id": "46392e63-3580-41c8-8b89-97f26a4a838b"
+        "x-envoy-upstream-service-time": "646",
+        "x-request-id": "7bf3178d-b3cf-4e51-8705-929c27c48082"
       },
       "ResponseBody": {
-        "dataFeedId": "d6c1bd9c-08df-490f-881f-659c223e468e",
+        "dataFeedId": "a7ddad41-7d2c-437e-94fd-57e41bbc0b80",
         "dataFeedName": "dataFeedm7a4TvMx",
         "metrics": [
           {
-            "metricId": "44790c79-419a-4aa3-b9b8-488a8655fd20",
+            "metricId": "d66ad1ea-54aa-4963-a78f-3a658452a73a",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "a5fefd85-8919-46bb-9ba7-be14930e00e4",
+            "metricId": "94d81f82-9616-42f7-9b0e-4a8843f86316",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -126,7 +126,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:58:00Z",
         "dataSourceType": "AzureDataExplorer",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:33:06Z",
+        "createdTime": "2021-07-28T19:58:35Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -161,13 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d6c1bd9c-08df-490f-881f-659c223e468e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a7ddad41-7d2c-437e-94fd-57e41bbc0b80",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fd988288d6ad1a469036fdd82d68211f-196705598ce24046-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-c15a2ef4a67b3340adf928b16c4ffdc9-0a53e6fc197e0448-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "96c9a7e44dad54c16724ab1c108b8c60",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "81685593-4daa-4e86-aca4-98b4a94fb181",
+        "apim-request-id": "3c54bca1-1972-4b26-af77-84169fd529f6",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:33:13 GMT",
+        "Date": "Wed, 28 Jul 2021 19:58:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1097",
-        "x-request-id": "81685593-4daa-4e86-aca4-98b4a94fb181"
+        "x-envoy-upstream-service-time": "1629",
+        "x-request-id": "3c54bca1-1972-4b26-af77-84169fd529f6"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:33:13.2054063-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:58:24.1413731-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataLakeStorageDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataLakeStorageDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "1068",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c27454a222e99b499a874b3577a830c1-2c266c0b77ceb045-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-497fb7fb1bd4424f82575f7a7cd08a23-861054a7a220d848-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b767ab3e417b47e9adbff30e210e2df0",
         "x-ms-return-client-request-id": "true"
@@ -49,7 +49,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:56:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -67,25 +67,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "98691d66-7ecd-4d9d-98b3-8e8be31a1b48",
+        "apim-request-id": "95585a99-f0db-464a-8f61-f86d5a64eb05",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:10 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/423a3d81-b1a3-49aa-9e1e-f37d94b482e5",
+        "Date": "Wed, 28 Jul 2021 19:56:12 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bbd03ee-a522-4e4c-b31c-80eed177f76e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6862",
-        "x-request-id": "98691d66-7ecd-4d9d-98b3-8e8be31a1b48"
+        "x-envoy-upstream-service-time": "7027",
+        "x-request-id": "95585a99-f0db-464a-8f61-f86d5a64eb05"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/423a3d81-b1a3-49aa-9e1e-f37d94b482e5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bbd03ee-a522-4e4c-b31c-80eed177f76e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c27454a222e99b499a874b3577a830c1-7caff237faac5343-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-497fb7fb1bd4424f82575f7a7cd08a23-df0dad1fca111a4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "61738f682f588fc798bcb625fdbfe036",
         "x-ms-return-client-request-id": "true"
@@ -93,27 +93,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dc3199f7-fd23-46a3-97e8-7210e8b528ff",
+        "apim-request-id": "d10b9feb-9dde-497d-ada4-67b1584ea014",
         "Content-Length": "1443",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:31:11 GMT",
+        "Date": "Wed, 28 Jul 2021 19:56:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "623",
-        "x-request-id": "dc3199f7-fd23-46a3-97e8-7210e8b528ff"
+        "x-envoy-upstream-service-time": "598",
+        "x-request-id": "d10b9feb-9dde-497d-ada4-67b1584ea014"
       },
       "ResponseBody": {
-        "dataFeedId": "423a3d81-b1a3-49aa-9e1e-f37d94b482e5",
+        "dataFeedId": "4bbd03ee-a522-4e4c-b31c-80eed177f76e",
         "dataFeedName": "dataFeed2ZTAxTdn",
         "metrics": [
           {
-            "metricId": "4afd949b-520f-481e-bb89-bfb51364e399",
+            "metricId": "b1b1f4c9-a280-41b1-af4c-d71287a03436",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "ffc4d784-006c-42db-891d-d4d691f9b7d1",
+            "metricId": "8e1be0b9-64ee-4905-9507-08ad5bff2de1",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -129,7 +129,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:56:00Z",
         "dataSourceType": "AzureDataLakeStorageGen2",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -154,7 +154,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:31:09Z",
+        "createdTime": "2021-07-28T19:56:11Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -167,13 +167,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/423a3d81-b1a3-49aa-9e1e-f37d94b482e5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bbd03ee-a522-4e4c-b31c-80eed177f76e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9a3eb9e8700a064d97c6167831eb8972-06401e5e7e6c8b47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-64e30c3b5576654ba7317651817f08b9-ae818da430b13441-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8135ba773a9edd4f64a6bdaa52d33b16",
         "x-ms-return-client-request-id": "true"
@@ -181,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4d61180e-4f1a-49bc-a81a-0cd2778880f7",
+        "apim-request-id": "dc414d48-a393-4692-b20a-ebbf762c5696",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:12 GMT",
+        "Date": "Wed, 28 Jul 2021 19:56:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1226",
-        "x-request-id": "4d61180e-4f1a-49bc-a81a-0cd2778880f7"
+        "x-envoy-upstream-service-time": "6293",
+        "x-request-id": "dc414d48-a393-4692-b20a-ebbf762c5696"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:31:11.3429472-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:56:05.5577023-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataLakeStorageDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataLakeStorageDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "1068",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-142c614090e16b4295f22848f2aa5ab1-79816055c7b55c4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-8e0bc6f5ff5b1c4eb4689eb7cd537234-c19fafd9f9f6da4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dffee865c239b8cba4f76ee47ec25f26",
         "x-ms-return-client-request-id": "true"
@@ -49,7 +49,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:58:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -67,25 +67,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e3ea3814-f5dc-4273-9a9f-ff3db29ca83c",
+        "apim-request-id": "8bcf6927-ebc6-4739-8ca8-474b60babb8e",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:33:15 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/09d1f58f-880d-4f6a-93c2-436064065370",
+        "Date": "Wed, 28 Jul 2021 19:58:44 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97e717f5-d182-4dd8-94bd-33676b171384",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "2007",
-        "x-request-id": "e3ea3814-f5dc-4273-9a9f-ff3db29ca83c"
+        "x-envoy-upstream-service-time": "7035",
+        "x-request-id": "8bcf6927-ebc6-4739-8ca8-474b60babb8e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/09d1f58f-880d-4f6a-93c2-436064065370",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97e717f5-d182-4dd8-94bd-33676b171384",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-142c614090e16b4295f22848f2aa5ab1-5a387d464cd1294d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-8e0bc6f5ff5b1c4eb4689eb7cd537234-0a6c0872621da347-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a3968a613c1cd124c04d3e57af5eb91a",
         "x-ms-return-client-request-id": "true"
@@ -93,27 +93,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "291f00a6-7e72-40d3-89ae-0276a0cb4d31",
+        "apim-request-id": "c294a3f8-c838-4c8a-ba08-e48228a76da6",
         "Content-Length": "1443",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:33:16 GMT",
+        "Date": "Wed, 28 Jul 2021 19:58:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "754",
-        "x-request-id": "291f00a6-7e72-40d3-89ae-0276a0cb4d31"
+        "x-envoy-upstream-service-time": "10817",
+        "x-request-id": "c294a3f8-c838-4c8a-ba08-e48228a76da6"
       },
       "ResponseBody": {
-        "dataFeedId": "09d1f58f-880d-4f6a-93c2-436064065370",
+        "dataFeedId": "97e717f5-d182-4dd8-94bd-33676b171384",
         "dataFeedName": "dataFeedyzWlsjAo",
         "metrics": [
           {
-            "metricId": "ece5e1d3-167f-463b-b06d-84aad8962ea3",
+            "metricId": "c82bcd63-62a6-40a4-a6b1-2fb3997f04f0",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "9c8d4566-c0cd-427f-af92-858ae0104075",
+            "metricId": "ec627fea-b1dc-4dbf-aede-79bb5e9788c9",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -129,7 +129,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:58:00Z",
         "dataSourceType": "AzureDataLakeStorageGen2",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -154,7 +154,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:33:15Z",
+        "createdTime": "2021-07-28T19:58:45Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -167,13 +167,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/09d1f58f-880d-4f6a-93c2-436064065370",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97e717f5-d182-4dd8-94bd-33676b171384",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2b156b2f5083aa498cbfc7d7f468fca9-7e57aa1490af2147-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-81957b062df2c743b31ea10b0d7cd6a1-b79215e7e0378e4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "54fa63dadbb594d78f7887b74eda96dd",
         "x-ms-return-client-request-id": "true"
@@ -181,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "44370fc6-85bd-40b3-ae39-195fbcbd7068",
+        "apim-request-id": "b6f97915-bf75-4f0d-91d1-830b04c433de",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:33:17 GMT",
+        "Date": "Wed, 28 Jul 2021 19:59:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1124",
-        "x-request-id": "44370fc6-85bd-40b3-ae39-195fbcbd7068"
+        "x-envoy-upstream-service-time": "6257",
+        "x-request-id": "b6f97915-bf75-4f0d-91d1-830b04c433de"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:33:17.1964297-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:58:38.6286649-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureTableDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureTableDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "990",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dabd85189ee4e94bbb642042aea14dd3-79d76c42a578644a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-770d3c2ca881ca46949a2e23f3323321-6d850006a1b64740-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7b541ec617384f29e42891ad533c507c",
         "x-ms-return-client-request-id": "true"
@@ -47,7 +47,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:56:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -65,25 +65,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "231ba47c-ff4b-4a9f-b6dc-dd6a63f82f46",
+        "apim-request-id": "33fa01fe-bad1-4a08-b96e-81cba8e1e442",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:14 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/94ba230e-b9e0-4c77-a07f-d3ba043a624a",
+        "Date": "Wed, 28 Jul 2021 19:56:21 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/74e32c5b-5f42-4e11-b33c-06c45626a58a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1651",
-        "x-request-id": "231ba47c-ff4b-4a9f-b6dc-dd6a63f82f46"
+        "x-envoy-upstream-service-time": "2425",
+        "x-request-id": "33fa01fe-bad1-4a08-b96e-81cba8e1e442"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/94ba230e-b9e0-4c77-a07f-d3ba043a624a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/74e32c5b-5f42-4e11-b33c-06c45626a58a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dabd85189ee4e94bbb642042aea14dd3-39d371f7a9efc14f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-770d3c2ca881ca46949a2e23f3323321-c1e298ec64b7d548-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "735c82eef4b8afece104d4f875c81292",
         "x-ms-return-client-request-id": "true"
@@ -91,27 +91,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b2d96787-dc76-4d5a-a365-d1131b5cefa2",
+        "apim-request-id": "b2dc2473-d058-47c7-bc33-eb783bcd790f",
         "Content-Length": "1359",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:31:14 GMT",
+        "Date": "Wed, 28 Jul 2021 19:56:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "615",
-        "x-request-id": "b2d96787-dc76-4d5a-a365-d1131b5cefa2"
+        "x-envoy-upstream-service-time": "646",
+        "x-request-id": "b2dc2473-d058-47c7-bc33-eb783bcd790f"
       },
       "ResponseBody": {
-        "dataFeedId": "94ba230e-b9e0-4c77-a07f-d3ba043a624a",
+        "dataFeedId": "74e32c5b-5f42-4e11-b33c-06c45626a58a",
         "dataFeedName": "dataFeedgoOWLhzw",
         "metrics": [
           {
-            "metricId": "6e23ec6a-f77e-46f9-98e4-5f7f20d7bbf2",
+            "metricId": "47945833-92b9-4aac-ba40-6af9747d6852",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "18307760-f452-4432-a328-b41e1d63c74b",
+            "metricId": "b143740f-fc70-47f3-af9a-ddbf5e3c56ea",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -127,7 +127,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:56:00Z",
         "dataSourceType": "AzureTable",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -152,7 +152,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:31:13Z",
+        "createdTime": "2021-07-28T19:56:21Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -163,13 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/94ba230e-b9e0-4c77-a07f-d3ba043a624a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/74e32c5b-5f42-4e11-b33c-06c45626a58a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-493ba09069654445b551de013a51bbc8-c5d9caaec9906840-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-ae9bad1af8fd77459d7d2a30ab5c17b3-1346a3022d7a0841-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "787aa66edcf6580eeb463b14dcba66be",
         "x-ms-return-client-request-id": "true"
@@ -177,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "fa472c5f-b2ef-493e-986c-1482ce0e2b1e",
+        "apim-request-id": "95d84a3a-777f-4315-ba2d-f0ea2e98a559",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:20 GMT",
+        "Date": "Wed, 28 Jul 2021 19:56:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6174",
-        "x-request-id": "fa472c5f-b2ef-493e-986c-1482ce0e2b1e"
+        "x-envoy-upstream-service-time": "6373",
+        "x-request-id": "95d84a3a-777f-4315-ba2d-f0ea2e98a559"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:31:14.9805496-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:56:19.6365104-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureTableDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureTableDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "990",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0c699dad10cf654aabe1f40531d8a23a-cb5df4c39f765541-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-f770f59342537a49b29361b1f2a28889-0f4308a82d54d947-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "14dc436633c61796ce19383771675ea3",
         "x-ms-return-client-request-id": "true"
@@ -47,7 +47,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:59:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -65,25 +65,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c720deb4-c017-4d93-a05d-566f16303df6",
+        "apim-request-id": "87cc7892-d0c3-4f26-ab7b-c2fb29142b76",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:33:25 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f9e96fe2-2e4b-4f1f-8c86-03bc79c5fcbf",
+        "Date": "Wed, 28 Jul 2021 19:59:09 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/29f8a43d-c8fc-4295-9364-310c3464225e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7341",
-        "x-request-id": "c720deb4-c017-4d93-a05d-566f16303df6"
+        "x-envoy-upstream-service-time": "7161",
+        "x-request-id": "87cc7892-d0c3-4f26-ab7b-c2fb29142b76"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f9e96fe2-2e4b-4f1f-8c86-03bc79c5fcbf",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/29f8a43d-c8fc-4295-9364-310c3464225e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0c699dad10cf654aabe1f40531d8a23a-0a9581792ae4c54a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-f770f59342537a49b29361b1f2a28889-ab7942bda269dc4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3f967ef51b90d7390e7f116ccdaa8750",
         "x-ms-return-client-request-id": "true"
@@ -91,27 +91,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5fb86cff-59e8-4b19-a8d9-d7aa1a12caea",
+        "apim-request-id": "5ab66432-9ef3-435c-963f-78c0c3a79b06",
         "Content-Length": "1359",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:33:26 GMT",
+        "Date": "Wed, 28 Jul 2021 19:59:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "642",
-        "x-request-id": "5fb86cff-59e8-4b19-a8d9-d7aa1a12caea"
+        "x-envoy-upstream-service-time": "591",
+        "x-request-id": "5ab66432-9ef3-435c-963f-78c0c3a79b06"
       },
       "ResponseBody": {
-        "dataFeedId": "f9e96fe2-2e4b-4f1f-8c86-03bc79c5fcbf",
+        "dataFeedId": "29f8a43d-c8fc-4295-9364-310c3464225e",
         "dataFeedName": "dataFeedMKSbBurZ",
         "metrics": [
           {
-            "metricId": "a3fd640e-d16d-4d2a-a932-1ddcf4709ba9",
+            "metricId": "b2cad0d9-1c20-46f8-a9e8-46b1776be4e5",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "14ebca1a-dac4-49d5-a88a-573998d544cf",
+            "metricId": "90883c34-2d79-4119-a3ff-e76f1dc745b7",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -127,7 +127,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:59:00Z",
         "dataSourceType": "AzureTable",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -152,7 +152,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:33:24Z",
+        "createdTime": "2021-07-28T19:59:09Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -163,13 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f9e96fe2-2e4b-4f1f-8c86-03bc79c5fcbf",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/29f8a43d-c8fc-4295-9364-310c3464225e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-30dd6dc9096905469f620753fa5c9a1f-4063b45f5250d443-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-9adc191b553aea489bb0167d2856f0a7-5c72d19943c4fe4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0a3c3d6ac58d11657dbaf588b357e796",
         "x-ms-return-client-request-id": "true"
@@ -177,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "cbeb95a9-df68-42d2-be49-4a276ac9841e",
+        "apim-request-id": "3508b4a0-4621-4d95-bb72-72e8c6d7e67e",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:33:32 GMT",
+        "Date": "Wed, 28 Jul 2021 19:59:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6700",
-        "x-request-id": "cbeb95a9-df68-42d2-be49-4a276ac9841e"
+        "x-envoy-upstream-service-time": "6259",
+        "x-request-id": "3508b4a0-4621-4d95-bb72-72e8c6d7e67e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:33:26.4428858-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:59:02.8531142-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetInfluxDbDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetInfluxDbDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "1039",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-40831c9e56c33349881d2e99d1588126-a8ad66e8da97f541-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-cc2273f153bdb74f81f9cebc5417c57e-410aa9aedcd0a049-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9d041078b1e3a7e73e7f0c61fc6a0ba5",
         "x-ms-return-client-request-id": "true"
@@ -49,7 +49,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:56:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -67,25 +67,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "cd49bcc2-7cfc-4d48-b8a5-a0adb1c037f6",
+        "apim-request-id": "a9436dcd-fefc-427d-ab50-650d17be3d41",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:27 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5eaa54e2-2a70-4596-a20e-01bd5ffdab9c",
+        "Date": "Wed, 28 Jul 2021 19:56:40 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/272e6e0e-b9a3-4573-8511-030135fcbe91",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6970",
-        "x-request-id": "cd49bcc2-7cfc-4d48-b8a5-a0adb1c037f6"
+        "x-envoy-upstream-service-time": "12109",
+        "x-request-id": "a9436dcd-fefc-427d-ab50-650d17be3d41"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5eaa54e2-2a70-4596-a20e-01bd5ffdab9c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/272e6e0e-b9a3-4573-8511-030135fcbe91",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-40831c9e56c33349881d2e99d1588126-2fb4cac4d37e4240-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-cc2273f153bdb74f81f9cebc5417c57e-c2cf015a8d5f984c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4d557079890c486dd931d4fd34d89ef4",
         "x-ms-return-client-request-id": "true"
@@ -93,27 +93,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "caf50849-60ab-472a-8040-8549abb458e0",
+        "apim-request-id": "93324e32-27e2-40e3-95ed-dd12c124014b",
         "Content-Length": "1416",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:31:28 GMT",
+        "Date": "Wed, 28 Jul 2021 19:56:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "548",
-        "x-request-id": "caf50849-60ab-472a-8040-8549abb458e0"
+        "x-envoy-upstream-service-time": "798",
+        "x-request-id": "93324e32-27e2-40e3-95ed-dd12c124014b"
       },
       "ResponseBody": {
-        "dataFeedId": "5eaa54e2-2a70-4596-a20e-01bd5ffdab9c",
+        "dataFeedId": "272e6e0e-b9a3-4573-8511-030135fcbe91",
         "dataFeedName": "dataFeedinA3Na3s",
         "metrics": [
           {
-            "metricId": "e13922ec-d89d-4c7f-a40d-8298d4fa2d55",
+            "metricId": "c3e7a55e-cec9-4dd2-a6c6-61b4e48a8060",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "e33937f6-42da-4183-b5ed-386707b8c08d",
+            "metricId": "4300de93-fbaf-4658-bac7-99fef4615488",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -129,7 +129,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:56:00Z",
         "dataSourceType": "InfluxDB",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -154,7 +154,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:31:27Z",
+        "createdTime": "2021-07-28T19:56:40Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -167,13 +167,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5eaa54e2-2a70-4596-a20e-01bd5ffdab9c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/272e6e0e-b9a3-4573-8511-030135fcbe91",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d6430e19a72ed04c8a1114430a1c7268-b317e90e31020f4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-7a4554a05ff4564ca08fc28ab180b6b1-7d8316a938382844-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8780e974466a4acc05a84f2a3a546c4b",
         "x-ms-return-client-request-id": "true"
@@ -181,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "bc8c9abe-d3f6-489c-8b62-22382e6387a6",
+        "apim-request-id": "7eb9980a-b3f7-447a-a2a6-8e98f04968cf",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:29 GMT",
+        "Date": "Wed, 28 Jul 2021 19:56:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1180",
-        "x-request-id": "bc8c9abe-d3f6-489c-8b62-22382e6387a6"
+        "x-envoy-upstream-service-time": "1695",
+        "x-request-id": "7eb9980a-b3f7-447a-a2a6-8e98f04968cf"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:31:28.8272104-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:56:29.2004270-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetInfluxDbDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetInfluxDbDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "1039",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b0700f95e38c9341aa3758d252a53745-b972b89b00a62440-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-7ec85d0f279daa47a3fdc2c994b080dd-28c368908133db49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6252c472d46e4a19cdab563ce87e761a",
         "x-ms-return-client-request-id": "true"
@@ -49,7 +49,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:59:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -67,25 +67,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "0ec39469-c89f-421d-876c-88fcf545d62f",
+        "apim-request-id": "db131235-001e-45d9-b2d1-23b7c97ad03d",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:33:35 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd500d2c-d8a7-4547-b026-fad8b7e1e130",
+        "Date": "Wed, 28 Jul 2021 19:59:19 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/95cd7c71-8325-4843-9d35-b68acddea51b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "2278",
-        "x-request-id": "0ec39469-c89f-421d-876c-88fcf545d62f"
+        "x-envoy-upstream-service-time": "2056",
+        "x-request-id": "db131235-001e-45d9-b2d1-23b7c97ad03d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd500d2c-d8a7-4547-b026-fad8b7e1e130",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/95cd7c71-8325-4843-9d35-b68acddea51b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b0700f95e38c9341aa3758d252a53745-178704f1ad35834d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-7ec85d0f279daa47a3fdc2c994b080dd-391b35aca62d4f48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "54fddd90ef48400529fbfbfe7ae94084",
         "x-ms-return-client-request-id": "true"
@@ -93,27 +93,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "50bf46ac-6bbb-4a88-9111-ec7d1831e45b",
+        "apim-request-id": "6564cc67-8def-4568-92c8-10eb0d50cc09",
         "Content-Length": "1416",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:33:35 GMT",
+        "Date": "Wed, 28 Jul 2021 19:59:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "623",
-        "x-request-id": "50bf46ac-6bbb-4a88-9111-ec7d1831e45b"
+        "x-envoy-upstream-service-time": "569",
+        "x-request-id": "6564cc67-8def-4568-92c8-10eb0d50cc09"
       },
       "ResponseBody": {
-        "dataFeedId": "bd500d2c-d8a7-4547-b026-fad8b7e1e130",
+        "dataFeedId": "95cd7c71-8325-4843-9d35-b68acddea51b",
         "dataFeedName": "dataFeedby5qOJIr",
         "metrics": [
           {
-            "metricId": "64a2e453-c669-43e4-b1ec-3eecfbdac517",
+            "metricId": "d486f7a4-7563-4ceb-8e36-8f5d89683272",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "c73129d8-ea2e-4156-908d-3e23531795cd",
+            "metricId": "842790a9-3fe4-465d-b5c7-712fea94d337",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -129,7 +129,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:59:00Z",
         "dataSourceType": "InfluxDB",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -154,7 +154,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:33:34Z",
+        "createdTime": "2021-07-28T19:59:18Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -167,13 +167,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd500d2c-d8a7-4547-b026-fad8b7e1e130",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/95cd7c71-8325-4843-9d35-b68acddea51b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-50e2f2702211df4fa7822fc690a677e0-e9c7a497b0b5874f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b3cd0b3850e9654ca3502a296898b248-301074c93994384d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "95e68dedd826cee89b6fe292722f9845",
         "x-ms-return-client-request-id": "true"
@@ -181,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "9e1e8a26-6892-4c7e-8ac8-2424b19fd26e",
+        "apim-request-id": "291c454c-6d1c-4b49-860b-c88fad755db3",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:33:36 GMT",
+        "Date": "Wed, 28 Jul 2021 19:59:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1306",
-        "x-request-id": "9e1e8a26-6892-4c7e-8ac8-2424b19fd26e"
+        "x-envoy-upstream-service-time": "11333",
+        "x-request-id": "291c454c-6d1c-4b49-860b-c88fad755db3"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:33:36.1578576-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:59:16.9798384-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetLogAnalyticsDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetLogAnalyticsDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "1049",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-561b71a460bfec47bfdf3a1f40d252b3-04b20b9ce7c5bb45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-1aace718d78dda49a9b498893c3c99cc-351a213943e10544-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8bbc5ba463fc3daa96fbb651e2e138d8",
         "x-ms-return-client-request-id": "true"
@@ -49,7 +49,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:56:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -67,25 +67,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d6e64e9b-7429-4e74-acd7-ad8c9f7b1900",
+        "apim-request-id": "b9cd0719-1efc-4535-a88d-f79fd0cec7c1",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:31 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4cf77e43-f957-47ff-b11b-5debb0784810",
+        "Date": "Wed, 28 Jul 2021 19:56:45 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/77aefe84-6181-4d75-bccd-467e71e52bd8",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1722",
-        "x-request-id": "d6e64e9b-7429-4e74-acd7-ad8c9f7b1900"
+        "x-envoy-upstream-service-time": "2016",
+        "x-request-id": "b9cd0719-1efc-4535-a88d-f79fd0cec7c1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4cf77e43-f957-47ff-b11b-5debb0784810",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/77aefe84-6181-4d75-bccd-467e71e52bd8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-561b71a460bfec47bfdf3a1f40d252b3-2e0b001d3a7fee4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-1aace718d78dda49a9b498893c3c99cc-a7ad33e9203e0442-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6dda933264de5f798b48cdecda7db8c9",
         "x-ms-return-client-request-id": "true"
@@ -93,27 +93,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4084856f-bff7-4995-aa23-fd8f183e7eb3",
+        "apim-request-id": "bcb35eec-7d61-4219-8ffb-484791ff748d",
         "Content-Length": "1422",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:31:36 GMT",
+        "Date": "Wed, 28 Jul 2021 19:56:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5605",
-        "x-request-id": "4084856f-bff7-4995-aa23-fd8f183e7eb3"
+        "x-envoy-upstream-service-time": "5921",
+        "x-request-id": "bcb35eec-7d61-4219-8ffb-484791ff748d"
       },
       "ResponseBody": {
-        "dataFeedId": "4cf77e43-f957-47ff-b11b-5debb0784810",
+        "dataFeedId": "77aefe84-6181-4d75-bccd-467e71e52bd8",
         "dataFeedName": "dataFeed6V6SKuho",
         "metrics": [
           {
-            "metricId": "60327b2e-bd97-430b-be37-a8079979cb26",
+            "metricId": "3d6e4224-fd1e-4759-9dc5-ff18a76f8404",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "96790f3d-3993-4f69-9b04-2ba6438a8a17",
+            "metricId": "e5289151-722e-4980-aed3-02d51909db82",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -129,7 +129,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:56:00Z",
         "dataSourceType": "AzureLogAnalytics",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -154,7 +154,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:31:31Z",
+        "createdTime": "2021-07-28T19:56:44Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -167,13 +167,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4cf77e43-f957-47ff-b11b-5debb0784810",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/77aefe84-6181-4d75-bccd-467e71e52bd8",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1d1cd5c2f19fbc47bcfcd5f69bdf10ad-7c10c9eff7d5ad4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-573d0c3fe8c730458f89afeeea090ce0-3a16d4b18c4e5e43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b643adf0fec8f14f8c7b53c9a67f4d90",
         "x-ms-return-client-request-id": "true"
@@ -181,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "91dbb74c-dec5-438f-8074-e3ecbbaa5e84",
+        "apim-request-id": "447d5213-0c88-48a2-a45a-8c698029715d",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:37 GMT",
+        "Date": "Wed, 28 Jul 2021 19:56:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1148",
-        "x-request-id": "91dbb74c-dec5-438f-8074-e3ecbbaa5e84"
+        "x-envoy-upstream-service-time": "6421",
+        "x-request-id": "447d5213-0c88-48a2-a45a-8c698029715d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:31:37.4792487-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:56:43.9252798-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetLogAnalyticsDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetLogAnalyticsDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "1049",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-30823b7c43be584a91016198b514e31d-85fe89e1fc4df14e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-5d1b861d293a7a479f24c564187030cb-cc1528deab10ad4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "842372337f1355eab22bbd5bd878307f",
         "x-ms-return-client-request-id": "true"
@@ -49,7 +49,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:59:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -67,25 +67,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "53151add-47d0-4f7e-8e23-0233eca6a932",
+        "apim-request-id": "98661a71-e777-4638-a082-e205a2563da1",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:33:38 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5aa40e16-2666-483a-8ec4-0d61987ec937",
+        "Date": "Wed, 28 Jul 2021 19:59:38 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/65f7d9af-9687-452d-8fa2-4bdd1d17be27",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "2074",
-        "x-request-id": "53151add-47d0-4f7e-8e23-0233eca6a932"
+        "x-envoy-upstream-service-time": "8193",
+        "x-request-id": "98661a71-e777-4638-a082-e205a2563da1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5aa40e16-2666-483a-8ec4-0d61987ec937",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/65f7d9af-9687-452d-8fa2-4bdd1d17be27",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-30823b7c43be584a91016198b514e31d-463646cda4e1a644-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-5d1b861d293a7a479f24c564187030cb-3ca4f51a3f169d4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e806cb763b8bcd239c6615a2e2c3a8b8",
         "x-ms-return-client-request-id": "true"
@@ -93,27 +93,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c702bc24-91f3-4995-9711-b68df548265f",
+        "apim-request-id": "dc72e59b-80d9-477f-ab9d-92a4e9eb1fdd",
         "Content-Length": "1422",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:33:45 GMT",
+        "Date": "Wed, 28 Jul 2021 19:59:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5857",
-        "x-request-id": "c702bc24-91f3-4995-9711-b68df548265f"
+        "x-envoy-upstream-service-time": "708",
+        "x-request-id": "dc72e59b-80d9-477f-ab9d-92a4e9eb1fdd"
       },
       "ResponseBody": {
-        "dataFeedId": "5aa40e16-2666-483a-8ec4-0d61987ec937",
+        "dataFeedId": "65f7d9af-9687-452d-8fa2-4bdd1d17be27",
         "dataFeedName": "dataFeedH31fBBJa",
         "metrics": [
           {
-            "metricId": "4f14db67-d8a4-4981-9075-69dd44ee5e9a",
+            "metricId": "61387468-96c8-4c88-9113-7dafe9c741c0",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "7c218f3f-fed9-4514-b334-17cad755b077",
+            "metricId": "97a3cd62-0f69-47c0-82cf-1d0c40d82a91",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -129,7 +129,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:59:00Z",
         "dataSourceType": "AzureLogAnalytics",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -154,7 +154,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:33:38Z",
+        "createdTime": "2021-07-28T19:59:38Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -167,13 +167,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5aa40e16-2666-483a-8ec4-0d61987ec937",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/65f7d9af-9687-452d-8fa2-4bdd1d17be27",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1bef9c7c780b474f92d6594ef1681025-357b119e6b0c8045-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b5b9380bfee11f46b760fe6b6c9483b6-98f154af7e71bd41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "79d6b8f9c1fb9970747c7fe99fea1b1e",
         "x-ms-return-client-request-id": "true"
@@ -181,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d152148e-1c66-4098-858b-68d9d268c09a",
+        "apim-request-id": "b1c0c222-31f6-441a-97cd-735a60227468",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:33:46 GMT",
+        "Date": "Wed, 28 Jul 2021 19:59:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1737",
-        "x-request-id": "d152148e-1c66-4098-858b-68d9d268c09a"
+        "x-envoy-upstream-service-time": "1769",
+        "x-request-id": "b1c0c222-31f6-441a-97cd-735a60227468"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:33:45.5574322-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:59:31.0692726-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMongoDbDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMongoDbDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "997",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1af5df699682f248830f3c8c98c700c0-76f29fb6ebe9fd40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-65f41b47991b574692b20d81cf1074c8-ea12992753162c4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a3d43c7745a4a24592be10940793c8c7",
         "x-ms-return-client-request-id": "true"
@@ -47,7 +47,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:56:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -65,25 +65,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "3e216b18-05ea-4ecd-b28d-c52c1bb2a5b0",
+        "apim-request-id": "4b62d104-bdd0-4d0a-a6a6-08cdc3ead66d",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:45 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0802bc4c-330a-4af0-98ea-1a0bd7a52ad3",
+        "Date": "Wed, 28 Jul 2021 19:57:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/685eba35-9944-488f-8492-ae7a0852c396",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7215",
-        "x-request-id": "3e216b18-05ea-4ecd-b28d-c52c1bb2a5b0"
+        "x-envoy-upstream-service-time": "6777",
+        "x-request-id": "4b62d104-bdd0-4d0a-a6a6-08cdc3ead66d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0802bc4c-330a-4af0-98ea-1a0bd7a52ad3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/685eba35-9944-488f-8492-ae7a0852c396",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1af5df699682f248830f3c8c98c700c0-e9f7520c41f47a46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-65f41b47991b574692b20d81cf1074c8-aa82986c83ea414b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "40b6c8316da078e7396b4d6494e8a1c1",
         "x-ms-return-client-request-id": "true"
@@ -91,27 +91,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b5776439-2240-48ee-9e10-11db3eb338d2",
+        "apim-request-id": "1b59e15b-0188-4e36-a47b-e75da3f59443",
         "Content-Length": "1366",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:31:51 GMT",
+        "Date": "Wed, 28 Jul 2021 19:57:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5739",
-        "x-request-id": "b5776439-2240-48ee-9e10-11db3eb338d2"
+        "x-envoy-upstream-service-time": "5662",
+        "x-request-id": "1b59e15b-0188-4e36-a47b-e75da3f59443"
       },
       "ResponseBody": {
-        "dataFeedId": "0802bc4c-330a-4af0-98ea-1a0bd7a52ad3",
+        "dataFeedId": "685eba35-9944-488f-8492-ae7a0852c396",
         "dataFeedName": "dataFeedsR6T7Z02",
         "metrics": [
           {
-            "metricId": "f77094f6-9ede-4d2d-b019-4acb367361ec",
+            "metricId": "8e0bcddc-4418-45c5-b457-25efe6be353e",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "b2c9c81f-9c5c-43ce-aa8b-bbccc6d1ee3e",
+            "metricId": "b3b6732f-af73-4b6a-bdf4-a9a223ff2c97",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -127,7 +127,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:56:00Z",
         "dataSourceType": "MongoDB",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -152,7 +152,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:31:44Z",
+        "createdTime": "2021-07-28T19:57:04Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -163,13 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0802bc4c-330a-4af0-98ea-1a0bd7a52ad3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/685eba35-9944-488f-8492-ae7a0852c396",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f7364c8285a8b34c939fc280de0efa50-20d5162fe40f7046-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-cd7f5f04d702ed438eaad657566c797c-ced4c7d39cbef04a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8167193d7b9fbd03e6d2724fa4381163",
         "x-ms-return-client-request-id": "true"
@@ -177,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e3a8c0a0-f1f9-4567-b791-209a02108614",
+        "apim-request-id": "0ba43874-97b4-48ac-a3cb-dd17c4077c9e",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:52 GMT",
+        "Date": "Wed, 28 Jul 2021 19:57:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1322",
-        "x-request-id": "e3a8c0a0-f1f9-4567-b791-209a02108614"
+        "x-envoy-upstream-service-time": "6126",
+        "x-request-id": "0ba43874-97b4-48ac-a3cb-dd17c4077c9e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:31:51.7181574-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:56:58.4131269-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMongoDbDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMongoDbDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "997",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ee2228ee9f56c14a99581c6fb6a16925-c17ee35504a00b47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-d2c5a1e79b8ff0489b10ec02fae4a8e9-c5b92fc358a5b140-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fc27be14c3879258a02f968a2d50ed27",
         "x-ms-return-client-request-id": "true"
@@ -47,7 +47,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:59:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -65,25 +65,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5c2a1e7a-ffd2-4bed-9475-626cc762020f",
+        "apim-request-id": "d1f2ff87-0eda-494f-b386-6d36a5141255",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:33:54 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0bd48bb9-2d5a-4e89-8509-588adfe2b2c8",
+        "Date": "Wed, 28 Jul 2021 19:59:48 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fd602d0b-7901-4b84-bdeb-c40716a65595",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7003",
-        "x-request-id": "5c2a1e7a-ffd2-4bed-9475-626cc762020f"
+        "x-envoy-upstream-service-time": "6778",
+        "x-request-id": "d1f2ff87-0eda-494f-b386-6d36a5141255"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0bd48bb9-2d5a-4e89-8509-588adfe2b2c8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fd602d0b-7901-4b84-bdeb-c40716a65595",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ee2228ee9f56c14a99581c6fb6a16925-dd36eefb416e2e45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-d2c5a1e79b8ff0489b10ec02fae4a8e9-3dbd317d849b5240-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0b19e60ffedc993d8eb2bf5d48e86834",
         "x-ms-return-client-request-id": "true"
@@ -91,27 +91,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "73919567-627e-4bd8-b0dc-fb62bbc9fd2f",
+        "apim-request-id": "31c7d8b2-4d68-4588-855d-2ee44f34d202",
         "Content-Length": "1366",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:33:59 GMT",
+        "Date": "Wed, 28 Jul 2021 19:59:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5516",
-        "x-request-id": "73919567-627e-4bd8-b0dc-fb62bbc9fd2f"
+        "x-envoy-upstream-service-time": "5574",
+        "x-request-id": "31c7d8b2-4d68-4588-855d-2ee44f34d202"
       },
       "ResponseBody": {
-        "dataFeedId": "0bd48bb9-2d5a-4e89-8509-588adfe2b2c8",
+        "dataFeedId": "fd602d0b-7901-4b84-bdeb-c40716a65595",
         "dataFeedName": "dataFeedLS0fekdV",
         "metrics": [
           {
-            "metricId": "8f4d21f3-bf99-4be1-a545-65db59f43928",
+            "metricId": "4b42af69-5a14-49af-add5-941a0b1a9397",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "39f6c171-300f-4a9f-bcb1-8402c7d110f2",
+            "metricId": "70b41540-39a7-4a88-95bc-4cb8ea5ff43b",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -127,7 +127,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:59:00Z",
         "dataSourceType": "MongoDB",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -152,7 +152,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:33:53Z",
+        "createdTime": "2021-07-28T19:59:47Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -163,13 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0bd48bb9-2d5a-4e89-8509-588adfe2b2c8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fd602d0b-7901-4b84-bdeb-c40716a65595",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e3d69cb9356a7147b4724d3bdc63529b-bfe8e44fb03ff542-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6a030a1e5ae1a748a836b95ed107724b-ee259b6dc5a75d4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cc62f72efeebda40a8930ed2bb234980",
         "x-ms-return-client-request-id": "true"
@@ -177,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3c35abb2-499b-467c-980e-04bd3dcbeba0",
+        "apim-request-id": "1e6b369e-da32-4591-8f97-f3acca04f7ad",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:34:00 GMT",
+        "Date": "Wed, 28 Jul 2021 19:59:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1134",
-        "x-request-id": "3c35abb2-499b-467c-980e-04bd3dcbeba0"
+        "x-envoy-upstream-service-time": "1361",
+        "x-request-id": "1e6b369e-da32-4591-8f97-f3acca04f7ad"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:33:59.9269884-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:59:41.8783022-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMySqlDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMySqlDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "969",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f1e2c3dabf9c4a4badef25539e9e4c4c-756fe94a5c69404a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-0d484ed23368a846bf492c77be2691c4-44401da7ff173246-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9ac4891ef145b15dfe07db041d5dc281",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:57:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -64,25 +64,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "85343ac9-a3f5-4191-9fcb-111ccd69ce70",
+        "apim-request-id": "faec42dc-3cf1-4e5c-97fa-5bf2289a8507",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:31:54 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1d742fd1-7263-49b4-b39e-ef4b76c9490c",
+        "Date": "Wed, 28 Jul 2021 19:57:19 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c1be0d47-f331-491f-b88a-8b72bc69d3c9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "2112",
-        "x-request-id": "85343ac9-a3f5-4191-9fcb-111ccd69ce70"
+        "x-envoy-upstream-service-time": "2245",
+        "x-request-id": "faec42dc-3cf1-4e5c-97fa-5bf2289a8507"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1d742fd1-7263-49b4-b39e-ef4b76c9490c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c1be0d47-f331-491f-b88a-8b72bc69d3c9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f1e2c3dabf9c4a4badef25539e9e4c4c-d37fcb9f9f928c42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-0d484ed23368a846bf492c77be2691c4-81b7c1630f6d4f49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "49fe086974f57d567a21c51fd8605f46",
         "x-ms-return-client-request-id": "true"
@@ -90,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d60abdab-b773-49d8-83e3-510a9e162cd5",
+        "apim-request-id": "e4e0df9d-4966-4060-92f7-c6fbedebaa84",
         "Content-Length": "1338",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:32:00 GMT",
+        "Date": "Wed, 28 Jul 2021 19:57:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5532",
-        "x-request-id": "d60abdab-b773-49d8-83e3-510a9e162cd5"
+        "x-envoy-upstream-service-time": "708",
+        "x-request-id": "e4e0df9d-4966-4060-92f7-c6fbedebaa84"
       },
       "ResponseBody": {
-        "dataFeedId": "1d742fd1-7263-49b4-b39e-ef4b76c9490c",
+        "dataFeedId": "c1be0d47-f331-491f-b88a-8b72bc69d3c9",
         "dataFeedName": "dataFeed4J2AWNot",
         "metrics": [
           {
-            "metricId": "8e56af28-7acf-45d6-8c6e-7ebb08cccf46",
+            "metricId": "2fb32084-d437-4117-a745-a328a659b676",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "b92142fa-b9f1-48c1-87df-13dc8708579b",
+            "metricId": "d4d6fc01-f194-47fd-805b-f8fa89ffb385",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -126,7 +126,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:57:00Z",
         "dataSourceType": "MySql",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:31:54Z",
+        "createdTime": "2021-07-28T19:57:18Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -161,13 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1d742fd1-7263-49b4-b39e-ef4b76c9490c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c1be0d47-f331-491f-b88a-8b72bc69d3c9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1c2a8b85620c2c4ba2ac935335a60542-5b9baad7829ce848-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-13f2f4b454cdcf4d84b053a75342bab9-8f4207df75858d4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3c99d52a0aa7f1180d2646e9e27d1ae0",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2b093e94-d716-4a0e-b5b3-705d071f8aa7",
+        "apim-request-id": "12dcabe6-bb8f-4bae-acba-71598118f000",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:32:01 GMT",
+        "Date": "Wed, 28 Jul 2021 19:57:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1194",
-        "x-request-id": "2b093e94-d716-4a0e-b5b3-705d071f8aa7"
+        "x-envoy-upstream-service-time": "1258",
+        "x-request-id": "12dcabe6-bb8f-4bae-acba-71598118f000"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:32:00.7993585-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:57:17.1243706-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMySqlDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMySqlDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "969",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ffb6cfe679a0b94988a24e49e90877ab-71b0cb1f2cd27045-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-dde74043f093a84fad8ae6664acab0c7-c9c7a01e9e0bec45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9e702109323119494ec56a4f8b9494db",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:59:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -64,25 +64,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d1d68aff-16ec-42e1-8d11-b8cd4f68fadc",
+        "apim-request-id": "ee4f6300-33e3-4777-81bf-5bb580175e2e",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:34:02 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a18439a1-acde-4c7d-bd30-0d1728e01018",
+        "Date": "Wed, 28 Jul 2021 20:00:02 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb09bac1-e1fc-4f5c-9a7a-78e64ac4bdaa",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1749",
-        "x-request-id": "d1d68aff-16ec-42e1-8d11-b8cd4f68fadc"
+        "x-envoy-upstream-service-time": "6895",
+        "x-request-id": "ee4f6300-33e3-4777-81bf-5bb580175e2e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a18439a1-acde-4c7d-bd30-0d1728e01018",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb09bac1-e1fc-4f5c-9a7a-78e64ac4bdaa",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ffb6cfe679a0b94988a24e49e90877ab-2ba60e05e7d0c84c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-dde74043f093a84fad8ae6664acab0c7-abc5adf0ea79b946-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "eba95d2cd342a5963911b433617ee200",
         "x-ms-return-client-request-id": "true"
@@ -90,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4184e8bf-8878-4926-aced-57a1aa57dacd",
+        "apim-request-id": "d2321759-76a7-4924-ae29-ccc7d2978fc9",
         "Content-Length": "1338",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:34:02 GMT",
+        "Date": "Wed, 28 Jul 2021 20:00:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "529",
-        "x-request-id": "4184e8bf-8878-4926-aced-57a1aa57dacd"
+        "x-envoy-upstream-service-time": "5742",
+        "x-request-id": "d2321759-76a7-4924-ae29-ccc7d2978fc9"
       },
       "ResponseBody": {
-        "dataFeedId": "a18439a1-acde-4c7d-bd30-0d1728e01018",
+        "dataFeedId": "eb09bac1-e1fc-4f5c-9a7a-78e64ac4bdaa",
         "dataFeedName": "dataFeedk7wnLUbS",
         "metrics": [
           {
-            "metricId": "a906ec5d-7e4f-47fd-8871-5d12890e8650",
+            "metricId": "b7fe7934-abe0-4b21-9e45-2dcbe5254fc5",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "be92c7f8-149a-4633-9338-30e1140d8afd",
+            "metricId": "7bea4bb6-9cd0-498c-b614-4188b7168ee8",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -126,7 +126,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:59:00Z",
         "dataSourceType": "MySql",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:34:02Z",
+        "createdTime": "2021-07-28T20:00:01Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -161,13 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a18439a1-acde-4c7d-bd30-0d1728e01018",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb09bac1-e1fc-4f5c-9a7a-78e64ac4bdaa",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6062c6aa8165a84a8dd5c7053b05cfa7-74c8ded032c76a44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-76a7fa80d7953347b996ab2e350fdbfe-b255a5c570a67043-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "30a15f015ea302b019442594bbcd9e12",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "aff6cb60-ddf1-4c5d-afdc-5a3fadef0f7a",
+        "apim-request-id": "7ef35819-5ce2-4f09-8522-8c71a1f95d90",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:34:03 GMT",
+        "Date": "Wed, 28 Jul 2021 20:00:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1183",
-        "x-request-id": "aff6cb60-ddf1-4c5d-afdc-5a3fadef0f7a"
+        "x-envoy-upstream-service-time": "6313",
+        "x-request-id": "7ef35819-5ce2-4f09-8522-8c71a1f95d90"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:34:03.4652383-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:59:55.7188954-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetPostgreSqlDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetPostgreSqlDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "974",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a1cbb86a840bdb4ea94a9213491b7bbc-19ee97a2a404b14a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-ad0b59dd6c9fe849bac4299910583bd4-d1b9ac5cce39134e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "051b7626a9142028f6f00e9ad56b9615",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:57:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -64,25 +64,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "fdf1adc9-271f-46ef-ac4f-31f77d2fa20b",
+        "apim-request-id": "a0cd205b-9d49-4cdc-b993-836e51f14e13",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:32:03 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e52b3006-0969-4ce0-91f2-086e35f7c5ce",
+        "Date": "Wed, 28 Jul 2021 19:57:27 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d3b891-abba-49dc-a6d6-f2013bfcd6a0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1847",
-        "x-request-id": "fdf1adc9-271f-46ef-ac4f-31f77d2fa20b"
+        "x-envoy-upstream-service-time": "6979",
+        "x-request-id": "a0cd205b-9d49-4cdc-b993-836e51f14e13"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e52b3006-0969-4ce0-91f2-086e35f7c5ce",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d3b891-abba-49dc-a6d6-f2013bfcd6a0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a1cbb86a840bdb4ea94a9213491b7bbc-b1376b983b9d1240-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-ad0b59dd6c9fe849bac4299910583bd4-11a2b7a3fa23d349-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4e3642bb69b6d1ef9041c21785e9eb14",
         "x-ms-return-client-request-id": "true"
@@ -90,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "59e97069-a40a-45df-896e-67ce0c3d8d34",
+        "apim-request-id": "944152f1-f404-441a-a1b3-a786f2d493c6",
         "Content-Length": "1343",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:32:03 GMT",
+        "Date": "Wed, 28 Jul 2021 19:57:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "556",
-        "x-request-id": "59e97069-a40a-45df-896e-67ce0c3d8d34"
+        "x-envoy-upstream-service-time": "10730",
+        "x-request-id": "944152f1-f404-441a-a1b3-a786f2d493c6"
       },
       "ResponseBody": {
-        "dataFeedId": "e52b3006-0969-4ce0-91f2-086e35f7c5ce",
+        "dataFeedId": "b2d3b891-abba-49dc-a6d6-f2013bfcd6a0",
         "dataFeedName": "dataFeedzyytIbjH",
         "metrics": [
           {
-            "metricId": "92a9bcdf-5f72-44ff-8cf3-3b20254ae953",
+            "metricId": "e96cfa06-be62-406e-9c3a-ef37fb2630ec",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "f6f1adc7-ddc3-4a36-9789-ae8e178694db",
+            "metricId": "5b52a8d1-2543-473d-bd6b-196650840f5c",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -126,7 +126,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:57:00Z",
         "dataSourceType": "PostgreSql",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:32:03Z",
+        "createdTime": "2021-07-28T19:57:27Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -161,13 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e52b3006-0969-4ce0-91f2-086e35f7c5ce",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d3b891-abba-49dc-a6d6-f2013bfcd6a0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-abd286307a62a642b9fa903d7a3f1abd-6a5011f04f924042-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-9e9366f014076b43b979d41b9d0aeaed-4dd70f794c260345-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d328cdf5145aaa205cc97670b7a50f7e",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f4ebd376-4e20-48bc-9ee0-884cd4d63694",
+        "apim-request-id": "29cb8684-a02f-4f38-b14d-93ff527fd879",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:32:04 GMT",
+        "Date": "Wed, 28 Jul 2021 19:57:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1200",
-        "x-request-id": "f4ebd376-4e20-48bc-9ee0-884cd4d63694"
+        "x-envoy-upstream-service-time": "6450",
+        "x-request-id": "29cb8684-a02f-4f38-b14d-93ff527fd879"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:32:04.5132193-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:57:21.4510858-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetPostgreSqlDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetPostgreSqlDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "974",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f604d04d6b1ed040a762fbe9264eabcc-ffb058c6bba27b46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e76ae8c0c39a744295c9a155e590bd98-73d2319d41c7ac46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fb5ff9a17356a5f50d9e9fbe2f10a2f4",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T20:00:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -64,25 +64,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "7ddd50e5-fc22-4271-9b30-9d2574a493d7",
+        "apim-request-id": "19fc4ae0-dd71-4c51-b4b8-d7d57c708d0e",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:34:05 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/de4014eb-6e72-4d75-9409-e25a75f73bb7",
+        "Date": "Wed, 28 Jul 2021 20:00:15 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e5b7817a-0b67-472f-8055-7b813ebff02e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1698",
-        "x-request-id": "7ddd50e5-fc22-4271-9b30-9d2574a493d7"
+        "x-envoy-upstream-service-time": "1835",
+        "x-request-id": "19fc4ae0-dd71-4c51-b4b8-d7d57c708d0e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/de4014eb-6e72-4d75-9409-e25a75f73bb7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e5b7817a-0b67-472f-8055-7b813ebff02e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f604d04d6b1ed040a762fbe9264eabcc-a7faaf16786cbb4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e76ae8c0c39a744295c9a155e590bd98-5bc70318247e6047-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "79ad770bba1d3760ff157f7ab63e5bf1",
         "x-ms-return-client-request-id": "true"
@@ -90,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6ac48b9c-5c8b-448d-b30b-ef627b8c3579",
+        "apim-request-id": "77e012d9-1337-43cd-bd35-8f7f2b8f17e3",
         "Content-Length": "1343",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:34:06 GMT",
+        "Date": "Wed, 28 Jul 2021 20:00:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "582",
-        "x-request-id": "6ac48b9c-5c8b-448d-b30b-ef627b8c3579"
+        "x-envoy-upstream-service-time": "5768",
+        "x-request-id": "77e012d9-1337-43cd-bd35-8f7f2b8f17e3"
       },
       "ResponseBody": {
-        "dataFeedId": "de4014eb-6e72-4d75-9409-e25a75f73bb7",
+        "dataFeedId": "e5b7817a-0b67-472f-8055-7b813ebff02e",
         "dataFeedName": "dataFeedffsJE0BR",
         "metrics": [
           {
-            "metricId": "c69e893e-da33-4896-8981-123aef2e6db5",
+            "metricId": "ea589f18-cd89-4554-8ba0-933fc788166c",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "bd5062a1-29df-441c-9d3b-80d8cb74eef9",
+            "metricId": "75ecc63c-71bb-46cc-b032-be85e5075077",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -126,7 +126,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T20:00:00Z",
         "dataSourceType": "PostgreSql",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:34:05Z",
+        "createdTime": "2021-07-28T20:00:15Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -161,13 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/de4014eb-6e72-4d75-9409-e25a75f73bb7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e5b7817a-0b67-472f-8055-7b813ebff02e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0acf6ef84b392e4495396355f06f936f-e5e46859f363a148-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-60ae0392fba6cb46a8aef95aca01043e-d46b4676f2e57445-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "91dc330bf653f0a370bd5f171f7bbb25",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "829367c4-6517-4f9d-938b-cc006553f0be",
+        "apim-request-id": "ffc95725-4030-4414-b4d5-cb50c5d7f7c5",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:34:13 GMT",
+        "Date": "Wed, 28 Jul 2021 20:00:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6200",
-        "x-request-id": "829367c4-6517-4f9d-938b-cc006553f0be"
+        "x-envoy-upstream-service-time": "1333",
+        "x-request-id": "ffc95725-4030-4414-b4d5-cb50c5d7f7c5"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:34:07.1904951-07:00",
+    "DateTimeOffsetNow": "2021-07-28T13:00:14.7808550-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetSqlServerDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetSqlServerDataFeedWithOptionalMembers.json
@@ -8,8 +8,8 @@
         "Content-Length": "973",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a590a503b9238540ab7475e230333502-3a542ce30e78e840-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-41f749099712d64c886afcadcaa36f09-dfbe860425301c47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9506268ea80a218e20797da422fde083",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:57:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -64,25 +64,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5a412768-fc1f-4ca5-86dc-1173cd1998b5",
+        "apim-request-id": "8d4230b6-e58e-49bd-b6e2-47ba583cc0f9",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:32:12 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a3f9f1c8-8364-4720-9698-76af643a7eac",
+        "Date": "Wed, 28 Jul 2021 19:57:47 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1d67274e-8e03-4bf6-b07e-af6911d8a8e5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6802",
-        "x-request-id": "5a412768-fc1f-4ca5-86dc-1173cd1998b5"
+        "x-envoy-upstream-service-time": "1993",
+        "x-request-id": "8d4230b6-e58e-49bd-b6e2-47ba583cc0f9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a3f9f1c8-8364-4720-9698-76af643a7eac",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1d67274e-8e03-4bf6-b07e-af6911d8a8e5",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a590a503b9238540ab7475e230333502-9e38864087415842-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-41f749099712d64c886afcadcaa36f09-1423b2b5a6ba0447-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "69e2e68fe7210dcae10286033f839142",
         "x-ms-return-client-request-id": "true"
@@ -90,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0bef0251-2f6b-49f3-85f8-d96813221c56",
+        "apim-request-id": "298c680a-82a6-4f51-900f-4d9301e0c117",
         "Content-Length": "1342",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:32:23 GMT",
+        "Date": "Wed, 28 Jul 2021 19:57:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10974",
-        "x-request-id": "0bef0251-2f6b-49f3-85f8-d96813221c56"
+        "x-envoy-upstream-service-time": "520",
+        "x-request-id": "298c680a-82a6-4f51-900f-4d9301e0c117"
       },
       "ResponseBody": {
-        "dataFeedId": "a3f9f1c8-8364-4720-9698-76af643a7eac",
+        "dataFeedId": "1d67274e-8e03-4bf6-b07e-af6911d8a8e5",
         "dataFeedName": "dataFeed5atufFei",
         "metrics": [
           {
-            "metricId": "e7444e7f-8b7c-4bd9-b2ff-8c4122b43dca",
+            "metricId": "53c0e3af-81c3-44f1-b815-19ea4767eaeb",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "d22f0387-88a6-4a45-bca5-75458161ac15",
+            "metricId": "8c1c6e38-f407-463c-ace6-73fd63b7326b",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -126,7 +126,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T19:57:00Z",
         "dataSourceType": "SqlServer",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:32:12Z",
+        "createdTime": "2021-07-28T19:57:46Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -161,13 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a3f9f1c8-8364-4720-9698-76af643a7eac",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1d67274e-8e03-4bf6-b07e-af6911d8a8e5",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5842f5ae6bdfc24cbc3cec841651469a-612a5a1dc7dea444-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e9f389aba52ef841a1cd56b4d5cbbb1e-10719119b457774d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ec81eab9ca01446e43b47aab8df25752",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e4f6a321-1049-483d-b002-00f1d2e4b6b9",
+        "apim-request-id": "7d6ea521-3409-4832-99a2-7960bb34b0d5",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:32:24 GMT",
+        "Date": "Wed, 28 Jul 2021 19:57:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1158",
-        "x-request-id": "e4f6a321-1049-483d-b002-00f1d2e4b6b9"
+        "x-envoy-upstream-service-time": "1624",
+        "x-request-id": "7d6ea521-3409-4832-99a2-7960bb34b0d5"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:32:23.8404506-07:00",
+    "DateTimeOffsetNow": "2021-07-28T12:57:45.7307994-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetSqlServerDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetSqlServerDataFeedWithOptionalMembersAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "973",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-802b5ca06a6ece41a95eb086faddb8f2-5141ef86b7a5ac4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-2a3356d122cdce45acdd4c327e5d41d5-b20c52a2e9942445-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9534f4446271ed34e922df1675e21907",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
           }
         ],
         "timestampColumn": "timestamp",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T20:00:00Z",
         "startOffsetInSeconds": 1800,
         "maxConcurrency": 5,
         "minRetryIntervalInSeconds": 80,
@@ -64,25 +64,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "874933ce-dbaa-4b19-939a-e19f26292cab",
+        "apim-request-id": "86bc740e-5663-496b-9803-7f6bc48504ae",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:34:15 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f229aa-d334-4c86-862e-18d1c8e9794c",
+        "Date": "Wed, 28 Jul 2021 20:00:25 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/976cee3d-e0f8-4be2-966f-6bb04e7bb3d0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1704",
-        "x-request-id": "874933ce-dbaa-4b19-939a-e19f26292cab"
+        "x-envoy-upstream-service-time": "1744",
+        "x-request-id": "86bc740e-5663-496b-9803-7f6bc48504ae"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f229aa-d334-4c86-862e-18d1c8e9794c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/976cee3d-e0f8-4be2-966f-6bb04e7bb3d0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-802b5ca06a6ece41a95eb086faddb8f2-da162d623b840148-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-2a3356d122cdce45acdd4c327e5d41d5-db393e59deaeda44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2fd5808ac9b1909764cc43d88a3d83a1",
         "x-ms-return-client-request-id": "true"
@@ -90,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9500e1c1-32fb-4348-921f-2855afb13b5f",
+        "apim-request-id": "66a3dd61-6bfd-4065-99a6-d42c48909291",
         "Content-Length": "1342",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 08 Jul 2021 23:34:15 GMT",
+        "Date": "Wed, 28 Jul 2021 20:00:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "634",
-        "x-request-id": "9500e1c1-32fb-4348-921f-2855afb13b5f"
+        "x-envoy-upstream-service-time": "652",
+        "x-request-id": "66a3dd61-6bfd-4065-99a6-d42c48909291"
       },
       "ResponseBody": {
-        "dataFeedId": "00f229aa-d334-4c86-862e-18d1c8e9794c",
+        "dataFeedId": "976cee3d-e0f8-4be2-966f-6bb04e7bb3d0",
         "dataFeedName": "dataFeedP9n9URW6",
         "metrics": [
           {
-            "metricId": "c929ac6b-1a24-4c3b-b629-73963b4869a6",
+            "metricId": "2bf41b7e-729b-4cf3-b997-b7039f994051",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "e05058b6-ade9-405c-96fd-dfdd5aab1ecb",
+            "metricId": "506e1f50-a80f-4563-aa46-35fa1ba64431",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -126,7 +126,7 @@
             "dimensionDisplayName": "city"
           }
         ],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2021-07-26T20:00:00Z",
         "dataSourceType": "SqlServer",
         "timestampColumn": "timestamp",
         "startOffsetInSeconds": 1800,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-07-08T23:34:14Z",
+        "createdTime": "2021-07-28T20:00:24Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -161,13 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f229aa-d334-4c86-862e-18d1c8e9794c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/976cee3d-e0f8-4be2-966f-6bb04e7bb3d0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c9d8c3e309f92347b43b12e1468567fe-41947b784d30e74a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210708.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-614c656142bd754c94cd3582344e5321-0bb5f0bd4d00064c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.1.0-alpha.20210728.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c6589d421c17f0f97de1835868666960",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "24b4db81-dd42-401f-9ffa-3144105d945c",
+        "apim-request-id": "72e09c11-b580-4210-8a8e-0f33b76d0eff",
         "Content-Length": "0",
-        "Date": "Thu, 08 Jul 2021 23:34:16 GMT",
+        "Date": "Wed, 28 Jul 2021 20:00:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1085",
-        "x-request-id": "24b4db81-dd42-401f-9ffa-3144105d945c"
+        "x-envoy-upstream-service-time": "6354",
+        "x-request-id": "72e09c11-b580-4210-8a8e-0f33b76d0eff"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-07-08T16:34:15.8713128-07:00",
+    "DateTimeOffsetNow": "2021-07-28T13:00:23.8840564-07:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/tests.yml
+++ b/sdk/metricsadvisor/tests.yml
@@ -4,6 +4,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: metricsadvisor
+    TimeoutInMinutes: 180
     EnvVars:
       METRICSADVISOR_ACCOUNT_NAME: "js-metrics-advisor"
       METRICSADVISOR_SUBSCRIPTION_KEY: $(metricsadvisor-test-subscription-key)

--- a/sdk/metricsadvisor/tests.yml
+++ b/sdk/metricsadvisor/tests.yml
@@ -4,7 +4,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: metricsadvisor
-    TimeoutInMinutes: 90
+    TimeoutInMinutes: 120
     EnvVars:
       METRICSADVISOR_ACCOUNT_NAME: "js-metrics-advisor"
       METRICSADVISOR_SUBSCRIPTION_KEY: $(metricsadvisor-test-subscription-key)

--- a/sdk/metricsadvisor/tests.yml
+++ b/sdk/metricsadvisor/tests.yml
@@ -4,7 +4,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: metricsadvisor
-    TimeoutInMinutes: 180
+    TimeoutInMinutes: 90
     EnvVars:
       METRICSADVISOR_ACCOUNT_NAME: "js-metrics-advisor"
       METRICSADVISOR_SUBSCRIPTION_KEY: $(metricsadvisor-test-subscription-key)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/22939.

The problem happens during the creation of a data feed. Given the ingestion start time + granularity (intervals in which data is ingested), the amount of data to be ingested is too large for the service to retain. We faced the same problem before, and we fixed it by increasing granularity.

However, since our ingestion start time is fixed, as time passes, the amount of data the service needs to ingest upon data feed creation increases, and we eventually need to face the same problem again.

This PR fixes this by making the ingestion start time relative (UtcNow - 2 days), so the ingested data will always be limited by 2 days.