### PR TITLE
Update Microsoft.NETFramework.ReferenceAssemblies to latest version

### DIFF
--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -50,6 +50,13 @@
       CA2000; <!-- Call dispose on IDisposable objects -->
       CA2012; <!-- ValueTask should only be awaited once - conflicts with EnsureCompleted check -->
     </NoWarn>
+    <!--
+      
+    -->
+    <NoWarn>
+      $(NoWarn);
+      MSB3245;
+    </NoWarn>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -51,11 +51,11 @@
       CA2012; <!-- ValueTask should only be awaited once - conflicts with EnsureCompleted check -->
     </NoWarn>
     <!--
-      
+      Disable some MSBuild warnings
     -->
     <NoWarn>
       $(NoWarn);
-      MSB3245;
+      MSB3245; <!-- Do not warn if a package reference is unavailable -->
     </NoWarn>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -144,7 +144,7 @@
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20467.1" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.19552.1" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Update="SauceControl.InheritDoc" Version="1.2.0" PrivateAssets="All" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.333" PrivateAssets="All" />


### PR DESCRIPTION
Recent agent updated version of VS which might have broken some targeting packs so testing to see if updating to the latest version helps.

cc @heaths 
