### PR TITLE
Documentation tweak and addition of ParseCertificate method

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
@@ -353,6 +353,7 @@ Console.WriteLine($"The latest ledger entry from the sub-ledger is {latestSubLed
 ##### Ranged queries
 
 Ledger entries in a sub-ledger may be retrieved over a range of transaction ids.
+Note: Both ranges are optional; they can be provided individually or not all all.
 
 ```C# Snippet:RangedQuery
 ledgerClient.GetLedgerEntries(fromTransactionId: "2.1", toTransactionId: subLedgerTransactionId);

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
@@ -353,7 +353,7 @@ Console.WriteLine($"The latest ledger entry from the sub-ledger is {latestSubLed
 ##### Ranged queries
 
 Ledger entries in a sub-ledger may be retrieved over a range of transaction ids.
-Note: Both ranges are optional; they can be provided individually or not all all.
+Note: Both ranges are optional; they can be provided individually or not at all.
 
 ```C# Snippet:RangedQuery
 ledgerClient.GetLedgerEntries(fromTransactionId: "2.1", toTransactionId: subLedgerTransactionId);

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/api/Azure.Security.ConfidentialLedger.netstandard2.0.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/api/Azure.Security.ConfidentialLedger.netstandard2.0.cs
@@ -49,5 +49,6 @@ namespace Azure.Security.ConfidentialLedger
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
         public virtual Azure.Response GetLedgerIdentity(string ledgerId, Azure.RequestOptions options = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> GetLedgerIdentityAsync(string ledgerId, Azure.RequestOptions options = null) { throw null; }
+        public static System.Security.Cryptography.X509Certificates.X509Certificate2 ParseCertificate(Azure.Response getIdentityResponse) { throw null; }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
@@ -30,6 +30,8 @@
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)PemReader.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)LightweightPkcs8Decoder.cs" LinkBase="Shared" />
   </ItemGroup>
 
 </Project>

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/Azure.Security.ConfidentialLedger.Tests.csproj
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/Azure.Security.ConfidentialLedger.Tests.csproj
@@ -22,9 +22,4 @@
     <Folder Include="SessionRecords\ConfidentialLedgerClientLiveTests" />
   </ItemGroup>
 
-  <!-- Shared source from Azure.Core -->
-  <ItemGroup>
-    <Compile Include="$(AzureCoreSharedSources)PemReader.cs" LinkBase="Shared" />
-    <Compile Include="$(AzureCoreSharedSources)LightweightPkcs8Decoder.cs" LinkBase="Shared" />
-  </ItemGroup>
 </Project>

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/Azure.Security.ConfidentialLedger.Tests.csproj
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/Azure.Security.ConfidentialLedger.Tests.csproj
@@ -21,4 +21,10 @@
     <Folder Include="SessionRecords" />
     <Folder Include="SessionRecords\ConfidentialLedgerClientLiveTests" />
   </ItemGroup>
+
+  <!-- Shared source from Azure.Core -->
+  <ItemGroup>
+    <Compile Include="$(AzureCoreSharedSources)PemReader.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)LightweightPkcs8Decoder.cs" LinkBase="Shared" />
+  </ItemGroup>
 </Project>

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerIdentityServiceTests.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerIdentityServiceTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Security.ConfidentialLedger.Tests
+{
+    public class ConfidentialLedgerIdentityServiceTests
+    {
+        [Test]
+        public void ParseCertificate()
+        {
+            var ledgerCert =
+                new LedgerIdentityResponse
+                {
+                    ledgerTlsCertificate =
+                        "-----BEGIN CERTIFICATE-----\nMIIBezCCASGgAwIBAgIRAJm8lmSE26KV0eDDXrRD6LQwCgYIKoZIzj0EAwIwFjEU\nMBIGA1UEAwwLQ0NGIE5ldHdvcmswHhcNMjEwMzExMDAwMDAwWhcNMjMwNjExMjM1\nOTU5WjAWMRQwEgYDVQQDDAtDQ0YgTmV0d29yazBZMBMGByqGSM49AgEGCCqGSM49\nAwEHA0IABJDsxegT33aucCNaiHPK2YNPqwRg1Y2xxVVkII9yUCs6QyNJoCWI4Zfv\nj7iCOpaaBFxDBOuXcqyzXix\u002Be0r3rZyjUDBOMAwGA1UdEwQFMAMBAf8wHQYDVR0O\nBBYEFLmINpd7X6PFiqD3z0FsjUgDyHtDMB8GA1UdIwQYMBaAFLmINpd7X6PFiqD3\nz0FsjUgDyHtDMAoGCCqGSM49BAMCA0gAMEUCIQD13yI1tEd9m0CtyfSqUnN80wYr\n6QRh9JO3tuSMA10b2gIgGZTs\u002BkowdDjP//U5fgCBovlcGIhdiBBF2wuHnLfqAkI=\n-----END CERTIFICATE-----\n\u0000"
+                };
+
+            var response = new MockResponse(200);
+            response.SetContent(System.Text.Json.JsonSerializer.Serialize(ledgerCert));
+
+            var cert = ConfidentialLedgerIdentityServiceClient.ParseCertificate(response);
+
+            Assert.AreEqual("5D2E98B216B73220C960EE2978E56EEFEEACA30D", cert.Thumbprint);
+        }
+
+        public class LedgerIdentityResponse
+        {
+            public string ledgerTlsCertificate { get; set; }
+            public string ledgerId { get; set; }
+        }
+    }
+}

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/samples/HelloWorldSamples.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/samples/HelloWorldSamples.cs
@@ -46,7 +46,8 @@ namespace Azure.Security.ConfidentialLedger.Tests.samples
                 .GetString();
 
             // construct an X509Certificate2 with the ECC PEM value.
-            X509Certificate2 ledgerTlsCert = new X509Certificate2(Encoding.UTF8.GetBytes(eccPem));
+            var span = new ReadOnlySpan<char>(eccPem.ToCharArray());
+            X509Certificate2 ledgerTlsCert = PemReader.LoadCertificate(span, null, PemReader.KeyType.Auto, true);
 
             #endregion
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/samples/HelloWorldSamples.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/samples/HelloWorldSamples.cs
@@ -38,17 +38,7 @@ namespace Azure.Security.ConfidentialLedger.Tests.samples
             ledgerId = ledgerId.Substring(0, ledgerId.IndexOf('.'));
 #endif
             Response response = identityClient.GetLedgerIdentity(ledgerId);
-
-            // extract the ECC PEM value from the response.
-            var eccPem = JsonDocument.Parse(response.Content)
-                .RootElement
-                .GetProperty("ledgerTlsCertificate")
-                .GetString();
-
-            // construct an X509Certificate2 with the ECC PEM value.
-            var span = new ReadOnlySpan<char>(eccPem.ToCharArray());
-            X509Certificate2 ledgerTlsCert = PemReader.LoadCertificate(span, null, PemReader.KeyType.Auto, true);
-
+            X509Certificate2 ledgerTlsCert = ConfidentialLedgerIdentityServiceClient.ParseCertificate(response);
             #endregion
 
             #region Snippet:CreateClient
@@ -62,6 +52,7 @@ namespace Azure.Security.ConfidentialLedger.Tests.samples
             certificateChain.ChainPolicy.UrlRetrievalTimeout = new TimeSpan(0, 0, 0);
             certificateChain.ChainPolicy.ExtraStore.Add(ledgerTlsCert);
 
+            var f = certificateChain.Build(ledgerTlsCert);
             // Define a validation function to ensure that the ledger certificate is trusted by the ledger identity TLS certificate.
             bool CertValidationCheck(HttpRequestMessage httpRequestMessage, X509Certificate2 cert, X509Chain x509Chain, SslPolicyErrors sslPolicyErrors)
             {


### PR DESCRIPTION
closes #23292

ParseCertificate uses the shared source PemReader from Core, which loads certs properly on MacOS.