### PR TITLE
[Azure.Core] Update TokenCredential Remarks

### DIFF
--- a/sdk/core/Azure.Core/src/TokenCredential.cs
+++ b/sdk/core/Azure.Core/src/TokenCredential.cs
@@ -18,6 +18,7 @@ namespace Azure.Core
         /// <param name="requestContext">The <see cref="TokenRequestContext"/> with authentication information.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>A valid <see cref="AccessToken"/>.</returns>
+        /// <remarks>Caching and management of the lifespan for the <see cref="AccessToken"/> is considered the responsibility of the caller: each call should request a fresh token being requested.</remarks>
         public abstract ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken);
 
         /// <summary>
@@ -26,6 +27,7 @@ namespace Azure.Core
         /// <param name="requestContext">The <see cref="TokenRequestContext"/> with authentication information.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>A valid <see cref="AccessToken"/>.</returns>
+        /// <remarks>Caching and management of the lifespan for the <see cref="AccessToken"/> is considered the responsibility of the caller: each call should request a fresh token being requested.</remarks>
         public abstract AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to add a set of remarks to the methods of the `TokenCredential` to clarify that any call for an access token is considered a request for a fresh token and that caching is the responsibility of the caller.

# Context and Discussion

An issue that was recently opened exposed a misunderstanding in the messaging services, where it was believed that the `TokenCredential` was caching `AccessToken`s that had been returned and only making active requests when the token was near expiration.  A discussion with @christothes clarified the error, and my take-away from the conversation was that our intended plan was that any `TokenCredential` implementation by `Azure.Identity` would assume the caller held responsibility for caching.

To avoid future confusion, I've added some remarks to this effect.  However, I recognize that as an abstract class `TokenCredential` implementations may differ;  because our client libraries are aware only of `TokenCredential` and have no knowledge of the underlying token provider, I assume the cache assertion that I'm introducing is a reasonable assertion to make.  

That said, I wanted to confirm that assumption to avoid potentially misleading if we end up in a future state where this invariant doesn't hold.   Since 