### PR TITLE
Adding Dynamic Concurrency support to WebJobs SDK ServiceBus Extension

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.0.0-beta.7 (Unreleased)
 
 ### Features Added
+- Adding DynamicConcurrency support
 
 ### Breaking Changes
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusExtensionConfigProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusExtensionConfigProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.ServiceBus.Bindings;
 using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
@@ -30,6 +31,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
         private readonly MessagingProvider _messagingProvider;
         private readonly IConverterManager _converterManager;
         private readonly ServiceBusClientFactory _clientFactory;
+        private readonly ConcurrencyManager _concurrencyManager;
 
         /// <summary>
         /// Creates a new <see cref="ServiceBusExtensionConfigProvider"/> instance.
@@ -41,7 +43,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
             INameResolver nameResolver,
             ILoggerFactory loggerFactory,
             IConverterManager converterManager,
-            ServiceBusClientFactory clientFactory)
+            ServiceBusClientFactory clientFactory,
+            ConcurrencyManager concurrencyManager)
         {
             _options = options.Value;
             _messagingProvider = messagingProvider;
@@ -49,6 +52,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
             _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
             _converterManager = converterManager;
             _clientFactory = clientFactory;
+            _concurrencyManager = concurrencyManager;
         }
 
         /// <summary>
@@ -85,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
                 .AddOpenConverter<ServiceBusReceivedMessage, OpenType.Poco>(typeof(MessageToPocoConverter<>), _options.JsonSerializerSettings);
 
             // register our trigger binding provider
-            ServiceBusTriggerAttributeBindingProvider triggerBindingProvider = new ServiceBusTriggerAttributeBindingProvider(_nameResolver, _options, _messagingProvider, _loggerFactory, _converterManager, _clientFactory);
+            ServiceBusTriggerAttributeBindingProvider triggerBindingProvider = new ServiceBusTriggerAttributeBindingProvider(_nameResolver, _options, _messagingProvider, _loggerFactory, _converterManager, _clientFactory, _concurrencyManager);
             context.AddBindingRule<ServiceBusTriggerAttribute>()
                 .BindToTrigger(triggerBindingProvider);
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Hosting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -85,9 +86,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         }
         private TimeSpan _maxAutoRenewDuration = TimeSpan.FromMinutes(5);
 
-        /// <summary>Gets or sets the maximum number of concurrent calls to a function. Note each call
-        /// would be passing a different message. This does not apply for functions that receive a batch of messages.
-        /// The default is 16 times the return value of <see cref="Utility.GetProcessorCount"/>.
+        /// <summary>
+        /// Gets or sets the maximum number of messages that can be processed concurrently by a function.
+        /// This setting does not apply for functions that receive a batch of messages. The default is 16 times
+        /// the return value of <see cref="Utility.GetProcessorCount"/>. When <see cref="ConcurrencyOptions.DynamicConcurrencyEnabled"/>
+        /// is true, this value will be ignored, and concurrency will be increased/decreased dynamically.
         /// </summary>
         public int MaxConcurrentCalls
         {
@@ -104,6 +107,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <summary>
         /// Gets or sets the maximum number of sessions that can be processed concurrently by a function.
         /// The default value is 8. This does not apply for functions that receive a batch of messages.
+        /// When <see cref="ConcurrencyOptions.DynamicConcurrencyEnabled"/> is true, this value will be ignored,
+        /// and concurrency will be increased/decreased dynamically.
         /// </summary>
         public int MaxConcurrentSessions
         {
@@ -193,24 +198,52 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             return Task.CompletedTask;
         }
 
-        internal ServiceBusProcessorOptions ToProcessorOptions(bool autoCompleteMessagesOptionEvaluatedValue) =>
-            new ServiceBusProcessorOptions
+        internal ServiceBusProcessorOptions ToProcessorOptions(bool autoCompleteMessagesOptionEvaluatedValue, bool dynamicConcurrencyEnabled)
+        {
+           var processorOptions = new ServiceBusProcessorOptions
             {
                 AutoCompleteMessages = autoCompleteMessagesOptionEvaluatedValue,
                 PrefetchCount = PrefetchCount,
-                MaxAutoLockRenewalDuration = MaxAutoLockRenewalDuration,
-                MaxConcurrentCalls = MaxConcurrentCalls
+                MaxAutoLockRenewalDuration = MaxAutoLockRenewalDuration
             };
 
-        internal ServiceBusSessionProcessorOptions ToSessionProcessorOptions(bool autoCompleteMessagesOptionEvaluatedValue) =>
-            new ServiceBusSessionProcessorOptions
+            if (dynamicConcurrencyEnabled)
+            {
+                // when DC is enabled, concurrency starts at 1 and will be dynamically adjusted over time
+                // by UpdateConcurrency.
+                processorOptions.MaxConcurrentCalls = 1;
+            }
+            else
+            {
+                processorOptions.MaxConcurrentCalls = MaxConcurrentCalls;
+            }
+
+            return processorOptions;
+        }
+
+        internal ServiceBusSessionProcessorOptions ToSessionProcessorOptions(bool autoCompleteMessagesOptionEvaluatedValue, bool dynamicConcurrencyEnabled)
+        {
+            var processorOptions = new ServiceBusSessionProcessorOptions
             {
                 AutoCompleteMessages = autoCompleteMessagesOptionEvaluatedValue,
                 PrefetchCount = PrefetchCount,
                 MaxAutoLockRenewalDuration = MaxAutoLockRenewalDuration,
-                MaxConcurrentSessions = MaxConcurrentSessions,
                 SessionIdleTimeout = SessionIdleTimeout
             };
+
+            if (dynamicConcurrencyEnabled)
+            {
+                // when DC is enabled, session concurrency starts at 1 and will be dynamically adjusted over time
+                // by UpdateConcurrency.
+                processorOptions.MaxConcurrentSessions = 1;
+            }
+            else
+            {
+                processorOptions.MaxConcurrentSessions = MaxConcurrentSessions;
+            }
+
+            return processorOptions;
+        }
 
         internal ServiceBusReceiverOptions ToReceiverOptions() =>
             new ServiceBusReceiverOptions

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -33,11 +33,13 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         private readonly Lazy<ServiceBusClient> _client;
         private readonly Lazy<SessionMessageProcessor> _sessionMessageProcessor;
         private readonly Lazy<ServiceBusScaleMonitor> _scaleMonitor;
+        private readonly ConcurrencyUpdateManager _concurrencyUpdateManager;
 
         private volatile bool _disposed;
         private volatile bool _started;
         // Serialize execution of StopAsync to avoid calling Unregister* concurrently
         private readonly SemaphoreSlim _stopAsyncSemaphore = new SemaphoreSlim(1, 1);
+        private readonly string _functionId;
         private CancellationTokenRegistration _batchReceiveRegistration;
         private Task _batchLoop;
 
@@ -53,7 +55,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             MessagingProvider messagingProvider,
             ILoggerFactory loggerFactory,
             bool singleDispatch,
-            ServiceBusClientFactory clientFactory)
+            ServiceBusClientFactory clientFactory,
+            ConcurrencyManager concurrencyManager)
         {
             _entityPath = entityPath;
             _isSessionsEnabled = isSessionsEnabled;
@@ -61,6 +64,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             _triggerExecutor = triggerExecutor;
             _cancellationTokenSource = new CancellationTokenSource();
             _logger = loggerFactory.CreateLogger<ServiceBusListener>();
+            _functionId = functionId;
 
             _client = new Lazy<ServiceBusClient>(
                 () =>
@@ -73,16 +77,18 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                     options.ToReceiverOptions()));
 
             _messageProcessor = new Lazy<MessageProcessor>(
-                () => messagingProvider.CreateMessageProcessor(
-                    _client.Value,
-                    _entityPath,
-                    options.ToProcessorOptions(_autoCompleteMessagesOptionEvaluatedValue)));
+                () =>
+                {
+                    var processorOptions = options.ToProcessorOptions(_autoCompleteMessagesOptionEvaluatedValue, concurrencyManager.Enabled);
+                    return messagingProvider.CreateMessageProcessor(_client.Value, _entityPath, processorOptions);
+                });
 
             _sessionMessageProcessor = new Lazy<SessionMessageProcessor>(
-                () => messagingProvider.CreateSessionMessageProcessor(
-                    _client.Value,
-                    _entityPath,
-                    options.ToSessionProcessorOptions(_autoCompleteMessagesOptionEvaluatedValue)));
+                () =>
+                {
+                    var sessionProcessorOptions = options.ToSessionProcessorOptions(_autoCompleteMessagesOptionEvaluatedValue, concurrencyManager.Enabled);
+                    return messagingProvider.CreateSessionMessageProcessor(_client.Value,_entityPath, sessionProcessorOptions);
+                });
 
             _scaleMonitor = new Lazy<ServiceBusScaleMonitor>(
                 () => new ServiceBusScaleMonitor(
@@ -93,6 +99,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                     _batchReceiver,
                     loggerFactory,
                     clientFactory));
+
+            if (concurrencyManager.Enabled)
+            {
+                _concurrencyUpdateManager = new ConcurrencyUpdateManager(concurrencyManager, _messageProcessor, _sessionMessageProcessor, _isSessionsEnabled, _functionId, _logger);
+            }
 
             _singleDispatch = singleDispatch;
             _serviceBusOptions = options;
@@ -119,6 +130,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                     _messageProcessor.Value.Processor.ProcessMessageAsync += ProcessMessageAsync;
                     await _messageProcessor.Value.Processor.StartProcessingAsync(cancellationToken).ConfigureAwait(false);
                 }
+
+                _concurrencyUpdateManager?.Start();
             }
             else
             {
@@ -130,6 +143,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         public async Task StopAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
+
+            _concurrencyUpdateManager?.Stop();
+
             await _stopAsyncSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             {
                 try
@@ -212,12 +228,15 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             _stopAsyncSemaphore.Dispose();
             _cancellationTokenSource.Dispose();
             _batchReceiveRegistration.Dispose();
+            _concurrencyUpdateManager?.Dispose();
 
             _disposed = true;
         }
 
         internal async Task ProcessMessageAsync(ProcessMessageEventArgs args)
         {
+            _concurrencyUpdateManager?.MessageProcessed();
+
             using (CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(args.CancellationToken, _cancellationTokenSource.Token))
             {
                 var actions = new ServiceBusMessageActions(args);
@@ -237,6 +256,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 
         internal async Task ProcessSessionMessageAsync(ProcessSessionMessageEventArgs args)
         {
+            _concurrencyUpdateManager?.MessageProcessed();
+
             using (CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(args.CancellationToken, _cancellationTokenSource.Token))
             {
                 var actions = new ServiceBusSessionMessageActions(args);
@@ -267,6 +288,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                 receiver = _batchReceiver.Value;
             }
 
+            // The batch receive loop below only executes functions at a concurrency level of 1,
+            // so we don't need to do anything special when DynamicConcurrency is enabled. If in
+            // the future we make this loop concurrent, we'll have to check with ConcurrencyManager.
             while (true)
             {
                 try
@@ -409,6 +433,127 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         public IScaleMonitor GetMonitor()
         {
             return _scaleMonitor.Value;
+        }
+
+        /// <summary>
+        /// Responsible for handling dynamic concurrency concurrency updates for message processors.
+        /// </summary>
+        internal class ConcurrencyUpdateManager : IDisposable
+        {
+            private const int ConcurrencyUpdateIntervalMS = 1000;
+
+            private readonly Timer _concurrencyUpdateTimer;
+            private readonly ConcurrencyManager _concurrencyManager;
+            private readonly string _functionId;
+            private readonly bool _isSessionsEnabled;
+            private readonly Lazy<MessageProcessor> _messageProcessor;
+            private readonly Lazy<SessionMessageProcessor> _sessionMessageProcessor;
+            private readonly ILogger _logger;
+
+            private volatile bool _messagesProcessedSinceLastConcurrencyUpdate;
+            private bool _disposed;
+
+            public ConcurrencyUpdateManager(ConcurrencyManager concurrencyManager, Lazy<MessageProcessor> messageProcessor, Lazy<SessionMessageProcessor> sessionMessageProcessor, bool sessionsEnabled, string functionId, ILogger logger)
+            {
+                _concurrencyManager = concurrencyManager;
+                _messageProcessor = messageProcessor;
+                _sessionMessageProcessor = sessionMessageProcessor;
+                _isSessionsEnabled = sessionsEnabled;
+                _functionId = functionId;
+                _logger = logger;
+
+                if (concurrencyManager.Enabled)
+                {
+                    _concurrencyUpdateTimer = new Timer(UpdateConcurrency, null, Timeout.Infinite, Timeout.Infinite);
+                }
+            }
+
+            public void Start()
+            {
+                _concurrencyUpdateTimer?.Change(ConcurrencyUpdateIntervalMS, Timeout.Infinite);
+            }
+
+            public void Stop()
+            {
+                _concurrencyUpdateTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+            }
+
+            public void MessageProcessed()
+            {
+                _messagesProcessedSinceLastConcurrencyUpdate = true;
+            }
+
+            private void UpdateConcurrency(object state)
+            {
+                try
+                {
+                    UpdateConcurrency();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Unhandled exception in concurrency update handler.");
+                }
+                finally
+                {
+                    _concurrencyUpdateTimer.Change(ConcurrencyUpdateIntervalMS, Timeout.Infinite);
+                }
+            }
+
+            /// <summary>
+            /// Check current concurrency levels for this function, and adjust processor concurrency as necessary.
+            /// </summary>
+            public void UpdateConcurrency()
+            {
+                if (!_messagesProcessedSinceLastConcurrencyUpdate)
+                {
+                    // if the function is currently inactive, we can skip the concurrency update check
+                    return;
+                }
+                _messagesProcessedSinceLastConcurrencyUpdate = false;
+
+                // below we'll dynamically update the processor with new concurrency values if any
+                // need to be changed
+                var concurrencyStatus = _concurrencyManager.GetStatus(_functionId);
+                var currentConcurrency = concurrencyStatus.CurrentConcurrency;
+
+                if (_isSessionsEnabled)
+                {
+                    var sessionProcessor = _sessionMessageProcessor.Value.Processor;
+                    if (currentConcurrency != sessionProcessor.MaxConcurrentSessions)
+                    {
+                        // Per session call concurrency is limited to 1 meaning sessions are 1:1 with invocations.
+                        // So we can scale MaxConcurrentSessions 1:1 with CurrentConcurrency.
+                        sessionProcessor.UpdateConcurrency(currentConcurrency, sessionProcessor.MaxConcurrentCallsPerSession);
+                    }
+                }
+                else
+                {
+                    var processor = _messageProcessor.Value.Processor;
+                    if (currentConcurrency != processor.MaxConcurrentCalls)
+                    {
+                        processor.UpdateConcurrency(currentConcurrency);
+                    }
+                }
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!_disposed)
+                {
+                    if (disposing)
+                    {
+                        _concurrencyUpdateTimer?.Dispose();
+                    }
+
+                    _disposed = true;
+                }
+            }
+
+            public void Dispose()
+            {
+                Dispose(disposing: true);
+                GC.SuppressFinalize(this);
+            }
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusOptionsTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusOptionsTests.cs
@@ -86,5 +86,84 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
             Assert.AreSame(ex, logMessage.Exception);
             Assert.AreEqual(expectedMessage, logMessage.FormattedMessage);
         }
+
+        [Test]
+        public void ToProcessorOptions_ReturnsExpectedValue()
+        {
+            ServiceBusOptions sbOptions = new ServiceBusOptions
+            {
+                AutoCompleteMessages = false,
+                PrefetchCount = 123,
+                MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(123),
+                SessionIdleTimeout = TimeSpan.FromSeconds(123),
+                MaxConcurrentCalls = 123
+            };
+
+            ServiceBusProcessorOptions processorOptions = sbOptions.ToProcessorOptions(true, false);
+            Assert.AreEqual(true, processorOptions.AutoCompleteMessages);
+            Assert.AreEqual(sbOptions.PrefetchCount, processorOptions.PrefetchCount);
+            Assert.AreEqual(sbOptions.MaxAutoLockRenewalDuration, processorOptions.MaxAutoLockRenewalDuration);
+            Assert.AreEqual(sbOptions.MaxConcurrentCalls, processorOptions.MaxConcurrentCalls);
+        }
+
+        [Test]
+        [Category("DynamicConcurrency")]
+        public void ToProcessorOptions_DynamicConcurrencyEnabled_ReturnsExpectedValue()
+        {
+            ServiceBusOptions sbOptions = new ServiceBusOptions
+            {
+                AutoCompleteMessages = false,
+                PrefetchCount = 123,
+                MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(123),
+                MaxConcurrentCalls = 123
+            };
+
+            ServiceBusProcessorOptions processorOptions = sbOptions.ToProcessorOptions(true, true);
+            Assert.AreEqual(true, processorOptions.AutoCompleteMessages);
+            Assert.AreEqual(sbOptions.PrefetchCount, processorOptions.PrefetchCount);
+            Assert.AreEqual(sbOptions.MaxAutoLockRenewalDuration, processorOptions.MaxAutoLockRenewalDuration);
+            Assert.AreEqual(1, processorOptions.MaxConcurrentCalls);
+        }
+
+        [Test]
+        public void ToSessionProcessorOptions_ReturnsExpectedValue()
+        {
+            ServiceBusOptions sbOptions = new ServiceBusOptions
+            {
+                AutoCompleteMessages = false,
+                PrefetchCount = 123,
+                MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(123),
+                SessionIdleTimeout = TimeSpan.FromSeconds(123),
+                MaxConcurrentSessions = 123
+            };
+
+            ServiceBusSessionProcessorOptions processorOptions = sbOptions.ToSessionProcessorOptions(true, false);
+            Assert.AreEqual(true, processorOptions.AutoCompleteMessages);
+            Assert.AreEqual(sbOptions.PrefetchCount, processorOptions.PrefetchCount);
+            Assert.AreEqual(sbOptions.MaxAutoLockRenewalDuration, processorOptions.MaxAutoLockRenewalDuration);
+            Assert.AreEqual(sbOptions.SessionIdleTimeout, processorOptions.SessionIdleTimeout);
+            Assert.AreEqual(sbOptions.MaxConcurrentSessions, processorOptions.MaxConcurrentSessions);
+        }
+
+        [Test]
+        [Category("DynamicConcurrency")]
+        public void ToSessionProcessorOptions_DynamicConcurrencyEnabled_ReturnsExpectedValue()
+        {
+            ServiceBusOptions sbOptions = new ServiceBusOptions
+            {
+                AutoCompleteMessages = false,
+                PrefetchCount = 123,
+                MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(123),
+                SessionIdleTimeout = TimeSpan.FromSeconds(123),
+                MaxConcurrentSessions = 123
+            };
+
+            ServiceBusSessionProcessorOptions processorOptions = sbOptions.ToSessionProcessorOptions(true, true);
+            Assert.AreEqual(true, processorOptions.AutoCompleteMessages);
+            Assert.AreEqual(sbOptions.PrefetchCount, processorOptions.PrefetchCount);
+            Assert.AreEqual(sbOptions.MaxAutoLockRenewalDuration, processorOptions.MaxAutoLockRenewalDuration);
+            Assert.AreEqual(sbOptions.SessionIdleTimeout, processorOptions.SessionIdleTimeout);
+            Assert.AreEqual(1, processorOptions.MaxConcurrentSessions);
+        }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusListenerTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusListenerTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
@@ -33,14 +35,16 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
         private readonly string _functionId = "test-functionid";
         private readonly string _entityPath = "test-entity-path";
         private readonly string _testConnection = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123=";
+        private readonly Mock<IConcurrencyThrottleManager> _mockConcurrencyThrottleManager;
+        private readonly ServiceBusClient _client;
 
         public ServiceBusListenerTests()
         {
             _mockExecutor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
 
-            var client = new ServiceBusClient(_testConnection);
-            ServiceBusProcessor processor = client.CreateProcessor(_entityPath);
-            ServiceBusReceiver receiver = client.CreateReceiver(_entityPath);
+            _client = new ServiceBusClient(_testConnection);
+            ServiceBusProcessor processor = _client.CreateProcessor(_entityPath);
+            ServiceBusReceiver receiver = _client.CreateReceiver(_entityPath);
             var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>("connection", _testConnection));
 
             ServiceBusOptions config = new ServiceBusOptions
@@ -63,6 +67,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             _loggerProvider = new TestLoggerProvider();
             _loggerFactory.AddProvider(_loggerProvider);
 
+            var concurrencyOptions = new OptionsWrapper<ConcurrencyOptions>(new ConcurrencyOptions());
+            _mockConcurrencyThrottleManager = new Mock<IConcurrencyThrottleManager>(MockBehavior.Strict);
+            var concurrencyManager = new ConcurrencyManager(concurrencyOptions, _loggerFactory, _mockConcurrencyThrottleManager.Object);
+
             _listener = new ServiceBusListener(
                 _functionId,
                 ServiceBusEntityType.Queue,
@@ -75,7 +83,72 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
                 _mockMessagingProvider.Object,
                 _loggerFactory,
                 false,
-                _mockClientFactory.Object);
+                _mockClientFactory.Object,
+                concurrencyManager);
+        }
+
+        [Test]
+        [Category("DynamicConcurrency")]
+        public void ConcurrencyUpdateManager_UpdatesProcessorConcurrency()
+        {
+            var concurrencyOptions = new OptionsWrapper<ConcurrencyOptions>(new ConcurrencyOptions { DynamicConcurrencyEnabled = true });
+            var concurrencyManager = new ConcurrencyManager(concurrencyOptions, _loggerFactory, _mockConcurrencyThrottleManager.Object);
+            _mockConcurrencyThrottleManager.Setup(p => p.GetStatus()).Returns(new ConcurrencyThrottleAggregateStatus { State = ThrottleState.Disabled });
+            ServiceBusProcessor processor = _client.CreateProcessor(_entityPath);
+            Lazy<MessageProcessor> messageProcessor = new Lazy<MessageProcessor>(() => new MessageProcessor(processor));
+            ILogger logger = _loggerFactory.CreateLogger("test");
+            ServiceBusListener.ConcurrencyUpdateManager concurrencyUpdateManager = new ServiceBusListener.ConcurrencyUpdateManager(concurrencyManager, messageProcessor, null, false, _functionId, logger);
+
+            // when no messages are being processed, concurrency is not adjusted
+            Assert.AreEqual(1, processor.MaxConcurrentCalls);
+            SetFunctionCurrentConcurrency(concurrencyManager, _functionId, 10);
+            concurrencyUpdateManager.UpdateConcurrency();
+            Assert.AreEqual(1, processor.MaxConcurrentCalls);
+
+            // ensure processor concurrency is adjusted up
+            concurrencyUpdateManager.MessageProcessed();
+            concurrencyUpdateManager.UpdateConcurrency();
+            Assert.AreEqual(10, processor.MaxConcurrentCalls);
+
+            // ensure processor concurrency is adjusted down
+            SetFunctionCurrentConcurrency(concurrencyManager, _functionId, 5);
+            concurrencyUpdateManager.MessageProcessed();
+            concurrencyUpdateManager.UpdateConcurrency();
+            Assert.AreEqual(5, processor.MaxConcurrentCalls);
+        }
+
+        [Test]
+        [Category("DynamicConcurrency")]
+        public void ConcurrencyUpdateManager_Sessions_UpdatesProcessorConcurrency()
+        {
+            var concurrencyOptions = new OptionsWrapper<ConcurrencyOptions>(new ConcurrencyOptions { DynamicConcurrencyEnabled = true });
+            var concurrencyManager = new ConcurrencyManager(concurrencyOptions, _loggerFactory, _mockConcurrencyThrottleManager.Object);
+            _mockConcurrencyThrottleManager.Setup(p => p.GetStatus()).Returns(new ConcurrencyThrottleAggregateStatus { State = ThrottleState.Disabled });
+            ServiceBusSessionProcessor sessionProcessor = _client.CreateSessionProcessor(_entityPath, new ServiceBusSessionProcessorOptions { MaxConcurrentSessions = 1, MaxConcurrentCallsPerSession = 1 });
+            Lazy<SessionMessageProcessor> sessionMessageProcessor = new Lazy<SessionMessageProcessor>(() => new SessionMessageProcessor(sessionProcessor));
+            ILogger logger = _loggerFactory.CreateLogger("test");
+            ServiceBusListener.ConcurrencyUpdateManager concurrencyUpdateManager = new ServiceBusListener.ConcurrencyUpdateManager(concurrencyManager, null, sessionMessageProcessor, true, _functionId, logger);
+
+            // when no messages are being processed, concurrency is not adjusted
+            Assert.AreEqual(1, sessionProcessor.MaxConcurrentSessions);
+            Assert.AreEqual(1, sessionProcessor.MaxConcurrentCallsPerSession);
+            SetFunctionCurrentConcurrency(concurrencyManager, _functionId, 10);
+            concurrencyUpdateManager.UpdateConcurrency();
+            Assert.AreEqual(1, sessionProcessor.MaxConcurrentSessions);
+            Assert.AreEqual(1, sessionProcessor.MaxConcurrentCallsPerSession);
+
+            // ensure processor concurrency is adjusted up
+            concurrencyUpdateManager.MessageProcessed();
+            concurrencyUpdateManager.UpdateConcurrency();
+            Assert.AreEqual(10, sessionProcessor.MaxConcurrentSessions);
+            Assert.AreEqual(1, sessionProcessor.MaxConcurrentCallsPerSession);
+
+            // ensure processor concurrency is adjusted down
+            SetFunctionCurrentConcurrency(concurrencyManager, _functionId, 5);
+            concurrencyUpdateManager.MessageProcessed();
+            concurrencyUpdateManager.UpdateConcurrency();
+            Assert.AreEqual(5, sessionProcessor.MaxConcurrentSessions);
+            Assert.AreEqual(1, sessionProcessor.MaxConcurrentCallsPerSession);
         }
 
         [Test]
@@ -136,6 +209,13 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
         private Task ExceptionReceivedHandler(ProcessErrorEventArgs eventArgs)
         {
             return Task.CompletedTask;
+        }
+
+        private void SetFunctionCurrentConcurrency(ConcurrencyManager concurrencyManager, string functionId, int concurrency)
+        {
+            var concurrencyStatus = concurrencyManager.GetStatus(functionId);
+            var propertyInfo = typeof(ConcurrencyStatus).GetProperty("CurrentConcurrency", BindingFlags.Instance | BindingFlags.Public);
+            propertyInfo.SetValue(concurrencyStatus, concurrency);
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
@@ -71,6 +71,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             _loggerProvider = new TestLoggerProvider();
             _loggerFactory.AddProvider(_loggerProvider);
 
+            var concurrencyOptions = new OptionsWrapper<ConcurrencyOptions>(new ConcurrencyOptions());
+            var mockConcurrencyThrottleManager = new Mock<IConcurrencyThrottleManager>(MockBehavior.Strict);
+            var concurrencyManager = new ConcurrencyManager(concurrencyOptions, _loggerFactory, mockConcurrencyThrottleManager.Object);
+
             _listener = new ServiceBusListener(
                 _functionId,
                 ServiceBusEntityType.Queue,
@@ -83,7 +87,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
                 _mockProvider.Object,
                 _loggerFactory,
                 false,
-                _mockClientFactory.Object);
+                _mockClientFactory.Object,
+                concurrencyManager);
 
             _scaleMonitor = (ServiceBusScaleMonitor)_listener.GetMonitor();
         }
@@ -191,6 +196,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
 
         private ServiceBusListener CreateListener()
         {
+            var concurrencyOptions = new OptionsWrapper<ConcurrencyOptions>(new ConcurrencyOptions());
+            var mockConcurrencyThrottleManager = new Mock<IConcurrencyThrottleManager>(MockBehavior.Strict);
+            var concurrencyManager = new ConcurrencyManager(concurrencyOptions, _loggerFactory, mockConcurrencyThrottleManager.Object);
+
             return new ServiceBusListener(
                 _functionId,
                 ServiceBusEntityType.Queue,
@@ -203,7 +212,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
                 _mockProvider.Object,
                 _loggerFactory,
                 false,
-                _mockClientFactory.Object);
+                _mockClientFactory.Object,
+                concurrencyManager);
         }
 
         [Test]

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/MessagingProviderTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/MessagingProviderTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
         {
             var options = new ServiceBusOptions();
             var provider = new MessagingProvider(new OptionsWrapper<ServiceBusOptions>(options));
-            var processorOptions = options.ToProcessorOptions(options.AutoCompleteMessages);
+            var processorOptions = options.ToProcessorOptions(options.AutoCompleteMessages, false);
 
             var processor = provider.CreateProcessor(_client, "entityPath", processorOptions);
             Assert.AreEqual("entityPath", processor.EntityPath);
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             options.PrefetchCount = 100;
             options.MaxConcurrentCalls = 5;
             options.MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(30);
-            processor = provider.CreateProcessor(_client, "entityPath1", options.ToProcessorOptions(options.AutoCompleteMessages));
+            processor = provider.CreateProcessor(_client, "entityPath1", options.ToProcessorOptions(options.AutoCompleteMessages, false));
             Assert.AreEqual(options.PrefetchCount, processor.PrefetchCount);
             Assert.AreEqual(options.MaxConcurrentCalls, processor.MaxConcurrentCalls);
             Assert.AreEqual(options.MaxAutoLockRenewalDuration, processor.MaxAutoLockRenewalDuration);
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
         {
             var options = new ServiceBusOptions();
             var provider = new MessagingProvider(new OptionsWrapper<ServiceBusOptions>(options));
-            var processorOptions = options.ToSessionProcessorOptions(options.AutoCompleteMessages);
+            var processorOptions = options.ToSessionProcessorOptions(options.AutoCompleteMessages, false);
 
             var processor = provider.CreateSessionProcessor(_client, "entityPath", processorOptions);
             Assert.AreEqual("entityPath", processor.EntityPath);
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             options.PrefetchCount = 100;
             options.MaxConcurrentSessions = 5;
             options.MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(30);
-            processor = provider.CreateSessionProcessor(_client, "entityPath1", options.ToSessionProcessorOptions(options.AutoCompleteMessages));
+            processor = provider.CreateSessionProcessor(_client, "entityPath1", options.ToSessionProcessorOptions(options.AutoCompleteMessages, false));
             Assert.AreEqual(options.PrefetchCount, processor.PrefetchCount);
             Assert.AreEqual(options.MaxConcurrentSessions, processor.MaxConcurrentSessions);
             Assert.AreEqual(options.MaxAutoLockRenewalDuration, processor.MaxAutoLockRenewalDuration);

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -11,7 +11,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Tests;
+using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -371,6 +373,68 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 var logs = host.GetTestLoggerProvider().GetAllLogMessages().Select(p => p.FormattedMessage).ToList();
                 Assert.Contains("Input(foobar)", logs);
+                await host.StopAsync();
+            }
+        }
+
+        [Test]
+        [Category("DynamicConcurrency")]
+        public async Task DynamicConcurrencyTest()
+        {
+            DynamicConcurrencyTestJob.InvocationCount = 0;
+
+            var host = BuildHost<DynamicConcurrencyTestJob>(b =>
+            {
+                b.ConfigureWebJobs(b =>
+                 {
+                     b.Services.AddOptions<ConcurrencyOptions>().Configure(options =>
+                     {
+                         options.DynamicConcurrencyEnabled = true;
+
+                         // ensure on each test run we work up from 1
+                         options.SnapshotPersistenceEnabled = false;
+                     });
+                 }).ConfigureLogging((context, b) =>
+                 {
+                     // ensure we get all concurrency logs
+                     b.SetMinimumLevel(LogLevel.Debug);
+                 });
+            }, startHost: false);
+
+            using (host)
+            {
+                // ensure initial concurrency is 1
+                MethodInfo methodInfo = typeof(DynamicConcurrencyTestJob).GetMethod("ProcessMessage", BindingFlags.Public | BindingFlags.Static);
+                string functionId = $"{methodInfo.DeclaringType.FullName}.{methodInfo.Name}";
+                var concurrencyManager = host.Services.GetServices<ConcurrencyManager>().SingleOrDefault();
+                var concurrencyStatus = concurrencyManager.GetStatus(functionId);
+                Assert.AreEqual(1, concurrencyStatus.CurrentConcurrency);
+
+                // write a bunch of messages in batch
+                int numMessages = 500;
+                string[] messages = new string[numMessages];
+                for (int i = 0; i < numMessages; i++)
+                {
+                    messages[i] = Guid.NewGuid().ToString();
+                }
+                await WriteQueueMessages(messages);
+
+                // start the host and wait for all messages to be processed
+                await host.StartAsync();
+                await TestHelpers.Await(() =>
+                {
+                    return DynamicConcurrencyTestJob.InvocationCount >= numMessages;
+                });
+
+                // ensure we've dynamically increased concurrency
+                concurrencyStatus = concurrencyManager.GetStatus(functionId);
+                Assert.GreaterOrEqual(concurrencyStatus.CurrentConcurrency, 10);
+
+                // check a few of the concurrency logs
+                var concurrencyLogs = host.GetTestLoggerProvider().GetAllLogMessages().Where(p => p.Category == LogCategories.Concurrency).Select(p => p.FormattedMessage).ToList();
+                int concurrencyIncreaseLogCount = concurrencyLogs.Count(p => p.Contains("ProcessMessage Increasing concurrency"));
+                Assert.GreaterOrEqual(concurrencyIncreaseLogCount, 3);
+
                 await host.StopAsync();
             }
         }
@@ -1015,6 +1079,18 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 logger.LogInformation($"Input({input})");
                 _waitHandle1.Set();
+            }
+        }
+
+        public class DynamicConcurrencyTestJob
+        {
+            public static int InvocationCount;
+
+            public static async Task ProcessMessage([ServiceBusTrigger(FirstQueueNameKey)] string message, ILogger logger)
+            {
+                await Task.Delay(250);
+
+                Interlocked.Increment(ref InvocationCount);
             }
         }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
@@ -197,6 +197,33 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             await sender.SendMessageAsync(messageObj);
         }
 
+        internal async Task WriteQueueMessages(string[] messages, string[] sessionIds = null, string connectionString = default, string queueName = default)
+        {
+            await using ServiceBusClient client = new ServiceBusClient(connectionString ?? ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
+            var sender = client.CreateSender(queueName ?? _firstQueueScope.QueueName);
+
+            ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
+            int sessionCounter = 0;
+            for (int i = 0; i < messages.Length; i++)
+            {
+                var message = new ServiceBusMessage(messages[i]);
+                message.ContentType = "application/text";
+
+                if (sessionIds != null && sessionIds.Length > 0)
+                {
+                    // evenly distribute the messages across sessions
+                    message.SessionId = sessionIds[sessionCounter++ % sessionIds.Length];
+                }
+
+                if (!batch.TryAddMessage(message))
+                {
+                    throw new InvalidOperationException("Unable to add message to batch.");
+                }
+            }
+
+            await sender.SendMessagesAsync(batch);
+        }
+
         internal async Task WriteQueueMessage(TestPoco obj, string sessionId = null)
         {
             var serializer = new DataContractSerializer(typeof(TestPoco));


### PR DESCRIPTION
Implements the Dynamic Concurrency features in https://github.com/Azure/azure-functions-host/issues/7300.

Related PR for Dynamic Concurrency support in Storage Queues extension: https://github.com/Azure/azure-sdk-for-net/pull/22283

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
