### PR TITLE
[ServiceBus] Abandon not needed if AutoComplete is false

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/MessageReceivePump.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/MessageReceivePump.cs
@@ -221,7 +221,8 @@ namespace Microsoft.Azure.ServiceBus
         {
             try
             {
-                if (this.messageReceiver.ReceiveMode == ReceiveMode.PeekLock)
+                if (this.messageReceiver.ReceiveMode == ReceiveMode.PeekLock &&
+                    this.registerHandlerOptions.AutoComplete)
                 {
                     await this.messageReceiver.AbandonAsync(message.SystemProperties.LockToken).ConfigureAwait(false);
                 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SessionReceivePump.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SessionReceivePump.cs
@@ -104,7 +104,8 @@ namespace Microsoft.Azure.ServiceBus
         {
             try
             {
-                if (session.ReceiveMode == ReceiveMode.PeekLock)
+                if (session.ReceiveMode == ReceiveMode.PeekLock &&
+                    this.sessionHandlerOptions.AutoComplete)
                 {
                     await session.AbandonAsync(message.SystemProperties.LockToken).ConfigureAwait(false);
                 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/FakeMessageReceiver.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/FakeMessageReceiver.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Azure.ServiceBus.Core;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.ServiceBus.UnitTests
+{
+    public sealed class FakeMessageReceiver : MessageReceiver
+    {
+        private readonly Func<int, TimeSpan, Task<IList<Message>>> onReceiveCallback;
+        private readonly Func<IEnumerable<string>, Task> onCompleteCallback;
+        private readonly Func<string, IDictionary<string, object>, Task> onAbandonCallback;
+
+        public FakeMessageReceiver(
+            Func<int, TimeSpan, Task<IList<Message>>> onReceiveCallback,
+            Func<IEnumerable<string>, Task> onCompleteCallback = default,
+            Func<string, IDictionary<string, object>, Task> onAbandonCallback = default,
+            ReceiveMode receiveMode = ReceiveMode.PeekLock)
+            : base(
+                  new ServiceBusConnectionStringBuilder("blah.com", "path", "key-name", "key-value"),
+                  receiveMode)
+        {
+            this.onReceiveCallback = onReceiveCallback;
+            this.onCompleteCallback = onCompleteCallback;
+            this.onAbandonCallback = onAbandonCallback;
+        }
+
+        protected override Task<IList<Message>> OnReceiveAsync(int maxMessageCount, TimeSpan serverWaitTime)
+        {
+            return this.onReceiveCallback(maxMessageCount, serverWaitTime);
+        }
+
+        protected override Task OnCompleteAsync(IEnumerable<string> lockTokens)
+        {
+            this.onCompleteCallback(lockTokens);
+            return base.OnCompleteAsync(lockTokens);
+        }
+
+        protected override Task OnAbandonAsync(string lockToken, IDictionary<string, object> propertiesToModify = null)
+        {
+            this.onAbandonCallback(lockToken, propertiesToModify);
+            return base.OnAbandonAsync(lockToken, propertiesToModify);
+        }
+    }
+}

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/MessageReceivePumpTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/MessageReceivePumpTests.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus.UnitTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class MessageReceivePumpTests : IDisposable
+    {
+        private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        public void Dispose()
+        {
+            cancellationTokenSource.Cancel();
+            cancellationTokenSource.Dispose();
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task CompleteMessageIfNeededAsync_should_complete_with_autocomplete()
+        {
+            var (completeCalled, abandonCalled) = await CheckMessageResolution(true, false);
+            Assert.True(completeCalled);
+            Assert.False(abandonCalled);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task CompleteMessageIfNeededAsync_should_not_complete_without_autocomplete()
+        {
+            var (completeCalled, abandonCalled) = await CheckMessageResolution(false, false);
+            Assert.False(completeCalled);
+            Assert.False(abandonCalled);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task AbandonMessageIfNeededAsync_should_abandon_on_exception_with_autocomplete()
+        {
+            var (completeCalled, abandonCalled) = await CheckMessageResolution(true, true);
+            Assert.False(completeCalled);
+            Assert.True(abandonCalled);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task AbandonMessageIfNeededAsync_should_not_abandon_on_exception_without_autocomplete()
+        {
+            var (completeCalled, abandonCalled) = await CheckMessageResolution(false, true);
+            Assert.False(completeCalled);
+            Assert.False(abandonCalled);
+        }
+
+        private async Task<(bool completeCalled, bool abandonCalled)> CheckMessageResolution(bool autoComplete, bool throwException)
+        {
+            var receiverCalled = false;
+            var completeCalled = false;
+            var abandonCalled = false;
+            var exceptionReceived = false;
+
+            var lockTokenGuid = new Guid("00000000-0000-0000-0000-000000000001");
+            var receiver = new FakeMessageReceiver(
+                async (int maxMessageCount, TimeSpan serverWaitTime) =>
+                {
+                    await Task.Delay(1); // Force the pump to release the thread
+
+                    if (receiverCalled)
+                    {
+                        return Enumerable.Empty<Message>()
+                            .ToList();
+                    }
+
+                    receiverCalled = true;
+
+                    return new List<Message> { new Message { SystemProperties = new Message.SystemPropertiesCollection { SequenceNumber = 1, LockTokenGuid = lockTokenGuid } } };
+                },
+                (lockTokens) =>
+                {
+                    Assert.Contains(lockTokenGuid.ToString(), lockTokens);
+                    completeCalled = true;
+                    return Task.CompletedTask;
+                },
+                (lockToken, propertiesToModify) =>
+                {
+                    Assert.Equal(lockTokenGuid.ToString(), lockToken);
+                    abandonCalled = true;
+                    return Task.CompletedTask;
+                });
+
+            var exception = new Exception("Test exception");
+
+            var pump = new MessageReceivePump(
+                receiver,
+                new MessageHandlerOptions(
+                    (eventArgs) =>
+                    {
+                        if (eventArgs.Exception == exception)
+                        {
+                            exceptionReceived = true;
+                        }
+                        return Task.CompletedTask;
+                    })
+                {
+                    AutoComplete = autoComplete
+                },
+                (message, cancellationToken) =>
+                {
+                    if (throwException)
+                    {
+                        throw exception;
+                    }
+                    return Task.CompletedTask;
+                },
+                new Uri("http://blah.com"),
+                cancellationTokenSource.Token,
+                default);
+
+            pump.StartPump();
+
+            var stopwatch = Stopwatch.StartNew();
+            while (stopwatch.Elapsed.TotalSeconds <= 8)
+            {
+                if (completeCalled)
+                {
+                    TestUtility.Log($"Complete Called.");
+                    break;
+                }
+                if (exceptionReceived)
+                {
+                    TestUtility.Log($"Exception Received.");
+                    break;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            return (completeCalled, abandonCalled);
+        }
+    }
+}


### PR DESCRIPTION
Resolving issues [Azure/azure-functions-servicebus-extension#183](Azure/azure-functions-servicebus-extension#183) and [Azure/azure-functions-servicebus-extension#142](https://github.com/Azure/azure-functions-servicebus-extension/issues/142)

If `AutoComplete` is `false`, then it should not attempt to abandon the message.

This change brings `AbandonMessageIfNeededAsync` in line with `CompleteMessageIfNeededAsync`.

I'm not sure if this counts as a breaking change. It's fixing an issue to bring it [in line with the documentation](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus#hostjson-settings), but that results in different behavior - throwing an exception will no longer cause the message to be abandoned if AutoComplete is false.

There were no existing unit tests for `MessageReceivePump` so I attempted to add some. Guidance welcome.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [n/a] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [n/a] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [n/a] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [n/a] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [n/a] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
