### PR TITLE
[CredScan] Renamed Core test secrets

### DIFF
--- a/sdk/core/Azure.Core/tests/HttpEnvironmentProxyTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpEnvironmentProxyTest.cs
@@ -130,7 +130,7 @@ namespace System.Net.Http.Tests
         [Test]
         public void HttpProxy_CredentialParsing_Basic()
         {
-            Environment.SetEnvironmentVariable("all_proxy", "http://foo:bar@1.1.1.1:3000");
+            Environment.SetEnvironmentVariable("all_proxy", "http://foo:pwd1@1.1.1.1:3000");
             Assert.True(HttpEnvironmentProxy.TryCreate(out IWebProxy p));
             Assert.NotNull(p);
             Assert.NotNull(p.Credentials);
@@ -142,7 +142,7 @@ namespace System.Net.Http.Tests
             Assert.NotNull(p.Credentials);
 
             // Use different user for http and https
-            Environment.SetEnvironmentVariable("https_proxy", "http://foo1:bar1@1.1.1.1:3000");
+            Environment.SetEnvironmentVariable("https_proxy", "http://foo1:pwd2@1.1.1.1:3000");
             Assert.True(HttpEnvironmentProxy.TryCreate(out p));
             Assert.NotNull(p);
             Uri u = p.GetProxy(s_fooHttp);
@@ -158,7 +158,7 @@ namespace System.Net.Http.Tests
         public void HttpProxy_Exceptions_Match()
         {
             Environment.SetEnvironmentVariable("no_proxy", ".test.com,, foo.com");
-            Environment.SetEnvironmentVariable("all_proxy", "http://foo:bar@1.1.1.1:3000");
+            Environment.SetEnvironmentVariable("all_proxy", "http://foo:pwd1@1.1.1.1:3000");
             Assert.True(HttpEnvironmentProxy.TryCreate(out IWebProxy p));
             Assert.NotNull(p);
 
@@ -181,7 +181,7 @@ namespace System.Net.Http.Tests
         [TestCaseSource(nameof(HttpProxyNoProxyEnvVarMemberData))]
         public void HttpProxy_TryCreate_CaseInsensitiveVariables(string proxyEnvVar, string noProxyEnvVar)
         {
-            string proxy = "http://foo:bar@1.1.1.1:3000";
+            string proxy = "http://foo:pwd1@1.1.1.1:3000";
 
             Environment.SetEnvironmentVariable(proxyEnvVar, proxy);
             Environment.SetEnvironmentVariable(noProxyEnvVar, ".test.com, foo.com");


### PR DESCRIPTION
Renaming secrets `bar` => `pwd1` and `bar1` => `pwd2` so the suppression file catches them.