### PR TITLE
DocumentFilterProperties asc property renaming.

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/api/Azure.AI.Translation.Document.netstandard2.0.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/api/Azure.AI.Translation.Document.netstandard2.0.cs
@@ -11,7 +11,7 @@ namespace Azure.AI.Translation.Document
     }
     public partial class DocumentFilterOrder
     {
-        public DocumentFilterOrder(Azure.AI.Translation.Document.DocumentFilterProperty property, bool asc = true) { }
+        public DocumentFilterOrder(Azure.AI.Translation.Document.DocumentFilterProperty property, bool ascending = true) { }
         public Azure.AI.Translation.Document.DocumentFilterProperty Property { get { throw null; } set { } }
     }
     public enum DocumentFilterProperty

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentFilterOrder.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentFilterOrder.cs
@@ -16,15 +16,15 @@ namespace Azure.AI.Translation.Document
         /// <summary>
         /// Initializes an instance of <see cref="DocumentFilterOrder"/>.
         /// </summary>
-        public DocumentFilterOrder(DocumentFilterProperty property, bool asc = true)
+        public DocumentFilterOrder(DocumentFilterProperty property, bool ascending = true)
         {
             Property = property;
-            Asc = asc;
+            Ascending = ascending;
         }
         /// <summary>
         /// Sort results ascendingly if true, or descendingly if false.
         /// </summary>
-        internal bool Asc { get; set; }
+        internal bool Ascending { get; set; }
         /// <summary>
         /// See <see cref="DocumentFilterProperty"/> for list of properties supported.
         /// </summary>
@@ -47,7 +47,7 @@ namespace Azure.AI.Translation.Document
             }
 
             // sorting direction
-            var direction = Asc ? "Asc" : "Desc";
+            var direction = Ascending ? "Asc" : "Desc";
 
             return $"{property} {direction}";
         }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/GetAllDocumentsFilterTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/GetAllDocumentsFilterTests.cs
@@ -93,7 +93,7 @@ namespace Azure.AI.Translation.Document.Tests
             // list docs
             var filter = new DocumentFilter
             {
-                OrderBy = { new DocumentFilterOrder(property: DocumentFilterProperty.CreatedOn, asc: false) }
+                OrderBy = { new DocumentFilterOrder(property: DocumentFilterProperty.CreatedOn, ascending: false) }
             };
 
             var filterResults = operation.GetAllDocumentStatuses(filter: filter);


### PR DESCRIPTION
Renamed asc to ascending as requested in the issue [#23353](https://github.com/Azure/azure-sdk-for-net/issues/23353) and modified samples.