### PR TITLE
[CredScan] Adding Identity mock file to suppression file

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -51,6 +51,7 @@
             "file":[
                 "sdk/identity/Azure.Identity/tests/Data/cert.pfx",
                 "sdk/identity/Azure.Identity/tests/Data/cert-invalid-data.pem",
+                "sdk/identity/Azure.Identity/tests/Data/cert-password-protected.pfx",
                 "sdk/identity/Azure.Identity/tests/Data/cert.pem",
                 "sdk/identity/Azure.Identity/tests/Data/mock-arc-mi-key.key",
                 "sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/cert.pem"


### PR DESCRIPTION
Ignoring mock file used by Identity tests. [Here's the affected file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/tests/Data/cert-password-protected.pfx).