### PR TITLE
[CredScan] Adding Tables fake secret to suppression file

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -43,7 +43,8 @@
                 "Yukon900!",
                 "sql@zure123!",
                 "asdsadsad",
-                "Kg=="
+                "Kg==",
+                "jQetX8odiJoZ7Yo0X8vWgh%2FMqRv9WE3GU%2Fr%2BLNMK3GU%3D"
             ],
             "_justification": "Secret used by test code, it is fake."
         },


### PR DESCRIPTION
Ignoring fake secret used by Tables tests. Example:
https://github.com/Azure/azure-sdk-for-net/blob/4810906df4e0bb0e8b37b57b59c9343aba77524a/sdk/tables/Azure.Data.Tables/tests/TableUriBuilderTests.cs#L235