### PR TITLE
[Smoke Tests] Relocate Canary Resources

### DIFF
--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -60,7 +60,7 @@ jobs:
           TestTargetFramework: netcoreapp3.1
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
           ArmTemplateParameters: $(azureCloudArmParameters)
-          Location: "eastus2euap"
+          Location: "centraluseuap"
         Windows_NetCoreApp (AzureCloud):
           Pool: "azsdk-pool-mms-win-2019-general"
           OSVmImage: "MMS2019"


### PR DESCRIPTION
# Summary

The focus of these changes is to move the resources used in the Canary cloud to a new region, as the existing region appears to be out of capacity for IoT Hub instances.