### PR TITLE
Make the accept session concurrency dynamic

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -99,7 +99,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 credential,
                 options.TransportType,
                 options.WebProxy,
-                options.EnableCrossEntityTransactions);
+                options.EnableCrossEntityTransactions,
+                options.RetryOptions.TryTimeout);
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -146,28 +146,30 @@ namespace Azure.Messaging.ServiceBus.Amqp
         private string _sendViaReceiverEntityPath;
 
         private readonly object _syncLock = new();
+        private readonly TimeSpan _operationTimeout;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="AmqpConnectionScope"/> class.
         /// </summary>
-        ///
         /// <param name="serviceEndpoint">Endpoint for the Service Bus service to which the scope is associated.</param>
         /// <param name="credential">The credential to use for authorization with the Service Bus service.</param>
         /// <param name="transport">The transport to use for communication.</param>
         /// <param name="proxy">The proxy, if any, to use for communication.</param>
         /// <param name="useSingleSession">If true, all links will use a single session.</param>
-        ///
+        /// <param name="operationTimeout">The timeout for operations associated with the connection.</param>
         public AmqpConnectionScope(
             Uri serviceEndpoint,
             ServiceBusTokenCredential credential,
             ServiceBusTransportType transport,
             IWebProxy proxy,
-            bool useSingleSession)
+            bool useSingleSession,
+            TimeSpan operationTimeout)
         {
             Argument.AssertNotNull(serviceEndpoint, nameof(serviceEndpoint));
             Argument.AssertNotNull(credential, nameof(credential));
             ValidateTransport(transport);
 
+            _operationTimeout = operationTimeout;
             ServiceEndpoint = serviceEndpoint;
             Transport = transport;
             Proxy = proxy;
@@ -506,6 +508,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 var linkSettings = new AmqpLinkSettings();
                 linkSettings.AddProperty(AmqpClientConstants.TimeoutName, (uint)timeout.CalculateRemaining(stopWatch.GetElapsedTime()).TotalMilliseconds);
                 linkSettings.AddProperty(AmqpClientConstants.EntityTypeName, AmqpClientConstants.EntityTypeManagement);
+                linkSettings.OperationTimeout = _operationTimeout;
                 entityPath += '/' + AmqpClientConstants.ManagementAddress;
 
                 // Perform the initial authorization for the link.
@@ -639,7 +642,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     AutoSendFlow = prefetchCount > 0,
                     SettleType = (receiveMode == ServiceBusReceiveMode.PeekLock) ? SettleMode.SettleOnDispose : SettleMode.SettleOnSend,
                     Source = new Source { Address = endpoint.AbsolutePath, FilterSet = filters },
-                    Target = new Target { Address = Guid.NewGuid().ToString() }
+                    Target = new Target { Address = Guid.NewGuid().ToString() },
+                    OperationTimeout = _operationTimeout
                 };
 
                 var link = new ReceivingAmqpLink(linkSettings);
@@ -777,7 +781,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     Role = false,
                     InitialDeliveryCount = 0,
                     Source = new Source { Address = Guid.NewGuid().ToString() },
-                    Target = new Target { Address = destinationEndpoint.AbsolutePath }
+                    Target = new Target { Address = destinationEndpoint.AbsolutePath },
+                    OperationTimeout = _operationTimeout
                 };
 
                 linkSettings.AddProperty(AmqpClientConstants.TimeoutName, (uint)timeout.CalculateRemaining(stopWatch.GetElapsedTime()).TotalMilliseconds);
@@ -1046,40 +1051,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
             string entityPath = default,
             bool isProcessor = default)
         {
-            CancellationTokenRegistration registration;
             try
             {
-                var openObjectCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-                // Only allow cancelling in-flight opens when it is from a processor.
-                // This would occur when the processor is stopped or closed by the user.
-                if (isProcessor)
-                {
-                    // use a static delegate with tuple state to avoid allocating a closure
-                    registration = cancellationToken.Register(static state =>
-                    {
-                        var (tcs, target) = ((TaskCompletionSource<object>, AmqpObject))state;
-                        if (tcs.TrySetCanceled())
-                        {
-                            target.SafeClose();
-                        }
-                    }, (openObjectCompletionSource, target), useSynchronizationContext: false);
-                }
-
-                static async Task Open(AmqpObject target, TimeSpan timeout, TaskCompletionSource<object> openObjectCompletionSource)
-                {
-                    try
-                    {
-                        await target.OpenAsync(timeout).ConfigureAwait(false);
-                        openObjectCompletionSource.TrySetResult(null);
-                    }
-                    catch (Exception ex)
-                    {
-                        openObjectCompletionSource.TrySetException(ex);
-                    }
-                }
-
-                _ = Open(target, timeout, openObjectCompletionSource);
-                await openObjectCompletionSource.Task.ConfigureAwait(false);
+                await target.OpenAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -1108,13 +1082,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                     default:
                         throw;
-                }
-            }
-            finally
-            {
-                if (isProcessor)
-                {
-                    registration.Dispose();
                 }
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -881,7 +881,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
-        [Event(ProcessorStoppingReceiveCanceledEvent, Level = EventLevel.Verbose, Message = "A receive operation was cancelled while stopping the processor. (Identifier '{0}'). Error Message: '{1}'")]
+        [Event(ProcessorStoppingReceiveCanceledEvent, Level = EventLevel.Verbose, Message = "A receive operation was cancelled while stopping the processor or scaling down concurrency. (Identifier '{0}'). Error Message: '{1}'")]
         public void ProcessorStoppingReceiveCanceled(string identifier, string exception)
         {
             if (IsEnabled())
@@ -890,7 +890,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
-        [Event(ProcessorStoppingAcceptSessionCanceledEvent, Level = EventLevel.Verbose, Message = "An accept session operation was cancelled while stopping the processor. (Namespace '{0}', Entity path '{1}'). Error Message: '{2}'")]
+        [Event(ProcessorStoppingAcceptSessionCanceledEvent, Level = EventLevel.Verbose, Message = "An accept session operation was cancelled while stopping the processor or scaling down concurrency. (Namespace '{0}', Entity path '{1}'). Error Message: '{2}'")]
         public void ProcessorStoppingAcceptSessionCanceled(string fullyQualifiedNamespace, string entityPath, string exception)
         {
             if (IsEnabled())

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -186,6 +186,7 @@ namespace Azure.Messaging.ServiceBus
         internal readonly List<(Task Task, CancellationTokenSource Cts, ReceiverManager ReceiverManager)> _tasks = new();
         private readonly List<ReceiverManager> _orphanedReceiverManagers = new();
         private CancellationTokenSource _handlerCts = new();
+        private readonly int _processorCount = Environment.ProcessorCount;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceBusProcessor"/> class.
@@ -1030,7 +1031,7 @@ namespace Azure.Messaging.ServiceBus
 
             if (IsSessionProcessor)
             {
-                int maxAcceptSessions = Math.Min(maxConcurrentCalls, 2 * Environment.ProcessorCount);
+                int maxAcceptSessions = Math.Min(maxConcurrentCalls, 2 * _processorCount);
                 int diffAcceptSessions = maxAcceptSessions - _currentAcceptSessions;
                 if (diffAcceptSessions > 0)
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -295,10 +295,7 @@ namespace Azure.Messaging.ServiceBus
                 }
             }
             catch (Exception ex)
-            when (ex is not TaskCanceledException ||
-            // If the user manually throws a TCE, then we should log it.
-            (!_sessionCancellationSource.IsCancellationRequested &&
-             !processorCancellationToken.IsCancellationRequested))
+            when (ex is not TaskCanceledException)
             {
                 if (ex is ServiceBusException sbException)
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -198,7 +198,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 Uri serviceEndpoint,
                 ServiceBusTokenCredential credential,
                 ServiceBusTransportType transport,
-                IWebProxy proxy) : base(serviceEndpoint, credential, transport, proxy, false)
+                IWebProxy proxy) : base(serviceEndpoint, credential, transport, proxy, false, default)
             {
                 MockConnection = new Mock<AmqpConnection>(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -198,7 +198,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         }
 
         [Test]
-        [Ignore("reverted cancellation support outside of processor")]
         public async Task AcceptNextSessionRespectsCancellation()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -360,6 +360,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         }
 
         [Test]
+        [Ignore("issue with AMQP lib not using link level timeout")]
         public async Task DoesNotLogAcceptSessionTimeoutAsError()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -853,8 +853,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
 
                 async Task ProcessMessage(ProcessMessageEventArgs args)
                 {
-                    var ct = Interlocked.Increment(ref receivedCount);
-                    if (ct == messageCount)
+                    var count = Interlocked.Increment(ref receivedCount);
+                    if (count == messageCount)
                     {
                         tcs.SetResult(true);
                     }
@@ -896,27 +896,27 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                         await args.AbandonMessageAsync(args.Message);
                     }
 
-                    var ct = Interlocked.Increment(ref receivedCount);
-                    if (ct == messageCount)
+                    var count = Interlocked.Increment(ref receivedCount);
+                    if (count == messageCount)
                     {
                         tcs.SetResult(true);
                     }
 
                     // decrease concurrency
-                    if (ct == 100)
+                    if (count == 100)
                     {
                         processor.UpdateConcurrency(1);
                         Assert.AreEqual(1, processor.MaxConcurrentCalls);
                     }
 
                     // increase concurrency
-                    if (ct == 150)
+                    if (count == 150)
                     {
                         Assert.LessOrEqual(processor._tasks.Where(t => !t.Task.IsCompleted).Count(), 1);
                         processor.UpdateConcurrency(10);
                         Assert.AreEqual(10, processor.MaxConcurrentCalls);
                     }
-                    if (ct == 175)
+                    if (count == 175)
                     {
                         Assert.GreaterOrEqual(processor._tasks.Where(t => !t.Task.IsCompleted).Count(), 5);
                     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
@@ -425,7 +425,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             var cts = new CancellationTokenSource();
 
             // mutate the cancellation token to distinguish it from CancellationToken.None
-            cts.CancelAfter(100);
+            cts.CancelAfter(500);
 
             await mockProcessor.Object.CloseAsync(cts.Token);
             mockProcessor.Verify(p => p.StopProcessingAsync(It.Is<CancellationToken>(ct => ct == cts.Token)));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -1835,30 +1835,30 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                         await args.AbandonMessageAsync(args.Message);
                     }
 
-                    var ct = Interlocked.Increment(ref receivedCount);
-                    if (ct == messageCount)
+                    var count = Interlocked.Increment(ref receivedCount);
+                    if (count == messageCount)
                     {
                         tcs.SetResult(true);
                     }
 
-                    if (ct == 5)
+                    if (count == 5)
                     {
                         processor.UpdateConcurrency(20, 2);
                         Assert.AreEqual(20, processor.MaxConcurrentSessions);
                         Assert.AreEqual(2, processor.MaxConcurrentCallsPerSession);
                     }
 
-                    if (ct == 50)
+                    if (count == 50)
                     {
                         Assert.GreaterOrEqual(processor.InnerProcessor._tasks.Count, 20);
                     }
-                    if (ct == 75)
+                    if (count == 75)
                     {
                         processor.UpdateConcurrency(1, 1);
                         Assert.AreEqual(1, processor.MaxConcurrentSessions);
                         Assert.AreEqual(1, processor.MaxConcurrentCallsPerSession);
                     }
-                    if (ct == 95)
+                    if (count == 95)
                     {
                         Assert.LessOrEqual(processor.InnerProcessor._tasks.Where(t => !t.Task.IsCompleted).Count(), 1);
                     }
@@ -1899,19 +1899,19 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                         await args.AbandonMessageAsync(args.Message);
                     }
 
-                    var ct = Interlocked.Increment(ref receivedCount);
-                    if (ct == messageCount)
+                    var count = Interlocked.Increment(ref receivedCount);
+                    if (count == messageCount)
                     {
                         tcs.SetResult(true);
                     }
 
-                    if (ct == 5)
+                    if (count == 5)
                     {
                         processor.UpdateConcurrency(5, 20);
                         Assert.AreEqual(5, processor.MaxConcurrentSessions);
                         Assert.AreEqual(20, processor.MaxConcurrentCallsPerSession);
                     }
-                    if (ct == 50)
+                    if (count == 50)
                     {
                         // tasks will generally be 100 here, but allow some forgiveness as this is not deterministic
                         Assert.GreaterOrEqual(processor.InnerProcessor._tasks.Count, 50);
@@ -1919,7 +1919,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                         Assert.AreEqual(1, processor.MaxConcurrentSessions);
                         Assert.AreEqual(1, processor.MaxConcurrentCallsPerSession);
                     }
-                    if (ct == 95)
+                    if (count == 95)
                     {
                         Assert.LessOrEqual(processor.InnerProcessor._tasks.Where(t => !t.Task.IsCompleted).Count(), 1);
                     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
@@ -385,7 +385,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             var cts = new CancellationTokenSource();
 
             // mutate the cancellation token to distinguish it from CancellationToken.None
-            cts.CancelAfter(100);
+            cts.CancelAfter(500);
 
             await mockSessionProcessor.Object.CloseAsync(cts.Token);
             mockProcessor.Verify(p => p.StopProcessingAsync(It.Is<CancellationToken>(ct => ct == cts.Token)));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -57,6 +57,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var receiverWithPrefetch = client.CreateReceiver(scope.QueueName,
                     options: new ServiceBusReceiverOptions() {PrefetchCount = 10});
 
+                // establish the receive link up front before measuring elapsed time
+                await receiverWithPrefetch.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
                 var stopwatch = new Stopwatch();
                 stopwatch.Start();
                 await receiverWithPrefetch.ReceiveMessagesAsync(10, TimeSpan.Zero).ConfigureAwait(false);


### PR DESCRIPTION
Porting still applicable changes from https://github.com/Azure/azure-sdk-for-net/pull/23282
- Accepting a session should respect the updated concurrency
- Use CT when opening link
- Set link level timeout

Filed https://github.com/Azure/azure-sdk-for-net/issues/23333 to complete CT migration.