### PR TITLE
[MetricsAdvisor] Ignoring AAD tests

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorLiveTestBase.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorLiveTestBase.cs
@@ -42,6 +42,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
         public MetricsAdvisorAdministrationClient GetMetricsAdvisorAdministrationClient(bool useTokenCredential = false)
         {
+            // TODO: remove 'if' block when (https://github.com/Azure/azure-sdk-for-net/issues/23268) is solved
+            if (useTokenCredential)
+            {
+                Assert.Ignore();
+            }
+
             var endpoint = new Uri(TestEnvironment.MetricsAdvisorUri);
             var instrumentedOptions = GetInstrumentedOptions();
 
@@ -54,6 +60,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
         public MetricsAdvisorClient GetMetricsAdvisorClient(bool useTokenCredential = false)
         {
+            // TODO: remove 'if' block when (https://github.com/Azure/azure-sdk-for-net/issues/23268) is solved
+            if (useTokenCredential)
+            {
+                Assert.Ignore();
+            }
+
             var endpoint = new Uri(TestEnvironment.MetricsAdvisorUri);
             var instrumentedOptions = GetInstrumentedOptions();
 


### PR DESCRIPTION
AAD tests started failing. Ignoring them until issue is fixed service-side. Tracked by https://github.com/Azure/azure-sdk-for-net/issues/23268.