### PR TITLE
AmqpMessageConverter: support AbsoluteExpiryTime larger than max DateTimeOffset

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -403,7 +403,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 if (amqpMessage.Properties.AbsoluteExpiryTime != null)
                 {
-                    annotatedMessage.Properties.AbsoluteExpiryTime = amqpMessage.Properties.AbsoluteExpiryTime;
+                    annotatedMessage.Properties.AbsoluteExpiryTime =
+                        amqpMessage.Properties.AbsoluteExpiryTime >= DateTimeOffset.MaxValue.UtcDateTime
+                        ? DateTimeOffset.MaxValue
+                        : amqpMessage.Properties.AbsoluteExpiryTime;
                 }
             }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConverterTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConverterTests.cs
@@ -136,5 +136,17 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             Assert.IsTrue(body.TryGetValue(out val));
             Assert.AreEqual("value", ((Dictionary<string, object>)val)["key"]);
         }
+
+        [Test]
+        public void CanParseMaxAbsoluteExpiryTime()
+        {
+            var data = new Data();
+            var amqpMessage = AmqpMessage.Create(data);
+            amqpMessage.Properties.AbsoluteExpiryTime = DateTime.MaxValue;
+
+            var convertedSbMessage = AmqpMessageConverter.AmqpMessageToSBMessage(amqpMessage);
+
+            Assert.AreEqual(DateTimeOffset.MaxValue, convertedSbMessage.ExpiresAt);
+        }
     }
 }


### PR DESCRIPTION
`AbsoluteExpiryTime` from `Microsoft.Azure.Amqp` is a `DateTime`. On the other hand, `AmqpMessage.Properties.AbsoluteExpiryTime` is a `DateTimeOffset`. Some `DateTime` cannot be converted to `DateTimeOffset`, causing `ArgumentOutOfRangeException` ("The UTC time represented when the offset is applied must be between year 0 and 10,000."). This has been observed on a message that was sent and received using `Azure.Messaging.ServiceBus` between 2 processes running in the EST timezone.

Here the `AmqpMessageConverter` is adjusted to work when the `DateTime` is out of range.

A unit test is added. This unit test fails without the change to the `AmqpMessageConverter`, and when the timezone of the local machine is set to a timezone that lags behind UTC.