### PR TITLE
Ensure SessionReceiverManager is cleaned up when closing

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -941,6 +941,7 @@ namespace Azure.Messaging.ServiceBus
         public async ValueTask DisposeAsync()
         {
             await CloseAsync().ConfigureAwait(false);
+            _handlerCts.Dispose();
             GC.SuppressFinalize(this);
         }
 
@@ -980,6 +981,7 @@ namespace Azure.Messaging.ServiceBus
             // wake up the handler loop
             var handlerCts = Interlocked.Exchange(ref _handlerCts, new CancellationTokenSource());
             handlerCts.Cancel();
+            handlerCts.Dispose();
         }
 
         private async Task ReconcileConcurrencyAsync()

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -220,12 +220,12 @@ namespace Azure.Messaging.ServiceBus
             catch (Exception exception)
             {
                 await RaiseExceptionReceived(
-                        new ProcessErrorEventArgs(
-                            exception,
-                            ServiceBusErrorSource.CloseSession,
-                            Processor.FullyQualifiedNamespace,
-                            Processor.EntityPath,
-                            cancellationToken))
+                    new ProcessErrorEventArgs(
+                        exception,
+                        ServiceBusErrorSource.CloseSession,
+                        Processor.FullyQualifiedNamespace,
+                        Processor.EntityPath,
+                        cancellationToken))
                     .ConfigureAwait(false);
             }
             finally

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -1925,7 +1925,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                         Assert.LessOrEqual(processor.InnerProcessor._tasks.Where(t => !t.Task.IsCompleted).Count(), 1);
                     }
                 }
-\
+
                 processor.ProcessMessageAsync += ProcessMessage;
                 processor.ProcessErrorAsync += SessionErrorHandler;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -1925,7 +1925,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                         Assert.LessOrEqual(processor.InnerProcessor._tasks.Where(t => !t.Task.IsCompleted).Count(), 1);
                     }
                 }
-                
+\
                 processor.ProcessMessageAsync += ProcessMessage;
                 processor.ProcessErrorAsync += SessionErrorHandler;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -692,6 +692,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var options = new ServiceBusSessionProcessorOptions
                 {
                     MaxConcurrentSessions = numThreads,
+                    MaxConcurrentCallsPerSession = maxCallsPerSession,
                     AutoCompleteMessages = false,
                     MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(autoLockRenewalDuration)
                 };
@@ -908,6 +909,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var options = new ServiceBusSessionProcessorOptions
                 {
                     MaxConcurrentSessions = numThreads,
+                    MaxConcurrentCallsPerSession = maxCallsPerSession,
                     AutoCompleteMessages = autoComplete,
                 };
                 for (int i = 0; i < specifiedSessionCount; i++)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -662,14 +662,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         }
 
         [Test]
-        [TestCase(1, 0, 1)]
-        [TestCase(5, 0, 3)]
-        [TestCase(10, 1, 5)]
-        [TestCase(20, 1, 10)]
+        [TestCase(1, 0)]
+        [TestCase(5, 0)]
+        [TestCase(10, 1)]
+        [TestCase(20, 1)]
         public async Task MaxAutoLockRenewalDurationRespected(
             int numThreads,
-            int autoLockRenewalDuration,
-            int maxCallsPerSession)
+            int autoLockRenewalDuration)
         {
             var lockDuration = TimeSpan.FromSeconds(10);
             await using (var scope = await ServiceBusScope.CreateWithQueue(
@@ -692,7 +691,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var options = new ServiceBusSessionProcessorOptions
                 {
                     MaxConcurrentSessions = numThreads,
-                    MaxConcurrentCallsPerSession = maxCallsPerSession,
                     AutoCompleteMessages = false,
                     MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(autoLockRenewalDuration)
                 };


### PR DESCRIPTION
While investigating https://github.com/Azure/azure-sdk-for-net/issues/23065, I noticed that there is a case where _receiver may not be reset to null even after we attempt to Dispose it, this could lead to a new session never getting accepted. I don't think it would lead to the behavior from the issue, as we should still be exiting the receive loop once we have a sessionLockLost error.