### PR TITLE
[DT] Fixing Failing Test "GetTranslationStatusesFilterByStatusTest"

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/tests/GetAllTranslationsFilterTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/GetAllTranslationsFilterTests.cs
@@ -38,7 +38,7 @@ namespace Azure.AI.Translation.Document.Tests
                 else if (jobTerminalStatus == DocumentTranslationStatus.Canceled)
                 {
                     await translationOp.CancelAsync(default);
-                    Thread.Sleep(3000); // wait for cancel status to propagate!
+                    Thread.Sleep(6000); // wait for cancel status to propagate!
                 }
             }
 


### PR DESCRIPTION
The test that fails is GetTranslationStatusesFilterByStatusTest(), the one where we create a translation operation and cancel it, then use a filter to query for cancelled operations. I took the following steps:

1. initially tests were succeeding locally, but I noticed that there were a few runs where it did not succeed. [Live]

2. Did some debugging which led me to believe that the times where it fails, the cancelled state had not yet propagated to the operation before we query it.

3. I increased the waiting time (3 seconds -> 6 seconds) and now every run succeeds locally.

Now we need to run the pipeline again to ensure that this fixed the issue.