### PR TITLE
Produce more descriptive error for GenerateSasUri when using TokenCredential

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/TableClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableClient.cs
@@ -1405,6 +1405,10 @@ namespace Azure.Data.Tables
         public virtual Uri GenerateSasUri(
             TableSasBuilder builder)
         {
+            if (SharedKeyCredential == null)
+            {
+                throw new InvalidOperationException($"{nameof(GenerateSasUri)} requires a credential other than {nameof(TokenCredential)} in order to sign the SAS token.");
+            }
             builder = builder ?? throw Errors.ArgumentNull(nameof(builder));
             if (!builder.TableName.Equals(Name, StringComparison.InvariantCulture))
             {

--- a/sdk/tables/Azure.Data.Tables/src/TableClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableClient.cs
@@ -1407,7 +1407,7 @@ namespace Azure.Data.Tables
         {
             if (SharedKeyCredential == null)
             {
-                throw new InvalidOperationException($"{nameof(GenerateSasUri)} requires a credential other than {nameof(TokenCredential)} in order to sign the SAS token.");
+                throw new InvalidOperationException($"{nameof(GenerateSasUri)} requires that this client be constructed with a credential type other than {nameof(TokenCredential)} in order to sign the SAS token.");
             }
             builder = builder ?? throw Errors.ArgumentNull(nameof(builder));
             if (!builder.TableName.Equals(Name, StringComparison.InvariantCulture))

--- a/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
@@ -911,6 +911,10 @@ namespace Azure.Data.Tables
             TableAccountSasBuilder builder)
         {
             Argument.AssertNotNull(builder, nameof(builder));
+            if (SharedKeyCredential == null)
+            {
+                throw new InvalidOperationException($"{nameof(GenerateSasUri)} requires a credential other than {nameof(TokenCredential)} in order to sign the SAS token.");
+            }
 
             TableUriBuilder sasUri = new(_endpoint);
             sasUri.Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString();

--- a/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
@@ -913,7 +913,7 @@ namespace Azure.Data.Tables
             Argument.AssertNotNull(builder, nameof(builder));
             if (SharedKeyCredential == null)
             {
-                throw new InvalidOperationException($"{nameof(GenerateSasUri)} requires a credential other than {nameof(TokenCredential)} in order to sign the SAS token.");
+                throw new InvalidOperationException($"{nameof(GenerateSasUri)} requires that this client be constructed with a credential type other than {nameof(TokenCredential)} in order to sign the SAS token.");
             }
 
             TableUriBuilder sasUri = new(_endpoint);


### PR DESCRIPTION
The current exception message thrown when attempting to call GenerateSasUri with a client constructed with a TokenCredential could be more descriptive. 