### PR TITLE
[Search] Skip track1 packages for the release jobs

### DIFF
--- a/sdk/search/ci.yml
+++ b/sdk/search/ci.yml
@@ -31,10 +31,10 @@ extends:
       safeName: AzureSearchDocuments
     # Skip track 1 Microsoft.Azure.* packages for the release jobs
     # - name: Microsoft.Azure.Search
-      # safeName: MicrosoftAzureSearch
+    #   safeName: MicrosoftAzureSearch
     # - name: Microsoft.Azure.Search.Common
-      # safeName: MicrosoftAzureSearchCommon
+    #   safeName: MicrosoftAzureSearchCommon
     # - name: Microsoft.Azure.Search.Data
-      # safeName: MicrosoftAzureSearchData
+    #   safeName: MicrosoftAzureSearchData
     # - name: Microsoft.Azure.Search.Service
-      # safeName: MicrosoftAzureSearchService
+    #   safeName: MicrosoftAzureSearchService

--- a/sdk/search/ci.yml
+++ b/sdk/search/ci.yml
@@ -29,31 +29,12 @@ extends:
     Artifacts:
     - name: Azure.Search.Documents
       safeName: AzureSearchDocuments
-    - name: Microsoft.Azure.Search
-      safeName: MicrosoftAzureSearch
-      skipPublishPackage: true
-      skipSymbolsUpload: true
-      skipPublishDocMs: true
-      skipPublishDocGithubIo: true
-      skipUpdatePackageVersion: true
-    - name: Microsoft.Azure.Search.Common
-      safeName: MicrosoftAzureSearchCommon
-      skipPublishPackage: true
-      skipSymbolsUpload: true
-      skipPublishDocMs: true
-      skipPublishDocGithubIo: true
-      skipUpdatePackageVersion: true
-    - name: Microsoft.Azure.Search.Data
-      safeName: MicrosoftAzureSearchData
-      skipPublishPackage: true
-      skipSymbolsUpload: true
-      skipPublishDocMs: true
-      skipPublishDocGithubIo: true
-      skipUpdatePackageVersion: true
-    - name: Microsoft.Azure.Search.Service
-      safeName: MicrosoftAzureSearchService
-      skipPublishPackage: true
-      skipSymbolsUpload: true
-      skipPublishDocMs: true
-      skipPublishDocGithubIo: true
-      skipUpdatePackageVersion: true
+    # Skip track 1 Microsoft.Azure.* packages for the release jobs
+    # - name: Microsoft.Azure.Search
+      # safeName: MicrosoftAzureSearch
+    # - name: Microsoft.Azure.Search.Common
+      # safeName: MicrosoftAzureSearchCommon
+    # - name: Microsoft.Azure.Search.Data
+      # safeName: MicrosoftAzureSearchData
+    # - name: Microsoft.Azure.Search.Service
+      # safeName: MicrosoftAzureSearchService

--- a/sdk/search/ci.yml
+++ b/sdk/search/ci.yml
@@ -31,9 +31,13 @@ extends:
       safeName: AzureSearchDocuments
     - name: Microsoft.Azure.Search
       safeName: MicrosoftAzureSearch
+      skipPublishPackage: true
     - name: Microsoft.Azure.Search.Common
       safeName: MicrosoftAzureSearchCommon
+      skipPublishPackage: true
     - name: Microsoft.Azure.Search.Data
       safeName: MicrosoftAzureSearchData
+      skipPublishPackage: true
     - name: Microsoft.Azure.Search.Service
       safeName: MicrosoftAzureSearchService
+      skipPublishPackage: true

--- a/sdk/search/ci.yml
+++ b/sdk/search/ci.yml
@@ -32,12 +32,28 @@ extends:
     - name: Microsoft.Azure.Search
       safeName: MicrosoftAzureSearch
       skipPublishPackage: true
+      skipSymbolsUpload: true
+      skipPublishDocMs: true
+      skipPublishDocGithubIo: true
+      skipUpdatePackageVersion: true
     - name: Microsoft.Azure.Search.Common
       safeName: MicrosoftAzureSearchCommon
       skipPublishPackage: true
+      skipSymbolsUpload: true
+      skipPublishDocMs: true
+      skipPublishDocGithubIo: true
+      skipUpdatePackageVersion: true
     - name: Microsoft.Azure.Search.Data
       safeName: MicrosoftAzureSearchData
       skipPublishPackage: true
+      skipSymbolsUpload: true
+      skipPublishDocMs: true
+      skipPublishDocGithubIo: true
+      skipUpdatePackageVersion: true
     - name: Microsoft.Azure.Search.Service
       safeName: MicrosoftAzureSearchService
       skipPublishPackage: true
+      skipSymbolsUpload: true
+      skipPublishDocMs: true
+      skipPublishDocGithubIo: true
+      skipUpdatePackageVersion: true


### PR DESCRIPTION
With this change, only the one track2 package appears in the ['Release' stage](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1023617&view=results).