### PR TITLE
Smoke test isolation per package

### DIFF
--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -22,6 +22,9 @@
 
     <!-- This is needed to resolve a build conflict and force the correct version -->
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    
+    <!-- This is needed for non-nightly smoke test runs -->
+    <PackageReference Include="Azure.Template" Version="1.0.2" />
   </ItemGroup>
 
   <!-- Sample: IoT Hub Connection String Translation -->

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -2,9 +2,9 @@ parameters:
   - name: Daily
     type: boolean
     default: true
-  - name: Artifacts
+  - name: Artifact
     type: object
-    default: []
+    default: {}
   - name: ArtifactName
     type: string
     default: ""
@@ -21,19 +21,18 @@ jobs:
       displayName: Check Smoke Test Eligibility
       steps:
         # pipelines only supports template each when it generates the entire script block.
-        - ${{ each artifact in parameters.Artifacts }}:
-          - ${{ if and(ne(variables['Skip.Release'], 'true'), ne(artifact.skipPublishPackage, 'true')) }}:
-            - pwsh: |
-                $deps = (Select-Xml -Path ./common/SmokeTests/SmokeTest/SmokeTest.csproj `
-                                    -Xpath //ItemGroup/PackageReference/@Include).Node.Value
-                if ($deps.Contains("${{ artifact.name }}")) {
-                  Write-Host "Smoke tests will run for ${{ artifact.name }}"
-                  Write-Host "##vso[task.setvariable variable=RunSmokeTests]true"
-                } else {
-                  Write-Host "Smoke tests will NOT run for ${{ artifact.name }}"
-                }
-              name: check_smoke_tests_${{ artifact.safeName }}
-              displayName: Check smoke test eligibility for ${{ artifact.name }}
+        - ${{ if and(ne(variables['Skip.Release'], 'true'), ne(parameters.Artifact.skipPublishPackage, 'true')) }}:
+          - pwsh: |
+              $deps = (Select-Xml -Path ./common/SmokeTests/SmokeTest/SmokeTest.csproj `
+                                  -Xpath //ItemGroup/PackageReference/@Include).Node.Value
+              if ($deps.Contains("${{ parameters.Artifact.name }}")) {
+                Write-Host "Smoke tests will run for ${{ parameters.Artifact.name }}"
+                Write-Host "##vso[task.setvariable variable=RunSmokeTests]true"
+              } else {
+                Write-Host "Smoke tests will NOT run for ${{ parameters.Artifact.name }}"
+              }
+            name: check_smoke_tests_${{ parameters.Artifact.safeName }}
+            displayName: Check smoke test eligibility for ${{ parameters.Artifact.name }}
         - pwsh: |
             Write-Host "Setting RunSmokeTests to ${env:RunSmokeTests}"
             Write-Host "##vso[task.setvariable variable=RunSmokeTests;isOutput=true]${env:RunSmokeTests}"
@@ -42,6 +41,7 @@ jobs:
             RunSmokeTests: $(RunSmokeTests)
 
   - job: SmokeTest
+    displayName: Run Smoke Test
     ${{ if eq(parameters.Daily, false) }}:
       dependsOn: smoke_test_eligibility
       condition: and(succeeded(), eq(dependencies.smoke_test_eligibility.outputs['output_eligibility.RunSmokeTests'], true))

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -226,15 +226,12 @@ stages:
                           PRLabels: "auto-merge"
                           CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
 
-  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - stage: SmokeTest_Release_Packages
-      displayName: Smoke Test Release Packages
-      jobs:
-        - template: /eng/pipelines/templates/jobs/smoke.tests.yml
-          parameters:
-            Daily: false
-            Artifacts: ${{ parameters.Artifacts }}
-            ArtifactName: ${{ parameters.ArtifactName }}
+          - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+            - template: /eng/pipelines/templates/jobs/smoke.tests.yml
+              parameters:
+                Daily: false
+                Artifact: ${{ artifact }}
+                ArtifactName: ${{ parameters.ArtifactName }}
 
   - stage: Integration
     dependsOn: Signing


### PR DESCRIPTION
This isolates the smoke tests by running it per package, rather than after the entire release, as discussed here: https://github.com/Azure/azure-sdk-tools/issues/1841

Pipeline ref: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1046302&view=results

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
