### PR TITLE
Fix typo in the docs for the EventHubsConnectionStringBuilder class

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Primitives/EventHubsConnectionStringBuilder.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Primitives/EventHubsConnectionStringBuilder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.EventHubs
     ///     "EventHubsEntityName", // Event Hub Name 
     ///     "SharedAccessSignatureKeyName", 
     ///     "SharedAccessSignatureKey");
-    ///  string connectionString = connectionStringBuiler.ToString();
+    ///  string connectionString = connectionStringBuilder.ToString();
     /// </code>
     /// </example>
     public class EventHubsConnectionStringBuilder


### PR DESCRIPTION
This PR fixes the typo in the docs for the EventHubsConnectionStringBuilder class and fixes #22533
