### PR TITLE
Add Core tests to resourcemanager build

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -26,7 +26,6 @@ pr:
     - sdk/testcommon/
     - eng/
     - samples/
-    - sdk/resourcemanager/
     exclude:
     - eng/mgmt/
 

--- a/sdk/resourcemanager/service.projects
+++ b/sdk/resourcemanager/service.projects
@@ -1,0 +1,9 @@
+<Project>
+  <ItemGroup>
+    <!--
+      Include Azure.Core.Tests project when building Azure.ResourceManager.Tests so we can validate that
+      core management test infrastructure isn't broken.
+    -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\core\Azure.Core\tests\Azure.Core.Tests.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Include Azure.Core.Tests project when building
Azure.ResourceManager.Tests so we can validate that
core management test infrastructure isn't broken.

