### PR TITLE
Fix SystemData and v1 ErrorResponse, remove PropertyReferenceType for ProviderResourceType

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.netstandard2.0.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.netstandard2.0.cs
@@ -1287,7 +1287,7 @@ namespace Azure.ResourceManager.Resources.Models
     public partial class ResourceGroupExportResult
     {
         internal ResourceGroupExportResult() { }
-        public Azure.ResourceManager.Resources.Models.ErrorResponse Error { get { throw null; } }
+        public Azure.ResourceManager.Resources.Models.ErrorDetail Error { get { throw null; } }
         public object Template { get { throw null; } }
     }
     public partial class ResourceGroupExportTemplateOperation : Azure.Operation<Azure.ResourceManager.Resources.Models.ResourceGroupExportResult>
@@ -1463,12 +1463,12 @@ namespace Azure.ResourceManager.Resources.Models
     public partial class SystemData
     {
         public SystemData() { }
-        public System.DateTimeOffset? CreatedAt { get { throw null; } set { } }
-        public string CreatedBy { get { throw null; } set { } }
-        public Azure.ResourceManager.Resources.Models.CreatedByType? CreatedByType { get { throw null; } set { } }
-        public System.DateTimeOffset? LastModifiedAt { get { throw null; } set { } }
-        public string LastModifiedBy { get { throw null; } set { } }
-        public Azure.ResourceManager.Resources.Models.CreatedByType? LastModifiedByType { get { throw null; } set { } }
+        public System.DateTimeOffset? CreatedAt { get { throw null; } }
+        public string CreatedBy { get { throw null; } }
+        public Azure.ResourceManager.Resources.Models.CreatedByType? CreatedByType { get { throw null; } }
+        public System.DateTimeOffset? LastModifiedAt { get { throw null; } }
+        public string LastModifiedBy { get { throw null; } }
+        public Azure.ResourceManager.Resources.Models.CreatedByType? LastModifiedByType { get { throw null; } }
     }
     public partial class Tag : Azure.ResourceManager.Resources.Models.Resource
     {

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Generated/Models/SystemData.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Generated/Models/SystemData.Serialization.cs
@@ -18,36 +18,6 @@ namespace Azure.ResourceManager.Resources.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            if (Optional.IsDefined(CreatedBy))
-            {
-                writer.WritePropertyName("createdBy");
-                writer.WriteStringValue(CreatedBy);
-            }
-            if (Optional.IsDefined(CreatedByType))
-            {
-                writer.WritePropertyName("createdByType");
-                writer.WriteStringValue(CreatedByType.Value.ToString());
-            }
-            if (Optional.IsDefined(CreatedAt))
-            {
-                writer.WritePropertyName("createdAt");
-                writer.WriteStringValue(CreatedAt.Value, "O");
-            }
-            if (Optional.IsDefined(LastModifiedBy))
-            {
-                writer.WritePropertyName("lastModifiedBy");
-                writer.WriteStringValue(LastModifiedBy);
-            }
-            if (Optional.IsDefined(LastModifiedByType))
-            {
-                writer.WritePropertyName("lastModifiedByType");
-                writer.WriteStringValue(LastModifiedByType.Value.ToString());
-            }
-            if (Optional.IsDefined(LastModifiedAt))
-            {
-                writer.WritePropertyName("lastModifiedAt");
-                writer.WriteStringValue(LastModifiedAt.Value, "O");
-            }
             writer.WriteEndObject();
         }
 

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Generated/Models/SystemData.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Generated/Models/SystemData.cs
@@ -39,16 +39,16 @@ namespace Azure.ResourceManager.Resources.Models
         }
 
         /// <summary> The identity that created the resource. </summary>
-        public string CreatedBy { get; set; }
+        public string CreatedBy { get; }
         /// <summary> The type of identity that created the resource. </summary>
-        public CreatedByType? CreatedByType { get; set; }
+        public CreatedByType? CreatedByType { get; }
         /// <summary> The timestamp of resource creation (UTC). </summary>
-        public DateTimeOffset? CreatedAt { get; set; }
+        public DateTimeOffset? CreatedAt { get; }
         /// <summary> The identity that last modified the resource. </summary>
-        public string LastModifiedBy { get; set; }
+        public string LastModifiedBy { get; }
         /// <summary> The type of identity that last modified the resource. </summary>
-        public CreatedByType? LastModifiedByType { get; set; }
+        public CreatedByType? LastModifiedByType { get; }
         /// <summary> The timestamp of resource last modification (UTC). </summary>
-        public DateTimeOffset? LastModifiedAt { get; set; }
+        public DateTimeOffset? LastModifiedAt { get; }
     }
 }

--- a/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ProviderResourceType.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ProviderResourceType.Serialization.cs
@@ -13,7 +13,6 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.Resources.Models
 {
-    [JsonConverter(typeof(ProviderResourceTypeConverter))]
     public partial class ProviderResourceType
     {
         internal static ProviderResourceType DeserializeProviderResourceType(JsonElement element)
@@ -136,19 +135,6 @@ namespace Azure.ResourceManager.Resources.Models
                 }
             }
             return new ProviderResourceType(resourceType.Value, Optional.ToList(locations), Optional.ToList(locationMappings), Optional.ToList(aliases), Optional.ToList(apiVersions), defaultApiVersion.Value, Optional.ToList(apiProfiles), capabilities.Value, Optional.ToDictionary(properties));
-        }
-
-        internal partial class ProviderResourceTypeConverter : JsonConverter<ProviderResourceType>
-        {
-            public override void Write(Utf8JsonWriter writer, ProviderResourceType providerResourceType, JsonSerializerOptions options)
-            {
-                writer.WriteObjectValue(providerResourceType);
-            }
-            public override ProviderResourceType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                using var document = JsonDocument.ParseValue(ref reader);
-                return DeserializeProviderResourceType(document.RootElement);
-            }
         }
     }
 }

--- a/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ProviderResourceType.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ProviderResourceType.Serialization.cs
@@ -5,10 +5,8 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.ResourceManager.Resources.Models

--- a/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ProviderResourceType.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ProviderResourceType.cs
@@ -12,11 +12,9 @@ using Azure.ResourceManager.Core;
 namespace Azure.ResourceManager.Resources.Models
 {
     /// <summary> Resource type managed by the resource provider. </summary>
-    [PropertyReferenceType]
     public partial class ProviderResourceType
     {
         /// <summary> Initializes a new instance of ProviderResourceType. </summary>
-        [InitializationConstructor]
         public ProviderResourceType()
         {
             Locations = new ChangeTrackingList<string>();
@@ -37,7 +35,6 @@ namespace Azure.ResourceManager.Resources.Models
         /// <param name="apiProfiles"> The API profiles for the resource provider. </param>
         /// <param name="capabilities"> The additional capabilities offered by this resource type. </param>
         /// <param name="properties"> The properties. </param>
-        [SerializationConstructor]
         internal ProviderResourceType(string resourceType, IReadOnlyList<string> locations, IReadOnlyList<ProviderExtendedLocation> locationMappings, IReadOnlyList<Alias> aliases, IReadOnlyList<string> apiVersions, string defaultApiVersion, IReadOnlyList<ApiProfile> apiProfiles, string capabilities, IReadOnlyDictionary<string, string> properties)
         {
             ResourceType = resourceType;

--- a/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ProviderResourceType.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ProviderResourceType.cs
@@ -7,7 +7,6 @@
 
 using System.Collections.Generic;
 using Azure.Core;
-using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Resources.Models
 {

--- a/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ResourceGroupExportResult.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ResourceGroupExportResult.Serialization.cs
@@ -15,7 +15,7 @@ namespace Azure.ResourceManager.Resources.Models
         internal static ResourceGroupExportResult DeserializeResourceGroupExportResult(JsonElement element)
         {
             Optional<object> template = default;
-            Optional<ErrorResponse> error = default;
+            Optional<ErrorDetail> error = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("template"))
@@ -35,7 +35,7 @@ namespace Azure.ResourceManager.Resources.Models
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    error = ErrorResponse.DeserializeErrorResponse(property.Value);
+                    error = ErrorDetail.DeserializeErrorDetail(property.Value);
                     continue;
                 }
             }

--- a/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ResourceGroupExportResult.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/ResourceGroupExportResult.cs
@@ -18,7 +18,7 @@ namespace Azure.ResourceManager.Resources.Models
         /// <summary> Initializes a new instance of ResourceGroupExportResult. </summary>
         /// <param name="template"> The template content. </param>
         /// <param name="error"> The template export error. </param>
-        internal ResourceGroupExportResult(object template, ErrorResponse error)
+        internal ResourceGroupExportResult(object template, ErrorDetail error)
         {
             Template = template;
             Error = error;
@@ -27,6 +27,6 @@ namespace Azure.ResourceManager.Resources.Models
         /// <summary> The template content. </summary>
         public object Template { get; }
         /// <summary> The template export error. </summary>
-        public ErrorResponse Error { get; }
+        public ErrorDetail Error { get; }
     }
 }

--- a/sdk/resourcemanager/Azure.ResourceManager/src/autorest.md
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/autorest.md
@@ -60,4 +60,8 @@ directive:
     where: $.definitions.*.properties[?(@.enum)]
     transform: >
       $["x-accessibility"] = "public"
+  - from: types.json
+    where: $.definitions.systemData.properties.*
+    transform: >
+      $["readOnly"] = true
 ```


### PR DESCRIPTION
1. SystemData is marked as readonly, but there seems a bug when working with configurations like `$["x-csharp-usage"] = "model,input,output"`. To bypass the bug, we need to mark every properties of SystemData to be readonly to generate the right model. ErrorDetail and ErrorAdditional is doing the right thing in the swagger.

2. Resources use common type v1 ErrorResponse and it's renamed to ErrorDetail in v2. v2 also added an ErrorResponse, but that's different from the one in v1. This PR renamed the v1 ErrorResponse to ErrorDetail  where it is used.

3. This PR also removes PropertyReferenceType for ProviderResourceType. Previously it's a property of Provider and needs to be placed. But later we've marked ProviderData as PropertyReferenceType, the Provider in Resources SDK will be replaced by ProviderData in core. So we no longer need to replace ProviderResourceType.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
