### PR TITLE
[Smoke Tests] Mitigate Failures

### DIFF
--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -11,13 +11,13 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Add an OverrideDailyVersion attribute to prevent the Update-Dependencies script from overwriting it with a daily build version -->
-    <PackageReference Include="Azure.Identity" Version="1.5.0-beta.2" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.5.0" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.5.0" />
-    <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.2.0" />
+    <PackageReference Include="Azure.Identity" Version="1.5.0-beta.3" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.6.0" />
+    <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.3.0-beta.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.9.1" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.13" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.34.0" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.5.1" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.35.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.15.0" />
 
     <!-- This is needed to resolve a build conflict and force the correct version -->

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -54,13 +54,6 @@ jobs:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
           Location: "westus"
-        Linux (AzureCloud Canary):
-          Pool: "azsdk-pool-mms-ubuntu-2004-general"
-          OSVmImage: "MMSUbuntu20.04"
-          TestTargetFramework: netcoreapp3.1
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(azureCloudArmParameters)
-          Location: "centraluseuap"
         Windows_NetCoreApp (AzureCloud):
           Pool: "azsdk-pool-mms-win-2019-general"
           OSVmImage: "MMS2019"

--- a/samples/iothub-connect-to-eventhubs/IotHubToEventHubsSample.csproj
+++ b/samples/iothub-connect-to-eventhubs/IotHubToEventHubsSample.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.5.0" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.13" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.34.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.0" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.5.1" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.35.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Summary

The focus of these changes is to mitigate the current failures for the smoke tests.   To do so, references for packages have been updated to match the latest August milestone deployments.  The `canary` Azure region has been temporarily disabled due to test resource deployment issues that require a new service version to fix.  

# References and Related

- [[Smoke Tests] Restore Canary Environment (#23286)](https://github.com/Azure/azure-sdk-for-net/issues/23286)