### PR TITLE
Log MSAL for ConfidentialClient

### DIFF
--- a/sdk/identity/Azure.Identity/src/AuthorizationCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/AuthorizationCodeCredential.cs
@@ -93,7 +93,15 @@ namespace Azure.Identity
                 _ => null
             };
 
-            _client = client ?? new MsalConfidentialClient(_pipeline, tenantId, clientId, clientSecret, options as ITokenCacheOptions, null);
+            _client = client ??
+                      new MsalConfidentialClient(
+                          _pipeline,
+                          tenantId,
+                          clientId,
+                          clientSecret,
+                          options as ITokenCacheOptions,
+                          null,
+                          options?.IsLoggingPIIEnabled ?? false);
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/ClientCertificateCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ClientCertificateCredential.cs
@@ -134,7 +134,16 @@ namespace Azure.Identity
 
             ClientCertificateCredentialOptions certCredOptions = (options as ClientCertificateCredentialOptions);
 
-            Client = client ?? new MsalConfidentialClient(_pipeline, tenantId, clientId, certificateProvider, certCredOptions?.SendCertificateChain ?? false, options as ITokenCacheOptions, certCredOptions?.RegionalAuthority);
+            Client = client ??
+                     new MsalConfidentialClient(
+                         _pipeline,
+                         tenantId,
+                         clientId,
+                         certificateProvider,
+                         certCredOptions?.SendCertificateChain ?? false,
+                         options as ITokenCacheOptions,
+                         certCredOptions?.RegionalAuthority,
+                         options?.IsLoggingPIIEnabled ?? false);
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/ClientSecretCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ClientSecretCredential.cs
@@ -90,7 +90,15 @@ namespace Azure.Identity
             ClientSecret = clientSecret;
             _allowMultiTenantAuthentication = options?.AllowMultiTenantAuthentication ?? false;
             _pipeline = pipeline ?? CredentialPipeline.GetInstance(options);
-            Client = client ?? new MsalConfidentialClient(_pipeline, tenantId, clientId, clientSecret, options as ITokenCacheOptions, (options as ClientSecretCredentialOptions)?.RegionalAuthority);
+            Client = client ??
+                     new MsalConfidentialClient(
+                         _pipeline,
+                         tenantId,
+                         clientId,
+                         clientSecret,
+                         options as ITokenCacheOptions,
+                         (options as ClientSecretCredentialOptions)?.RegionalAuthority,
+                         options?.IsLoggingPIIEnabled ?? false);
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/MsalClientBase.cs
+++ b/sdk/identity/Azure.Identity/src/MsalClientBase.cs
@@ -11,6 +11,7 @@ namespace Azure.Identity
         where TClient : IClientApplicationBase
     {
         private readonly AsyncLockWithValue<TClient> _clientAsyncLock;
+        internal protected bool LogPII { get; protected set; }
 
         /// <summary>
         /// For mocking purposes only.

--- a/sdk/identity/Azure.Identity/src/MsalConfidentialClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalConfidentialClient.cs
@@ -22,19 +22,21 @@ namespace Azure.Identity
         {
         }
 
-        public MsalConfidentialClient(CredentialPipeline pipeline, string tenantId, string clientId, string clientSecret, ITokenCacheOptions cacheOptions, RegionalAuthority? regionalAuthority)
+        public MsalConfidentialClient(CredentialPipeline pipeline, string tenantId, string clientId, string clientSecret, ITokenCacheOptions cacheOptions, RegionalAuthority? regionalAuthority, bool logPii)
             : base(pipeline, tenantId, clientId, cacheOptions)
         {
             _clientSecret = clientSecret;
             RegionalAuthority = regionalAuthority;
+            LogPII = logPii;
         }
 
-        public MsalConfidentialClient(CredentialPipeline pipeline, string tenantId, string clientId, ClientCertificateCredential.IX509Certificate2Provider certificateProvider, bool includeX5CClaimHeader, ITokenCacheOptions cacheOptions, RegionalAuthority? regionalAuthority)
+        public MsalConfidentialClient(CredentialPipeline pipeline, string tenantId, string clientId, ClientCertificateCredential.IX509Certificate2Provider certificateProvider, bool includeX5CClaimHeader, ITokenCacheOptions cacheOptions, RegionalAuthority? regionalAuthority, bool logPii)
             : base(pipeline, tenantId, clientId, cacheOptions)
         {
             _includeX5CClaimHeader = includeX5CClaimHeader;
             _certificateProvider = certificateProvider;
             RegionalAuthority = regionalAuthority;
+            LogPII = logPii;
         }
 
         internal RegionalAuthority? RegionalAuthority { get; }
@@ -43,7 +45,8 @@ namespace Azure.Identity
         {
             ConfidentialClientApplicationBuilder confClientBuilder = ConfidentialClientApplicationBuilder.Create(ClientId)
                 .WithAuthority(Pipeline.AuthorityHost.AbsoluteUri, TenantId)
-                .WithHttpClientFactory(new HttpPipelineClientFactory(Pipeline.HttpPipeline));
+                .WithHttpClientFactory(new HttpPipelineClientFactory(Pipeline.HttpPipeline))
+                .WithLogging(AzureIdentityEventSource.Singleton.LogMsal, enablePiiLogging: LogPII);
 
             if (_clientSecret != null)
             {

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -14,7 +14,6 @@ namespace Azure.Identity
     internal class MsalPublicClient : MsalClientBase<IPublicClientApplication>
     {
         internal string RedirectUrl { get; }
-        internal bool LogPII { get; }
 
         protected MsalPublicClient()
         { }

--- a/sdk/identity/Azure.Identity/tests/samples/TokenCacheSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/TokenCacheSnippets.cs
@@ -12,9 +12,7 @@ namespace Azure.Identity.Samples
 {
     public class TokenCacheSnippets
     {
-        #region Snippet:Identity_TokenCache_CustomPersistence_Usage_TokenCachePath
         private const string TOKEN_CACHE_PATH = "./tokencache.bin";
-        #endregion
 
         public void Identity_TokenCache_PersistentDefault()
         {


### PR DESCRIPTION
Previously MSAL logging was not being produced for MsalConfidentialClient credentials.