### PR TITLE
[Purview] Fix `dotnet add package` gesture in README.md

### DIFF
--- a/sdk/purview/Azure.Analytics.Purview.Catalog/README.md
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/README.md
@@ -17,7 +17,7 @@ Azure Purview Catalog is a fully managed cloud service whose users can discover 
 Install the Azure Purview Catalog client library for .NET with [NuGet][client_nuget_package]:
 
 ```
-dotnet add package Azure.Analysis.Purview.Catalog --prerelease
+dotnet add package Azure.Analytics.Purview.Catalog --prerelease
 ```
 
 ### Prerequisites

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/README.md
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/README.md
@@ -17,7 +17,7 @@ Azure Purview Scanning is a fully managed cloud service whose users can scan you
 Install the Azure Purview Scanning client library for .NET with [NuGet][client_nuget_package]:
 
 ```
-dotnet add package Azure.Analysis.Purview.Scanning --prerelease
+dotnet add package Azure.Analytics.Purview.Scanning --prerelease
 ```
 
 ### Prerequisites


### PR DESCRIPTION
We were using the wrong name for the package (Analysis vs Analytics),
this fixes that.
