### PR TITLE
[TextAnalytics] Reduced size of Analyze Operation samples

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -573,9 +573,6 @@ This functionality allows running multiple actions in one or more documents. Act
     {
         ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
         RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
-        RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
-        RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
-        AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
         DisplayName = "AnalyzeOperationSample"
     };
 
@@ -598,9 +595,6 @@ This functionality allows running multiple actions in one or more documents. Act
     {
         IReadOnlyCollection<ExtractKeyPhrasesActionResult> keyPhrasesResults = documentsInPage.ExtractKeyPhrasesResults;
         IReadOnlyCollection<RecognizeEntitiesActionResult> entitiesResults = documentsInPage.RecognizeEntitiesResults;
-        IReadOnlyCollection<RecognizePiiEntitiesActionResult> piiResults = documentsInPage.RecognizePiiEntitiesResults;
-        IReadOnlyCollection<RecognizeLinkedEntitiesActionResult> entityLinkingResults = documentsInPage.RecognizeLinkedEntitiesResults;
-        IReadOnlyCollection<AnalyzeSentimentActionResult> analyzeSentimentResults = documentsInPage.AnalyzeSentimentResults;
 
         Console.WriteLine("Recognized Entities");
         int docNumber = 1;
@@ -612,28 +606,6 @@ This functionality allows running multiple actions in one or more documents. Act
                 Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} entities:");
 
                 foreach (CategorizedEntity entity in documentResults.Entities)
-                {
-                    Console.WriteLine($"  Entity: {entity.Text}");
-                    Console.WriteLine($"  Category: {entity.Category}");
-                    Console.WriteLine($"  Offset: {entity.Offset}");
-                    Console.WriteLine($"  Length: {entity.Length}");
-                    Console.WriteLine($"  ConfidenceScore: {entity.ConfidenceScore}");
-                    Console.WriteLine($"  SubCategory: {entity.SubCategory}");
-                }
-                Console.WriteLine("");
-            }
-        }
-
-        Console.WriteLine("Recognized PII Entities");
-        docNumber = 1;
-        foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
-        {
-            foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
-            {
-                Console.WriteLine($" Document #{docNumber++}");
-                Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} PII entities:");
-
-                foreach (PiiEntity entity in documentResults.Entities)
                 {
                     Console.WriteLine($"  Entity: {entity.Text}");
                     Console.WriteLine($"  Category: {entity.Category}");
@@ -659,52 +631,6 @@ This functionality allows running multiple actions in one or more documents. Act
                 {
                     Console.WriteLine($"  {keyphrase}");
                 }
-                Console.WriteLine("");
-            }
-        }
-
-        Console.WriteLine("Recognized Linked Entities");
-        docNumber = 1;
-        foreach (RecognizeLinkedEntitiesActionResult linkedEntitiesActionResults in entityLinkingResults)
-        {
-            foreach (RecognizeLinkedEntitiesResult documentResults in linkedEntitiesActionResults.DocumentsResults)
-            {
-                Console.WriteLine($" Document #{docNumber++}");
-                Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} linked entities:");
-
-                foreach (LinkedEntity entity in documentResults.Entities)
-                {
-                    Console.WriteLine($"  Entity: {entity.Name}");
-                    Console.WriteLine($"  DataSource: {entity.DataSource}");
-                    Console.WriteLine($"  DataSource EntityId: {entity.DataSourceEntityId}");
-                    Console.WriteLine($"  Language: {entity.Language}");
-                    Console.WriteLine($"  DataSource Url: {entity.Url}");
-
-                    Console.WriteLine($"  Total Matches: {entity.Matches.Count()}");
-                    foreach (LinkedEntityMatch match in entity.Matches)
-                    {
-                        Console.WriteLine($"    Match Text: {match.Text}");
-                        Console.WriteLine($"    ConfidenceScore: {match.ConfidenceScore}");
-                        Console.WriteLine($"    Offset: {match.Offset}");
-                        Console.WriteLine($"    Length: {match.Length}");
-                    }
-                    Console.WriteLine("");
-                }
-                Console.WriteLine("");
-            }
-        }
-
-        Console.WriteLine("Analyze Sentiment");
-        docNumber = 1;
-        foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
-        {
-            foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
-            {
-                Console.WriteLine($" Document #{docNumber++}");
-                Console.WriteLine($"  Sentiment is {documentResults.DocumentSentiment.Sentiment}, with confidence scores: ");
-                Console.WriteLine($"    Positive confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Positive}.");
-                Console.WriteLine($"    Neutral confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Neutral}.");
-                Console.WriteLine($"    Negative confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Negative}.");
                 Console.WriteLine("");
             }
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -551,7 +551,7 @@ await foreach (AnalyzeHealthcareEntitiesResultCollection documentsInPage in heal
 ```
 
 ### Run multiple actions Asynchronously
-This functionality allows running multiple actions in one or more documents. Actions include entity recognition, linked entity recognition, key phrase extraction, Personally Identifiable Information (PII) Recognition, and sentiment analysis. For more information see [Using analyze][analyze_operation_howto].
+This functionality allows running multiple actions in one or more documents. Actions include entity recognition, linked entity recognition, key phrase extraction, Personally Identifiable Information (PII) Recognition, sentiment analysis, and Extractive Text Summarization. For more information see [Using analyze][analyze_operation_howto].
 
 ```C# Snippet:AnalyzeOperationConvenienceAsync
     string documentA = @"We love this trail and make the trip every year. The views are breathtaking and well

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_AnalyzeActions.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_AnalyzeActions.md
@@ -37,9 +37,6 @@ To run multiple actions in multiple documents, call `StartAnalyzeActionsAsync` o
     {
         ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
         RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
-        RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
-        RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
-        AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
         DisplayName = "AnalyzeOperationSample"
     };
 
@@ -62,9 +59,6 @@ To run multiple actions in multiple documents, call `StartAnalyzeActionsAsync` o
     {
         IReadOnlyCollection<ExtractKeyPhrasesActionResult> keyPhrasesResults = documentsInPage.ExtractKeyPhrasesResults;
         IReadOnlyCollection<RecognizeEntitiesActionResult> entitiesResults = documentsInPage.RecognizeEntitiesResults;
-        IReadOnlyCollection<RecognizePiiEntitiesActionResult> piiResults = documentsInPage.RecognizePiiEntitiesResults;
-        IReadOnlyCollection<RecognizeLinkedEntitiesActionResult> entityLinkingResults = documentsInPage.RecognizeLinkedEntitiesResults;
-        IReadOnlyCollection<AnalyzeSentimentActionResult> analyzeSentimentResults = documentsInPage.AnalyzeSentimentResults;
 
         Console.WriteLine("Recognized Entities");
         int docNumber = 1;
@@ -76,28 +70,6 @@ To run multiple actions in multiple documents, call `StartAnalyzeActionsAsync` o
                 Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} entities:");
 
                 foreach (CategorizedEntity entity in documentResults.Entities)
-                {
-                    Console.WriteLine($"  Entity: {entity.Text}");
-                    Console.WriteLine($"  Category: {entity.Category}");
-                    Console.WriteLine($"  Offset: {entity.Offset}");
-                    Console.WriteLine($"  Length: {entity.Length}");
-                    Console.WriteLine($"  ConfidenceScore: {entity.ConfidenceScore}");
-                    Console.WriteLine($"  SubCategory: {entity.SubCategory}");
-                }
-                Console.WriteLine("");
-            }
-        }
-
-        Console.WriteLine("Recognized PII Entities");
-        docNumber = 1;
-        foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
-        {
-            foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
-            {
-                Console.WriteLine($" Document #{docNumber++}");
-                Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} PII entities:");
-
-                foreach (PiiEntity entity in documentResults.Entities)
                 {
                     Console.WriteLine($"  Entity: {entity.Text}");
                     Console.WriteLine($"  Category: {entity.Category}");
@@ -123,52 +95,6 @@ To run multiple actions in multiple documents, call `StartAnalyzeActionsAsync` o
                 {
                     Console.WriteLine($"  {keyphrase}");
                 }
-                Console.WriteLine("");
-            }
-        }
-
-        Console.WriteLine("Recognized Linked Entities");
-        docNumber = 1;
-        foreach (RecognizeLinkedEntitiesActionResult linkedEntitiesActionResults in entityLinkingResults)
-        {
-            foreach (RecognizeLinkedEntitiesResult documentResults in linkedEntitiesActionResults.DocumentsResults)
-            {
-                Console.WriteLine($" Document #{docNumber++}");
-                Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} linked entities:");
-
-                foreach (LinkedEntity entity in documentResults.Entities)
-                {
-                    Console.WriteLine($"  Entity: {entity.Name}");
-                    Console.WriteLine($"  DataSource: {entity.DataSource}");
-                    Console.WriteLine($"  DataSource EntityId: {entity.DataSourceEntityId}");
-                    Console.WriteLine($"  Language: {entity.Language}");
-                    Console.WriteLine($"  DataSource Url: {entity.Url}");
-
-                    Console.WriteLine($"  Total Matches: {entity.Matches.Count()}");
-                    foreach (LinkedEntityMatch match in entity.Matches)
-                    {
-                        Console.WriteLine($"    Match Text: {match.Text}");
-                        Console.WriteLine($"    ConfidenceScore: {match.ConfidenceScore}");
-                        Console.WriteLine($"    Offset: {match.Offset}");
-                        Console.WriteLine($"    Length: {match.Length}");
-                    }
-                    Console.WriteLine("");
-                }
-                Console.WriteLine("");
-            }
-        }
-
-        Console.WriteLine("Analyze Sentiment");
-        docNumber = 1;
-        foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
-        {
-            foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
-            {
-                Console.WriteLine($" Document #{docNumber++}");
-                Console.WriteLine($"  Sentiment is {documentResults.DocumentSentiment.Sentiment}, with confidence scores: ");
-                Console.WriteLine($"    Positive confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Positive}.");
-                Console.WriteLine($"    Neutral confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Neutral}.");
-                Console.WriteLine($"    Negative confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Negative}.");
                 Console.WriteLine("");
             }
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperation.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Azure.AI.TextAnalytics.Tests;
 using Azure.Core.TestFramework;
@@ -47,9 +46,6 @@ namespace Azure.AI.TextAnalytics.Samples
             {
                 ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
                 RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
-                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
-                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
-                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
                 DisplayName = "AnalyzeOperationSample"
             };
 
@@ -81,9 +77,6 @@ namespace Azure.AI.TextAnalytics.Samples
             {
                 IReadOnlyCollection<ExtractKeyPhrasesActionResult> keyPhrasesResults = documentsInPage.ExtractKeyPhrasesResults;
                 IReadOnlyCollection<RecognizeEntitiesActionResult> entitiesResults = documentsInPage.RecognizeEntitiesResults;
-                IReadOnlyCollection<RecognizePiiEntitiesActionResult> piiResults = documentsInPage.RecognizePiiEntitiesResults;
-                IReadOnlyCollection<RecognizeLinkedEntitiesActionResult> entityLinkingResults = documentsInPage.RecognizeLinkedEntitiesResults;
-                IReadOnlyCollection<AnalyzeSentimentActionResult> analyzeSentimentResults = documentsInPage.AnalyzeSentimentResults;
 
                 Console.WriteLine("Recognized Entities");
                 int docNumber = 1;
@@ -95,28 +88,6 @@ namespace Azure.AI.TextAnalytics.Samples
                         Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} entities:");
 
                         foreach (CategorizedEntity entity in documentResults.Entities)
-                        {
-                            Console.WriteLine($"  Entity: {entity.Text}");
-                            Console.WriteLine($"  Category: {entity.Category}");
-                            Console.WriteLine($"  Offset: {entity.Offset}");
-                            Console.WriteLine($"  Length: {entity.Length}");
-                            Console.WriteLine($"  ConfidenceScore: {entity.ConfidenceScore}");
-                            Console.WriteLine($"  SubCategory: {entity.SubCategory}");
-                        }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Recognized PII Entities");
-                docNumber = 1;
-                foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
-                {
-                    foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} PII entities:");
-
-                        foreach (PiiEntity entity in documentResults.Entities)
                         {
                             Console.WriteLine($"  Entity: {entity.Text}");
                             Console.WriteLine($"  Category: {entity.Category}");
@@ -142,52 +113,6 @@ namespace Azure.AI.TextAnalytics.Samples
                         {
                             Console.WriteLine($"  {keyphrase}");
                         }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Recognized Linked Entities");
-                docNumber = 1;
-                foreach (RecognizeLinkedEntitiesActionResult linkedEntitiesActionResults in entityLinkingResults)
-                {
-                    foreach (RecognizeLinkedEntitiesResult documentResults in linkedEntitiesActionResults.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} linked entities:");
-
-                        foreach (LinkedEntity entity in documentResults.Entities)
-                        {
-                            Console.WriteLine($"  Entity: {entity.Name}");
-                            Console.WriteLine($"  DataSource: {entity.DataSource}");
-                            Console.WriteLine($"  DataSource EntityId: {entity.DataSourceEntityId}");
-                            Console.WriteLine($"  Language: {entity.Language}");
-                            Console.WriteLine($"  DataSource Url: {entity.Url}");
-
-                            Console.WriteLine($"  Total Matches: {entity.Matches.Count()}");
-                            foreach (LinkedEntityMatch match in entity.Matches)
-                            {
-                                Console.WriteLine($"    Match Text: {match.Text}");
-                                Console.WriteLine($"    ConfidenceScore: {match.ConfidenceScore}");
-                                Console.WriteLine($"    Offset: {match.Offset}");
-                                Console.WriteLine($"    Length: {match.Length}");
-                            }
-                            Console.WriteLine("");
-                        }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Analyze Sentiment");
-                docNumber = 1;
-                foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
-                {
-                    foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Sentiment is {documentResults.DocumentSentiment.Sentiment}, with confidence scores: ");
-                        Console.WriteLine($"    Positive confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Positive}.");
-                        Console.WriteLine($"    Neutral confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Neutral}.");
-                        Console.WriteLine($"    Negative confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Negative}.");
                         Console.WriteLine("");
                     }
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationAsync.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Azure.AI.TextAnalytics.Models;
 using Azure.AI.TextAnalytics.Tests;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -48,9 +46,6 @@ namespace Azure.AI.TextAnalytics.Samples
             {
                 ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
                 RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
-                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
-                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
-                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
                 DisplayName = "AnalyzeOperationSample"
             };
 
@@ -73,9 +68,6 @@ namespace Azure.AI.TextAnalytics.Samples
             {
                 IReadOnlyCollection<ExtractKeyPhrasesActionResult> keyPhrasesResults = documentsInPage.ExtractKeyPhrasesResults;
                 IReadOnlyCollection<RecognizeEntitiesActionResult> entitiesResults = documentsInPage.RecognizeEntitiesResults;
-                IReadOnlyCollection<RecognizePiiEntitiesActionResult> piiResults = documentsInPage.RecognizePiiEntitiesResults;
-                IReadOnlyCollection<RecognizeLinkedEntitiesActionResult> entityLinkingResults = documentsInPage.RecognizeLinkedEntitiesResults;
-                IReadOnlyCollection<AnalyzeSentimentActionResult> analyzeSentimentResults = documentsInPage.AnalyzeSentimentResults;
 
                 Console.WriteLine("Recognized Entities");
                 int docNumber = 1;
@@ -87,28 +79,6 @@ namespace Azure.AI.TextAnalytics.Samples
                         Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} entities:");
 
                         foreach (CategorizedEntity entity in documentResults.Entities)
-                        {
-                            Console.WriteLine($"  Entity: {entity.Text}");
-                            Console.WriteLine($"  Category: {entity.Category}");
-                            Console.WriteLine($"  Offset: {entity.Offset}");
-                            Console.WriteLine($"  Length: {entity.Length}");
-                            Console.WriteLine($"  ConfidenceScore: {entity.ConfidenceScore}");
-                            Console.WriteLine($"  SubCategory: {entity.SubCategory}");
-                        }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Recognized PII Entities");
-                docNumber = 1;
-                foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
-                {
-                    foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} PII entities:");
-
-                        foreach (PiiEntity entity in documentResults.Entities)
                         {
                             Console.WriteLine($"  Entity: {entity.Text}");
                             Console.WriteLine($"  Category: {entity.Category}");
@@ -134,52 +104,6 @@ namespace Azure.AI.TextAnalytics.Samples
                         {
                             Console.WriteLine($"  {keyphrase}");
                         }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Recognized Linked Entities");
-                docNumber = 1;
-                foreach (RecognizeLinkedEntitiesActionResult linkedEntitiesActionResults in entityLinkingResults)
-                {
-                    foreach (RecognizeLinkedEntitiesResult documentResults in linkedEntitiesActionResults.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} linked entities:");
-
-                        foreach (LinkedEntity entity in documentResults.Entities)
-                        {
-                            Console.WriteLine($"  Entity: {entity.Name}");
-                            Console.WriteLine($"  DataSource: {entity.DataSource}");
-                            Console.WriteLine($"  DataSource EntityId: {entity.DataSourceEntityId}");
-                            Console.WriteLine($"  Language: {entity.Language}");
-                            Console.WriteLine($"  DataSource Url: {entity.Url}");
-
-                            Console.WriteLine($"  Total Matches: {entity.Matches.Count()}");
-                            foreach (LinkedEntityMatch match in entity.Matches)
-                            {
-                                Console.WriteLine($"    Match Text: {match.Text}");
-                                Console.WriteLine($"    ConfidenceScore: {match.ConfidenceScore}");
-                                Console.WriteLine($"    Offset: {match.Offset}");
-                                Console.WriteLine($"    Length: {match.Length}");
-                            }
-                            Console.WriteLine("");
-                        }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Analyze Sentiment");
-                docNumber = 1;
-                foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
-                {
-                    foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Sentiment is {documentResults.DocumentSentiment.Sentiment}, with confidence scores: ");
-                        Console.WriteLine($"    Positive confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Positive}.");
-                        Console.WriteLine($"    Neutral confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Neutral}.");
-                        Console.WriteLine($"    Negative confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Negative}.");
                         Console.WriteLine("");
                     }
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenience.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Azure.AI.TextAnalytics.Tests;
 using Azure.Core.TestFramework;
@@ -41,9 +40,6 @@ namespace Azure.AI.TextAnalytics.Samples
             {
                 ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
                 RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
-                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
-                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
-                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
                 DisplayName = "AnalyzeOperationSample"
             };
 
@@ -75,9 +71,6 @@ namespace Azure.AI.TextAnalytics.Samples
             {
                 IReadOnlyCollection<ExtractKeyPhrasesActionResult> keyPhrasesResults = documentsInPage.ExtractKeyPhrasesResults;
                 IReadOnlyCollection<RecognizeEntitiesActionResult> entitiesResults = documentsInPage.RecognizeEntitiesResults;
-                IReadOnlyCollection<RecognizePiiEntitiesActionResult> piiResults = documentsInPage.RecognizePiiEntitiesResults;
-                IReadOnlyCollection<RecognizeLinkedEntitiesActionResult> entityLinkingResults = documentsInPage.RecognizeLinkedEntitiesResults;
-                IReadOnlyCollection<AnalyzeSentimentActionResult> analyzeSentimentResults = documentsInPage.AnalyzeSentimentResults;
 
                 Console.WriteLine("Recognized Entities");
                 int docNumber = 1;
@@ -89,28 +82,6 @@ namespace Azure.AI.TextAnalytics.Samples
                         Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} entities:");
 
                         foreach (CategorizedEntity entity in documentResults.Entities)
-                        {
-                            Console.WriteLine($"  Entity: {entity.Text}");
-                            Console.WriteLine($"  Category: {entity.Category}");
-                            Console.WriteLine($"  Offset: {entity.Offset}");
-                            Console.WriteLine($"  Length: {entity.Length}");
-                            Console.WriteLine($"  ConfidenceScore: {entity.ConfidenceScore}");
-                            Console.WriteLine($"  SubCategory: {entity.SubCategory}");
-                        }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Recognized PII Entities");
-                docNumber = 1;
-                foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
-                {
-                    foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} PII entities:");
-
-                        foreach (PiiEntity entity in documentResults.Entities)
                         {
                             Console.WriteLine($"  Entity: {entity.Text}");
                             Console.WriteLine($"  Category: {entity.Category}");
@@ -136,52 +107,6 @@ namespace Azure.AI.TextAnalytics.Samples
                         {
                             Console.WriteLine($"  {keyphrase}");
                         }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Recognized Linked Entities");
-                docNumber = 1;
-                foreach (RecognizeLinkedEntitiesActionResult linkedEntitiesActionResults in entityLinkingResults)
-                {
-                    foreach (RecognizeLinkedEntitiesResult documentResults in linkedEntitiesActionResults.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} linked entities:");
-
-                        foreach (LinkedEntity entity in documentResults.Entities)
-                        {
-                            Console.WriteLine($"  Entity: {entity.Name}");
-                            Console.WriteLine($"  DataSource: {entity.DataSource}");
-                            Console.WriteLine($"  DataSource EntityId: {entity.DataSourceEntityId}");
-                            Console.WriteLine($"  Language: {entity.Language}");
-                            Console.WriteLine($"  DataSource Url: {entity.Url}");
-
-                            Console.WriteLine($"  Total Matches: {entity.Matches.Count()}");
-                            foreach (LinkedEntityMatch match in entity.Matches)
-                            {
-                                Console.WriteLine($"    Match Text: {match.Text}");
-                                Console.WriteLine($"    ConfidenceScore: {match.ConfidenceScore}");
-                                Console.WriteLine($"    Offset: {match.Offset}");
-                                Console.WriteLine($"    Length: {match.Length}");
-                            }
-                            Console.WriteLine("");
-                        }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Analyze Sentiment");
-                docNumber = 1;
-                foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
-                {
-                    foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Sentiment is {documentResults.DocumentSentiment.Sentiment}, with confidence scores: ");
-                        Console.WriteLine($"    Positive confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Positive}.");
-                        Console.WriteLine($"    Neutral confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Neutral}.");
-                        Console.WriteLine($"    Negative confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Negative}.");
                         Console.WriteLine("");
                     }
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenienceAsync.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Azure.AI.TextAnalytics.Models;
 using Azure.AI.TextAnalytics.Tests;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -43,9 +41,6 @@ namespace Azure.AI.TextAnalytics.Samples
             {
                 ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
                 RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
-                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
-                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
-                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
                 DisplayName = "AnalyzeOperationSample"
             };
 
@@ -68,9 +63,6 @@ namespace Azure.AI.TextAnalytics.Samples
             {
                 IReadOnlyCollection<ExtractKeyPhrasesActionResult> keyPhrasesResults = documentsInPage.ExtractKeyPhrasesResults;
                 IReadOnlyCollection<RecognizeEntitiesActionResult> entitiesResults = documentsInPage.RecognizeEntitiesResults;
-                IReadOnlyCollection<RecognizePiiEntitiesActionResult> piiResults = documentsInPage.RecognizePiiEntitiesResults;
-                IReadOnlyCollection<RecognizeLinkedEntitiesActionResult> entityLinkingResults = documentsInPage.RecognizeLinkedEntitiesResults;
-                IReadOnlyCollection<AnalyzeSentimentActionResult> analyzeSentimentResults = documentsInPage.AnalyzeSentimentResults;
 
                 Console.WriteLine("Recognized Entities");
                 int docNumber = 1;
@@ -82,28 +74,6 @@ namespace Azure.AI.TextAnalytics.Samples
                         Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} entities:");
 
                         foreach (CategorizedEntity entity in documentResults.Entities)
-                        {
-                            Console.WriteLine($"  Entity: {entity.Text}");
-                            Console.WriteLine($"  Category: {entity.Category}");
-                            Console.WriteLine($"  Offset: {entity.Offset}");
-                            Console.WriteLine($"  Length: {entity.Length}");
-                            Console.WriteLine($"  ConfidenceScore: {entity.ConfidenceScore}");
-                            Console.WriteLine($"  SubCategory: {entity.SubCategory}");
-                        }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Recognized PII Entities");
-                docNumber = 1;
-                foreach (RecognizePiiEntitiesActionResult piiActionResults in piiResults)
-                {
-                    foreach (RecognizePiiEntitiesResult documentResults in piiActionResults.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} PII entities:");
-
-                        foreach (PiiEntity entity in documentResults.Entities)
                         {
                             Console.WriteLine($"  Entity: {entity.Text}");
                             Console.WriteLine($"  Category: {entity.Category}");
@@ -129,52 +99,6 @@ namespace Azure.AI.TextAnalytics.Samples
                         {
                             Console.WriteLine($"  {keyphrase}");
                         }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Recognized Linked Entities");
-                docNumber = 1;
-                foreach (RecognizeLinkedEntitiesActionResult linkedEntitiesActionResults in entityLinkingResults)
-                {
-                    foreach (RecognizeLinkedEntitiesResult documentResults in linkedEntitiesActionResults.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Recognized the following {documentResults.Entities.Count} linked entities:");
-
-                        foreach (LinkedEntity entity in documentResults.Entities)
-                        {
-                            Console.WriteLine($"  Entity: {entity.Name}");
-                            Console.WriteLine($"  DataSource: {entity.DataSource}");
-                            Console.WriteLine($"  DataSource EntityId: {entity.DataSourceEntityId}");
-                            Console.WriteLine($"  Language: {entity.Language}");
-                            Console.WriteLine($"  DataSource Url: {entity.Url}");
-
-                            Console.WriteLine($"  Total Matches: {entity.Matches.Count()}");
-                            foreach (LinkedEntityMatch match in entity.Matches)
-                            {
-                                Console.WriteLine($"    Match Text: {match.Text}");
-                                Console.WriteLine($"    ConfidenceScore: {match.ConfidenceScore}");
-                                Console.WriteLine($"    Offset: {match.Offset}");
-                                Console.WriteLine($"    Length: {match.Length}");
-                            }
-                            Console.WriteLine("");
-                        }
-                        Console.WriteLine("");
-                    }
-                }
-
-                Console.WriteLine("Analyze Sentiment");
-                docNumber = 1;
-                foreach (AnalyzeSentimentActionResult analyzeSentimentActionsResult in analyzeSentimentResults)
-                {
-                    foreach (AnalyzeSentimentResult documentResults in analyzeSentimentActionsResult.DocumentsResults)
-                    {
-                        Console.WriteLine($" Document #{docNumber++}");
-                        Console.WriteLine($"  Sentiment is {documentResults.DocumentSentiment.Sentiment}, with confidence scores: ");
-                        Console.WriteLine($"    Positive confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Positive}.");
-                        Console.WriteLine($"    Neutral confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Neutral}.");
-                        Console.WriteLine($"    Negative confidence score: {documentResults.DocumentSentiment.ConfidenceScores.Negative}.");
                         Console.WriteLine("");
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/azure/azure-sdk-for-net/issues/23112.

There's no need to illustrate all actions in Analyze Operation. In order to reduce sample sizes, reduced it to only two actions (Recognize Entities and Extract Key Phrases).