### PR TITLE
Workaround fix for nigthly test failure in VSCC

### DIFF
--- a/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
+++ b/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
@@ -142,7 +142,6 @@ namespace Azure.Identity.Tests
 
             var client = PublicClientApplicationBuilder.Create(clientId)
                 .WithAuthority(authorityUri)
-                .WithTenantId(testEnvironment.TestTenantId)
                 .Build();
 
             var retriever = new RefreshTokenRetriever(client.UserTokenCache);


### PR DESCRIPTION
This is a fix to the helper method `GetRefreshTokenAsync`