### PR TITLE
[CredScan] Adding Event Hubs fake secret to suppression file

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -4,6 +4,7 @@
         {
             "placeholder": [
                 "Sanitized",
+                "%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D",
                 "fake",
                 "Test12345",
                 "default",


### PR DESCRIPTION
Ignoring fake secret used by Event Hubs tests. Example: https://github.com/Azure/azure-sdk-for-net/blob/4810906df4e0bb0e8b37b57b59c9343aba77524a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Authorization/SharedAccessSignatureTests.cs#L347-L348