### PR TITLE
Renaming DocumentStatus and TranslationStatus

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/README.md
+++ b/sdk/translation/Azure.AI.Translation.Document/README.md
@@ -207,7 +207,7 @@ Console.WriteLine($"    Failed: {operation.DocumentsFailed}");
 Console.WriteLine($"    In Progress: {operation.DocumentsInProgress}");
 Console.WriteLine($"    Not started: {operation.DocumentsNotStarted}");
 
-await foreach (DocumentStatus document in operation.Value)
+await foreach (DocumentStatusResult document in operation.Value)
 {
     Console.WriteLine($"Document with Id: {document.Id}");
     Console.WriteLine($"  Status:{document.Status}");
@@ -235,7 +235,7 @@ int docsCanceled = 0;
 int docsSucceeded = 0;
 int docsFailed = 0;
 
-await foreach (TranslationStatus translationStatus in client.GetTranslationStatusesAsync())
+await foreach (TranslationStatusResult translationStatus in client.GetTranslationStatusesAsync())
 {
     if (translationStatus.Status == DocumentTranslationStatus.NotStarted ||
         translationStatus.Status == DocumentTranslationStatus.Running)
@@ -287,7 +287,7 @@ DocumentTranslationOperation operation = await client.StartTranslationAsync(inpu
 
 await operation.WaitForCompletionAsync();
 
-await foreach (DocumentStatus document in operation.GetValuesAsync())
+await foreach (DocumentStatusResult document in operation.GetValuesAsync())
 {
     Console.WriteLine($"Document with Id: {document.Id}");
     Console.WriteLine($"  Status:{document.Status}");
@@ -345,7 +345,7 @@ while (true)
     }
 }
 
-foreach (DocumentStatus document in operation.GetValues())
+foreach (DocumentStatusResult document in operation.GetValues())
 {
     Console.WriteLine($"Document with Id: {document.Id}");
     Console.WriteLine($"  Status:{document.Status}");

--- a/sdk/translation/Azure.AI.Translation.Document/api/Azure.AI.Translation.Document.netstandard2.0.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/api/Azure.AI.Translation.Document.netstandard2.0.cs
@@ -9,9 +9,9 @@ namespace Azure.AI.Translation.Document
     {
         CreatedOn = 0,
     }
-    public partial class DocumentStatus
+    public partial class DocumentStatusResult
     {
-        internal DocumentStatus() { }
+        internal DocumentStatusResult() { }
         public long CharactersCharged { get { throw null; } }
         public System.DateTimeOffset CreatedOn { get { throw null; } }
         public Azure.AI.Translation.Document.DocumentTranslationError Error { get { throw null; } }
@@ -34,12 +34,12 @@ namespace Azure.AI.Translation.Document
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public virtual Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.AI.Translation.Document.FileFormat>> GetSupportedDocumentFormats(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.AI.Translation.Document.FileFormat>>> GetSupportedDocumentFormatsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.AI.Translation.Document.FileFormat>> GetSupportedGlossaryFormats(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.AI.Translation.Document.FileFormat>>> GetSupportedGlossaryFormatsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.AI.Translation.Document.TranslationStatus> GetTranslationStatuses(Azure.AI.Translation.Document.GetTranslationStatusesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.AI.Translation.Document.TranslationStatus> GetTranslationStatusesAsync(Azure.AI.Translation.Document.GetTranslationStatusesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.AI.Translation.Document.DocumentTranslationFileFormat>> GetSupportedDocumentFormats(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.AI.Translation.Document.DocumentTranslationFileFormat>>> GetSupportedDocumentFormatsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.AI.Translation.Document.DocumentTranslationFileFormat>> GetSupportedGlossaryFormats(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.AI.Translation.Document.DocumentTranslationFileFormat>>> GetSupportedGlossaryFormatsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.AI.Translation.Document.TranslationStatusResult> GetTranslationStatuses(Azure.AI.Translation.Document.GetTranslationStatusesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.AI.Translation.Document.TranslationStatusResult> GetTranslationStatusesAsync(Azure.AI.Translation.Document.GetTranslationStatusesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AI.Translation.Document.DocumentTranslationOperation StartTranslation(Azure.AI.Translation.Document.DocumentTranslationInput input, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AI.Translation.Document.DocumentTranslationOperation StartTranslation(System.Collections.Generic.IEnumerable<Azure.AI.Translation.Document.DocumentTranslationInput> inputs, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.AI.Translation.Document.DocumentTranslationOperation> StartTranslationAsync(Azure.AI.Translation.Document.DocumentTranslationInput input, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -87,6 +87,15 @@ namespace Azure.AI.Translation.Document
         public static bool operator !=(Azure.AI.Translation.Document.DocumentTranslationErrorCode left, Azure.AI.Translation.Document.DocumentTranslationErrorCode right) { throw null; }
         public override string ToString() { throw null; }
     }
+    public partial class DocumentTranslationFileFormat
+    {
+        internal DocumentTranslationFileFormat() { }
+        public System.Collections.Generic.IReadOnlyList<string> ContentTypes { get { throw null; } }
+        public string DefaultFormatVersion { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<string> FileExtensions { get { throw null; } }
+        public string Format { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<string> FormatVersions { get { throw null; } }
+    }
     public partial class DocumentTranslationInput
     {
         public DocumentTranslationInput(Azure.AI.Translation.Document.TranslationSource source, System.Collections.Generic.IEnumerable<Azure.AI.Translation.Document.TranslationTarget> targets) { }
@@ -98,13 +107,13 @@ namespace Azure.AI.Translation.Document
     }
     public static partial class DocumentTranslationModelFactory
     {
-        public static Azure.AI.Translation.Document.DocumentStatus DocumentStatus(string id, System.Uri sourceDocumentUri, Azure.AI.Translation.Document.DocumentTranslationError error, System.DateTimeOffset createdOn, System.DateTimeOffset lastModified, Azure.AI.Translation.Document.DocumentTranslationStatus status, string translatedTo, float progress, long charactersCharged) { throw null; }
-        public static Azure.AI.Translation.Document.DocumentStatus DocumentStatus(string id, System.Uri sourceDocumentUri, System.Uri translatedDocumentUri, System.DateTimeOffset createdOn, System.DateTimeOffset lastModified, Azure.AI.Translation.Document.DocumentTranslationStatus status, string translatedTo, float progress, long charactersCharged) { throw null; }
+        public static Azure.AI.Translation.Document.DocumentStatusResult DocumentStatus(string id, System.Uri sourceDocumentUri, Azure.AI.Translation.Document.DocumentTranslationError error, System.DateTimeOffset createdOn, System.DateTimeOffset lastModified, Azure.AI.Translation.Document.DocumentTranslationStatus status, string translatedTo, float progress, long charactersCharged) { throw null; }
+        public static Azure.AI.Translation.Document.DocumentStatusResult DocumentStatus(string id, System.Uri sourceDocumentUri, System.Uri translatedDocumentUri, System.DateTimeOffset createdOn, System.DateTimeOffset lastModified, Azure.AI.Translation.Document.DocumentTranslationStatus status, string translatedTo, float progress, long charactersCharged) { throw null; }
         public static Azure.AI.Translation.Document.DocumentTranslationError DocumentTranslationError(Azure.AI.Translation.Document.DocumentTranslationErrorCode errorCode, string message, string target) { throw null; }
-        public static Azure.AI.Translation.Document.FileFormat FileFormat(string format = null, System.Collections.Generic.IEnumerable<string> fileExtensions = null, System.Collections.Generic.IEnumerable<string> contentTypes = null, string defaultFormatVersion = null, System.Collections.Generic.IEnumerable<string> formatVersions = null) { throw null; }
-        public static Azure.AI.Translation.Document.TranslationStatus TranslationStatus(string id, System.DateTimeOffset createdOn, System.DateTimeOffset lastModified, Azure.AI.Translation.Document.DocumentTranslationStatus status, Azure.AI.Translation.Document.DocumentTranslationError error, int total, int failed, int success, int inProgress, int notYetStarted, int canceled, long totalCharacterCharged) { throw null; }
+        public static Azure.AI.Translation.Document.DocumentTranslationFileFormat DocumentTranslationFileFormat(string format = null, System.Collections.Generic.IEnumerable<string> fileExtensions = null, System.Collections.Generic.IEnumerable<string> contentTypes = null, string defaultFormatVersion = null, System.Collections.Generic.IEnumerable<string> formatVersions = null) { throw null; }
+        public static Azure.AI.Translation.Document.TranslationStatusResult TranslationStatus(string id, System.DateTimeOffset createdOn, System.DateTimeOffset lastModified, Azure.AI.Translation.Document.DocumentTranslationStatus status, Azure.AI.Translation.Document.DocumentTranslationError error, int total, int failed, int success, int inProgress, int notYetStarted, int canceled, long totalCharacterCharged) { throw null; }
     }
-    public partial class DocumentTranslationOperation : Azure.PageableOperation<Azure.AI.Translation.Document.DocumentStatus>
+    public partial class DocumentTranslationOperation : Azure.PageableOperation<Azure.AI.Translation.Document.DocumentStatusResult>
     {
         protected DocumentTranslationOperation() { }
         public DocumentTranslationOperation(string translationId, Azure.AI.Translation.Document.DocumentTranslationClient client) { }
@@ -121,20 +130,20 @@ namespace Azure.AI.Translation.Document
         public virtual System.DateTimeOffset LastModified { get { throw null; } }
         public virtual Azure.AI.Translation.Document.DocumentTranslationStatus Status { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override Azure.AsyncPageable<Azure.AI.Translation.Document.DocumentStatus> Value { get { throw null; } }
+        public override Azure.AsyncPageable<Azure.AI.Translation.Document.DocumentStatusResult> Value { get { throw null; } }
         public virtual void Cancel(System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task CancelAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
-        public virtual Azure.Response<Azure.AI.Translation.Document.DocumentStatus> GetDocumentStatus(string documentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.Translation.Document.DocumentStatus>> GetDocumentStatusAsync(string documentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.AI.Translation.Document.DocumentStatus> GetDocumentStatuses(Azure.AI.Translation.Document.GetDocumentStatusesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.AI.Translation.Document.DocumentStatus> GetDocumentStatusesAsync(Azure.AI.Translation.Document.GetDocumentStatusesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.Translation.Document.DocumentStatusResult> GetDocumentStatus(string documentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.Translation.Document.DocumentStatusResult>> GetDocumentStatusAsync(string documentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.AI.Translation.Document.DocumentStatusResult> GetDocumentStatuses(Azure.AI.Translation.Document.GetDocumentStatusesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.AI.Translation.Document.DocumentStatusResult> GetDocumentStatusesAsync(Azure.AI.Translation.Document.GetDocumentStatusesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override Azure.Response GetRawResponse() { throw null; }
-        public override Azure.Pageable<Azure.AI.Translation.Document.DocumentStatus> GetValues(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public override Azure.AsyncPageable<Azure.AI.Translation.Document.DocumentStatus> GetValuesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override Azure.Pageable<Azure.AI.Translation.Document.DocumentStatusResult> GetValues(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override Azure.AsyncPageable<Azure.AI.Translation.Document.DocumentStatusResult> GetValuesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override Azure.Response UpdateStatus(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.ValueTask<Azure.Response> UpdateStatusAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public override System.Threading.Tasks.ValueTask<Azure.Response<Azure.AsyncPageable<Azure.AI.Translation.Document.DocumentStatus>>> WaitForCompletionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public override System.Threading.Tasks.ValueTask<Azure.Response<Azure.AsyncPageable<Azure.AI.Translation.Document.DocumentStatus>>> WaitForCompletionAsync(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override System.Threading.Tasks.ValueTask<Azure.Response<Azure.AsyncPageable<Azure.AI.Translation.Document.DocumentStatusResult>>> WaitForCompletionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override System.Threading.Tasks.ValueTask<Azure.Response<Azure.AsyncPageable<Azure.AI.Translation.Document.DocumentStatusResult>>> WaitForCompletionAsync(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DocumentTranslationStatus : System.IEquatable<Azure.AI.Translation.Document.DocumentTranslationStatus>
@@ -215,9 +224,9 @@ namespace Azure.AI.Translation.Document
         public System.Uri SourceUri { get { throw null; } }
         public string Suffix { get { throw null; } set { } }
     }
-    public partial class TranslationStatus
+    public partial class TranslationStatusResult
     {
-        internal TranslationStatus() { }
+        internal TranslationStatusResult() { }
         public System.DateTimeOffset CreatedOn { get { throw null; } }
         public int DocumentsCanceled { get { throw null; } }
         public int DocumentsFailed { get { throw null; } }

--- a/sdk/translation/Azure.AI.Translation.Document/api/Azure.AI.Translation.Document.netstandard2.0.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/api/Azure.AI.Translation.Document.netstandard2.0.cs
@@ -168,15 +168,6 @@ namespace Azure.AI.Translation.Document
         public static bool operator !=(Azure.AI.Translation.Document.DocumentTranslationStatus left, Azure.AI.Translation.Document.DocumentTranslationStatus right) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class FileFormat
-    {
-        internal FileFormat() { }
-        public System.Collections.Generic.IReadOnlyList<string> ContentTypes { get { throw null; } }
-        public string DefaultFormatVersion { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyList<string> FileExtensions { get { throw null; } }
-        public string Format { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyList<string> FormatVersions { get { throw null; } }
-    }
     public partial class GetDocumentStatusesOptions
     {
         public GetDocumentStatusesOptions() { }

--- a/sdk/translation/Azure.AI.Translation.Document/samples/Sample1_StartTranslation.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/Sample1_StartTranslation.md
@@ -40,7 +40,7 @@ Console.WriteLine($"    Failed: {operation.DocumentsFailed}");
 Console.WriteLine($"    In Progress: {operation.DocumentsInProgress}");
 Console.WriteLine($"    Not started: {operation.DocumentsNotStarted}");
 
-await foreach (DocumentStatus document in operation.Value)
+await foreach (DocumentStatusResult document in operation.Value)
 {
     Console.WriteLine($"Document with Id: {document.Id}");
     Console.WriteLine($"  Status:{document.Status}");

--- a/sdk/translation/Azure.AI.Translation.Document/samples/Sample2_PollIndividualDocuments.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/Sample2_PollIndividualDocuments.md
@@ -27,11 +27,11 @@ DocumentTranslationOperation operation = await client.StartTranslationAsync(inpu
 
 TimeSpan pollingInterval = new(1000);
 
-await foreach (DocumentStatus document in operation.GetDocumentStatusesAsync())
+await foreach (DocumentStatusResult document in operation.GetDocumentStatusesAsync())
 {
     Console.WriteLine($"Polling Status for document{document.SourceDocumentUri}");
 
-    Response<DocumentStatus> responseDocumentStatus = await operation.GetDocumentStatusAsync(document.Id);
+    Response<DocumentStatusResult> responseDocumentStatus = await operation.GetDocumentStatusAsync(document.Id);
 
     while (responseDocumentStatus.Value.Status != DocumentTranslationStatus.Failed &&
               responseDocumentStatus.Value.Status != DocumentTranslationStatus.Succeeded)

--- a/sdk/translation/Azure.AI.Translation.Document/samples/Sample3_OperationsHistory.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/Sample3_OperationsHistory.md
@@ -26,7 +26,7 @@ int docsCanceled = 0;
 int docsSucceeded = 0;
 int docsFailed = 0;
 
-await foreach (TranslationStatus translationStatus in client.GetTranslationStatusesAsync())
+await foreach (TranslationStatusResult translationStatus in client.GetTranslationStatusesAsync())
 {
     if (translationStatus.Status == DocumentTranslationStatus.NotStarted ||
         translationStatus.Status == DocumentTranslationStatus.Running)

--- a/sdk/translation/Azure.AI.Translation.Document/samples/Sample4_MultipleInputs.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/Sample4_MultipleInputs.md
@@ -48,7 +48,7 @@ DocumentTranslationOperation operation = await client.StartTranslationAsync(inpu
 
 await operation.WaitForCompletionAsync();
 
-await foreach (DocumentStatus document in operation.GetValuesAsync())
+await foreach (DocumentStatusResult document in operation.GetValuesAsync())
 {
     Console.WriteLine($"Document with Id: {document.Id}");
     Console.WriteLine($"  Status:{document.Status}");

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentFilterProperty.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentFilterProperty.cs
@@ -10,7 +10,7 @@ namespace Azure.AI.Translation.Document
     public enum DocumentFilterProperty
     {
         /// <summary>
-        /// Sorting property corresponding to <see cref="DocumentStatus.CreatedOn"/>.
+        /// Sorting property corresponding to <see cref="DocumentStatusResult.CreatedOn"/>.
         /// </summary>
         CreatedOn = 0,
     }

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentStatusResult.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentStatusResult.cs
@@ -35,7 +35,7 @@ namespace Azure.AI.Translation.Document
         /// This property will have a value only when the document was successfully processed.
         /// </summary>
         [CodeGenMember("To")]
-        public string TranslatedToLanguageCode { get; }
+        public string TranslatedTo { get; }
 
         /// <summary>
         /// The date time when the document was created.

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentStatusResult.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentStatusResult.cs
@@ -10,7 +10,7 @@ namespace Azure.AI.Translation.Document
     /// Status information about a particular document within a translation operation.
     /// </summary>
     [CodeGenModel("DocumentStatus")]
-    public partial class DocumentStatus
+    public partial class DocumentStatusResult
     {
         /// <summary>
         /// Document Id.
@@ -35,7 +35,7 @@ namespace Azure.AI.Translation.Document
         /// This property will have a value only when the document was successfully processed.
         /// </summary>
         [CodeGenMember("To")]
-        public string TranslatedTo { get; }
+        public string TranslatedToLanguageCode { get; }
 
         /// <summary>
         /// The date time when the document was created.

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClient.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClient.cs
@@ -219,9 +219,9 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         /// <param name="options">Options to use when filtering result.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual Pageable<TranslationStatus> GetTranslationStatuses(GetTranslationStatusesOptions options = default, CancellationToken cancellationToken = default)
+        public virtual Pageable<TranslationStatusResult> GetTranslationStatuses(GetTranslationStatusesOptions options = default, CancellationToken cancellationToken = default)
         {
-            Page<TranslationStatus> FirstPageFunc(int? pageSizeHint)
+            Page<TranslationStatusResult> FirstPageFunc(int? pageSizeHint)
             {
                 using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(DocumentTranslationClient)}.{nameof(GetTranslationStatuses)}");
                 scope.Start();
@@ -248,7 +248,7 @@ namespace Azure.AI.Translation.Document
                 }
             }
 
-            Page<TranslationStatus> NextPageFunc(string nextLink, int? pageSizeHint)
+            Page<TranslationStatusResult> NextPageFunc(string nextLink, int? pageSizeHint)
             {
                 using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(DocumentTranslationClient)}.{nameof(GetTranslationStatuses)}");
                 scope.Start();
@@ -273,9 +273,9 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         /// <param name="options">Options to use when filtering result.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual AsyncPageable<TranslationStatus> GetTranslationStatusesAsync(GetTranslationStatusesOptions options = default, CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<TranslationStatusResult> GetTranslationStatusesAsync(GetTranslationStatusesOptions options = default, CancellationToken cancellationToken = default)
         {
-            async Task<Page<TranslationStatus>> FirstPageFunc(int? pageSizeHint)
+            async Task<Page<TranslationStatusResult>> FirstPageFunc(int? pageSizeHint)
             {
                 using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(DocumentTranslationClient)}.{nameof(GetTranslationStatuses)}");
                 scope.Start();
@@ -303,7 +303,7 @@ namespace Azure.AI.Translation.Document
                 }
             }
 
-            async Task<Page<TranslationStatus>> NextPageFunc(string nextLink, int? pageSizeHint)
+            async Task<Page<TranslationStatusResult>> NextPageFunc(string nextLink, int? pageSizeHint)
             {
                 using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(DocumentTranslationClient)}.{nameof(GetTranslationStatuses)}");
                 scope.Start();

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClient.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClient.cs
@@ -329,7 +329,7 @@ namespace Azure.AI.Translation.Document
         /// Get the list of the glossary formats supported by the Document Translation service.
         /// </summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual Response<IReadOnlyList<FileFormat>> GetSupportedGlossaryFormats(CancellationToken cancellationToken = default)
+        public virtual Response<IReadOnlyList<DocumentTranslationFileFormat>> GetSupportedGlossaryFormats(CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(DocumentTranslationClient)}.{nameof(GetSupportedGlossaryFormats)}");
             scope.Start();
@@ -350,7 +350,7 @@ namespace Azure.AI.Translation.Document
         /// Get the list of the glossary formats supported by the Document Translation service.
         /// </summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual async Task<Response<IReadOnlyList<FileFormat>>> GetSupportedGlossaryFormatsAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<IReadOnlyList<DocumentTranslationFileFormat>>> GetSupportedGlossaryFormatsAsync(CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(DocumentTranslationClient)}.{nameof(GetSupportedGlossaryFormats)}");
             scope.Start();
@@ -371,7 +371,7 @@ namespace Azure.AI.Translation.Document
         /// Get the list of the document formats supported by the Document Translation service.
         /// </summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual Response<IReadOnlyList<FileFormat>> GetSupportedDocumentFormats(CancellationToken cancellationToken = default)
+        public virtual Response<IReadOnlyList<DocumentTranslationFileFormat>> GetSupportedDocumentFormats(CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(DocumentTranslationClient)}.{nameof(GetSupportedDocumentFormats)}");
             scope.Start();
@@ -392,7 +392,7 @@ namespace Azure.AI.Translation.Document
         /// Get the list of the document formats supported by the Document Translation service.
         /// </summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual async Task<Response<IReadOnlyList<FileFormat>>> GetSupportedDocumentFormatsAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<IReadOnlyList<DocumentTranslationFileFormat>>> GetSupportedDocumentFormatsAsync(CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(DocumentTranslationClient)}.{nameof(GetSupportedDocumentFormats)}");
             scope.Start();

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationFileFormat.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationFileFormat.cs
@@ -10,7 +10,7 @@ namespace Azure.AI.Translation.Document
     /// Possible file formats supported by the Document Translation service.
     /// </summary>
     [CodeGenModel("FileFormat")]
-    public partial class FileFormat
+    public partial class DocumentTranslationFileFormat
     {
         /// <summary> Supported format versions. </summary>
         [CodeGenMember("Versions")]

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationModelFactory.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationModelFactory.cs
@@ -119,8 +119,8 @@ namespace Azure.AI.Translation.Document
             long totalCharacterCharged
             )
         {
-            StatusSummary newSummary = new StatusSummary(total, failed, success, inProgress, notYetStarted, cancelled, totalCharacterCharged);
-            return new TranslationStatus(id, createdOn, lastModified, status, error, newSummary);
+            StatusSummary newSummary = new StatusSummary(total, failed, success, inProgress, notYetStarted, canceled, totalCharacterCharged);
+            return new TranslationStatusResult(id, createdOn, lastModified, status, error, newSummary);
         }
         #endregion Statuses
     }

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationModelFactory.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationModelFactory.cs
@@ -33,19 +33,19 @@ namespace Azure.AI.Translation.Document
 
         #region Statuses
         /// <summary>
-        /// Initializes a new instance of <see cref="Document.DocumentStatus"/> for mocking purposes.
+        /// Initializes a new instance of <see cref="Document.DocumentStatusResult"/> for mocking purposes.
         /// </summary>
-        /// <param name="id">Sets the <see cref="DocumentStatus.Id"/> property.</param>
-        /// <param name="sourceDocumentUri">Sets the <see cref="DocumentStatus.SourceDocumentUri"/> property.</param>
-        /// <param name="translatedDocumentUri">Sets the <see cref="DocumentStatus.TranslatedDocumentUri"/> property.</param>
-        /// <param name="createdOn">Sets the <see cref="DocumentStatus.CreatedOn"/> property.</param>
-        /// <param name="lastModified">Sets the <see cref="DocumentStatus.LastModified"/> property.</param>
-        /// <param name="status">Sets the <see cref="DocumentStatus.Status"/> property.</param>
-        /// <param name="translatedTo">Sets the <see cref="DocumentStatus.TranslatedTo"/> property.</param>
-        /// <param name="progress">Sets the <see cref="DocumentStatus.Progress"/> property.</param>
-        /// <param name="charactersCharged">Sets the <see cref="DocumentStatus.CharactersCharged"/> property.</param>
-        /// <returns>A new instance of <see cref="Document.DocumentStatus"/> for mocking purposes.</returns>
-        public static DocumentStatus DocumentStatus(
+        /// <param name="id">Sets the <see cref="DocumentStatusResult.Id"/> property.</param>
+        /// <param name="sourceDocumentUri">Sets the <see cref="DocumentStatusResult.SourceDocumentUri"/> property.</param>
+        /// <param name="translatedDocumentUri">Sets the <see cref="DocumentStatusResult.TranslatedDocumentUri"/> property.</param>
+        /// <param name="createdOn">Sets the <see cref="DocumentStatusResult.CreatedOn"/> property.</param>
+        /// <param name="lastModified">Sets the <see cref="DocumentStatusResult.LastModified"/> property.</param>
+        /// <param name="status">Sets the <see cref="DocumentStatusResult.Status"/> property.</param>
+        /// <param name="translatedTo">Sets the <see cref="DocumentStatusResult.TranslatedTo"/> property.</param>
+        /// <param name="progress">Sets the <see cref="DocumentStatusResult.Progress"/> property.</param>
+        /// <param name="charactersCharged">Sets the <see cref="DocumentStatusResult.CharactersCharged"/> property.</param>
+        /// <returns>A new instance of <see cref="Document.DocumentStatusResult"/> for mocking purposes.</returns>
+        public static DocumentStatusResult DocumentStatus(
             string id,
             Uri sourceDocumentUri,
             Uri translatedDocumentUri,
@@ -57,23 +57,23 @@ namespace Azure.AI.Translation.Document
             long charactersCharged
             )
         {
-            return new DocumentStatus(translatedDocumentUri, sourceDocumentUri, createdOn, lastModified, status, translatedTo, default, progress, id, charactersCharged);
+            return new DocumentStatusResult(translatedDocumentUri, sourceDocumentUri, createdOn, lastModified, status, translatedTo, default, progress, id, charactersCharged);
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="Document.DocumentStatus"/> for mocking purposes.
+        /// Initializes a new instance of <see cref="Document.DocumentStatusResult"/> for mocking purposes.
         /// </summary>
-        /// <param name="id">Sets the <see cref="DocumentStatus.Id"/> property.</param>
-        /// <param name="sourceDocumentUri">Sets the <see cref="DocumentStatus.SourceDocumentUri"/> property.</param>
-        /// <param name="error">Sets the <see cref="DocumentStatus.Error"/> property.</param>
-        /// <param name="createdOn">Sets the <see cref="DocumentStatus.CreatedOn"/> property.</param>
-        /// <param name="lastModified">Sets the <see cref="DocumentStatus.LastModified"/> property.</param>
-        /// <param name="status">Sets the <see cref="DocumentStatus.Status"/> property.</param>
-        /// <param name="translatedTo">Sets the <see cref="DocumentStatus.TranslatedTo"/> property.</param>
-        /// <param name="progress">Sets the <see cref="DocumentStatus.Progress"/> property.</param>
-        /// <param name="charactersCharged">Sets the <see cref="DocumentStatus.CharactersCharged"/> property.</param>
-        /// <returns>A new instance of <see cref="Document.DocumentStatus"/> for mocking purposes.</returns>
-        public static DocumentStatus DocumentStatus(
+        /// <param name="id">Sets the <see cref="DocumentStatusResult.Id"/> property.</param>
+        /// <param name="sourceDocumentUri">Sets the <see cref="DocumentStatusResult.SourceDocumentUri"/> property.</param>
+        /// <param name="error">Sets the <see cref="DocumentStatusResult.Error"/> property.</param>
+        /// <param name="createdOn">Sets the <see cref="DocumentStatusResult.CreatedOn"/> property.</param>
+        /// <param name="lastModified">Sets the <see cref="DocumentStatusResult.LastModified"/> property.</param>
+        /// <param name="status">Sets the <see cref="DocumentStatusResult.Status"/> property.</param>
+        /// <param name="translatedTo">Sets the <see cref="DocumentStatusResult.TranslatedTo"/> property.</param>
+        /// <param name="progress">Sets the <see cref="DocumentStatusResult.Progress"/> property.</param>
+        /// <param name="charactersCharged">Sets the <see cref="DocumentStatusResult.CharactersCharged"/> property.</param>
+        /// <returns>A new instance of <see cref="Document.DocumentStatusResult"/> for mocking purposes.</returns>
+        public static DocumentStatusResult DocumentStatus(
             string id,
             Uri sourceDocumentUri,
             DocumentTranslationError error,
@@ -85,26 +85,26 @@ namespace Azure.AI.Translation.Document
             long charactersCharged
             )
         {
-            return new DocumentStatus(default, sourceDocumentUri, createdOn, lastModified, status, translatedTo, error, progress, id, charactersCharged);
+            return new DocumentStatusResult(default, sourceDocumentUri, createdOn, lastModified, status, translatedTo, error, progress, id, charactersCharged);
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="Document.TranslationStatus"/> for mocking purposes.
+        /// Initializes a new instance of <see cref="Document.TranslationStatusResult"/> for mocking purposes.
         /// </summary>
-        /// <param name="id">Sets the <see cref="TranslationStatus.Id"/> property.</param>
-        /// <param name="createdOn">Sets the <see cref="TranslationStatus.CreatedOn"/> property.</param>
-        /// <param name="lastModified">Sets the <see cref="TranslationStatus.LastModified"/> property.</param>
-        /// <param name="status">Sets the <see cref="TranslationStatus.Status"/> property.</param>
-        /// <param name="error">Sets the <see cref="TranslationStatus.Error"/> property.</param>
-        /// <param name="total">Sets the <see cref="StatusSummary.Total"/> and the <see cref="TranslationStatus.DocumentsTotal"/> properties.</param>
-        /// <param name="failed">Sets the <see cref="StatusSummary.Failed"/> and the <see cref="TranslationStatus.DocumentsFailed"/> properties.</param>
-        /// <param name="success">Sets the <see cref="StatusSummary.Success"/> and the <see cref="TranslationStatus.DocumentsSucceeded"/> properties.</param>
-        /// <param name="inProgress">Sets the <see cref="StatusSummary.InProgress"/> and the <see cref="TranslationStatus.DocumentsInProgress"/> properties.</param>
-        /// <param name="notYetStarted">Sets the <see cref="StatusSummary.NotYetStarted"/> and the <see cref="TranslationStatus.DocumentsNotStarted"/> properties.</param>
-        /// <param name="canceled">Sets the <see cref="StatusSummary.Cancelled"/> and the <see cref="TranslationStatus.DocumentsCanceled"/> properties.</param>
-        /// <param name="totalCharacterCharged">Sets the <see cref="StatusSummary.TotalCharacterCharged"/> and the <see cref="TranslationStatus.TotalCharactersCharged"/> properties.</param>
-        /// <returns>A new instance of <see cref="Document.TranslationStatus"/> for mocking purposes.</returns>
-        public static TranslationStatus TranslationStatus(
+        /// <param name="id">Sets the <see cref="TranslationStatusResult.Id"/> property.</param>
+        /// <param name="createdOn">Sets the <see cref="TranslationStatusResult.CreatedOn"/> property.</param>
+        /// <param name="lastModified">Sets the <see cref="TranslationStatusResult.LastModified"/> property.</param>
+        /// <param name="status">Sets the <see cref="TranslationStatusResult.Status"/> property.</param>
+        /// <param name="error">Sets the <see cref="TranslationStatusResult.Error"/> property.</param>
+        /// <param name="total">Sets the <see cref="StatusSummary.Total"/> and the <see cref="TranslationStatusResult.DocumentsTotal"/> properties.</param>
+        /// <param name="failed">Sets the <see cref="StatusSummary.Failed"/> and the <see cref="TranslationStatusResult.DocumentsFailed"/> properties.</param>
+        /// <param name="success">Sets the <see cref="StatusSummary.Success"/> and the <see cref="TranslationStatusResult.DocumentsSucceeded"/> properties.</param>
+        /// <param name="inProgress">Sets the <see cref="StatusSummary.InProgress"/> and the <see cref="TranslationStatusResult.DocumentsInProgress"/> properties.</param>
+        /// <param name="notYetStarted">Sets the <see cref="StatusSummary.NotYetStarted"/> and the <see cref="TranslationStatusResult.DocumentsNotStarted"/> properties.</param>
+        /// <param name="canceled">Sets the <see cref="StatusSummary.Cancelled"/> and the <see cref="TranslationStatusResult.DocumentsCanceled"/> properties.</param>
+        /// <param name="totalCharacterCharged">Sets the <see cref="StatusSummary.TotalCharacterCharged"/> and the <see cref="TranslationStatusResult.TotalCharactersCharged"/> properties.</param>
+        /// <returns>A new instance of <see cref="Document.TranslationStatusResult"/> for mocking purposes.</returns>
+        public static TranslationStatusResult TranslationStatus(
             string id,
             DateTimeOffset createdOn,
             DateTimeOffset lastModified,
@@ -119,7 +119,7 @@ namespace Azure.AI.Translation.Document
             long totalCharacterCharged
             )
         {
-            StatusSummary newSummary = new StatusSummary(total, failed, success, inProgress, notYetStarted, canceled, totalCharacterCharged);
+            StatusSummary newSummary = new StatusSummary(total, failed, success, inProgress, notYetStarted, cancelled, totalCharacterCharged);
             return new TranslationStatus(id, createdOn, lastModified, status, error, newSummary);
         }
         #endregion Statuses

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationOperation.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationOperation.cs
@@ -14,7 +14,7 @@ using Azure.Core.Pipeline;
 namespace Azure.AI.Translation.Document
 {
     /// <summary> Tracks the status of a long-running operation for translating documents. </summary>
-    public class DocumentTranslationOperation : PageableOperation<DocumentStatus>
+    public class DocumentTranslationOperation : PageableOperation<DocumentStatusResult>
     {
         // TODO: Respect retry after #19442
         private readonly TimeSpan DefaultPollingInterval = TimeSpan.FromSeconds(30);
@@ -93,7 +93,7 @@ namespace Azure.AI.Translation.Document
         /// This property can be accessed only after the operation completes successfully (HasValue is true).
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override AsyncPageable<DocumentStatus> Value => GetValuesAsync();
+        public override AsyncPageable<DocumentStatusResult> Value => GetValuesAsync();
 
         /// <summary>
         /// <c>true</c> if the long-running operation has completed. Otherwise, <c>false</c>.
@@ -125,7 +125,7 @@ namespace Azure.AI.Translation.Document
         /// <summary>
         /// Provides the results for the first page.
         /// </summary>
-        private Page<DocumentStatus> _firstPage;
+        private Page<DocumentStatusResult> _firstPage;
 
         /// <summary>
         /// Returns true if the long-running operation completed successfully and has produced final result (accessible by Value property).
@@ -205,7 +205,7 @@ namespace Azure.AI.Translation.Document
         /// This method will periodically call UpdateStatusAsync till HasCompleted is true.
         /// An API call is then made to retrieve the status of the documents.
         /// </remarks>
-        public override ValueTask<Response<AsyncPageable<DocumentStatus>>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
+        public override ValueTask<Response<AsyncPageable<DocumentStatusResult>>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
             WaitForCompletionAsync(DefaultPollingInterval, cancellationToken);
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace Azure.AI.Translation.Document
         /// This method will periodically call UpdateStatusAsync till HasCompleted is true.
         /// An API call is then made to retrieve the status of the documents.
         /// </remarks>
-        public async override ValueTask<Response<AsyncPageable<DocumentStatus>>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default)
+        public async override ValueTask<Response<AsyncPageable<DocumentStatusResult>>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default)
         {
             while (true)
             {
@@ -237,7 +237,7 @@ namespace Azure.AI.Translation.Document
                     var response = await _serviceClient.GetDocumentsStatusAsync(new Guid(Id), cancellationToken: cancellationToken).ConfigureAwait(false);
                     _firstPage = Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                     _hasValue = true;
-                    async Task<Page<DocumentStatus>> NextPageFunc(string nextLink, int? pageSizeHint)
+                    async Task<Page<DocumentStatusResult>> NextPageFunc(string nextLink, int? pageSizeHint)
                     {
                         // TODO: diagnostics scope?
                         try
@@ -320,7 +320,7 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         /// <param name="documentId">ID of the document.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> used for the service call.</param>
-        public virtual Response<DocumentStatus> GetDocumentStatus(string documentId, CancellationToken cancellationToken = default)
+        public virtual Response<DocumentStatusResult> GetDocumentStatus(string documentId, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(DocumentTranslationOperation)}.{nameof(GetDocumentStatus)}");
             scope.Start();
@@ -342,7 +342,7 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         /// <param name="documentId">ID of the document.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> used for the service call.</param>
-        public virtual async Task<Response<DocumentStatus>> GetDocumentStatusAsync(string documentId, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<DocumentStatusResult>> GetDocumentStatusAsync(string documentId, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(DocumentTranslationOperation)}.{nameof(GetDocumentStatus)}");
             scope.Start();
@@ -364,9 +364,9 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         /// <param name="options">Options to use when filtering result.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> used for the service call.</param>
-        public virtual Pageable<DocumentStatus> GetDocumentStatuses(GetDocumentStatusesOptions options = default, CancellationToken cancellationToken = default)
+        public virtual Pageable<DocumentStatusResult> GetDocumentStatuses(GetDocumentStatusesOptions options = default, CancellationToken cancellationToken = default)
         {
-            Page<DocumentStatus> FirstPageFunc(int? pageSizeHint)
+            Page<DocumentStatusResult> FirstPageFunc(int? pageSizeHint)
             {
                 using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(DocumentTranslationOperation)}.{nameof(GetDocumentStatuses)}");
                 scope.Start();
@@ -394,7 +394,7 @@ namespace Azure.AI.Translation.Document
                 }
             }
 
-            Page<DocumentStatus> NextPageFunc(string nextLink, int? pageSizeHint)
+            Page<DocumentStatusResult> NextPageFunc(string nextLink, int? pageSizeHint)
             {
                 using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(DocumentTranslationOperation)}.{nameof(GetDocumentStatuses)}");
                 scope.Start();
@@ -419,9 +419,9 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         /// <param name="options">Options to use when filtering result.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> used for the service call.</param>
-        public virtual AsyncPageable<DocumentStatus> GetDocumentStatusesAsync(GetDocumentStatusesOptions options = default, CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<DocumentStatusResult> GetDocumentStatusesAsync(GetDocumentStatusesOptions options = default, CancellationToken cancellationToken = default)
         {
-            async Task<Page<DocumentStatus>> FirstPageFunc(int? pageSizeHint)
+            async Task<Page<DocumentStatusResult>> FirstPageFunc(int? pageSizeHint)
             {
                 using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(DocumentTranslationOperation)}.{nameof(GetDocumentStatuses)}");
                 scope.Start();
@@ -449,7 +449,7 @@ namespace Azure.AI.Translation.Document
                 }
             }
 
-            async Task<Page<DocumentStatus>> NextPageFunc(string nextLink, int? pageSizeHint)
+            async Task<Page<DocumentStatusResult>> NextPageFunc(string nextLink, int? pageSizeHint)
             {
                 using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(DocumentTranslationOperation)}.{nameof(GetDocumentStatuses)}");
                 scope.Start();
@@ -480,7 +480,7 @@ namespace Azure.AI.Translation.Document
 
             try
             {
-                Response<TranslationStatus> response = _serviceClient.CancelTranslation(new Guid(Id), cancellationToken);
+                Response<TranslationStatusResult> response = _serviceClient.CancelTranslation(new Guid(Id), cancellationToken);
                 _response = response.GetRawResponse();
             }
             catch (Exception e)
@@ -501,7 +501,7 @@ namespace Azure.AI.Translation.Document
 
             try
             {
-                Response<TranslationStatus> response = await _serviceClient.CancelTranslationAsync(new Guid(Id), cancellationToken).ConfigureAwait(false);
+                Response<TranslationStatusResult> response = await _serviceClient.CancelTranslationAsync(new Guid(Id), cancellationToken).ConfigureAwait(false);
                 _response = response.GetRawResponse();
             }
             catch (Exception e)
@@ -517,7 +517,7 @@ namespace Azure.AI.Translation.Document
         /// <remarks>
         /// Operation must complete successfully (HasValue is true) for it to provide values.
         /// </remarks>
-        public override AsyncPageable<DocumentStatus> GetValuesAsync(CancellationToken cancellationToken = default)
+        public override AsyncPageable<DocumentStatusResult> GetValuesAsync(CancellationToken cancellationToken = default)
         {
             ValidateOperationStatus();
 
@@ -530,7 +530,7 @@ namespace Azure.AI.Translation.Document
         /// <remarks>
         /// Operation must complete successfully (HasValue is true) for it to provide values.
         /// </remarks>
-        public override Pageable<DocumentStatus> GetValues(CancellationToken cancellationToken = default)
+        public override Pageable<DocumentStatusResult> GetValues(CancellationToken cancellationToken = default)
         {
             ValidateOperationStatus();
 

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/DocumentTranslationModelFactory.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/DocumentTranslationModelFactory.cs
@@ -13,20 +13,20 @@ namespace Azure.AI.Translation.Document
     /// <summary> Model factory for read-only models. </summary>
     public static partial class DocumentTranslationModelFactory
     {
-        /// <summary> Initializes a new instance of FileFormat. </summary>
+        /// <summary> Initializes a new instance of DocumentTranslationFileFormat. </summary>
         /// <param name="format"> Name of the format. </param>
         /// <param name="fileExtensions"> Supported file extension for this format. </param>
         /// <param name="contentTypes"> Supported Content-Types for this format. </param>
         /// <param name="defaultFormatVersion"> Default version if none is specified. </param>
         /// <param name="formatVersions"> Supported Version. </param>
-        /// <returns> A new <see cref="Document.FileFormat"/> instance for mocking. </returns>
-        public static FileFormat FileFormat(string format = null, IEnumerable<string> fileExtensions = null, IEnumerable<string> contentTypes = null, string defaultFormatVersion = null, IEnumerable<string> formatVersions = null)
+        /// <returns> A new <see cref="Document.DocumentTranslationFileFormat"/> instance for mocking. </returns>
+        public static DocumentTranslationFileFormat DocumentTranslationFileFormat(string format = null, IEnumerable<string> fileExtensions = null, IEnumerable<string> contentTypes = null, string defaultFormatVersion = null, IEnumerable<string> formatVersions = null)
         {
             fileExtensions ??= new List<string>();
             contentTypes ??= new List<string>();
             formatVersions ??= new List<string>();
 
-            return new FileFormat(format, fileExtensions?.ToList(), contentTypes?.ToList(), defaultFormatVersion, formatVersions?.ToList());
+            return new DocumentTranslationFileFormat(format, fileExtensions?.ToList(), contentTypes?.ToList(), defaultFormatVersion, formatVersions?.ToList());
         }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/DocumentTranslationRestClient.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/DocumentTranslationRestClient.cs
@@ -328,7 +328,7 @@ namespace Azure.AI.Translation.Document
         /// <param name="id"> Format - uuid.  The batch id. </param>
         /// <param name="documentId"> Format - uuid.  The document id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<ResponseWithHeaders<DocumentStatus, DocumentTranslationGetDocumentStatusHeaders>> GetDocumentStatusAsync(Guid id, Guid documentId, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<DocumentStatusResult, DocumentTranslationGetDocumentStatusHeaders>> GetDocumentStatusAsync(Guid id, Guid documentId, CancellationToken cancellationToken = default)
         {
             using var message = CreateGetDocumentStatusRequest(id, documentId);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -337,9 +337,9 @@ namespace Azure.AI.Translation.Document
             {
                 case 200:
                     {
-                        DocumentStatus value = default;
+                        DocumentStatusResult value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        value = DocumentStatus.DeserializeDocumentStatus(document.RootElement);
+                        value = DocumentStatusResult.DeserializeDocumentStatusResult(document.RootElement);
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:
@@ -351,7 +351,7 @@ namespace Azure.AI.Translation.Document
         /// <param name="id"> Format - uuid.  The batch id. </param>
         /// <param name="documentId"> Format - uuid.  The document id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public ResponseWithHeaders<DocumentStatus, DocumentTranslationGetDocumentStatusHeaders> GetDocumentStatus(Guid id, Guid documentId, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<DocumentStatusResult, DocumentTranslationGetDocumentStatusHeaders> GetDocumentStatus(Guid id, Guid documentId, CancellationToken cancellationToken = default)
         {
             using var message = CreateGetDocumentStatusRequest(id, documentId);
             _pipeline.Send(message, cancellationToken);
@@ -360,9 +360,9 @@ namespace Azure.AI.Translation.Document
             {
                 case 200:
                     {
-                        DocumentStatus value = default;
+                        DocumentStatusResult value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        value = DocumentStatus.DeserializeDocumentStatus(document.RootElement);
+                        value = DocumentStatusResult.DeserializeDocumentStatusResult(document.RootElement);
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:
@@ -391,7 +391,7 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         /// <param name="id"> Format - uuid.  The operation id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<ResponseWithHeaders<TranslationStatus, DocumentTranslationGetTranslationStatusHeaders>> GetTranslationStatusAsync(Guid id, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<TranslationStatusResult, DocumentTranslationGetTranslationStatusHeaders>> GetTranslationStatusAsync(Guid id, CancellationToken cancellationToken = default)
         {
             using var message = CreateGetTranslationStatusRequest(id);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -400,9 +400,9 @@ namespace Azure.AI.Translation.Document
             {
                 case 200:
                     {
-                        TranslationStatus value = default;
+                        TranslationStatusResult value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        value = TranslationStatus.DeserializeTranslationStatus(document.RootElement);
+                        value = TranslationStatusResult.DeserializeTranslationStatusResult(document.RootElement);
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:
@@ -416,7 +416,7 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         /// <param name="id"> Format - uuid.  The operation id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public ResponseWithHeaders<TranslationStatus, DocumentTranslationGetTranslationStatusHeaders> GetTranslationStatus(Guid id, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<TranslationStatusResult, DocumentTranslationGetTranslationStatusHeaders> GetTranslationStatus(Guid id, CancellationToken cancellationToken = default)
         {
             using var message = CreateGetTranslationStatusRequest(id);
             _pipeline.Send(message, cancellationToken);
@@ -425,9 +425,9 @@ namespace Azure.AI.Translation.Document
             {
                 case 200:
                     {
-                        TranslationStatus value = default;
+                        TranslationStatusResult value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        value = TranslationStatus.DeserializeTranslationStatus(document.RootElement);
+                        value = TranslationStatusResult.DeserializeTranslationStatusResult(document.RootElement);
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:
@@ -459,7 +459,7 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         /// <param name="id"> Format - uuid.  The operation-id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<Response<TranslationStatus>> CancelTranslationAsync(Guid id, CancellationToken cancellationToken = default)
+        public async Task<Response<TranslationStatusResult>> CancelTranslationAsync(Guid id, CancellationToken cancellationToken = default)
         {
             using var message = CreateCancelTranslationRequest(id);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -467,9 +467,9 @@ namespace Azure.AI.Translation.Document
             {
                 case 200:
                     {
-                        TranslationStatus value = default;
+                        TranslationStatusResult value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        value = TranslationStatus.DeserializeTranslationStatus(document.RootElement);
+                        value = TranslationStatusResult.DeserializeTranslationStatusResult(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -486,7 +486,7 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         /// <param name="id"> Format - uuid.  The operation-id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public Response<TranslationStatus> CancelTranslation(Guid id, CancellationToken cancellationToken = default)
+        public Response<TranslationStatusResult> CancelTranslation(Guid id, CancellationToken cancellationToken = default)
         {
             using var message = CreateCancelTranslationRequest(id);
             _pipeline.Send(message, cancellationToken);
@@ -494,9 +494,9 @@ namespace Azure.AI.Translation.Document
             {
                 case 200:
                     {
-                        TranslationStatus value = default;
+                        TranslationStatusResult value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        value = TranslationStatus.DeserializeTranslationStatus(document.RootElement);
+                        value = TranslationStatusResult.DeserializeTranslationStatusResult(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentStatusResult.Serialization.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentStatusResult.Serialization.cs
@@ -11,9 +11,9 @@ using Azure.Core;
 
 namespace Azure.AI.Translation.Document
 {
-    public partial class DocumentStatus
+    public partial class DocumentStatusResult
     {
-        internal static DocumentStatus DeserializeDocumentStatus(JsonElement element)
+        internal static DocumentStatusResult DeserializeDocumentStatusResult(JsonElement element)
         {
             Optional<Uri> path = default;
             Uri sourcePath = default;
@@ -93,7 +93,7 @@ namespace Azure.AI.Translation.Document
                     continue;
                 }
             }
-            return new DocumentStatus(path.Value, sourcePath, createdDateTimeUtc, lastActionDateTimeUtc, status, to, error, progress, id, characterCharged);
+            return new DocumentStatusResult(path.Value, sourcePath, createdDateTimeUtc, lastActionDateTimeUtc, status, to, error, progress, id, characterCharged);
         }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentStatusResult.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentStatusResult.cs
@@ -10,26 +10,26 @@ using System;
 namespace Azure.AI.Translation.Document
 {
     /// <summary> Document Status Response. </summary>
-    public partial class DocumentStatus
+    public partial class DocumentStatusResult
     {
-        /// <summary> Initializes a new instance of DocumentStatus. </summary>
+        /// <summary> Initializes a new instance of DocumentStatusResult. </summary>
         /// <param name="sourceDocumentUri"> Location of the source document. </param>
         /// <param name="createdOn"> Operation created date time. </param>
         /// <param name="lastModified"> Date time in which the operation&apos;s status has been updated. </param>
         /// <param name="status"> List of possible statuses for job or document. </param>
-        /// <param name="translatedTo"> To language. </param>
+        /// <param name="translatedToLanguageCode"> To language. </param>
         /// <param name="progress"> Progress of the translation if available. </param>
         /// <param name="id"> Document Id. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="sourceDocumentUri"/>, <paramref name="translatedTo"/>, or <paramref name="id"/> is null. </exception>
-        internal DocumentStatus(Uri sourceDocumentUri, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, string translatedTo, float progress, string id)
+        /// <exception cref="ArgumentNullException"> <paramref name="sourceDocumentUri"/>, <paramref name="translatedToLanguageCode"/>, or <paramref name="id"/> is null. </exception>
+        internal DocumentStatusResult(Uri sourceDocumentUri, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, string translatedToLanguageCode, float progress, string id)
         {
             if (sourceDocumentUri == null)
             {
                 throw new ArgumentNullException(nameof(sourceDocumentUri));
             }
-            if (translatedTo == null)
+            if (translatedToLanguageCode == null)
             {
-                throw new ArgumentNullException(nameof(translatedTo));
+                throw new ArgumentNullException(nameof(translatedToLanguageCode));
             }
             if (id == null)
             {
@@ -40,30 +40,30 @@ namespace Azure.AI.Translation.Document
             CreatedOn = createdOn;
             LastModified = lastModified;
             Status = status;
-            TranslatedTo = translatedTo;
+            TranslatedToLanguageCode = translatedToLanguageCode;
             Progress = progress;
             Id = id;
         }
 
-        /// <summary> Initializes a new instance of DocumentStatus. </summary>
+        /// <summary> Initializes a new instance of DocumentStatusResult. </summary>
         /// <param name="translatedDocumentUri"> Location of the document or folder. </param>
         /// <param name="sourceDocumentUri"> Location of the source document. </param>
         /// <param name="createdOn"> Operation created date time. </param>
         /// <param name="lastModified"> Date time in which the operation&apos;s status has been updated. </param>
         /// <param name="status"> List of possible statuses for job or document. </param>
-        /// <param name="translatedTo"> To language. </param>
+        /// <param name="translatedToLanguageCode"> To language. </param>
         /// <param name="error"> This contains an outer error with error code, message, details, target and an inner error with more descriptive details. </param>
         /// <param name="progress"> Progress of the translation if available. </param>
         /// <param name="id"> Document Id. </param>
         /// <param name="charactersCharged"> Character charged by the API. </param>
-        internal DocumentStatus(Uri translatedDocumentUri, Uri sourceDocumentUri, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, string translatedTo, DocumentTranslationError error, float progress, string id, long charactersCharged)
+        internal DocumentStatusResult(Uri translatedDocumentUri, Uri sourceDocumentUri, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, string translatedToLanguageCode, DocumentTranslationError error, float progress, string id, long charactersCharged)
         {
             TranslatedDocumentUri = translatedDocumentUri;
             SourceDocumentUri = sourceDocumentUri;
             CreatedOn = createdOn;
             LastModified = lastModified;
             Status = status;
-            TranslatedTo = translatedTo;
+            TranslatedToLanguageCode = translatedToLanguageCode;
             Error = error;
             Progress = progress;
             Id = id;

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentStatusResult.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentStatusResult.cs
@@ -17,19 +17,19 @@ namespace Azure.AI.Translation.Document
         /// <param name="createdOn"> Operation created date time. </param>
         /// <param name="lastModified"> Date time in which the operation&apos;s status has been updated. </param>
         /// <param name="status"> List of possible statuses for job or document. </param>
-        /// <param name="translatedToLanguageCode"> To language. </param>
+        /// <param name="translatedTo"> To language. </param>
         /// <param name="progress"> Progress of the translation if available. </param>
         /// <param name="id"> Document Id. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="sourceDocumentUri"/>, <paramref name="translatedToLanguageCode"/>, or <paramref name="id"/> is null. </exception>
-        internal DocumentStatusResult(Uri sourceDocumentUri, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, string translatedToLanguageCode, float progress, string id)
+        /// <exception cref="ArgumentNullException"> <paramref name="sourceDocumentUri"/>, <paramref name="translatedTo"/>, or <paramref name="id"/> is null. </exception>
+        internal DocumentStatusResult(Uri sourceDocumentUri, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, string translatedTo, float progress, string id)
         {
             if (sourceDocumentUri == null)
             {
                 throw new ArgumentNullException(nameof(sourceDocumentUri));
             }
-            if (translatedToLanguageCode == null)
+            if (translatedTo == null)
             {
-                throw new ArgumentNullException(nameof(translatedToLanguageCode));
+                throw new ArgumentNullException(nameof(translatedTo));
             }
             if (id == null)
             {
@@ -40,7 +40,7 @@ namespace Azure.AI.Translation.Document
             CreatedOn = createdOn;
             LastModified = lastModified;
             Status = status;
-            TranslatedToLanguageCode = translatedToLanguageCode;
+            TranslatedTo = translatedTo;
             Progress = progress;
             Id = id;
         }
@@ -51,19 +51,19 @@ namespace Azure.AI.Translation.Document
         /// <param name="createdOn"> Operation created date time. </param>
         /// <param name="lastModified"> Date time in which the operation&apos;s status has been updated. </param>
         /// <param name="status"> List of possible statuses for job or document. </param>
-        /// <param name="translatedToLanguageCode"> To language. </param>
+        /// <param name="translatedTo"> To language. </param>
         /// <param name="error"> This contains an outer error with error code, message, details, target and an inner error with more descriptive details. </param>
         /// <param name="progress"> Progress of the translation if available. </param>
         /// <param name="id"> Document Id. </param>
         /// <param name="charactersCharged"> Character charged by the API. </param>
-        internal DocumentStatusResult(Uri translatedDocumentUri, Uri sourceDocumentUri, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, string translatedToLanguageCode, DocumentTranslationError error, float progress, string id, long charactersCharged)
+        internal DocumentStatusResult(Uri translatedDocumentUri, Uri sourceDocumentUri, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, string translatedTo, DocumentTranslationError error, float progress, string id, long charactersCharged)
         {
             TranslatedDocumentUri = translatedDocumentUri;
             SourceDocumentUri = sourceDocumentUri;
             CreatedOn = createdOn;
             LastModified = lastModified;
             Status = status;
-            TranslatedToLanguageCode = translatedToLanguageCode;
+            TranslatedTo = translatedTo;
             Error = error;
             Progress = progress;
             Id = id;

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentTranslationFileFormat.Serialization.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentTranslationFileFormat.Serialization.cs
@@ -11,9 +11,9 @@ using Azure.Core;
 
 namespace Azure.AI.Translation.Document
 {
-    public partial class FileFormat
+    public partial class DocumentTranslationFileFormat
     {
-        internal static FileFormat DeserializeFileFormat(JsonElement element)
+        internal static DocumentTranslationFileFormat DeserializeDocumentTranslationFileFormat(JsonElement element)
         {
             string format = default;
             IReadOnlyList<string> fileExtensions = default;
@@ -68,7 +68,7 @@ namespace Azure.AI.Translation.Document
                     continue;
                 }
             }
-            return new FileFormat(format, fileExtensions, contentTypes, defaultVersion.Value, Optional.ToList(versions));
+            return new DocumentTranslationFileFormat(format, fileExtensions, contentTypes, defaultVersion.Value, Optional.ToList(versions));
         }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentTranslationFileFormat.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentTranslationFileFormat.cs
@@ -13,14 +13,14 @@ using Azure.Core;
 namespace Azure.AI.Translation.Document
 {
     /// <summary> The FileFormat. </summary>
-    public partial class FileFormat
+    public partial class DocumentTranslationFileFormat
     {
-        /// <summary> Initializes a new instance of FileFormat. </summary>
+        /// <summary> Initializes a new instance of DocumentTranslationFileFormat. </summary>
         /// <param name="format"> Name of the format. </param>
         /// <param name="fileExtensions"> Supported file extension for this format. </param>
         /// <param name="contentTypes"> Supported Content-Types for this format. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="format"/>, <paramref name="fileExtensions"/>, or <paramref name="contentTypes"/> is null. </exception>
-        internal FileFormat(string format, IEnumerable<string> fileExtensions, IEnumerable<string> contentTypes)
+        internal DocumentTranslationFileFormat(string format, IEnumerable<string> fileExtensions, IEnumerable<string> contentTypes)
         {
             if (format == null)
             {
@@ -41,13 +41,13 @@ namespace Azure.AI.Translation.Document
             FormatVersions = new ChangeTrackingList<string>();
         }
 
-        /// <summary> Initializes a new instance of FileFormat. </summary>
+        /// <summary> Initializes a new instance of DocumentTranslationFileFormat. </summary>
         /// <param name="format"> Name of the format. </param>
         /// <param name="fileExtensions"> Supported file extension for this format. </param>
         /// <param name="contentTypes"> Supported Content-Types for this format. </param>
         /// <param name="defaultFormatVersion"> Default version if none is specified. </param>
         /// <param name="formatVersions"> Supported Version. </param>
-        internal FileFormat(string format, IReadOnlyList<string> fileExtensions, IReadOnlyList<string> contentTypes, string defaultFormatVersion, IReadOnlyList<string> formatVersions)
+        internal DocumentTranslationFileFormat(string format, IReadOnlyList<string> fileExtensions, IReadOnlyList<string> contentTypes, string defaultFormatVersion, IReadOnlyList<string> formatVersions)
         {
             Format = format;
             FileExtensions = fileExtensions;

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentsStatus.Serialization.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentsStatus.Serialization.cs
@@ -16,16 +16,16 @@ namespace Azure.AI.Translation.Document.Models
     {
         internal static DocumentsStatus DeserializeDocumentsStatus(JsonElement element)
         {
-            IReadOnlyList<DocumentStatus> value = default;
+            IReadOnlyList<DocumentStatusResult> value = default;
             Optional<string> nextLink = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("value"))
                 {
-                    List<DocumentStatus> array = new List<DocumentStatus>();
+                    List<DocumentStatusResult> array = new List<DocumentStatusResult>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(DocumentStatus.DeserializeDocumentStatus(item));
+                        array.Add(DocumentStatusResult.DeserializeDocumentStatusResult(item));
                     }
                     value = array;
                     continue;

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentsStatus.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/DocumentsStatus.cs
@@ -18,7 +18,7 @@ namespace Azure.AI.Translation.Document.Models
         /// <summary> Initializes a new instance of DocumentsStatus. </summary>
         /// <param name="value"> The detail status of individual documents. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
-        internal DocumentsStatus(IEnumerable<DocumentStatus> value)
+        internal DocumentsStatus(IEnumerable<DocumentStatusResult> value)
         {
             if (value == null)
             {
@@ -31,14 +31,14 @@ namespace Azure.AI.Translation.Document.Models
         /// <summary> Initializes a new instance of DocumentsStatus. </summary>
         /// <param name="value"> The detail status of individual documents. </param>
         /// <param name="nextLink"> Url for the next page.  Null if no more pages available. </param>
-        internal DocumentsStatus(IReadOnlyList<DocumentStatus> value, string nextLink)
+        internal DocumentsStatus(IReadOnlyList<DocumentStatusResult> value, string nextLink)
         {
             Value = value;
             NextLink = nextLink;
         }
 
         /// <summary> The detail status of individual documents. </summary>
-        public IReadOnlyList<DocumentStatus> Value { get; }
+        public IReadOnlyList<DocumentStatusResult> Value { get; }
         /// <summary> Url for the next page.  Null if no more pages available. </summary>
         public string NextLink { get; }
     }

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/SupportedFileFormats.Serialization.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/SupportedFileFormats.Serialization.cs
@@ -16,15 +16,15 @@ namespace Azure.AI.Translation.Document.Models
     {
         internal static SupportedFileFormats DeserializeSupportedFileFormats(JsonElement element)
         {
-            IReadOnlyList<FileFormat> value = default;
+            IReadOnlyList<DocumentTranslationFileFormat> value = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("value"))
                 {
-                    List<FileFormat> array = new List<FileFormat>();
+                    List<DocumentTranslationFileFormat> array = new List<DocumentTranslationFileFormat>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(FileFormat.DeserializeFileFormat(item));
+                        array.Add(DocumentTranslationFileFormat.DeserializeDocumentTranslationFileFormat(item));
                     }
                     value = array;
                     continue;

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/SupportedFileFormats.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/SupportedFileFormats.cs
@@ -18,7 +18,7 @@ namespace Azure.AI.Translation.Document.Models
         /// <summary> Initializes a new instance of SupportedFileFormats. </summary>
         /// <param name="value"> list of objects. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
-        internal SupportedFileFormats(IEnumerable<FileFormat> value)
+        internal SupportedFileFormats(IEnumerable<DocumentTranslationFileFormat> value)
         {
             if (value == null)
             {
@@ -30,12 +30,12 @@ namespace Azure.AI.Translation.Document.Models
 
         /// <summary> Initializes a new instance of SupportedFileFormats. </summary>
         /// <param name="value"> list of objects. </param>
-        internal SupportedFileFormats(IReadOnlyList<FileFormat> value)
+        internal SupportedFileFormats(IReadOnlyList<DocumentTranslationFileFormat> value)
         {
             Value = value;
         }
 
         /// <summary> list of objects. </summary>
-        public IReadOnlyList<FileFormat> Value { get; }
+        public IReadOnlyList<DocumentTranslationFileFormat> Value { get; }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/TranslationStatusResult.Serialization.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/TranslationStatusResult.Serialization.cs
@@ -12,9 +12,9 @@ using Azure.Core;
 
 namespace Azure.AI.Translation.Document
 {
-    public partial class TranslationStatus
+    public partial class TranslationStatusResult
     {
-        internal static TranslationStatus DeserializeTranslationStatus(JsonElement element)
+        internal static TranslationStatusResult DeserializeTranslationStatusResult(JsonElement element)
         {
             string id = default;
             DateTimeOffset createdDateTimeUtc = default;
@@ -60,7 +60,7 @@ namespace Azure.AI.Translation.Document
                     continue;
                 }
             }
-            return new TranslationStatus(id, createdDateTimeUtc, lastActionDateTimeUtc, status, Optional.ToNullable(error), summary);
+            return new TranslationStatusResult(id, createdDateTimeUtc, lastActionDateTimeUtc, status, Optional.ToNullable(error), summary);
         }
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/TranslationStatusResult.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/TranslationStatusResult.cs
@@ -11,16 +11,16 @@ using Azure.AI.Translation.Document.Models;
 namespace Azure.AI.Translation.Document
 {
     /// <summary> Translation job status response. </summary>
-    public partial class TranslationStatus
+    public partial class TranslationStatusResult
     {
-        /// <summary> Initializes a new instance of TranslationStatus. </summary>
+        /// <summary> Initializes a new instance of TranslationStatusResult. </summary>
         /// <param name="id"> Id of the operation. </param>
         /// <param name="createdOn"> Operation created date time. </param>
         /// <param name="lastModified"> Date time in which the operation&apos;s status has been updated. </param>
         /// <param name="status"> List of possible statuses for job or document. </param>
         /// <param name="summary"></param>
         /// <exception cref="ArgumentNullException"> <paramref name="id"/> or <paramref name="summary"/> is null. </exception>
-        internal TranslationStatus(string id, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, StatusSummary summary)
+        internal TranslationStatusResult(string id, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, StatusSummary summary)
         {
             if (id == null)
             {
@@ -38,14 +38,14 @@ namespace Azure.AI.Translation.Document
             Summary = summary;
         }
 
-        /// <summary> Initializes a new instance of TranslationStatus. </summary>
+        /// <summary> Initializes a new instance of TranslationStatusResult. </summary>
         /// <param name="id"> Id of the operation. </param>
         /// <param name="createdOn"> Operation created date time. </param>
         /// <param name="lastModified"> Date time in which the operation&apos;s status has been updated. </param>
         /// <param name="status"> List of possible statuses for job or document. </param>
         /// <param name="error"> This contains an outer error with error code, message, details, target and an inner error with more descriptive details. </param>
         /// <param name="summary"></param>
-        internal TranslationStatus(string id, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, DocumentTranslationError? error, StatusSummary summary)
+        internal TranslationStatusResult(string id, DateTimeOffset createdOn, DateTimeOffset lastModified, DocumentTranslationStatus status, DocumentTranslationError? error, StatusSummary summary)
         {
             Id = id;
             CreatedOn = createdOn;

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/TranslationsStatus.Serialization.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/TranslationsStatus.Serialization.cs
@@ -16,16 +16,16 @@ namespace Azure.AI.Translation.Document.Models
     {
         internal static TranslationsStatus DeserializeTranslationsStatus(JsonElement element)
         {
-            IReadOnlyList<TranslationStatus> value = default;
+            IReadOnlyList<TranslationStatusResult> value = default;
             Optional<string> nextLink = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("value"))
                 {
-                    List<TranslationStatus> array = new List<TranslationStatus>();
+                    List<TranslationStatusResult> array = new List<TranslationStatusResult>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(TranslationStatus.DeserializeTranslationStatus(item));
+                        array.Add(TranslationStatusResult.DeserializeTranslationStatusResult(item));
                     }
                     value = array;
                     continue;

--- a/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/TranslationsStatus.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Generated/Models/TranslationsStatus.cs
@@ -18,7 +18,7 @@ namespace Azure.AI.Translation.Document.Models
         /// <summary> Initializes a new instance of TranslationsStatus. </summary>
         /// <param name="value"> The summary status of individual operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
-        internal TranslationsStatus(IEnumerable<TranslationStatus> value)
+        internal TranslationsStatus(IEnumerable<TranslationStatusResult> value)
         {
             if (value == null)
             {
@@ -31,14 +31,14 @@ namespace Azure.AI.Translation.Document.Models
         /// <summary> Initializes a new instance of TranslationsStatus. </summary>
         /// <param name="value"> The summary status of individual operation. </param>
         /// <param name="nextLink"> Url for the next page.  Null if no more pages available. </param>
-        internal TranslationsStatus(IReadOnlyList<TranslationStatus> value, string nextLink)
+        internal TranslationsStatus(IReadOnlyList<TranslationStatusResult> value, string nextLink)
         {
             Value = value;
             NextLink = nextLink;
         }
 
         /// <summary> The summary status of individual operation. </summary>
-        public IReadOnlyList<TranslationStatus> Value { get; }
+        public IReadOnlyList<TranslationStatusResult> Value { get; }
         /// <summary> Url for the next page.  Null if no more pages available. </summary>
         public string NextLink { get; }
     }

--- a/sdk/translation/Azure.AI.Translation.Document/src/GetDocumentStatusesOptions.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/GetDocumentStatusesOptions.cs
@@ -20,17 +20,17 @@ namespace Azure.AI.Translation.Document
         {
         }
         /// <summary>
-        /// Filter results by <see cref="DocumentStatus.CreatedOn"/>.
+        /// Filter results by <see cref="DocumentStatusResult.CreatedOn"/>.
         /// Get documents created after a certain date in UTC format.
         /// </summary>
         public DateTimeOffset ? CreatedAfter { get; set; }
         /// <summary>
-        /// Filter results by <see cref="DocumentStatus.CreatedOn"/>.
+        /// Filter results by <see cref="DocumentStatusResult.CreatedOn"/>.
         /// Get documents created before a certain date in UTC format.
         /// </summary>
         public DateTimeOffset ? CreatedBefore { get; set; }
         /// <summary>
-        /// Filter results by <see cref="DocumentStatus.Id"/>.
+        /// Filter results by <see cref="DocumentStatusResult.Id"/>.
         /// </summary>
         public IList<string> Ids { get; } = new List<string>();
         /// <summary>
@@ -39,7 +39,7 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         public IList<DocumentFilterOrder> OrderBy { get; } = new List<DocumentFilterOrder>();
         /// <summary>
-        /// Filter results by <see cref="DocumentStatus.Status"/>.
+        /// Filter results by <see cref="DocumentStatusResult.Status"/>.
         /// See <see cref="DocumentTranslationStatus"/> to know which statuses to use.
         /// </summary>
         public IList<DocumentTranslationStatus> Statuses { get; } = new List<DocumentTranslationStatus>();

--- a/sdk/translation/Azure.AI.Translation.Document/src/GetTranslationStatusesOptions.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/GetTranslationStatusesOptions.cs
@@ -19,17 +19,17 @@ namespace Azure.AI.Translation.Document
         {
         }
         /// <summary>
-        /// Filter results by <see cref="TranslationStatus.CreatedOn"/>.
+        /// Filter results by <see cref="TranslationStatusResult.CreatedOn"/>.
         /// Get translations created after a certain date in UTC format.
         /// </summary>
         public DateTimeOffset? CreatedAfter { get; set; }
         /// <summary>
-        /// Filter results by <see cref="TranslationStatus.CreatedOn"/>.
+        /// Filter results by <see cref="TranslationStatusResult.CreatedOn"/>.
         /// Get translations created before a certain date in UTC format.
         /// </summary>
         public DateTimeOffset? CreatedBefore { get; set; }
         /// <summary>
-        /// Filter results by <see cref="TranslationStatus.Id"/>.
+        /// Filter results by <see cref="TranslationStatusResult.Id"/>.
         /// </summary>
         public IList<string> Ids { get; } = new List<string>();
         /// <summary>
@@ -38,7 +38,7 @@ namespace Azure.AI.Translation.Document
         /// </summary>
         public IList<TranslationFilterOrder> OrderBy { get; } = new List<TranslationFilterOrder>();
         /// <summary>
-        /// Filter results by <see cref="TranslationStatus.Status"/>.
+        /// Filter results by <see cref="TranslationStatusResult.Status"/>.
         /// See <see cref="DocumentTranslationStatus"/> to know which statuses to use.
         /// </summary>
         public IList<DocumentTranslationStatus> Statuses { get; } = new List<DocumentTranslationStatus>();

--- a/sdk/translation/Azure.AI.Translation.Document/src/TranslationFilterProperty.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/TranslationFilterProperty.cs
@@ -10,7 +10,7 @@ namespace Azure.AI.Translation.Document
     public enum TranslationFilterProperty
     {
         /// <summary>
-        /// Sorting property corresponding to <see cref="TranslationStatus.CreatedOn"/>.
+        /// Sorting property corresponding to <see cref="TranslationStatusResult.CreatedOn"/>.
         /// </summary>
         CreatedOn = 0,
     }

--- a/sdk/translation/Azure.AI.Translation.Document/src/TranslationGlossary.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/TranslationGlossary.cs
@@ -26,7 +26,7 @@ namespace Azure.AI.Translation.Document
 
         /// <summary>
         /// Optional file format version. If not specified, the service will
-        /// use the <see cref="FileFormat.DefaultFormatVersion"/> for the file format returned from the
+        /// use the <see cref="DocumentTranslationFileFormat.DefaultFormatVersion"/> for the file format returned from the
         /// <see cref="DocumentTranslationClient.GetSupportedGlossaryFormatsAsync(System.Threading.CancellationToken)"/> client method.
         /// </summary>
         [CodeGenMember("Version")]

--- a/sdk/translation/Azure.AI.Translation.Document/src/TranslationStatusResult.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/TranslationStatusResult.cs
@@ -11,7 +11,7 @@ namespace Azure.AI.Translation.Document
     /// Status information about the translation operation.
     /// </summary>
     [CodeGenModel("TranslationStatus")]
-    public partial class TranslationStatus
+    public partial class TranslationStatusResult
     {
         /// <summary>
         /// Id of the translation operation.

--- a/sdk/translation/Azure.AI.Translation.Document/tests/DocumentTranslationClientLiveTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/DocumentTranslationClientLiveTests.cs
@@ -40,7 +40,7 @@ namespace Azure.AI.Translation.Document.Tests
             var documentFormats = await client.GetSupportedDocumentFormatsAsync();
 
             Assert.GreaterOrEqual(documentFormats.Value.Count, 0);
-            foreach (FileFormat fileFormat in documentFormats.Value)
+            foreach (DocumentTranslationFileFormat fileFormat in documentFormats.Value)
             {
                 Assert.IsFalse(string.IsNullOrEmpty(fileFormat.Format));
                 Assert.IsNotNull(fileFormat.FileExtensions);
@@ -58,7 +58,7 @@ namespace Azure.AI.Translation.Document.Tests
             var glossaryFormats = await client.GetSupportedGlossaryFormatsAsync();
 
             Assert.GreaterOrEqual(glossaryFormats.Value.Count, 0);
-            foreach (FileFormat glossaryFormat in glossaryFormats.Value)
+            foreach (DocumentTranslationFileFormat glossaryFormat in glossaryFormats.Value)
             {
                 Assert.IsFalse(string.IsNullOrEmpty(glossaryFormat.Format));
                 Assert.IsNotNull(glossaryFormat.FileExtensions);

--- a/sdk/translation/Azure.AI.Translation.Document/tests/DocumentTranslationClientLiveTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/DocumentTranslationClientLiveTests.cs
@@ -84,10 +84,10 @@ namespace Azure.AI.Translation.Document.Tests
             var input = new DocumentTranslationInput(source, target, "fr");
             await client.StartTranslationAsync(input);
 
-            List<TranslationStatus> translations = await client.GetTranslationStatusesAsync().ToEnumerableAsync();
+            List<TranslationStatusResult> translations = await client.GetTranslationStatusesAsync().ToEnumerableAsync();
 
             Assert.GreaterOrEqual(translations.Count, 1);
-            TranslationStatus oneTranslation = translations[0];
+            TranslationStatusResult oneTranslation = translations[0];
             Assert.AreNotEqual(new DateTimeOffset(), oneTranslation.CreatedOn);
             Assert.AreNotEqual(new DateTimeOffset(), oneTranslation.LastModified);
             Assert.GreaterOrEqual(oneTranslation.DocumentsCanceled, 0);

--- a/sdk/translation/Azure.AI.Translation.Document/tests/TranslationOperationLiveTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/TranslationOperationLiveTests.cs
@@ -201,14 +201,14 @@ namespace Azure.AI.Translation.Document.Tests
             var input = new DocumentTranslationInput(sourceUri, targetUri, translateTo);
             DocumentTranslationOperation operation = await client.StartTranslationAsync(input);
 
-            AsyncPageable<DocumentStatus> documentsFromOperation = await operation.WaitForCompletionAsync();
-            List<DocumentStatus> documentsFromOperationList = await documentsFromOperation.ToEnumerableAsync();
+            AsyncPageable<DocumentStatusResult> documentsFromOperation = await operation.WaitForCompletionAsync();
+            List<DocumentStatusResult> documentsFromOperationList = await documentsFromOperation.ToEnumerableAsync();
 
             Assert.AreEqual(1, documentsFromOperationList.Count);
             CheckDocumentStatus(documentsFromOperationList[0], translateTo);
 
-            AsyncPageable<DocumentStatus> documentsFromGetDocStatuses = operation.GetDocumentStatusesAsync();
-            List<DocumentStatus> documentsFromGetDocStatusesList = await documentsFromGetDocStatuses.ToEnumerableAsync();
+            AsyncPageable<DocumentStatusResult> documentsFromGetDocStatuses = operation.GetDocumentStatusesAsync();
+            List<DocumentStatusResult> documentsFromGetDocStatusesList = await documentsFromGetDocStatuses.ToEnumerableAsync();
 
             Assert.AreEqual(documentsFromOperationList[0].Status, documentsFromGetDocStatusesList[0].Status);
             Assert.AreEqual(documentsFromOperationList[0].Id, documentsFromGetDocStatusesList[0].Id);
@@ -233,13 +233,13 @@ namespace Azure.AI.Translation.Document.Tests
             DocumentTranslationOperation operation = await client.StartTranslationAsync(input);
 
             await operation.WaitForCompletionAsync();
-            AsyncPageable<DocumentStatus> documents = operation.GetDocumentStatusesAsync();
+            AsyncPageable<DocumentStatusResult> documents = operation.GetDocumentStatusesAsync();
 
-            List<DocumentStatus> documentsList = await documents.ToEnumerableAsync();
+            List<DocumentStatusResult> documentsList = await documents.ToEnumerableAsync();
 
             Assert.AreEqual(1, documentsList.Count);
 
-            DocumentStatus document = await operation.GetDocumentStatusAsync(documentsList[0].Id);
+            DocumentStatusResult document = await operation.GetDocumentStatusAsync(documentsList[0].Id);
 
             CheckDocumentStatus(document, translateTo);
         }
@@ -336,7 +336,7 @@ namespace Azure.AI.Translation.Document.Tests
             var input = new DocumentTranslationInput(source, target, "fr");
             DocumentTranslationOperation operation = await client.StartTranslationAsync(input);
 
-            AsyncPageable<DocumentStatus> documents = await operation.WaitForCompletionAsync();
+            AsyncPageable<DocumentStatusResult> documents = await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasCompleted);
             Assert.IsTrue(operation.HasValue);
@@ -349,7 +349,7 @@ namespace Azure.AI.Translation.Document.Tests
             Assert.AreEqual(0, operation.DocumentsInProgress);
             Assert.AreEqual(0, operation.DocumentsNotStarted);
 
-            List<DocumentStatus> documentsList = await documents.ToEnumerableAsync();
+            List<DocumentStatusResult> documentsList = await documents.ToEnumerableAsync();
             Assert.AreEqual(1, documentsList.Count);
             Assert.AreEqual(DocumentTranslationStatus.Failed, documentsList[0].Status);
             Assert.AreEqual(new DocumentTranslationErrorCode("WrongDocumentEncoding"), documentsList[0].Error.ErrorCode);
@@ -366,7 +366,7 @@ namespace Azure.AI.Translation.Document.Tests
             var input = new DocumentTranslationInput(source, target, "fr");
             DocumentTranslationOperation operation = await client.StartTranslationAsync(input);
 
-            AsyncPageable<DocumentStatus> documents = await operation.WaitForCompletionAsync();
+            AsyncPageable<DocumentStatusResult> documents = await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasCompleted);
             Assert.IsTrue(operation.HasValue);
@@ -379,7 +379,7 @@ namespace Azure.AI.Translation.Document.Tests
             Assert.AreEqual(0, operation.DocumentsInProgress);
             Assert.AreEqual(0, operation.DocumentsNotStarted);
 
-            List<DocumentStatus> documentsList = await documents.ToEnumerableAsync();
+            List<DocumentStatusResult> documentsList = await documents.ToEnumerableAsync();
             Assert.AreEqual(1, documentsList.Count);
             Assert.AreEqual(DocumentTranslationStatus.Failed, documentsList[0].Status);
             Assert.AreEqual(new DocumentTranslationErrorCode("TargetFileAlreadyExists"), documentsList[0].Error.ErrorCode);
@@ -465,7 +465,7 @@ namespace Azure.AI.Translation.Document.Tests
             }
         }
 
-        private void CheckDocumentStatus(DocumentStatus document, string translateTo)
+        private void CheckDocumentStatus(DocumentStatusResult document, string translateTo)
         {
             Assert.AreEqual(DocumentTranslationStatus.Succeeded, document.Status);
             Assert.IsFalse(string.IsNullOrEmpty(document.Id));

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_DocumentStatus.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_DocumentStatus.cs
@@ -46,8 +46,8 @@ namespace Azure.AI.Translation.Document.Samples
             {
                 operation.UpdateStatus();
 
-                Pageable<DocumentStatus> documentsStatus = operation.GetDocumentStatuses();
-                foreach (DocumentStatus docStatus in documentsStatus)
+                Pageable<DocumentStatusResult> documentsStatus = operation.GetDocumentStatuses();
+                foreach (DocumentStatusResult docStatus in documentsStatus)
                 {
                     if (documentscompleted.Contains(docStatus.Id))
                         continue;

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_DocumentStatusAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_DocumentStatusAsync.cs
@@ -45,8 +45,8 @@ namespace Azure.AI.Translation.Document.Samples
             {
                 await operation.UpdateStatusAsync();
 
-                AsyncPageable<DocumentStatus> documentsStatus = operation.GetDocumentStatusesAsync();
-                await foreach (DocumentStatus docStatus in documentsStatus)
+                AsyncPageable<DocumentStatusResult> documentsStatus = operation.GetDocumentStatusesAsync();
+                await foreach (DocumentStatusResult docStatus in documentsStatus)
                 {
                     if (documentscompleted.Contains(docStatus.Id))
                         continue;

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputs.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputs.cs
@@ -88,7 +88,7 @@ namespace Azure.AI.Translation.Document.Samples
                 }
             }
 
-            foreach (DocumentStatus document in operation.GetValues())
+            foreach (DocumentStatusResult document in operation.GetValues())
             {
                 Console.WriteLine($"Document with Id: {document.Id}");
                 Console.WriteLine($"  Status:{document.Status}");

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputsAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputsAsync.cs
@@ -63,7 +63,7 @@ namespace Azure.AI.Translation.Document.Samples
 
             await operation.WaitForCompletionAsync();
 
-            await foreach (DocumentStatus document in operation.GetValuesAsync())
+            await foreach (DocumentStatusResult document in operation.GetValuesAsync())
             {
                 Console.WriteLine($"Document with Id: {document.Id}");
                 Console.WriteLine($"  Status:{document.Status}");

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistory.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistory.cs
@@ -34,7 +34,7 @@ namespace Azure.AI.Translation.Document.Samples
 
             TimeSpan pollingInterval = new(1000);
 
-            foreach (TranslationStatus translationStatus in client.GetTranslationStatuses())
+            foreach (TranslationStatusResult translationStatus in client.GetTranslationStatuses())
             {
                 if (translationStatus.Status == DocumentTranslationStatus.NotStarted ||
                     translationStatus.Status == DocumentTranslationStatus.Running)

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistoryAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistoryAsync.cs
@@ -33,7 +33,7 @@ namespace Azure.AI.Translation.Document.Samples
             int docsSucceeded = 0;
             int docsFailed = 0;
 
-            await foreach (TranslationStatus translationStatus in client.GetTranslationStatusesAsync())
+            await foreach (TranslationStatusResult translationStatus in client.GetTranslationStatusesAsync())
             {
                 if (translationStatus.Status == DocumentTranslationStatus.NotStarted ||
                     translationStatus.Status == DocumentTranslationStatus.Running)

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocuments.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocuments.cs
@@ -37,11 +37,11 @@ namespace Azure.AI.Translation.Document.Samples
 
             TimeSpan pollingInterval = new(1000);
 
-            foreach (DocumentStatus document in operation.GetDocumentStatuses())
+            foreach (DocumentStatusResult document in operation.GetDocumentStatuses())
             {
                 Console.WriteLine($"Polling Status for document{document.SourceDocumentUri}");
 
-                Response<DocumentStatus> responseDocumentStatus = operation.GetDocumentStatus(document.Id);
+                Response<DocumentStatusResult> responseDocumentStatus = operation.GetDocumentStatus(document.Id);
 
                 while (responseDocumentStatus.Value.Status != DocumentTranslationStatus.Failed &&
                           responseDocumentStatus.Value.Status != DocumentTranslationStatus.Succeeded)

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocumentsAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocumentsAsync.cs
@@ -41,11 +41,11 @@ namespace Azure.AI.Translation.Document.Samples
 
             TimeSpan pollingInterval = new(1000);
 
-            await foreach (DocumentStatus document in operation.GetDocumentStatusesAsync())
+            await foreach (DocumentStatusResult document in operation.GetDocumentStatusesAsync())
             {
                 Console.WriteLine($"Polling Status for document{document.SourceDocumentUri}");
 
-                Response<DocumentStatus> responseDocumentStatus = await operation.GetDocumentStatusAsync(document.Id);
+                Response<DocumentStatusResult> responseDocumentStatus = await operation.GetDocumentStatusAsync(document.Id);
 
                 while (responseDocumentStatus.Value.Status != DocumentTranslationStatus.Failed &&
                           responseDocumentStatus.Value.Status != DocumentTranslationStatus.Succeeded)

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslation.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslation.cs
@@ -67,7 +67,7 @@ namespace Azure.AI.Translation.Document.Samples
                 }
             }
 
-            foreach (DocumentStatus document in operation.GetValues())
+            foreach (DocumentStatusResult document in operation.GetValues())
             {
                 Console.WriteLine($"Document with Id: {document.Id}");
                 Console.WriteLine($"  Status:{document.Status}");

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslationAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslationAsync.cs
@@ -49,7 +49,7 @@ namespace Azure.AI.Translation.Document.Samples
             Console.WriteLine($"    In Progress: {operation.DocumentsInProgress}");
             Console.WriteLine($"    Not started: {operation.DocumentsNotStarted}");
 
-            await foreach (DocumentStatus document in operation.Value)
+            await foreach (DocumentStatusResult document in operation.Value)
             {
                 Console.WriteLine($"Document with Id: {document.Id}");
                 Console.WriteLine($"  Status:{document.Status}");

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslationWithAzureBlob.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslationWithAzureBlob.cs
@@ -103,7 +103,7 @@ namespace Azure.AI.Translation.Document.Samples
             Console.WriteLine($"{operationResult.DocumentsFailed} failed");
             Console.WriteLine($"{operationResult.DocumentsSucceeded} succeeded");
 
-            await foreach (DocumentStatus document in operationResult.GetDocumentStatusesAsync())
+            await foreach (DocumentStatusResult document in operationResult.GetDocumentStatusesAsync())
             {
                 if (document.Status == DocumentTranslationStatus.Succeeded)
                 {


### PR DESCRIPTION
Renamed DocumentStatus to DocumentStatusResult  and TranslationStatus to TranslationStatusResult as was mentioned in the issue [#23349](https://github.com/Azure/azure-sdk-for-net/issues/23349)

Renamed FileFormat to DocumentTranslationFileFormat as was mentioned in the issue [#23351](https://github.com/Azure/azure-sdk-for-net/issues/23351)