### PR TITLE
Refactor TelemetryPartA and TelemetryPartB

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -31,7 +31,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         internal static string RoleInstance { get; set; }
 
+#pragma warning disable CA1801 // Review unused parameters
         internal static TelemetryItem GetTelemetryItem(Activity activity, ref TagEnumerationState monitorTags, Resource resource, string instrumentationKey)
+#pragma warning restore CA1801 // Review unused parameters
         {
             TelemetryItem telemetryItem = new TelemetryItem(PartA_Name_Mapping[activity.GetTelemetryType()], FormatUtcTimestamp(activity.StartTimeUtc))
             {
@@ -49,8 +51,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             }
 
             telemetryItem.Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.SdkVersion;
-
-            telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()] = GetOperationName(ref monitorTags.PartBTags);
 
             return telemetryItem;
         }
@@ -129,12 +129,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         internal static string FormatUtcTimestamp(System.DateTime utcTimestamp)
         {
             return utcTimestamp.ToString(DateTimeFormat, CultureInfo.InvariantCulture);
-        }
-
-        private static string GetOperationName(ref AzMonList partBTags)
-        {
-            // replace with correct implementation
-            return AzMonList.GetTagValue(ref partBTags, SemanticConventions.AttributeHttpMethod)?.ToString();
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -31,7 +31,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         internal static string RoleInstance { get; set; }
 
-        internal static TelemetryItem GetTelemetryItem(Activity activity, Resource resource, string instrumentationKey)
+        internal static TelemetryItem GetTelemetryItem(Activity activity, ref TagEnumerationState monitorTags, Resource resource, string instrumentationKey)
         {
             TelemetryItem telemetryItem = new TelemetryItem(PartA_Name_Mapping[activity.GetTelemetryType()], FormatUtcTimestamp(activity.StartTimeUtc))
             {
@@ -49,6 +49,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             }
 
             telemetryItem.Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.SdkVersion;
+
+            telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()] = GetOperationName(ref monitorTags.PartBTags);
 
             return telemetryItem;
         }
@@ -127,6 +129,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         internal static string FormatUtcTimestamp(System.DateTime utcTimestamp)
         {
             return utcTimestamp.ToString(DateTimeFormat, CultureInfo.InvariantCulture);
+        }
+
+        private static string GetOperationName(ref AzMonList partBTags)
+        {
+            // replace with correct implementation
+            return AzMonList.GetTagValue(ref partBTags, SemanticConventions.AttributeHttpMethod)?.ToString();
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartB.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartB.cs
@@ -28,10 +28,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes
         internal static readonly HashSet<string> SqlDbs = new HashSet<string>() {"mssql"};
 
-        internal static RequestData GetRequestData(Activity activity)
+        internal static RequestData GetRequestData(Activity activity, ref TagEnumerationState monitorTags)
         {
             string url = null;
-            var monitorTags = EnumerateActivityTags(activity);
 
             AddActivityLinksToPartCTags(activity.Links, ref monitorTags.PartCTags);
 
@@ -58,10 +57,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             return request;
         }
 
-        internal static RemoteDependencyData GetRemoteDependencyData(Activity activity)
+        internal static RemoteDependencyData GetRemoteDependencyData(Activity activity, ref TagEnumerationState monitorTags)
         {
-            var monitorTags = EnumerateActivityTags(activity);
-
             AddActivityLinksToPartCTags(activity.Links, ref monitorTags.PartCTags);
 
             var dependency = new RemoteDependencyData(2, activity.DisplayName, activity.Duration.ToString("c", CultureInfo.InvariantCulture))
@@ -108,18 +105,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 SeverityLevel = GetSeverityLevel(logRecord.LogLevel),
             };
-        }
-
-        private static TagEnumerationState EnumerateActivityTags(Activity activity)
-        {
-            var monitorTags = new TagEnumerationState
-            {
-                PartBTags = AzMonList.Initialize(),
-                PartCTags = AzMonList.Initialize()
-            };
-
-            monitorTags.ForEach(activity.TagObjects);
-            return monitorTags;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
@@ -121,7 +121,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 
             var resource = CreateTestResource();
 
-            var telemetryItem = TelemetryPartA.GetTelemetryItem(activity, resource, null);
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var telemetryItem = TelemetryPartA.GetTelemetryItem(activity, ref monitorTags, resource, null);
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryPartA.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
@@ -144,7 +146,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 
             var resource = CreateTestResource(serviceName: "my-service", serviceInstance: "my-instance");
 
-            var telemetryItem = TelemetryPartA.GetTelemetryItem(activity, resource, null);
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var telemetryItem = TelemetryPartA.GetTelemetryItem(activity, ref monitorTags, resource, null);
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryPartA.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
@@ -166,7 +170,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
                 startTime: DateTime.UtcNow);
             var resource = CreateTestResource();
 
-            var telemetryItem = TelemetryPartA.GetTelemetryItem(activity, resource, null);
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var telemetryItem = TelemetryPartA.GetTelemetryItem(activity, ref monitorTags, resource, null);
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryPartA.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
@@ -47,7 +47,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             activity.SetStatus(Status.Ok);
             activity.SetTag(SemanticConventions.AttributeHttpUrl, httpUrl); // only adding test via http.url. all possible combinations are covered in HttpHelperTests.
             activity.SetTag(SemanticConventions.AttributeHttpStatusCode, null);
-            var requestData = TelemetryPartB.GetRequestData(activity);
+
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var requestData = TelemetryPartB.GetRequestData(activity, ref monitorTags);
 
             Assert.Equal(activity.DisplayName, requestData.Name);
             Assert.Equal(activity.Context.SpanId.ToHexString(), requestData.Id);
@@ -75,7 +78,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             var httpResponsCode = httpStatusCode ?? "0";
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/search");
             activity.SetTag(SemanticConventions.AttributeHttpStatusCode, httpStatusCode);
-            var requestData = TelemetryPartB.GetRequestData(activity);
+
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var requestData = TelemetryPartB.GetRequestData(activity, ref monitorTags);
 
             Assert.Equal(httpResponsCode, requestData.ResponseCode);
         }
@@ -106,7 +112,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
                 activity.SetStatus(Status.Unset);
             }
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/search");
-            var requestData = TelemetryPartB.GetRequestData(activity);
+
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var requestData = TelemetryPartB.GetRequestData(activity, ref monitorTags);
 
             Assert.Equal(activity.GetStatus() != Status.Error, requestData.Success);
         }
@@ -124,7 +133,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
                 startTime: DateTime.UtcNow);
 
             activity.SetTag(SemanticConventions.AttributeDbSystem, dbSystem);
-            var remoteDependencyDataType = TelemetryPartB.GetRemoteDependencyData(activity).Type;
+
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var remoteDependencyDataType = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags).Type;
             var expectedType = TelemetryPartB.SqlDbs.Contains(dbSystem) ? "SQL" : dbSystem;
 
             Assert.Equal(expectedType, remoteDependencyDataType);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartCTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartCTests.cs
@@ -46,14 +46,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
                 parentContext: default,
                 startTime: DateTime.UtcNow);
 
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
             if (telemetryType == "RequestData")
             {
-                var telemetryPartBRequestData = TelemetryPartB.GetRequestData(activity);
+                var telemetryPartBRequestData = TelemetryPartB.GetRequestData(activity, ref monitorTags);
                 Assert.False(telemetryPartBRequestData.Properties.TryGetValue(msLinks, out var mslinks));
             }
             if (telemetryType == "RemoteDependencyData")
             {
-                var telemetryPartBRemoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity);
+                var telemetryPartBRemoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags);
                 Assert.False(telemetryPartBRemoteDependencyData.Properties.TryGetValue(msLinks, out var mslinks));
             }
         }
@@ -83,14 +85,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             string expectedMSlinks = GetExpectedMSlinks(links);
             string actualMSlinks = null;
 
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
             if (telemetryType == "RequestData")
             {
-                var telemetryPartBRequestData = TelemetryPartB.GetRequestData(activity);
+                var telemetryPartBRequestData = TelemetryPartB.GetRequestData(activity, ref monitorTags);
                 Assert.True(telemetryPartBRequestData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
             if (telemetryType == "RemoteDependencyData")
             {
-                var telemetryPartBRemoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity);
+                var telemetryPartBRemoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags);
                 Assert.True(telemetryPartBRemoteDependencyData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
 
@@ -127,14 +131,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
                 links,
                 startTime: DateTime.UtcNow);
 
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
             if (telemetryType == "RequestData")
             {
-                var telemetryPartBRequestData = TelemetryPartB.GetRequestData(activity);
+                var telemetryPartBRequestData = TelemetryPartB.GetRequestData(activity, ref monitorTags);
                 Assert.True(telemetryPartBRequestData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
             if (telemetryType == "RemoteDependencyData")
             {
-                var telemetryPartBRemoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity);
+                var telemetryPartBRemoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags);
                 Assert.True(telemetryPartBRemoteDependencyData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
 
@@ -180,14 +186,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             string expectedMslinks = GetExpectedMSlinks(links);
             string actualMSlinks = null;
 
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
             if (telemetryType == "RequestData")
             {
-                var telemetryPartBRequestData = TelemetryPartB.GetRequestData(activity);
+                var telemetryPartBRequestData = TelemetryPartB.GetRequestData(activity, ref monitorTags);
                 Assert.True(telemetryPartBRequestData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
             if (telemetryType == "RemoteDependencyData")
             {
-                var telemetryPartBRemoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity);
+                var telemetryPartBRemoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags);
                 Assert.True(telemetryPartBRemoteDependencyData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
 


### PR DESCRIPTION
In some cases tag values from PartB will be needed to define properties in PartA envelope. e.g. ai.operation.name, ai.location.ip, ai.user.useragent