### PR TITLE
Fix --tenant argument generated by AzureCliCredential

### DIFF
--- a/sdk/identity/Azure.Identity/src/AzureCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/AzureCliCredential.cs
@@ -179,7 +179,7 @@ namespace Azure.Identity
             string command = tenantId switch
             {
                 null => $"az account get-access-token --output json --resource {resource}",
-                _ => $"az account get-access-token --output json --resource {resource} -tenant {tenantId}"
+                _ => $"az account get-access-token --output json --resource {resource} --tenant {tenantId}"
             };
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
This PR solves issue with invalid tenant parameter generated by AzureCliCredential:

Fix https://github.com/Azure/azure-sdk-for-net/issues/23158