### PR TITLE
[Core.Experimental] Fix JsonData To<T> Bug

### DIFF
--- a/sdk/core/Azure.Core.Experimental/src/JsonData.cs
+++ b/sdk/core/Azure.Core.Experimental/src/JsonData.cs
@@ -242,7 +242,7 @@ namespace Azure.Core
         /// <returns>A new instance of <typeparamref name="T"/> constructed from the underlying JSON value.</returns>
         public T To<T>(JsonSerializerOptions options)
         {
-            return JsonSerializer.Deserialize<T>(ToString(), options);
+            return JsonSerializer.Deserialize<T>(ToJsonString(), options);
         }
 
         /// <summary>

--- a/sdk/core/Azure.Core.Experimental/tests/JsonDataTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/JsonDataTests.cs
@@ -301,6 +301,14 @@ namespace Azure.Core.Tests
             validate(roundTrip);
         }
 
+        [Test]
+        public void GetOfTWithStringWorks()
+        {
+            JsonData d = new JsonData();
+            d.Set("property", "Hello");
+            Assert.AreEqual("Hello", d.Get<string>("property"));
+        }
+
         private T JsonAsType<T>(string json)
         {
             dynamic jsonData = JsonData.FromString(json);


### PR DESCRIPTION
JsonData's `ToString()` method was changed to return unquoted strings
when the underlying value is a string, instead of always returing the
JSON representation of the value. Because of this, we must use
`ToJsonString()` to get a JSON String that we can deserialize into a
POCO.