### PR TITLE
Cherry pick event source fix for Identity 1.4.1 patch release

### DIFF
--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -34,6 +34,7 @@
     <Compile Include="Shared\AppContextSwitchHelper.cs" />
     <Compile Include="Shared\Argument.cs" />
     <Compile Include="Shared\AuthorizationChallengeParser.cs" />
+    <Compile Include="Shared\AzureEventSource.cs" />
     <Compile Include="Shared\AzureKeyCredentialPolicy.cs" />
     <Compile Include="Shared\AzureSasCredentialSynchronousPolicy.cs" />
     <Compile Include="Shared\Base64Url.cs" />

--- a/sdk/core/Azure.Core/src/Shared/AzureEventSource.cs
+++ b/sdk/core/Azure.Core/src/Shared/AzureEventSource.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace Azure.Core.Diagnostics
+{
+    internal abstract class AzureEventSource : EventSource
+    {
+        private const string SharedDataKey = "_AzureEventSourceNamesInUse";
+        private static readonly HashSet<string> NamesInUse;
+
+#pragma warning disable CA1810 // Use static initializer
+        static AzureEventSource()
+#pragma warning restore CA1810
+        {
+            // It's important for this code to run in a static constructor because runtime guarantees that
+            // a single instance is executed at a time
+            // This gives us a chance to store a shared hashset in the global dictionary without a race
+            var namesInUse = AppDomain.CurrentDomain.GetData(SharedDataKey) as HashSet<string>;
+            if (namesInUse == null)
+            {
+                namesInUse = new HashSet<string>();
+                AppDomain.CurrentDomain.SetData(SharedDataKey, namesInUse);
+            }
+
+            NamesInUse = namesInUse;
+        }
+
+        private static readonly string[] MainEventSourceTraits =
+        {
+            AzureEventSourceListener.TraitName,
+            AzureEventSourceListener.TraitValue
+        };
+
+        protected AzureEventSource(string eventSourceName) : base(
+            DeduplicateName(eventSourceName),
+            EventSourceSettings.Default,
+            MainEventSourceTraits
+        )
+        {
+        }
+
+        // The name de-duplication is required for the case where multiple versions of the same assembly are loaded
+        // in different assembly load contexts
+        private static string DeduplicateName(string eventSourceName)
+        {
+            lock (NamesInUse)
+            {
+                // pick up existing EventSources that might not participate in this logic
+                foreach (var source in GetSources())
+                {
+                    NamesInUse.Add(source.Name);
+                }
+
+                if (!NamesInUse.Contains(eventSourceName))
+                {
+                    NamesInUse.Add(eventSourceName);
+                    return eventSourceName;
+                }
+
+                int i = 1;
+                while (true)
+                {
+                    var candidate = $"{eventSourceName}-{i}";
+                    if (!NamesInUse.Contains(candidate))
+                    {
+                        NamesInUse.Add(candidate);
+                        return candidate;
+                    }
+                    i++;
+                }
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/AzureEventSourceTests.cs
+++ b/sdk/core/Azure.Core/tests/AzureEventSourceTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if NET5_0
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Azure.Core.Diagnostics;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class AzureEventSourceTests
+    {
+        [Test]
+        public void CanCreateMultipleEventSources()
+        {
+            EventSource GetEventSource(TestAssemblyLoadContext testAssemblyLoadContext)
+            {
+                return (EventSource)Activator.CreateInstance(testAssemblyLoadContext.Assemblies
+                    .Single()
+                    .GetType("Azure.Core.Tests.AzureEventSourceTests+TestEventSource"));
+            }
+
+            void LogEvent(EventSource azureCoreEventSource)
+            {
+                azureCoreEventSource.GetType()
+                    .GetMethod("LogSomething", BindingFlags.Public | BindingFlags.Instance)
+                    .Invoke(azureCoreEventSource, Array.Empty<object>());
+            }
+
+            var alc = new TestAssemblyLoadContext("Test 1");
+            var alc2 = new TestAssemblyLoadContext("Test 2");
+
+            try
+            {
+                List<EventWrittenEventArgs> events = new();
+                using var listener = new AzureEventSourceListener((args, s) => events.Add(args), EventLevel.Verbose);
+
+                alc.LoadFromAssemblyPath(typeof(TestEventSource).Assembly.Location);
+                alc2.LoadFromAssemblyPath(typeof(TestEventSource).Assembly.Location);
+
+                using var es0 = new TestEventSource();
+                using var es1 = GetEventSource(alc);
+                using var es2 = GetEventSource(alc2);
+
+                LogEvent(es0);
+                LogEvent(es1);
+                LogEvent(es2);
+
+                Assert.AreEqual("Azure-Corez", es0.Name);
+                Assert.AreEqual("Azure-Corez-1", es1.Name);
+                Assert.AreEqual("Azure-Corez-2", es2.Name);
+
+                Assert.AreEqual(3, events.Count);
+
+                Assert.AreEqual("Azure-Corez", events[0].EventSource.Name);
+                Assert.AreEqual("Azure-Corez-1", events[1].EventSource.Name);
+                Assert.AreEqual("Azure-Corez-2", events[2].EventSource.Name);
+            }
+            finally
+            {
+                alc.Unload();
+                alc2.Unload();
+            }
+        }
+
+        [Test]
+        public void SetsTraits()
+        {
+            using var es = new TestEventSource();
+            Assert.AreEqual("true", es.GetTrait("AzureEventSource"));
+        }
+
+        public class TestAssemblyLoadContext : AssemblyLoadContext
+        {
+            public TestAssemblyLoadContext(string name) : base(name, true)
+            {
+            }
+        }
+
+        internal class TestEventSource: AzureEventSource
+        {
+            public TestEventSource() : base("Azure-Corez")
+            {
+            }
+
+            [Event(1)]
+            public void LogSomething()
+            {
+                WriteEvent(1);
+            }
+        }
+    }
+}
+#endif

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.4.1 (2021-08-04)
+
+### Fixes and improvements
+
+- Fixed issue resulting in duplicate event source names when executing in Azure Functions
+
 ## 1.4.0 (2021-05-12)
 
 ### New Features

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>This is the implementation of the Azure SDK Client Library for Azure Identity</Description>
     <AssemblyTitle>Microsoft Azure.Identity Component</AssemblyTitle>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <ApiCompatVersion>1.3.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Identity;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
@@ -22,6 +22,7 @@
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)AzureEventSource.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared" />

--- a/sdk/identity/Azure.Identity/src/AzureIdentityEventSource.cs
+++ b/sdk/identity/Azure.Identity/src/AzureIdentityEventSource.cs
@@ -11,7 +11,7 @@ using Azure.Core.Diagnostics;
 namespace Azure.Identity
 {
     [EventSource(Name = EventSourceName)]
-    internal sealed class AzureIdentityEventSource : EventSource
+    internal sealed class AzureIdentityEventSource : AzureEventSource
     {
         private const string EventSourceName = "Azure-Identity";
 

--- a/sdk/identity/Azure.Identity/src/AzureIdentityEventSource.cs
+++ b/sdk/identity/Azure.Identity/src/AzureIdentityEventSource.cs
@@ -29,7 +29,6 @@ namespace Azure.Identity
         private const int InteractiveAuthenticationInlineExecutionEvent = 12;
 
         private AzureIdentityEventSource() : base(EventSourceName) { }
- { }
 
         public static AzureIdentityEventSource Singleton { get; } = new AzureIdentityEventSource();
 

--- a/sdk/identity/Azure.Identity/src/AzureIdentityEventSource.cs
+++ b/sdk/identity/Azure.Identity/src/AzureIdentityEventSource.cs
@@ -28,7 +28,8 @@ namespace Azure.Identity
         private const int InteractiveAuthenticationThreadPoolExecutionEvent = 11;
         private const int InteractiveAuthenticationInlineExecutionEvent = 12;
 
-        private AzureIdentityEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue) { }
+        private AzureIdentityEventSource() : base(EventSourceName) { }
+ { }
 
         public static AzureIdentityEventSource Singleton { get; } = new AzureIdentityEventSource();
 


### PR DESCRIPTION
Patching Azure Identity 1.4.0 with recent event source duplication fix.
